### PR TITLE
ci: history-scan should see all branches

### DIFF
--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -68,6 +68,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Fetch all branches
+        run: |
+          git fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
       - name: Decode patterns
         env:
           PATTERNS: ${{ secrets.SCAN_RULES_B64 }}
@@ -77,8 +80,8 @@ jobs:
       - name: Scan history
         run: |
           set -euo pipefail
-          git log --all --format='%H%n%an%n%ae%n%cn%n%ce%n%s%n%b' > /tmp/h
-          git log --all -p > /tmp/d
+          git log --all --remotes='origin/*' --format='%H%n%an%n%ae%n%cn%n%ce%n%s%n%b' > /tmp/h
+          git log --all --remotes='origin/*' -p > /tmp/d
           fail=0
           while IFS= read -r p; do
             [ -z "$p" ] && continue


### PR DESCRIPTION
Fix the history-scan job so it sees commits across all branches, not just the PR branch.

`actions/checkout@v4` with `fetch-depth: 0` gets full history of the checked-out ref but does not fetch other branches. Added an explicit `git fetch ... +refs/heads/*:refs/remotes/origin/*` step and switched the scan to `git log --all --remotes='origin/*'`.

## Test plan
- [ ] Staging Gate green on this PR
- [ ] history-scan completes successfully