### PR TITLE
feat: add Belief/Edge dataclasses and config module

### DIFF
--- a/src/aelfrice/__init__.py
+++ b/src/aelfrice/__init__.py
@@ -1,0 +1,2 @@
+"""aelfrice: Bayesian memory designed for feedback-driven learning."""
+__version__ = "0.2.0"

--- a/src/aelfrice/config.py
+++ b/src/aelfrice/config.py
@@ -1,0 +1,31 @@
+"""Minimum config surface for v0.1.0.
+
+Just the DB path and storage defaults. Larger config (retrieval budgets,
+feedback thresholds, etc.) lands with the modules that need them.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Final
+
+# Default DB location; overridable via AELFRICE_DB env var.
+DEFAULT_DB_DIR: Final[Path] = Path.home() / ".aelfrice"
+DEFAULT_DB_FILENAME: Final[str] = "memory.db"
+
+# Beta-Bernoulli prior. Jeffreys (0.5, 0.5) -- noninformative.
+DEFAULT_ALPHA_PRIOR: Final[float] = 0.5
+DEFAULT_BETA_PRIOR: Final[float] = 0.5
+
+# propagate_valence defaults.
+DEFAULT_VALENCE_DECAY: Final[float] = 0.5
+DEFAULT_VALENCE_MAX_HOPS: Final[int] = 3
+DEFAULT_VALENCE_MIN_THRESHOLD: Final[float] = 0.05
+
+
+def db_path() -> Path:
+    """Resolve the DB path from env or defaults. Caller creates the dir."""
+    override: str | None = os.environ.get("AELFRICE_DB")
+    if override:
+        return Path(override)
+    return DEFAULT_DB_DIR / DEFAULT_DB_FILENAME

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -1,0 +1,79 @@
+"""Domain dataclasses for aelfrice.
+
+Load-bearing fields only. 4 belief types, 5 edge types, 2 lock levels. No
+multi-source tagging, no rigor tier, no bitemporal event_time — those are
+deferred to a later release.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+# --- Belief types ---
+BELIEF_FACTUAL: Final[str] = "factual"
+BELIEF_CORRECTION: Final[str] = "correction"
+BELIEF_PREFERENCE: Final[str] = "preference"
+BELIEF_REQUIREMENT: Final[str] = "requirement"
+
+BELIEF_TYPES: Final[frozenset[str]] = frozenset({
+    BELIEF_FACTUAL,
+    BELIEF_CORRECTION,
+    BELIEF_PREFERENCE,
+    BELIEF_REQUIREMENT,
+})
+
+# --- Edge types ---
+EDGE_SUPPORTS: Final[str] = "SUPPORTS"
+EDGE_CITES: Final[str] = "CITES"
+EDGE_CONTRADICTS: Final[str] = "CONTRADICTS"
+EDGE_SUPERSEDES: Final[str] = "SUPERSEDES"
+EDGE_RELATES_TO: Final[str] = "RELATES_TO"
+
+# Edge-type valence multipliers for propagation.
+# Positive = propagate same sign; negative = invert; 0.0 = no propagation.
+EDGE_VALENCE: Final[dict[str, float]] = {
+    EDGE_SUPPORTS: 1.0,
+    EDGE_CITES: 0.5,
+    EDGE_CONTRADICTS: -0.5,
+    EDGE_SUPERSEDES: 0.0,
+    EDGE_RELATES_TO: 0.3,
+}
+
+EDGE_TYPES: Final[frozenset[str]] = frozenset(EDGE_VALENCE.keys())
+
+# --- Lock levels ---
+LOCK_NONE: Final[str] = "none"
+LOCK_USER: Final[str] = "user"
+
+LOCK_LEVELS: Final[frozenset[str]] = frozenset({LOCK_NONE, LOCK_USER})
+
+
+@dataclass
+class Belief:
+    """A unit of memory with Bayesian confidence and lock state.
+
+    Fields: id, content, content_hash, alpha, beta, type, lock_level,
+    locked_at, demotion_pressure, created_at, last_retrieved_at.
+    """
+
+    id: str
+    content: str
+    content_hash: str
+    alpha: float
+    beta: float
+    type: str
+    lock_level: str
+    locked_at: str | None
+    demotion_pressure: int
+    created_at: str
+    last_retrieved_at: str | None
+
+
+@dataclass
+class Edge:
+    """A typed, weighted directed link between two beliefs."""
+
+    src: str
+    dst: str
+    type: str
+    weight: float


### PR DESCRIPTION
Adds the foundational dataclasses (Belief, Edge) and a small config surface (DB path, prior alpha/beta, propagate_valence defaults). No store yet — that lands next.

## Test plan
- [ ] CI green
- [ ] Staging Gate green