### PR TITLE
feat: add SQLite store with CRUD, FTS5, WAL, propagate_valence

### DIFF
--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -1,0 +1,288 @@
+"""SQLite-backed store for Beliefs and Edges, with FTS5 full-text search.
+
+Stdlib-only (sqlite3). WAL journal mode for concurrent reads. FTS5 virtual
+table mirrors `beliefs.content` for keyword retrieval.
+
+`propagate_valence` lives here so v0.1.0 stays a small module set.
+Broker-confidence attenuation: each hop through an intermediate belief is
+dampened by that belief's alpha/(alpha+beta), so low-confidence brokers
+absorb propagation rather than amplify it.
+
+`demotion_pressure` is both written and read end-to-end here; the test
+suite locks that behaviour in from day one
+(see tests/test_demotion_pressure.py).
+"""
+from __future__ import annotations
+
+import sqlite3
+from typing import Iterable
+
+from aelfrice.models import (
+    EDGE_VALENCE,
+    Belief,
+    Edge,
+)
+
+# --- Schema ---------------------------------------------------------------
+
+_SCHEMA: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS beliefs (
+        id                  TEXT PRIMARY KEY,
+        content             TEXT NOT NULL,
+        content_hash        TEXT NOT NULL,
+        alpha               REAL NOT NULL,
+        beta                REAL NOT NULL,
+        type                TEXT NOT NULL,
+        lock_level          TEXT NOT NULL,
+        locked_at           TEXT,
+        demotion_pressure   INTEGER NOT NULL DEFAULT 0,
+        created_at          TEXT NOT NULL,
+        last_retrieved_at   TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS edges (
+        src     TEXT NOT NULL,
+        dst     TEXT NOT NULL,
+        type    TEXT NOT NULL,
+        weight  REAL NOT NULL,
+        PRIMARY KEY (src, dst, type)
+    )
+    """,
+    """
+    CREATE VIRTUAL TABLE IF NOT EXISTS beliefs_fts
+    USING fts5(id UNINDEXED, content, tokenize='porter unicode61')
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_edges_src ON edges(src)",
+    "CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst)",
+)
+
+
+def _row_to_belief(row: sqlite3.Row) -> Belief:
+    return Belief(
+        id=row["id"],
+        content=row["content"],
+        content_hash=row["content_hash"],
+        alpha=row["alpha"],
+        beta=row["beta"],
+        type=row["type"],
+        lock_level=row["lock_level"],
+        locked_at=row["locked_at"],
+        demotion_pressure=row["demotion_pressure"],
+        created_at=row["created_at"],
+        last_retrieved_at=row["last_retrieved_at"],
+    )
+
+
+def _row_to_edge(row: sqlite3.Row) -> Edge:
+    return Edge(
+        src=row["src"],
+        dst=row["dst"],
+        type=row["type"],
+        weight=row["weight"],
+    )
+
+
+class Store:
+    """SQLite store. Pass `:memory:` for tests, a path otherwise."""
+
+    def __init__(self, path: str) -> None:
+        self._conn: sqlite3.Connection = sqlite3.connect(path)
+        self._conn.row_factory = sqlite3.Row
+        # WAL only meaningful on-disk; harmless on :memory:.
+        try:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.DatabaseError:
+            pass
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        for stmt in _SCHEMA:
+            self._conn.execute(stmt)
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    # --- Belief CRUD ------------------------------------------------------
+
+    def insert_belief(self, b: Belief) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO beliefs (
+                id, content, content_hash, alpha, beta, type,
+                lock_level, locked_at, demotion_pressure,
+                created_at, last_retrieved_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                b.id, b.content, b.content_hash, b.alpha, b.beta, b.type,
+                b.lock_level, b.locked_at, b.demotion_pressure,
+                b.created_at, b.last_retrieved_at,
+            ),
+        )
+        self._conn.execute(
+            "INSERT INTO beliefs_fts (id, content) VALUES (?, ?)",
+            (b.id, b.content),
+        )
+        self._conn.commit()
+
+    def get_belief(self, belief_id: str) -> Belief | None:
+        cur = self._conn.execute(
+            "SELECT * FROM beliefs WHERE id = ?", (belief_id,)
+        )
+        row = cur.fetchone()
+        return _row_to_belief(row) if row else None
+
+    def update_belief(self, b: Belief) -> None:
+        """Full-row update; demotion_pressure included."""
+        self._conn.execute(
+            """
+            UPDATE beliefs SET
+                content = ?,
+                content_hash = ?,
+                alpha = ?,
+                beta = ?,
+                type = ?,
+                lock_level = ?,
+                locked_at = ?,
+                demotion_pressure = ?,
+                created_at = ?,
+                last_retrieved_at = ?
+            WHERE id = ?
+            """,
+            (
+                b.content, b.content_hash, b.alpha, b.beta, b.type,
+                b.lock_level, b.locked_at, b.demotion_pressure,
+                b.created_at, b.last_retrieved_at, b.id,
+            ),
+        )
+        self._conn.execute("DELETE FROM beliefs_fts WHERE id = ?", (b.id,))
+        self._conn.execute(
+            "INSERT INTO beliefs_fts (id, content) VALUES (?, ?)",
+            (b.id, b.content),
+        )
+        self._conn.commit()
+
+    def delete_belief(self, belief_id: str) -> None:
+        self._conn.execute("DELETE FROM beliefs WHERE id = ?", (belief_id,))
+        self._conn.execute("DELETE FROM beliefs_fts WHERE id = ?", (belief_id,))
+        self._conn.execute(
+            "DELETE FROM edges WHERE src = ? OR dst = ?",
+            (belief_id, belief_id),
+        )
+        self._conn.commit()
+
+    def search_beliefs(self, query: str, limit: int = 20) -> list[Belief]:
+        """FTS5 keyword search over belief content. Ranked by bm25."""
+        cur = self._conn.execute(
+            """
+            SELECT b.* FROM beliefs b
+            JOIN beliefs_fts f ON f.id = b.id
+            WHERE beliefs_fts MATCH ?
+            ORDER BY bm25(beliefs_fts)
+            LIMIT ?
+            """,
+            (query, limit),
+        )
+        return [_row_to_belief(r) for r in cur.fetchall()]
+
+    # --- Edge CRUD --------------------------------------------------------
+
+    def insert_edge(self, e: Edge) -> None:
+        self._conn.execute(
+            "INSERT INTO edges (src, dst, type, weight) VALUES (?, ?, ?, ?)",
+            (e.src, e.dst, e.type, e.weight),
+        )
+        self._conn.commit()
+
+    def get_edge(self, src: str, dst: str, type_: str) -> Edge | None:
+        cur = self._conn.execute(
+            "SELECT * FROM edges WHERE src = ? AND dst = ? AND type = ?",
+            (src, dst, type_),
+        )
+        row = cur.fetchone()
+        return _row_to_edge(row) if row else None
+
+    def update_edge(self, e: Edge) -> None:
+        self._conn.execute(
+            "UPDATE edges SET weight = ? WHERE src = ? AND dst = ? AND type = ?",
+            (e.weight, e.src, e.dst, e.type),
+        )
+        self._conn.commit()
+
+    def delete_edge(self, src: str, dst: str, type_: str) -> None:
+        self._conn.execute(
+            "DELETE FROM edges WHERE src = ? AND dst = ? AND type = ?",
+            (src, dst, type_),
+        )
+        self._conn.commit()
+
+    def edges_from(self, src: str) -> list[Edge]:
+        cur = self._conn.execute(
+            "SELECT * FROM edges WHERE src = ?", (src,)
+        )
+        return [_row_to_edge(r) for r in cur.fetchall()]
+
+    # --- Setr: propagate_valence -----------------------------------------
+
+    def propagate_valence(
+        self,
+        src_id: str,
+        valence: float,
+        max_hops: int = 3,
+        min_threshold: float = 0.05,
+    ) -> dict[str, float]:
+        """Propagate a valence signal outward through edges, attenuated by
+        broker confidence (alpha / (alpha + beta) of intermediate beliefs).
+
+        BFS over outbound edges. At each hop the carried magnitude is
+        multiplied by:
+            EDGE_VALENCE[edge.type] * broker_confidence(dst)
+        Stops when |carried| < min_threshold or hop count exceeds max_hops.
+
+        Returns: dict mapping touched belief_id -> sum of applied deltas.
+        The src_id itself is NOT included in the returned map (it's the
+        source, not a recipient).
+        """
+        applied: dict[str, float] = {}
+        # Frontier entries: (belief_id, magnitude_carried_into_it, hops_taken)
+        # The source contributes its outbound edges at hop 1.
+        frontier: list[tuple[str, float, int]] = [(src_id, valence, 0)]
+        visited: set[str] = {src_id}
+
+        while frontier:
+            next_frontier: list[tuple[str, float, int]] = []
+            for current_id, carried, hops in frontier:
+                if hops >= max_hops:
+                    continue
+                if abs(carried) < min_threshold:
+                    continue
+                for edge in self.edges_from(current_id):
+                    multiplier = EDGE_VALENCE.get(edge.type, 0.0)
+                    if multiplier == 0.0:
+                        continue
+                    dst = self.get_belief(edge.dst)
+                    if dst is None:
+                        continue
+                    denom = dst.alpha + dst.beta
+                    broker = (dst.alpha / denom) if denom > 0 else 0.0
+                    delta = carried * multiplier * broker
+                    if abs(delta) < min_threshold:
+                        continue
+                    applied[edge.dst] = applied.get(edge.dst, 0.0) + delta
+                    if edge.dst not in visited:
+                        visited.add(edge.dst)
+                        next_frontier.append((edge.dst, delta, hops + 1))
+            frontier = next_frontier
+
+        return applied
+
+    # --- Bulk helpers (used by tests / future modules) -------------------
+
+    def insert_beliefs(self, beliefs: Iterable[Belief]) -> None:
+        for b in beliefs:
+            self.insert_belief(b)
+
+    def insert_edges(self, edges: Iterable[Edge]) -> None:
+        for e in edges:
+            self.insert_edge(e)

--- a/tests/test_store_crud.py
+++ b/tests/test_store_crud.py
@@ -1,0 +1,122 @@
+"""CRUD + FTS5 tests for the SQLite store."""
+from __future__ import annotations
+
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_SUPPORTS,
+    LOCK_NONE,
+    Belief,
+    Edge,
+)
+from aelfrice.store import Store
+
+
+def _mk_belief(
+    bid: str = "b1",
+    content: str = "the sky is blue",
+    alpha: float = 1.0,
+    beta: float = 1.0,
+    demotion_pressure: int = 0,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash="h_" + bid,
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=demotion_pressure,
+        created_at="2026-04-25T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def test_belief_insert_and_get_roundtrip() -> None:
+    s = Store(":memory:")
+    b = _mk_belief()
+    s.insert_belief(b)
+    got = s.get_belief("b1")
+    assert got is not None
+    assert got.id == b.id
+    assert got.content == b.content
+    assert got.content_hash == b.content_hash
+    assert got.alpha == b.alpha
+    assert got.beta == b.beta
+    assert got.type == b.type
+    assert got.lock_level == b.lock_level
+    assert got.locked_at == b.locked_at
+    assert got.demotion_pressure == b.demotion_pressure
+    assert got.created_at == b.created_at
+    assert got.last_retrieved_at == b.last_retrieved_at
+
+
+def test_belief_update_persists_alpha_beta_and_demotion() -> None:
+    s = Store(":memory:")
+    b = _mk_belief()
+    s.insert_belief(b)
+    b.alpha = 5.5
+    b.beta = 2.25
+    b.demotion_pressure = 4
+    s.update_belief(b)
+    got = s.get_belief("b1")
+    assert got is not None
+    assert got.alpha == 5.5
+    assert got.beta == 2.25
+    assert got.demotion_pressure == 4
+
+
+def test_belief_delete_returns_none() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk_belief())
+    s.delete_belief("b1")
+    assert s.get_belief("b1") is None
+
+
+def test_edge_insert_get_update_delete() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk_belief("a"))
+    s.insert_belief(_mk_belief("b", content="thing two"))
+    e = Edge(src="a", dst="b", type=EDGE_SUPPORTS, weight=0.7)
+    s.insert_edge(e)
+    got = s.get_edge("a", "b", EDGE_SUPPORTS)
+    assert got is not None
+    assert got.weight == 0.7
+
+    e.weight = 0.9
+    s.update_edge(e)
+    got2 = s.get_edge("a", "b", EDGE_SUPPORTS)
+    assert got2 is not None
+    assert got2.weight == 0.9
+
+    s.delete_edge("a", "b", EDGE_SUPPORTS)
+    assert s.get_edge("a", "b", EDGE_SUPPORTS) is None
+
+
+def test_fts5_search_finds_belief_by_keyword() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk_belief("b1", content="apples are red and crunchy"))
+    s.insert_belief(_mk_belief("b2", content="bananas are yellow"))
+    s.insert_belief(_mk_belief("b3", content="grapes are purple"))
+
+    hits = s.search_beliefs("bananas")
+    assert len(hits) == 1
+    assert hits[0].id == "b2"
+
+    hits2 = s.search_beliefs("are")
+    ids = {h.id for h in hits2}
+    assert ids == {"b1", "b2", "b3"}
+
+
+def test_fts5_search_after_update_reflects_new_content() -> None:
+    s = Store(":memory:")
+    b = _mk_belief("b1", content="initial wording about cats")
+    s.insert_belief(b)
+    assert {h.id for h in s.search_beliefs("cats")} == {"b1"}
+
+    b.content = "rewritten to mention dogs only"
+    b.content_hash = "h_b1_v2"
+    s.update_belief(b)
+    assert s.search_beliefs("cats") == []
+    assert {h.id for h in s.search_beliefs("dogs")} == {"b1"}


### PR DESCRIPTION
Adds the storage layer. SQLite with WAL journaling, FTS5 keyword search, full Belief/Edge CRUD, and propagate_valence (broker-attenuated valence walk). One CRUD test covers insert/get/update/delete and FTS search.

## Test plan
- [ ] CI green
- [ ] Staging Gate green