### PR TITLE
feat: add retrieval module with L0 locked auto-load + L1 FTS5 BM25

### DIFF
--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -1,0 +1,69 @@
+"""Two-layer retrieval: L0 locked-beliefs auto-load + L1 FTS5 BM25 keyword search.
+
+Token-budgeted output (default 2000 tokens, ~4 chars/token estimate). L0
+beliefs are always present in the output above any L1 result and are never
+trimmed by the budget — locks are user-asserted ground truth and must
+survive retrieval.
+
+NO HRR, NO BFS multi-hop, NO entity-index in v1.0 (pre-commit #6). Those
+land in a later release once the retrieval upgrade R&D is validated against
+a real corpus.
+"""
+from __future__ import annotations
+
+from typing import Final
+
+from aelfrice.models import Belief
+from aelfrice.store import Store
+
+DEFAULT_TOKEN_BUDGET: Final[int] = 2000
+_CHARS_PER_TOKEN: Final[float] = 4.0
+DEFAULT_L1_LIMIT: Final[int] = 50
+
+
+def _estimate_tokens(text: str) -> int:
+    """Cheap char-based token estimate. Conservative (rounds up)."""
+    if not text:
+        return 0
+    return int((len(text) + _CHARS_PER_TOKEN - 1) // _CHARS_PER_TOKEN)
+
+
+def _belief_tokens(b: Belief) -> int:
+    return _estimate_tokens(b.content)
+
+
+def retrieve(
+    store: Store,
+    query: str,
+    token_budget: int = DEFAULT_TOKEN_BUDGET,
+    l1_limit: int = DEFAULT_L1_LIMIT,
+) -> list[Belief]:
+    """Return L0 locked beliefs first, then L1 FTS5 BM25 results.
+
+    Output is token-budgeted: L1 results are trimmed from the tail until the
+    estimated total token count is at or below `token_budget`. L0 beliefs
+    are never trimmed — if the locked set alone exceeds the budget, the
+    full L0 set is still returned and L1 is empty.
+
+    Dedupe: an L1 hit whose id already appears in L0 is dropped.
+
+    Empty query: returns L0 only (FTS5 has nothing to match against).
+    """
+    locked: list[Belief] = store.list_locked_beliefs()
+    locked_ids: set[str] = {b.id for b in locked}
+
+    l1: list[Belief] = []
+    if query.strip():
+        raw_l1: list[Belief] = store.search_beliefs(query, limit=l1_limit)
+        l1 = [b for b in raw_l1 if b.id not in locked_ids]
+
+    # Token accounting. L0 always survives.
+    used: int = sum(_belief_tokens(b) for b in locked)
+    out: list[Belief] = list(locked)
+    for b in l1:
+        cost: int = _belief_tokens(b)
+        if used + cost > token_budget:
+            break
+        out.append(b)
+        used += cost
+    return out

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -186,6 +186,21 @@ class Store:
         )
         return [_row_to_belief(r) for r in cur.fetchall()]
 
+    def list_locked_beliefs(self) -> list[Belief]:
+        """All beliefs with lock_level != 'none', ordered by locked_at DESC.
+
+        Used by the L0 retrieval layer: locked beliefs are user-asserted
+        ground truth and auto-load above any keyword-search results.
+        """
+        cur = self._conn.execute(
+            """
+            SELECT * FROM beliefs
+            WHERE lock_level != 'none'
+            ORDER BY locked_at DESC, id ASC
+            """
+        )
+        return [_row_to_belief(r) for r in cur.fetchall()]
+
     # --- Edge CRUD --------------------------------------------------------
 
     def insert_edge(self, e: Edge) -> None:

--- a/tests/test_retrieval_smoke.py
+++ b/tests/test_retrieval_smoke.py
@@ -1,0 +1,89 @@
+"""Retrieval module smoke + basic L0/L1 wiring.
+
+Confirms the two-layer flow runs end-to-end against an in-memory store:
+locked beliefs come back even when they don't match the query, and FTS5
+results come back when they do.
+"""
+from __future__ import annotations
+
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.retrieval import retrieve
+from aelfrice.store import Store
+
+
+def _mk(
+    bid: str,
+    content: str,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def test_retrieval_returns_l0_locked_beliefs_for_unrelated_query() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk("L1", "user pinned a fact about cats",
+                        lock_level=LOCK_USER, locked_at="2026-04-26T01:00:00Z"))
+    s.insert_belief(_mk("F1", "an unrelated fact about elephants"))
+
+    hits = retrieve(s, query="dogs")
+    ids = [b.id for b in hits]
+    # L0 fires regardless of query content.
+    assert "L1" in ids
+    # F1 doesn't match "dogs" so L1 produces nothing.
+    assert "F1" not in ids
+
+
+def test_retrieval_returns_l1_fts5_match_when_present() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk("F1", "the kitchen is full of bananas"))
+    s.insert_belief(_mk("F2", "the garage is full of tools"))
+
+    hits = retrieve(s, query="bananas")
+    ids = {b.id for b in hits}
+    assert ids == {"F1"}
+
+
+def test_retrieval_empty_query_returns_locked_only() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk("L1", "locked truth",
+                        lock_level=LOCK_USER, locked_at="2026-04-26T01:00:00Z"))
+    s.insert_belief(_mk("F1", "free-floating fact"))
+
+    hits = retrieve(s, query="")
+    ids = [b.id for b in hits]
+    assert ids == ["L1"]
+
+
+def test_retrieval_dedupes_locked_belief_appearing_in_fts5_match() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk("L1", "the user pinned a banana fact",
+                        lock_level=LOCK_USER, locked_at="2026-04-26T01:00:00Z"))
+    s.insert_belief(_mk("F1", "the kitchen is full of bananas"))
+
+    hits = retrieve(s, query="banana")
+    ids = [b.id for b in hits]
+    # L1 first (locked), F1 second (FTS5), no duplicate.
+    assert ids[0] == "L1"
+    assert ids.count("L1") == 1
+    assert "F1" in ids
+
+
+def test_retrieval_returns_pure_belief_objects() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk("F1", "a fact"))
+    hits = retrieve(s, query="fact")
+    assert len(hits) == 1
+    assert isinstance(hits[0], Belief)


### PR DESCRIPTION
## Summary

- New `src/aelfrice/retrieval.py` with `retrieve(store, query, token_budget=2000)`.
- L0: all locked beliefs auto-load (`lock_level != "none"`), ordered by `locked_at DESC, id ASC`. Never trimmed.
- L1: FTS5 BM25 keyword search, deduped against L0 by id, trimmed from tail when cumulative ~4-chars-per-token estimate exceeds the budget.
- Empty query short-circuits to L0 only.
- Adds `Store.list_locked_beliefs()` to support L0.
- 5 smoke tests covering L0 fires regardless of query, L1 hit path, empty-query fallback, dedupe, pure-Belief return.

Pre-commit #6 holds: no HRR, no BFS multi-hop, no entity-index. Those are gated on the real-corpus integration test.

## Test plan

- [x] `uv run pytest -q` → 29 passed (was 24, +5 new)
- [x] `uv run pyright src/aelfrice tests` → 0 errors, 0 warnings, 0 informations
- [x] `git log --show-signature -1` → `Good "git" signature`
- [ ] staging-gate green