### PR TITLE
feat: add apply_feedback central endpoint with Beta-Bernoulli update

### DIFF
--- a/src/aelfrice/feedback.py
+++ b/src/aelfrice/feedback.py
@@ -1,0 +1,115 @@
+"""Feedback endpoint: the single Bayesian-update path at runtime.
+
+`apply_feedback(store, belief_id, valence, source)` is the only function
+that mutates a belief's alpha/beta after onboarding. It also writes an
+audit row to `feedback_history` for every successful update so the
+project's feedback regime is recoverable after the fact.
+
+Demotion-pressure propagation and auto-demote at threshold land in
+follow-up commits; this module ships the core update + audit path
+first so the contract is stable before the propagation layer hooks in.
+
+`DEMOTION_THRESHOLD` is exposed here as a module-level configurable
+constant (default 5, per round-6 E22). Callers may rebind it for tests
+or domain-specific tuning. The auto-demote path that consumes it lands
+next.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Final
+
+from aelfrice.models import Belief
+from aelfrice.store import Store
+
+DEMOTION_THRESHOLD: int = 5
+
+POSITIVE: Final[str] = "positive"
+NEGATIVE: Final[str] = "negative"
+
+
+@dataclass
+class FeedbackResult:
+    """What apply_feedback did, returned to the caller for introspection."""
+
+    belief_id: str
+    event_id: int
+    prior_alpha: float
+    prior_beta: float
+    new_alpha: float
+    new_beta: float
+    valence: float
+    source: str
+
+
+def _utc_now_iso() -> str:
+    """ISO-8601 UTC timestamp suffixed Z. Stable across hosts."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _bayesian_update(b: Belief, valence: float) -> tuple[float, float]:
+    """Beta-Bernoulli update: positive valence -> alpha; negative -> beta.
+
+    Magnitude is the increment amount; ±1.0 is conventional but fractional
+    valences are honored for weighted feedback sources (e.g., propagated
+    signals attenuated by broker confidence).
+    """
+    if valence > 0.0:
+        return (b.alpha + valence, b.beta)
+    return (b.alpha, b.beta + (-valence))
+
+
+def apply_feedback(
+    store: Store,
+    belief_id: str,
+    valence: float,
+    source: str,
+    now: str | None = None,
+) -> FeedbackResult:
+    """Apply one feedback event to one belief.
+
+    1. Resolve the belief; raise ValueError if missing.
+    2. Reject zero valence: a no-update event is not a successful update,
+       and pre-commit #5 says feedback_history records every successful
+       update — so a zero call has no row to write.
+    3. Bayesian-update alpha or beta by valence sign.
+    4. Persist the new posterior on the belief row.
+    5. Append one row to feedback_history (created_at = `now` or UTC now).
+    6. Return a FeedbackResult with prior + new posteriors and the row id.
+    """
+    if valence == 0.0:
+        raise ValueError("valence must be nonzero")
+    if not source:
+        raise ValueError("source must be a non-empty string")
+
+    b: Belief | None = store.get_belief(belief_id)
+    if b is None:
+        raise ValueError(f"belief not found: {belief_id}")
+
+    prior_alpha: float = b.alpha
+    prior_beta: float = b.beta
+    new_alpha, new_beta = _bayesian_update(b, valence)
+
+    b.alpha = new_alpha
+    b.beta = new_beta
+    store.update_belief(b)
+
+    timestamp: str = now if now is not None else _utc_now_iso()
+    event_id: int = store.insert_feedback_event(
+        belief_id=belief_id,
+        valence=valence,
+        source=source,
+        created_at=timestamp,
+    )
+
+    return FeedbackResult(
+        belief_id=belief_id,
+        event_id=event_id,
+        prior_alpha=prior_alpha,
+        prior_beta=prior_beta,
+        new_alpha=new_alpha,
+        new_beta=new_beta,
+        valence=valence,
+        source=source,
+    )

--- a/tests/test_feedback_apply.py
+++ b/tests/test_feedback_apply.py
@@ -1,0 +1,217 @@
+"""apply_feedback: Bayesian-update + audit-row contract.
+
+One assertion per test where practical; every test uses an in-memory
+store and finishes in milliseconds.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aelfrice.feedback import FeedbackResult, apply_feedback
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
+from aelfrice.scoring import posterior_mean
+from aelfrice.store import Store
+
+
+def _mk(bid: str = "b1", alpha: float = 1.0, beta: float = 1.0) -> Belief:
+    return Belief(
+        id=bid,
+        content=f"belief {bid}",
+        content_hash=f"h_{bid}",
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _store_with(b: Belief) -> Store:
+    s = Store(":memory:")
+    s.insert_belief(b)
+    return s
+
+
+# --- Happy path ----------------------------------------------------------
+
+
+def test_positive_valence_increments_alpha() -> None:
+    s = _store_with(_mk(alpha=2.0, beta=3.0))
+    apply_feedback(s, "b1", valence=1.0, source="user")
+    got = s.get_belief("b1")
+    assert got is not None
+    assert got.alpha == 3.0
+
+
+def test_positive_valence_does_not_change_beta() -> None:
+    s = _store_with(_mk(alpha=2.0, beta=3.0))
+    apply_feedback(s, "b1", valence=1.0, source="user")
+    got = s.get_belief("b1")
+    assert got is not None
+    assert got.beta == 3.0
+
+
+def test_negative_valence_increments_beta() -> None:
+    s = _store_with(_mk(alpha=2.0, beta=3.0))
+    apply_feedback(s, "b1", valence=-1.0, source="user")
+    got = s.get_belief("b1")
+    assert got is not None
+    assert got.beta == 4.0
+
+
+def test_negative_valence_does_not_change_alpha() -> None:
+    s = _store_with(_mk(alpha=2.0, beta=3.0))
+    apply_feedback(s, "b1", valence=-1.0, source="user")
+    got = s.get_belief("b1")
+    assert got is not None
+    assert got.alpha == 2.0
+
+
+def test_fractional_valence_is_honored() -> None:
+    s = _store_with(_mk(alpha=2.0, beta=3.0))
+    apply_feedback(s, "b1", valence=0.25, source="user")
+    got = s.get_belief("b1")
+    assert got is not None
+    assert got.alpha == 2.25
+
+
+# --- Posterior math ------------------------------------------------------
+
+
+def test_positive_event_raises_posterior_mean() -> None:
+    s = _store_with(_mk(alpha=1.0, beta=1.0))
+    before = posterior_mean(1.0, 1.0)
+    apply_feedback(s, "b1", valence=1.0, source="user")
+    got = s.get_belief("b1")
+    assert got is not None
+    after = posterior_mean(got.alpha, got.beta)
+    assert after > before
+
+
+def test_negative_event_lowers_posterior_mean() -> None:
+    s = _store_with(_mk(alpha=1.0, beta=1.0))
+    before = posterior_mean(1.0, 1.0)
+    apply_feedback(s, "b1", valence=-1.0, source="user")
+    got = s.get_belief("b1")
+    assert got is not None
+    after = posterior_mean(got.alpha, got.beta)
+    assert after < before
+
+
+# --- Audit row contract --------------------------------------------------
+
+
+def test_each_call_writes_exactly_one_history_row() -> None:
+    s = _store_with(_mk())
+    assert s.count_feedback_events("b1") == 0
+    apply_feedback(s, "b1", valence=1.0, source="user")
+    assert s.count_feedback_events("b1") == 1
+
+
+def test_three_calls_write_three_history_rows() -> None:
+    s = _store_with(_mk())
+    apply_feedback(s, "b1", valence=1.0, source="user")
+    apply_feedback(s, "b1", valence=-1.0, source="user")
+    apply_feedback(s, "b1", valence=1.0, source="user")
+    assert s.count_feedback_events("b1") == 3
+
+
+def test_history_row_records_valence_verbatim() -> None:
+    s = _store_with(_mk())
+    apply_feedback(s, "b1", valence=0.7, source="user", now="2026-04-26T18:00:00Z")
+    events = s.list_feedback_events(belief_id="b1")
+    assert events[0].valence == 0.7
+
+
+def test_history_row_records_source_verbatim() -> None:
+    s = _store_with(_mk())
+    apply_feedback(s, "b1", valence=1.0, source="tool:pytest",
+                   now="2026-04-26T18:00:00Z")
+    events = s.list_feedback_events(belief_id="b1")
+    assert events[0].source == "tool:pytest"
+
+
+def test_history_row_records_provided_timestamp() -> None:
+    s = _store_with(_mk())
+    apply_feedback(s, "b1", valence=1.0, source="user",
+                   now="2026-04-26T18:00:00Z")
+    events = s.list_feedback_events(belief_id="b1")
+    assert events[0].created_at == "2026-04-26T18:00:00Z"
+
+
+def test_history_row_id_returned_in_result_matches_storage() -> None:
+    s = _store_with(_mk())
+    result = apply_feedback(s, "b1", valence=1.0, source="user",
+                            now="2026-04-26T18:00:00Z")
+    events = s.list_feedback_events(belief_id="b1")
+    assert events[0].id == result.event_id
+
+
+# --- Result object -------------------------------------------------------
+
+
+def test_result_object_is_feedback_result_typed() -> None:
+    s = _store_with(_mk())
+    result = apply_feedback(s, "b1", valence=1.0, source="user")
+    assert isinstance(result, FeedbackResult)
+
+
+def test_result_priors_match_pre_call_state() -> None:
+    s = _store_with(_mk(alpha=2.0, beta=3.0))
+    result = apply_feedback(s, "b1", valence=1.0, source="user")
+    assert result.prior_alpha == 2.0
+    assert result.prior_beta == 3.0
+
+
+def test_result_new_values_match_post_call_state() -> None:
+    s = _store_with(_mk(alpha=2.0, beta=3.0))
+    result = apply_feedback(s, "b1", valence=1.0, source="user")
+    assert result.new_alpha == 3.0
+    assert result.new_beta == 3.0
+
+
+# --- Errors --------------------------------------------------------------
+
+
+def test_zero_valence_raises_value_error() -> None:
+    s = _store_with(_mk())
+    with pytest.raises(ValueError):
+        apply_feedback(s, "b1", valence=0.0, source="user")
+
+
+def test_zero_valence_does_not_write_history() -> None:
+    s = _store_with(_mk())
+    with pytest.raises(ValueError):
+        apply_feedback(s, "b1", valence=0.0, source="user")
+    assert s.count_feedback_events("b1") == 0
+
+
+def test_zero_valence_does_not_change_posterior() -> None:
+    s = _store_with(_mk(alpha=2.0, beta=3.0))
+    with pytest.raises(ValueError):
+        apply_feedback(s, "b1", valence=0.0, source="user")
+    got = s.get_belief("b1")
+    assert got is not None
+    assert (got.alpha, got.beta) == (2.0, 3.0)
+
+
+def test_empty_source_raises_value_error() -> None:
+    s = _store_with(_mk())
+    with pytest.raises(ValueError):
+        apply_feedback(s, "b1", valence=1.0, source="")
+
+
+def test_unknown_belief_id_raises_value_error() -> None:
+    s = Store(":memory:")
+    with pytest.raises(ValueError):
+        apply_feedback(s, "nonexistent", valence=1.0, source="user")
+
+
+def test_unknown_belief_id_does_not_write_history() -> None:
+    s = Store(":memory:")
+    with pytest.raises(ValueError):
+        apply_feedback(s, "nonexistent", valence=1.0, source="user")
+    assert s.count_feedback_events() == 0


### PR DESCRIPTION
## Summary

- New `src/aelfrice/feedback.py` with `apply_feedback(store, belief_id, valence, source, now=None)` — the single runtime mutation path for `(alpha, beta)` per pre-commit #3.
- Positive valence -> alpha; negative -> beta; magnitude is the increment amount; fractional valences honored.
- Writes one `feedback_history` row per successful call (pre-commit #5).
- Returns a `FeedbackResult` dataclass with `prior_alpha`, `prior_beta`, `new_alpha`, `new_beta`, and `event_id`.
- Rejects zero valence, empty source, unknown belief_id; each rejection leaves the store untouched.
- `DEMOTION_THRESHOLD` module-level constant exposed (default 5) for the demotion path landing next.

22 atomic short tests; all under the 5s default timeout, deterministic, in-memory store, runs in ~0.09s for the full 67-test suite.

## Test plan

- [x] `uv run pytest -q` → 67 passed (was 45, +22 new)
- [x] `uv run pyright src/aelfrice tests` → 0/0/0
- [x] signed
- [ ] staging-gate green