### PR TITLE
feat: add no-LLM correction detector

### DIFF
--- a/src/aelfrice/correction.py
+++ b/src/aelfrice/correction.py
@@ -1,0 +1,142 @@
+"""No-LLM correction detector.
+
+Heuristic detector that identifies user corrections / directives by
+counting signal-class hits across seven categories: imperative-verb
+start, always/never absolutist language, negation, emphasis, prior
+reference, declarative override, and strong directive. A text counts
+as a correction when at least two distinct signals fire (precision
+trade-off: single-signal matches have ~60% precision; the explicit
+two-signal threshold trades recall for precision so the explicit
+correct-this-belief path covers the gap).
+
+Confidence is the signal count scaled by 0.3, capped at 1.0.
+
+Ported from the previous codebase's correction_detection.py
+(experiment-1-V2). Validated at 92% accuracy on the original
+correction corpus; that corpus is not part of v1.0 so this module
+ships the regex set verbatim and unit tests cover each signal class
+in isolation rather than retrying the corpus accuracy claim.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_IMPERATIVE_RE: re.Pattern[str] = re.compile(
+    r"^(use|add|remove|update|follow|convert|make|do|try|run|keep|"
+    r"leave|report|copy|stop|always|never|we are|calls|5k)\b"
+)
+
+_DECLARATIVE_RE: re.Pattern[str] = re.compile(
+    r"(?:is|are|needs to be|should be|must be) "
+    r"(?:the|a|an|\d|only|always)"
+)
+
+_ALWAYS_NEVER_TERMS: tuple[str, ...] = (
+    "always",
+    "never",
+    "every time",
+    "every single",
+    "from now on",
+    "permanently",
+    "period",
+)
+
+_NEGATION_TERMS: tuple[str, ...] = (
+    "do not",
+    "don't",
+    "dont",
+    "stop",
+    "not ",
+    "no more",
+    "no ",
+)
+
+_EMPHASIS_TERMS: tuple[str, ...] = (
+    "!",
+    "hate",
+    "stop",
+    "ever again",
+    "zero question",
+    "100 times",
+)
+
+_PRIOR_REF_TERMS: tuple[str, ...] = (
+    "we've been",
+    "i told you",
+    "we discussed",
+    "we agreed",
+    "already",
+    "iirc",
+    "we decided",
+)
+
+_DIRECTIVE_TERMS: tuple[str, ...] = (
+    "must",
+    "require",
+    "mandatory",
+    "hard cap",
+    "hard rule",
+)
+
+CORRECTION_SIGNAL_THRESHOLD: int = 2
+_CONFIDENCE_PER_SIGNAL: float = 0.3
+
+
+@dataclass
+class CorrectionResult:
+    """Output of detect_correction.
+
+    Fields:
+    - is_correction: True iff signals fired at least CORRECTION_SIGNAL_THRESHOLD
+      distinct categories.
+    - signals: deduped, deterministically-ordered list of signal categories
+      that fired.
+    - confidence: signal-count * 0.3, capped at 1.0.
+    """
+
+    is_correction: bool
+    signals: list[str]
+    confidence: float
+
+
+def detect_correction(text: str) -> CorrectionResult:
+    """Score `text` against the seven correction-signal categories.
+
+    Categories (in evaluation order, which is also the output order):
+        imperative, always_never, negation, emphasis, prior_ref,
+        declarative, directive
+
+    Pure function: no I/O, no side effects, deterministic for any input.
+    """
+    text_lower: str = text.lower().strip()
+    signals: list[str] = []
+
+    if _IMPERATIVE_RE.match(text_lower):
+        signals.append("imperative")
+
+    if any(term in text_lower for term in _ALWAYS_NEVER_TERMS):
+        signals.append("always_never")
+
+    if any(term in text_lower for term in _NEGATION_TERMS):
+        signals.append("negation")
+
+    if any(term in text_lower for term in _EMPHASIS_TERMS):
+        signals.append("emphasis")
+
+    if any(term in text_lower for term in _PRIOR_REF_TERMS):
+        signals.append("prior_ref")
+
+    if _DECLARATIVE_RE.search(text_lower):
+        signals.append("declarative")
+
+    if any(term in text_lower for term in _DIRECTIVE_TERMS):
+        signals.append("directive")
+
+    is_correction: bool = len(signals) >= CORRECTION_SIGNAL_THRESHOLD
+    confidence: float = min(1.0, len(signals) * _CONFIDENCE_PER_SIGNAL)
+    return CorrectionResult(
+        is_correction=is_correction,
+        signals=signals,
+        confidence=confidence,
+    )

--- a/tests/test_correction_detector.py
+++ b/tests/test_correction_detector.py
@@ -1,0 +1,187 @@
+"""correction.detect_correction: per-signal-class atomic tests.
+
+The corpus-level 92% accuracy claim is contingent on the original
+labeled corrections corpus, which is not part of v1.0. These tests
+cover each signal class in isolation, the threshold transition,
+confidence scaling, and the deterministic-output contract.
+"""
+from __future__ import annotations
+
+from aelfrice.correction import (
+    CORRECTION_SIGNAL_THRESHOLD,
+    CorrectionResult,
+    detect_correction,
+)
+
+
+# --- Signal-class isolation: each fires exactly when expected ------------
+
+
+def test_imperative_signal_fires_on_use_verb_start() -> None:
+    r = detect_correction("use snake_case for variable names")
+    assert "imperative" in r.signals
+
+
+def test_imperative_signal_does_not_fire_mid_sentence() -> None:
+    r = detect_correction("the team prefers to use snake_case")
+    assert "imperative" not in r.signals
+
+
+def test_always_never_signal_fires_on_always() -> None:
+    r = detect_correction("always run tests before pushing")
+    assert "always_never" in r.signals
+
+
+def test_always_never_signal_fires_on_never() -> None:
+    r = detect_correction("never commit secrets to the repo")
+    assert "always_never" in r.signals
+
+
+def test_always_never_signal_fires_on_from_now_on() -> None:
+    r = detect_correction("from now on we use main not master")
+    assert "always_never" in r.signals
+
+
+def test_negation_signal_fires_on_do_not() -> None:
+    r = detect_correction("do not amend commits after pushing")
+    assert "negation" in r.signals
+
+
+def test_negation_signal_fires_on_contraction() -> None:
+    r = detect_correction("don't squash main")
+    assert "negation" in r.signals
+
+
+def test_emphasis_signal_fires_on_exclamation() -> None:
+    r = detect_correction("we are switching to uv!")
+    assert "emphasis" in r.signals
+
+
+def test_emphasis_signal_fires_on_ever_again() -> None:
+    r = detect_correction("we are not using npm ever again")
+    assert "emphasis" in r.signals
+
+
+def test_prior_ref_signal_fires_on_we_discussed() -> None:
+    r = detect_correction("we discussed this last week")
+    assert "prior_ref" in r.signals
+
+
+def test_prior_ref_signal_fires_on_already() -> None:
+    r = detect_correction("we already agreed on the schema")
+    assert "prior_ref" in r.signals
+
+
+def test_declarative_signal_fires_on_is_the() -> None:
+    r = detect_correction("the source of truth is the manifest")
+    assert "declarative" in r.signals
+
+
+def test_declarative_signal_fires_on_should_be_only() -> None:
+    r = detect_correction("the export should be only json")
+    assert "declarative" in r.signals
+
+
+def test_directive_signal_fires_on_must() -> None:
+    r = detect_correction("commits must be signed")
+    assert "directive" in r.signals
+
+
+def test_directive_signal_fires_on_hard_rule() -> None:
+    r = detect_correction("hard rule: every PR has a test")
+    assert "directive" in r.signals
+
+
+# --- Threshold (default 2): is_correction transition --------------------
+
+
+def test_zero_signals_is_not_correction() -> None:
+    r = detect_correction("the cat sat on the mat quietly")
+    assert r.is_correction is False
+    assert r.signals == []
+
+
+def test_one_signal_is_not_correction() -> None:
+    r = detect_correction("commits must be signed")
+    # "must" -> directive only (one signal); below threshold of 2.
+    assert r.signals == ["directive"]
+    assert r.is_correction is False
+
+
+def test_two_signals_is_correction() -> None:
+    r = detect_correction("always use signed commits")
+    # "always" -> always_never; "use" at start -> imperative; 2 signals.
+    assert len(r.signals) >= CORRECTION_SIGNAL_THRESHOLD
+    assert r.is_correction is True
+
+
+def test_three_signals_is_correction() -> None:
+    r = detect_correction("never commit secrets! we discussed this")
+    # always_never + emphasis + prior_ref + (negation? "no" within "secrets"? no) -> 3
+    assert len(r.signals) >= 3
+    assert r.is_correction is True
+
+
+# --- Confidence scaling --------------------------------------------------
+
+
+def test_confidence_zero_when_no_signals() -> None:
+    r = detect_correction("the cat sat on the mat quietly")
+    assert r.confidence == 0.0
+
+
+def test_confidence_scales_linearly_below_cap() -> None:
+    r = detect_correction("commits must be signed")  # 1 signal
+    assert abs(r.confidence - 0.3) < 1e-9
+
+
+def test_confidence_caps_at_one() -> None:
+    # Construct text that fires at least 4 signals -> confidence >= 1.2 capped.
+    text = (
+        "always do not commit secrets! we already agreed it must be the rule"
+    )
+    r = detect_correction(text)
+    assert r.confidence == min(1.0, len(r.signals) * 0.3)
+    assert r.confidence <= 1.0
+
+
+# --- Determinism + output contract --------------------------------------
+
+
+def test_repeated_call_returns_same_signals() -> None:
+    text = "always run tests! we discussed this"
+    r1 = detect_correction(text)
+    r2 = detect_correction(text)
+    assert r1.signals == r2.signals
+    assert r1.is_correction == r2.is_correction
+    assert r1.confidence == r2.confidence
+
+
+def test_signals_list_has_no_duplicates() -> None:
+    r = detect_correction("always always always run tests")
+    assert len(r.signals) == len(set(r.signals))
+
+
+def test_result_object_is_correction_result_typed() -> None:
+    r = detect_correction("anything")
+    assert isinstance(r, CorrectionResult)
+
+
+def test_empty_string_input_returns_no_signals() -> None:
+    r = detect_correction("")
+    assert r.signals == []
+    assert r.is_correction is False
+
+
+def test_whitespace_only_input_returns_no_signals() -> None:
+    r = detect_correction("   \n\t  ")
+    assert r.signals == []
+
+
+# --- Case insensitivity --------------------------------------------------
+
+
+def test_uppercase_text_fires_same_signals_as_lowercase() -> None:
+    upper = detect_correction("ALWAYS RUN TESTS BEFORE PUSHING")
+    lower = detect_correction("always run tests before pushing")
+    assert upper.signals == lower.signals


### PR DESCRIPTION
## Summary

Heuristic detector that scores text against 7 correction-signal categories — imperative-verb start, always/never, negation, emphasis, prior reference, declarative override, strong directive — and returns `CorrectionResult(is_correction, signals, confidence)`. `is_correction` fires when >= 2 distinct signals matched; confidence scales 0.3/signal capped at 1.0.

Pure function, no I/O, no third-party deps. The earlier nltk plan is dropped — the ported detector uses regex + substring checks only, so v1.0 runtime deps remain empty.

Ported verbatim from the previous codebase's correction_detection.py (experiment-1-V2). The 92% corpus accuracy is a documented contingent property; v1.0 unit tests cover each signal class in isolation rather than retrying the corpus claim.

28 atomic short tests; full suite 128 passed in 0.12s.

## Test plan

- [x] `uv run pytest -q` → 128 passed (was 100, +28 new)
- [x] `uv run pyright src/aelfrice tests` → 0/0/0
- [x] signed
- [ ] staging-gate green