### PR TITLE
feat: add classification module with TYPE_PRIORS and regex fallback

### DIFF
--- a/src/aelfrice/classification.py
+++ b/src/aelfrice/classification.py
@@ -1,0 +1,246 @@
+"""Sentence classification: assign one of the four belief types and a
+source-adjusted Beta prior.
+
+v1.0 ships the synchronous regex/keyword fallback only. This is the
+single classifier used in onboarding, CI, and any environment without a
+host LLM. The polymorphic onboard handshake — where a host LLM
+classifies sentences in its own context and returns results — lands in
+v0.6.0 alongside the MCP server, when there's actually a host present.
+
+Aelfrice never imports the `anthropic` SDK at any point in v1.0
+(pre-commit #7). Classification calls flow through the host's existing
+LLM context via the polymorphic protocol, never via aelfrice's own
+network calls.
+
+Type priors (alpha, beta) are calibrated for user-sourced content. Non-
+user sources (scanner extracts, document text, agent-inferred) get
+deflated alpha so the feedback loop earns confidence rather than
+inheriting it.
+
+The four belief types correspond exactly to the v1.0 surface in
+`models.py` — `factual`, `correction`, `preference`, `requirement`.
+The richer agentmemory-v4 type catalog (DECISION, ASSUMPTION, ANALYSIS,
+TODO etc.) is collapsed into `factual` here; v1.x can re-expand the
+catalog if usage data justifies it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from aelfrice.correction import detect_correction
+from aelfrice.models import (
+    BELIEF_CORRECTION,
+    BELIEF_FACTUAL,
+    BELIEF_PREFERENCE,
+    BELIEF_REQUIREMENT,
+)
+
+# --- Priors (per Exp 61, restricted to v1.0's 4-type catalog) -----------
+
+TYPE_PRIORS: Final[dict[str, tuple[float, float]]] = {
+    BELIEF_REQUIREMENT: (9.0, 0.5),  # 94.7% prior — hard constraints
+    BELIEF_CORRECTION: (9.0, 0.5),   # 94.7% — user corrections
+    BELIEF_PREFERENCE: (7.0, 1.0),   # 87.5% — user preferences
+    BELIEF_FACTUAL: (3.0, 1.0),      # 75.0% — stated facts and analyses
+}
+
+# Deflation factor for non-user sources. TYPE_PRIORS are calibrated for
+# user-stated content; agent-inferred or document-extracted content
+# starts at lower alpha so the feedback loop earns the rest of the
+# confidence rather than inheriting it. Without this, scanner-extracted
+# beliefs would cluster at 90-95% confidence on day one and Thompson
+# sampling would lose discriminative power.
+_AGENT_INFERRED_DEFLATION: Final[float] = 0.2
+_DEFLATED_ALPHA_FLOOR: Final[float] = 0.5
+
+USER_SOURCE: Final[str] = "user"
+
+# --- Heuristic keyword sets ---------------------------------------------
+
+_REQUIREMENT_KEYWORDS: Final[tuple[str, ...]] = (
+    "must",
+    "require",
+    "mandatory",
+    "hard cap",
+    "constraint",
+    "hard rule",
+)
+
+_PREFERENCE_KEYWORDS: Final[tuple[str, ...]] = (
+    "prefer",
+    "favorite",
+    "always use",
+    "never use",
+    "i like",
+    "i hate",
+    "i want",
+)
+
+_QUESTION_PREFIXES: Final[tuple[str, ...]] = (
+    "what ",
+    "how ",
+    "why ",
+    "when ",
+    "where ",
+    "can ",
+    "does ",
+    "is there",
+    "should ",
+    "would ",
+    "could ",
+)
+
+
+# --- Output ---------------------------------------------------------------
+
+
+@dataclass
+class ClassificationResult:
+    """Output of classify_sentence.
+
+    Fields:
+    - belief_type: one of `factual / correction / preference / requirement`.
+      For non-persistable sentences (questions, coordination, meta), still
+      returns `factual` but `persist=False`.
+    - alpha, beta: Beta-Bernoulli prior, source-adjusted.
+    - persist: False for ephemeral content (questions, etc.); True
+      otherwise. Caller (scanner / onboarding) is responsible for
+      skipping non-persisting sentences before insertion.
+    - pending_classification: True when this was the regex-fallback path
+      and a future host-LLM pass could refine the type. Always True in
+      v1.0; the polymorphic-host-handshake path that flips this to False
+      lands in v0.6.0.
+    """
+
+    belief_type: str
+    alpha: float
+    beta: float
+    persist: bool
+    pending_classification: bool
+
+
+# --- Helpers --------------------------------------------------------------
+
+
+def get_source_adjusted_prior(
+    belief_type: str,
+    source: str,
+) -> tuple[float, float]:
+    """Resolve the Beta prior for a (type, source) pair.
+
+    User-sourced content gets the full TYPE_PRIORS value. Non-user
+    sources get alpha deflated by `_AGENT_INFERRED_DEFLATION`, with a
+    `_DEFLATED_ALPHA_FLOOR` so the deflated alpha never drops below 0.5
+    (which would make posterior_mean numerically degenerate at low beta).
+    """
+    prior = TYPE_PRIORS.get(belief_type)
+    if prior is None:
+        # Unknown type collapses to factual prior — keeps the function
+        # total without surfacing a partial-failure mode to callers.
+        prior = TYPE_PRIORS[BELIEF_FACTUAL]
+    alpha, beta = prior
+    if source != USER_SOURCE:
+        alpha = max(_DEFLATED_ALPHA_FLOOR, alpha * _AGENT_INFERRED_DEFLATION)
+    return (alpha, beta)
+
+
+def _is_question(text_lower: str) -> bool:
+    return text_lower.startswith(_QUESTION_PREFIXES) and text_lower.endswith("?")
+
+
+def _has_any(text_lower: str, keywords: tuple[str, ...]) -> bool:
+    return any(kw in text_lower for kw in keywords)
+
+
+# --- Public API -----------------------------------------------------------
+
+
+def classify_sentence(text: str, source: str) -> ClassificationResult:
+    """Synchronous, deterministic classification.
+
+    Pipeline (in evaluation order):
+    1. Empty / whitespace-only -> factual, persist=False.
+    2. Question form -> factual, persist=False.
+    3. User source + requirement keywords -> requirement.
+    4. User source + correction-detector positive -> correction.
+    5. Preference keywords -> preference.
+    6. Default -> factual.
+
+    Always sets pending_classification=True in v1.0; the host-handshake
+    path that flips it to False ships at v0.6.0.
+
+    Pure function. No I/O, no third-party deps, deterministic for any
+    (text, source) pair.
+    """
+    text_lower = text.lower().strip()
+
+    # 1. Empty.
+    if not text_lower:
+        alpha, beta = get_source_adjusted_prior(BELIEF_FACTUAL, source)
+        return ClassificationResult(
+            belief_type=BELIEF_FACTUAL,
+            alpha=alpha,
+            beta=beta,
+            persist=False,
+            pending_classification=True,
+        )
+
+    # 2. Questions don't persist.
+    if _is_question(text_lower):
+        alpha, beta = get_source_adjusted_prior(BELIEF_FACTUAL, source)
+        return ClassificationResult(
+            belief_type=BELIEF_FACTUAL,
+            alpha=alpha,
+            beta=beta,
+            persist=False,
+            pending_classification=True,
+        )
+
+    # 3. User-sourced requirement (must, mandatory, hard rule, ...)
+    #    Document text uses the same keywords descriptively; restrict
+    #    requirement classification to user sources to reduce false
+    #    positives during onboarding scans.
+    if source == USER_SOURCE and _has_any(text_lower, _REQUIREMENT_KEYWORDS):
+        alpha, beta = get_source_adjusted_prior(BELIEF_REQUIREMENT, source)
+        return ClassificationResult(
+            belief_type=BELIEF_REQUIREMENT,
+            alpha=alpha,
+            beta=beta,
+            persist=True,
+            pending_classification=True,
+        )
+
+    # 4. User-sourced correction (per the no-LLM detector).
+    if source == USER_SOURCE:
+        cresult = detect_correction(text)
+        if cresult.is_correction:
+            alpha, beta = get_source_adjusted_prior(BELIEF_CORRECTION, source)
+            return ClassificationResult(
+                belief_type=BELIEF_CORRECTION,
+                alpha=alpha,
+                beta=beta,
+                persist=True,
+                pending_classification=True,
+            )
+
+    # 5. Preference keywords (any source).
+    if _has_any(text_lower, _PREFERENCE_KEYWORDS):
+        alpha, beta = get_source_adjusted_prior(BELIEF_PREFERENCE, source)
+        return ClassificationResult(
+            belief_type=BELIEF_PREFERENCE,
+            alpha=alpha,
+            beta=beta,
+            persist=True,
+            pending_classification=True,
+        )
+
+    # 6. Default: factual.
+    alpha, beta = get_source_adjusted_prior(BELIEF_FACTUAL, source)
+    return ClassificationResult(
+        belief_type=BELIEF_FACTUAL,
+        alpha=alpha,
+        beta=beta,
+        persist=True,
+        pending_classification=True,
+    )

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -1,0 +1,237 @@
+"""classify_sentence: per-rule atomic tests.
+
+Each test asserts one rule of the synchronous classifier in isolation.
+The host-LLM handshake path (polymorphic onboard contract) does not
+exist yet at v0.5.0; it lands in v0.6.0 with the MCP server.
+"""
+from __future__ import annotations
+
+from aelfrice.classification import (
+    TYPE_PRIORS,
+    ClassificationResult,
+    classify_sentence,
+    get_source_adjusted_prior,
+)
+from aelfrice.models import (
+    BELIEF_CORRECTION,
+    BELIEF_FACTUAL,
+    BELIEF_PREFERENCE,
+    BELIEF_REQUIREMENT,
+)
+
+
+# --- TYPE_PRIORS table integrity -----------------------------------------
+
+
+def test_type_priors_keyed_on_v1_belief_types() -> None:
+    assert set(TYPE_PRIORS.keys()) == {
+        BELIEF_REQUIREMENT,
+        BELIEF_CORRECTION,
+        BELIEF_PREFERENCE,
+        BELIEF_FACTUAL,
+    }
+
+
+def test_requirement_prior_is_high_confidence() -> None:
+    a, b = TYPE_PRIORS[BELIEF_REQUIREMENT]
+    assert (a, b) == (9.0, 0.5)
+
+
+def test_correction_prior_matches_requirement() -> None:
+    assert TYPE_PRIORS[BELIEF_CORRECTION] == TYPE_PRIORS[BELIEF_REQUIREMENT]
+
+
+def test_preference_prior_below_correction() -> None:
+    pa, _ = TYPE_PRIORS[BELIEF_PREFERENCE]
+    ca, _ = TYPE_PRIORS[BELIEF_CORRECTION]
+    assert pa < ca
+
+
+def test_factual_prior_is_lowest_alpha() -> None:
+    fa, _ = TYPE_PRIORS[BELIEF_FACTUAL]
+    others = [TYPE_PRIORS[t][0] for t in TYPE_PRIORS if t != BELIEF_FACTUAL]
+    assert fa <= min(others)
+
+
+# --- get_source_adjusted_prior ------------------------------------------
+
+
+def test_user_source_returns_full_prior() -> None:
+    assert get_source_adjusted_prior(BELIEF_REQUIREMENT, "user") == (9.0, 0.5)
+
+
+def test_non_user_source_deflates_alpha() -> None:
+    a, b = get_source_adjusted_prior(BELIEF_REQUIREMENT, "scanner")
+    assert a < 9.0
+    assert b == 0.5  # beta unchanged
+
+
+def test_non_user_source_alpha_at_or_above_floor() -> None:
+    """Deflated alpha must never drop below 0.5 to keep posterior math sane."""
+    for t in TYPE_PRIORS:
+        a, _ = get_source_adjusted_prior(t, "scanner")
+        assert a >= 0.5
+
+
+def test_unknown_type_falls_back_to_factual_prior() -> None:
+    a, b = get_source_adjusted_prior("nonexistent", "user")
+    assert (a, b) == TYPE_PRIORS[BELIEF_FACTUAL]
+
+
+# --- Empty / whitespace --------------------------------------------------
+
+
+def test_empty_string_classifies_factual_no_persist() -> None:
+    r = classify_sentence("", "user")
+    assert r.belief_type == BELIEF_FACTUAL
+    assert r.persist is False
+
+
+def test_whitespace_only_classifies_factual_no_persist() -> None:
+    r = classify_sentence("   \n\t  ", "user")
+    assert r.belief_type == BELIEF_FACTUAL
+    assert r.persist is False
+
+
+# --- Question form -------------------------------------------------------
+
+
+def test_question_starts_what_classifies_factual_no_persist() -> None:
+    r = classify_sentence("what is the deploy command?", "user")
+    assert r.belief_type == BELIEF_FACTUAL
+    assert r.persist is False
+
+
+def test_question_starts_how_no_persist() -> None:
+    r = classify_sentence("how do I run the tests?", "user")
+    assert r.persist is False
+
+
+def test_question_starts_why_no_persist() -> None:
+    r = classify_sentence("why did we pick uv?", "user")
+    assert r.persist is False
+
+
+def test_statement_ending_with_period_persists() -> None:
+    r = classify_sentence("we deploy via the staging gate workflow.", "user")
+    assert r.persist is True
+
+
+def test_what_in_middle_of_sentence_is_not_a_question() -> None:
+    """Question heuristic checks prefix only; mid-sentence interrogatives
+    don't trip the filter."""
+    r = classify_sentence("the team agreed on what we ship.", "user")
+    assert r.persist is True
+
+
+# --- Requirement classification (user source only) -----------------------
+
+
+def test_user_must_keyword_classifies_requirement() -> None:
+    r = classify_sentence("commits must be signed", "user")
+    assert r.belief_type == BELIEF_REQUIREMENT
+
+
+def test_user_mandatory_classifies_requirement() -> None:
+    r = classify_sentence("CI on main is mandatory", "user")
+    assert r.belief_type == BELIEF_REQUIREMENT
+
+
+def test_non_user_must_does_not_classify_requirement() -> None:
+    """Document text uses 'must' descriptively. Restrict requirement
+    classification to user-sourced content."""
+    r = classify_sentence("you must restart the daemon", "doc")
+    assert r.belief_type != BELIEF_REQUIREMENT
+
+
+def test_requirement_uses_high_alpha_prior_for_user() -> None:
+    r = classify_sentence("commits must be signed", "user")
+    assert r.alpha == TYPE_PRIORS[BELIEF_REQUIREMENT][0]
+
+
+# --- Correction classification (user source only) ------------------------
+
+
+def test_user_correction_phrasing_classifies_correction() -> None:
+    r = classify_sentence("we discussed this; do not amend commits", "user")
+    assert r.belief_type == BELIEF_CORRECTION
+
+
+def test_non_user_correction_phrasing_does_not_classify_correction() -> None:
+    """Document scans contain correction-shaped phrasings without being
+    actual user corrections; the detector is restricted to user sources."""
+    r = classify_sentence("we discussed this; do not amend commits", "doc")
+    assert r.belief_type != BELIEF_CORRECTION
+
+
+# --- Preference classification (any source) ------------------------------
+
+
+def test_prefer_keyword_classifies_preference_user_source() -> None:
+    r = classify_sentence("we prefer uv over pip", "user")
+    assert r.belief_type == BELIEF_PREFERENCE
+
+
+def test_prefer_keyword_classifies_preference_doc_source() -> None:
+    """Preference keywords classify regardless of source — preference
+    statements in documents are still preferences."""
+    r = classify_sentence("we prefer uv over pip", "doc")
+    assert r.belief_type == BELIEF_PREFERENCE
+
+
+def test_doc_source_preference_uses_deflated_prior() -> None:
+    user_r = classify_sentence("we prefer uv over pip", "user")
+    doc_r = classify_sentence("we prefer uv over pip", "doc")
+    assert doc_r.alpha < user_r.alpha
+
+
+# --- Factual default -----------------------------------------------------
+
+
+def test_neutral_statement_classifies_factual() -> None:
+    r = classify_sentence("the project uses Python 3.12", "user")
+    assert r.belief_type == BELIEF_FACTUAL
+
+
+def test_factual_statement_persists() -> None:
+    r = classify_sentence("the project uses Python 3.12", "user")
+    assert r.persist is True
+
+
+def test_factual_default_uses_factual_prior() -> None:
+    r = classify_sentence("the project uses Python 3.12", "user")
+    a, b = TYPE_PRIORS[BELIEF_FACTUAL]
+    assert (r.alpha, r.beta) == (a, b)
+
+
+# --- Result object surface -----------------------------------------------
+
+
+def test_result_object_is_typed() -> None:
+    r = classify_sentence("anything", "user")
+    assert isinstance(r, ClassificationResult)
+
+
+def test_pending_classification_always_true_in_v05() -> None:
+    """v0.5.0 ships only the regex fallback. Every result is flagged
+    pending so a future v0.6.0 host-LLM pass can refine."""
+    r = classify_sentence("commits must be signed", "user")
+    assert r.pending_classification is True
+
+
+# --- Determinism --------------------------------------------------------
+
+
+def test_repeated_call_returns_same_result() -> None:
+    r1 = classify_sentence("we must always use signed commits", "user")
+    r2 = classify_sentence("we must always use signed commits", "user")
+    assert r1.belief_type == r2.belief_type
+    assert (r1.alpha, r1.beta) == (r2.alpha, r2.beta)
+    assert r1.persist == r2.persist
+    assert r1.pending_classification == r2.pending_classification
+
+
+def test_case_insensitive_keyword_match() -> None:
+    upper = classify_sentence("COMMITS MUST BE SIGNED", "user")
+    lower = classify_sentence("commits must be signed", "user")
+    assert upper.belief_type == lower.belief_type


### PR DESCRIPTION
## Summary

Synchronous, deterministic sentence classifier. Assigns one of the v1.0 belief types (factual / correction / preference / requirement) and a source-adjusted Beta prior.

- `TYPE_PRIORS` table restricted to v1.0's 4-type catalog with priors from Exp 61 (REQUIREMENT 9.0/0.5, CORRECTION 9.0/0.5, PREFERENCE 7.0/1.0, FACTUAL 3.0/1.0).
- `get_source_adjusted_prior(belief_type, source)`: non-user sources get alpha × 0.2 (floored at 0.5) so scanner-extracted beliefs earn confidence rather than inherit it.
- `classify_sentence(text, source) -> ClassificationResult`: empty/question short-circuit to `persist=False`; user-sourced requirement keywords → requirement; user-sourced correction-detector positives → correction; preference keywords (any source) → preference; default → factual.

Pre-commit #7 holds: no `anthropic` import anywhere in the package. The polymorphic host-LLM handshake lands in v0.6.0 with the MCP server. v0.5.0 always returns `pending_classification=True`.

32 atomic short tests; full suite **180 passed in 0.15s**.

## Test plan

- [x] `uv run pytest -q` → 180 passed (was 148, +32 new)
- [x] `uv run pyright src/aelfrice tests` → 0/0/0
- [x] `grep -r anthropic src/aelfrice/` → only docstring mentions
- [x] signed
- [ ] staging-gate green