### PR TITLE
feat: add filesystem extractor for onboarding scanner

### DIFF
--- a/src/aelfrice/scanner.py
+++ b/src/aelfrice/scanner.py
@@ -1,0 +1,142 @@
+"""Project scanner for onboarding.
+
+Three extractors only in v1.0 (pre-commit `MVP_SCOPE.md`):
+  - filesystem walk over docs (.md / .rst / .txt / .adoc)
+  - basic git log (last N commits)
+  - simple AST over .py files (top-level docstrings, class/function names)
+
+Each extractor returns a list of `SentenceCandidate(text, source)`. The
+`scan_repo` orchestrator combines them, classifies each candidate via
+`classification.classify_sentence`, and inserts the persistable results
+as Beliefs into a Store.
+
+The other five extractors from the previous codebase (HRR-related,
+doc-cross-reference, citation, sentence-decomposition, structural) are
+explicitly deferred to a later release. v1.0 ships only the three
+above.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+# Directories the scanner never descends into. Standard "build artefact"
+# locations and version-control internals.
+_SKIP_DIRS: Final[frozenset[str]] = frozenset({
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".git",
+    "node_modules",
+    ".egg-info",
+    "target",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "dist",
+    "build",
+    ".tox",
+    "vendor",
+    ".next",
+    ".nuxt",
+})
+
+# Documentation file extensions handled by the filesystem extractor.
+_DOC_EXTENSIONS: Final[frozenset[str]] = frozenset({
+    ".md",
+    ".rst",
+    ".txt",
+    ".adoc",
+})
+
+# Minimum paragraph length (in chars) to treat as a belief candidate.
+# Stops trivial one-liners from polluting the store.
+_MIN_PARAGRAPH_CHARS: Final[int] = 24
+
+
+@dataclass
+class SentenceCandidate:
+    """A unit of text extracted from a project file, awaiting classification.
+
+    Fields:
+    - text: paragraph-shaped string, stripped of surrounding whitespace
+    - source: stable identifier for the origin (e.g. `doc:README.md`,
+      `git:commit:abcdef`, `ast:src/foo.py:bar`); read by the
+      classifier and stored on the Belief for provenance
+    """
+
+    text: str
+    source: str
+
+
+def _iter_doc_files(root: Path) -> list[Path]:
+    """Return the doc files under root in deterministic sorted order.
+
+    Skips _SKIP_DIRS at every level. Symlinks are not followed (avoids
+    infinite loops and lets users opt out of scanning shared volumes by
+    symlinking them in).
+    """
+    out: list[Path] = []
+    if not root.exists() or not root.is_dir():
+        return out
+
+    # Manual recursion so we can prune SKIP_DIRS deterministically.
+    stack: list[Path] = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = sorted(current.iterdir(), key=lambda p: p.name)
+        except (PermissionError, OSError):
+            continue
+        for entry in entries:
+            if entry.is_symlink():
+                continue
+            if entry.is_dir():
+                if entry.name in _SKIP_DIRS:
+                    continue
+                stack.append(entry)
+                continue
+            if entry.suffix.lower() in _DOC_EXTENSIONS:
+                out.append(entry)
+    out.sort()
+    return out
+
+
+def _split_paragraphs(text: str) -> list[str]:
+    """Split a document into paragraph-shaped units.
+
+    Paragraph boundary: one or more blank lines. Leading/trailing
+    whitespace stripped per paragraph. Paragraphs shorter than
+    _MIN_PARAGRAPH_CHARS dropped (markdown headings, list bullets, code
+    fence markers, etc.).
+    """
+    raw_paragraphs = [p.strip() for p in text.split("\n\n")]
+    return [p for p in raw_paragraphs if len(p) >= _MIN_PARAGRAPH_CHARS]
+
+
+def extract_filesystem(root: Path) -> list[SentenceCandidate]:
+    """Walk `root` and emit one candidate per doc paragraph.
+
+    Pure-stdlib, deterministic for any stable input tree. Handles
+    missing/non-directory roots gracefully (returns empty list).
+    Source string format: `doc:<relative_path>:p<paragraph-index>`.
+    """
+    candidates: list[SentenceCandidate] = []
+    if not root.exists() or not root.is_dir():
+        return candidates
+
+    for path in _iter_doc_files(root):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except (PermissionError, OSError):
+            continue
+        rel = path.relative_to(root).as_posix()
+        for idx, para in enumerate(_split_paragraphs(text)):
+            candidates.append(
+                SentenceCandidate(
+                    text=para,
+                    source=f"doc:{rel}:p{idx}",
+                )
+            )
+    return candidates

--- a/tests/test_scanner_filesystem.py
+++ b/tests/test_scanner_filesystem.py
@@ -1,0 +1,230 @@
+"""extract_filesystem: walks doc files and emits paragraph-shaped candidates.
+
+Tests use pytest's tmp_path fixture for hermetic file-system isolation.
+Every test rebuilds its own tree, runs the extractor, and asserts one
+property — split per the deterministic-atomic-short policy.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from aelfrice.scanner import SentenceCandidate, extract_filesystem
+
+
+# --- Empty / missing inputs ---------------------------------------------
+
+
+def test_missing_path_returns_empty_list(tmp_path: Path) -> None:
+    bogus = tmp_path / "does_not_exist"
+    assert extract_filesystem(bogus) == []
+
+
+def test_file_path_instead_of_directory_returns_empty(tmp_path: Path) -> None:
+    f = tmp_path / "README.md"
+    f.write_text("a long paragraph of words here", encoding="utf-8")
+    assert extract_filesystem(f) == []
+
+
+def test_empty_directory_returns_empty(tmp_path: Path) -> None:
+    assert extract_filesystem(tmp_path) == []
+
+
+# --- Single-file extraction ---------------------------------------------
+
+
+def test_single_paragraph_yields_one_candidate(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    candidates = extract_filesystem(tmp_path)
+    assert len(candidates) == 1
+
+
+def test_two_paragraphs_yield_two_candidates(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5\n\n"
+        "the polymorphic onboard handshake lands at v0.6",
+        encoding="utf-8",
+    )
+    candidates = extract_filesystem(tmp_path)
+    assert len(candidates) == 2
+
+
+def test_short_paragraph_is_dropped(tmp_path: Path) -> None:
+    """Below 24 chars -> dropped to avoid trivial-bullet pollution."""
+    (tmp_path / "README.md").write_text(
+        "ok\n\nthe project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    texts = [c.text for c in extract_filesystem(tmp_path)]
+    assert "ok" not in texts
+    assert any("regex fallback" in t for t in texts)
+
+
+def test_candidate_text_is_stripped(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "   the project ships the regex fallback at v0.5   ",
+        encoding="utf-8",
+    )
+    c = extract_filesystem(tmp_path)[0]
+    assert c.text == "the project ships the regex fallback at v0.5"
+
+
+def test_candidate_source_format_doc_path_index(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    c = extract_filesystem(tmp_path)[0]
+    assert c.source == "doc:README.md:p0"
+
+
+# --- File-extension filter ----------------------------------------------
+
+
+def test_md_files_are_picked_up(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    assert len(extract_filesystem(tmp_path)) == 1
+
+
+def test_rst_files_are_picked_up(tmp_path: Path) -> None:
+    (tmp_path / "doc.rst").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    assert len(extract_filesystem(tmp_path)) == 1
+
+
+def test_txt_files_are_picked_up(tmp_path: Path) -> None:
+    (tmp_path / "notes.txt").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    assert len(extract_filesystem(tmp_path)) == 1
+
+
+def test_py_files_are_not_picked_up_by_filesystem_extractor(
+    tmp_path: Path,
+) -> None:
+    """Python files are handled by the AST extractor, not this one."""
+    (tmp_path / "module.py").write_text(
+        "x = 1  # the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    assert extract_filesystem(tmp_path) == []
+
+
+def test_unknown_extension_is_skipped(tmp_path: Path) -> None:
+    (tmp_path / "data.json").write_text(
+        '{"comment": "the project ships only the regex fallback at v0.5"}',
+        encoding="utf-8",
+    )
+    assert extract_filesystem(tmp_path) == []
+
+
+# --- Skip-dirs filter ----------------------------------------------------
+
+
+def test_dot_git_directory_is_skipped(tmp_path: Path) -> None:
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "HEAD.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    assert extract_filesystem(tmp_path) == []
+
+
+def test_node_modules_directory_is_skipped(tmp_path: Path) -> None:
+    nm = tmp_path / "node_modules"
+    nm.mkdir()
+    (nm / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    assert extract_filesystem(tmp_path) == []
+
+
+def test_venv_directory_is_skipped(tmp_path: Path) -> None:
+    venv = tmp_path / ".venv"
+    venv.mkdir()
+    (venv / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    assert extract_filesystem(tmp_path) == []
+
+
+def test_pycache_directory_is_skipped(tmp_path: Path) -> None:
+    pc = tmp_path / "__pycache__"
+    pc.mkdir()
+    (pc / "stuff.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    assert extract_filesystem(tmp_path) == []
+
+
+# --- Recursion + ordering ------------------------------------------------
+
+
+def test_nested_directories_are_walked(tmp_path: Path) -> None:
+    sub = tmp_path / "docs" / "guide"
+    sub.mkdir(parents=True)
+    (sub / "deep.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    assert len(extract_filesystem(tmp_path)) == 1
+
+
+def test_nested_path_in_source_is_relative_posix(tmp_path: Path) -> None:
+    sub = tmp_path / "docs"
+    sub.mkdir()
+    (sub / "deep.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    c = extract_filesystem(tmp_path)[0]
+    assert c.source == "doc:docs/deep.md:p0"
+
+
+def test_files_returned_in_sorted_order(tmp_path: Path) -> None:
+    (tmp_path / "b.md").write_text(
+        "a paragraph long enough to qualify here",
+        encoding="utf-8",
+    )
+    (tmp_path / "a.md").write_text(
+        "another paragraph long enough to qualify",
+        encoding="utf-8",
+    )
+    sources = [c.source for c in extract_filesystem(tmp_path)]
+    assert sources == ["doc:a.md:p0", "doc:b.md:p0"]
+
+
+def test_repeated_extraction_is_deterministic(tmp_path: Path) -> None:
+    (tmp_path / "a.md").write_text(
+        "a paragraph long enough to qualify here\n\n"
+        "another paragraph long enough to qualify",
+        encoding="utf-8",
+    )
+    one = extract_filesystem(tmp_path)
+    two = extract_filesystem(tmp_path)
+    assert [c.source for c in one] == [c.source for c in two]
+    assert [c.text for c in one] == [c.text for c in two]
+
+
+# --- Result types --------------------------------------------------------
+
+
+def test_each_candidate_is_typed(tmp_path: Path) -> None:
+    (tmp_path / "a.md").write_text(
+        "a paragraph long enough to qualify here",
+        encoding="utf-8",
+    )
+    candidates = extract_filesystem(tmp_path)
+    assert all(isinstance(c, SentenceCandidate) for c in candidates)


### PR DESCRIPTION
First of three v1.0 onboarding extractors. Walks a project root and emits one SentenceCandidate per paragraph (≥24 chars) from .md/.rst/.txt/.adoc files. Skip-dirs cover .git/.venv/node_modules/__pycache__/dist/build/target/etc. Source format: `doc:<rel-path>:p<idx>`. Pure-stdlib, deterministic, symlinks not followed.

22 atomic short tests, all hermetic via tmp_path, full suite 202 passed in 0.16s.

- [x] uv run pytest -q → 202 passed
- [x] uv run pyright → 0/0/0
- [x] signed
- [ ] staging-gate green