### PR TITLE
feat: add AST extractor for onboarding scanner

### DIFF
--- a/src/aelfrice/scanner.py
+++ b/src/aelfrice/scanner.py
@@ -17,6 +17,7 @@ above.
 """
 from __future__ import annotations
 
+import ast
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -119,6 +120,8 @@ def _split_paragraphs(text: str) -> list[str]:
 _GIT_LOG_DEFAULT_LIMIT: Final[int] = 100
 _GIT_LOG_TIMEOUT_SECONDS: Final[float] = 5.0
 
+_PY_EXTENSION: Final[str] = ".py"
+
 
 def extract_git_log(
     root: Path,
@@ -179,6 +182,119 @@ def extract_git_log(
                 source=f"git:commit:{sha[:7]}",
             )
         )
+    return candidates
+
+
+def _iter_py_files(root: Path) -> list[Path]:
+    """Return .py files under root in deterministic sorted order.
+
+    Honors the same _SKIP_DIRS exclusions as the doc walk.
+    """
+    out: list[Path] = []
+    if not root.exists() or not root.is_dir():
+        return out
+    stack: list[Path] = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = sorted(current.iterdir(), key=lambda p: p.name)
+        except (PermissionError, OSError):
+            continue
+        for entry in entries:
+            if entry.is_symlink():
+                continue
+            if entry.is_dir():
+                if entry.name in _SKIP_DIRS:
+                    continue
+                stack.append(entry)
+                continue
+            if entry.suffix == _PY_EXTENSION:
+                out.append(entry)
+    out.sort()
+    return out
+
+
+def _extract_from_module(
+    tree: ast.Module, rel: str
+) -> list[SentenceCandidate]:
+    """One pass over the module: collect module docstring + top-level
+    function and class docstrings.
+
+    No-docstring symbols are skipped (not enough signal). Nested
+    functions and methods are skipped (top-level only) — per the
+    v1.0 'simple AST' contract.
+    """
+    out: list[SentenceCandidate] = []
+
+    module_doc = ast.get_docstring(tree)
+    if module_doc:
+        out.append(
+            SentenceCandidate(
+                text=module_doc.strip(),
+                source=f"ast:{rel}:module",
+            )
+        )
+
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef):
+            doc = ast.get_docstring(node)
+            if doc:
+                out.append(
+                    SentenceCandidate(
+                        text=doc.strip(),
+                        source=f"ast:{rel}:func:{node.name}",
+                    )
+                )
+        elif isinstance(node, ast.AsyncFunctionDef):
+            doc = ast.get_docstring(node)
+            if doc:
+                out.append(
+                    SentenceCandidate(
+                        text=doc.strip(),
+                        source=f"ast:{rel}:func:{node.name}",
+                    )
+                )
+        elif isinstance(node, ast.ClassDef):
+            doc = ast.get_docstring(node)
+            if doc:
+                out.append(
+                    SentenceCandidate(
+                        text=doc.strip(),
+                        source=f"ast:{rel}:class:{node.name}",
+                    )
+                )
+    return out
+
+
+def extract_ast(root: Path) -> list[SentenceCandidate]:
+    """Walk .py files under root and extract docstrings as candidates.
+
+    Three sources only — module docstrings, top-level function
+    docstrings, top-level class docstrings — per the v1.0 'simple AST'
+    contract. Nested functions and methods are skipped intentionally;
+    the next release can expand if usage justifies it.
+
+    Files that fail to parse are skipped silently (returns the
+    candidates from the rest of the tree). Pure stdlib (`ast` module),
+    deterministic for any stable input tree.
+
+    Source formats:
+      `ast:<rel-path>:module`
+      `ast:<rel-path>:func:<name>`
+      `ast:<rel-path>:class:<name>`
+    """
+    candidates: list[SentenceCandidate] = []
+    for path in _iter_py_files(root):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except (PermissionError, OSError):
+            continue
+        try:
+            tree = ast.parse(text, filename=str(path))
+        except SyntaxError:
+            continue
+        rel = path.relative_to(root).as_posix()
+        candidates.extend(_extract_from_module(tree, rel))
     return candidates
 
 

--- a/tests/test_scanner_ast.py
+++ b/tests/test_scanner_ast.py
@@ -1,0 +1,270 @@
+"""extract_ast: walk .py files and emit docstring-based candidates.
+
+Tests use tmp_path to write Python source files, then invoke the
+extractor and assert one property each — split per the deterministic-
+atomic-short policy.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from aelfrice.scanner import SentenceCandidate, extract_ast
+
+
+# --- Empty / missing inputs ---------------------------------------------
+
+
+def test_missing_path_returns_empty(tmp_path: Path) -> None:
+    bogus = tmp_path / "nope"
+    assert extract_ast(bogus) == []
+
+
+def test_file_path_instead_of_directory_returns_empty(tmp_path: Path) -> None:
+    f = tmp_path / "module.py"
+    f.write_text('"""a module"""', encoding="utf-8")
+    assert extract_ast(f) == []
+
+
+def test_empty_directory_returns_empty(tmp_path: Path) -> None:
+    assert extract_ast(tmp_path) == []
+
+
+def test_directory_with_no_py_files_returns_empty(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("docs", encoding="utf-8")
+    (tmp_path / "data.json").write_text("{}", encoding="utf-8")
+    assert extract_ast(tmp_path) == []
+
+
+# --- Module docstrings --------------------------------------------------
+
+
+def test_module_docstring_yields_candidate(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        '"""the module ships only the regex fallback at v0.5"""\n',
+        encoding="utf-8",
+    )
+    candidates = extract_ast(tmp_path)
+    assert len(candidates) == 1
+
+
+def test_module_docstring_text_is_stripped(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        '"""\n  the module ships only the regex fallback at v0.5  \n"""\n',
+        encoding="utf-8",
+    )
+    c = extract_ast(tmp_path)[0]
+    assert c.text == "the module ships only the regex fallback at v0.5"
+
+
+def test_module_source_is_ast_module(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        '"""docs"""\n',
+        encoding="utf-8",
+    )
+    c = extract_ast(tmp_path)[0]
+    assert c.source == "ast:m.py:module"
+
+
+def test_module_without_docstring_is_skipped(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        "x = 1\n",
+        encoding="utf-8",
+    )
+    assert extract_ast(tmp_path) == []
+
+
+# --- Function docstrings ------------------------------------------------
+
+
+def test_top_level_function_docstring_yields_candidate(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        'def greet():\n    """says hello to the world"""\n    return "hi"\n',
+        encoding="utf-8",
+    )
+    candidates = extract_ast(tmp_path)
+    assert len(candidates) == 1
+
+
+def test_function_source_format(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        'def greet():\n    """says hello"""\n    return "hi"\n',
+        encoding="utf-8",
+    )
+    c = extract_ast(tmp_path)[0]
+    assert c.source == "ast:m.py:func:greet"
+
+
+def test_async_function_is_extracted(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        'async def fetch():\n    """async fetch from upstream"""\n    return None\n',
+        encoding="utf-8",
+    )
+    c = extract_ast(tmp_path)[0]
+    assert c.source == "ast:m.py:func:fetch"
+
+
+def test_function_without_docstring_is_skipped(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        "def greet():\n    return 'hi'\n",
+        encoding="utf-8",
+    )
+    assert extract_ast(tmp_path) == []
+
+
+def test_nested_function_is_not_extracted(tmp_path: Path) -> None:
+    """Top-level functions only; nested defs are skipped per v1.0 'simple AST'."""
+    (tmp_path / "m.py").write_text(
+        'def outer():\n'
+        '    """outer description"""\n'
+        '    def inner():\n'
+        '        """inner that should not be extracted"""\n'
+        '        return 1\n'
+        '    return inner\n',
+        encoding="utf-8",
+    )
+    sources = [c.source for c in extract_ast(tmp_path)]
+    assert "ast:m.py:func:outer" in sources
+    assert not any("inner" in s for s in sources)
+
+
+# --- Class docstrings ---------------------------------------------------
+
+
+def test_class_docstring_yields_candidate(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        'class Belief:\n    """a unit of memory"""\n    pass\n',
+        encoding="utf-8",
+    )
+    candidates = extract_ast(tmp_path)
+    assert len(candidates) == 1
+
+
+def test_class_source_format(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        'class Belief:\n    """a unit of memory"""\n    pass\n',
+        encoding="utf-8",
+    )
+    c = extract_ast(tmp_path)[0]
+    assert c.source == "ast:m.py:class:Belief"
+
+
+def test_class_without_docstring_is_skipped(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        "class Belief:\n    pass\n",
+        encoding="utf-8",
+    )
+    assert extract_ast(tmp_path) == []
+
+
+def test_method_docstrings_are_not_extracted(tmp_path: Path) -> None:
+    """Methods on top-level classes are skipped per v1.0 'simple AST'."""
+    (tmp_path / "m.py").write_text(
+        'class Foo:\n'
+        '    """class-level docstring"""\n'
+        '    def method(self):\n'
+        '        """method docstring that should be skipped"""\n'
+        '        return 1\n',
+        encoding="utf-8",
+    )
+    sources = [c.source for c in extract_ast(tmp_path)]
+    assert "ast:m.py:class:Foo" in sources
+    assert not any("method" in s for s in sources)
+
+
+# --- Multiple symbols per file ------------------------------------------
+
+
+def test_module_plus_function_plus_class_yield_three_candidates(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "m.py").write_text(
+        '"""the module ships the regex fallback at v0.5"""\n'
+        '\n'
+        'def greet():\n'
+        '    """says hello to the world"""\n'
+        '    return "hi"\n'
+        '\n'
+        'class Belief:\n'
+        '    """a unit of memory in the store"""\n'
+        '    pass\n',
+        encoding="utf-8",
+    )
+    candidates = extract_ast(tmp_path)
+    sources = [c.source for c in candidates]
+    assert "ast:m.py:module" in sources
+    assert "ast:m.py:func:greet" in sources
+    assert "ast:m.py:class:Belief" in sources
+
+
+# --- Skip-dirs filter ---------------------------------------------------
+
+
+def test_dot_git_directory_is_skipped(tmp_path: Path) -> None:
+    git = tmp_path / ".git"
+    git.mkdir()
+    (git / "hooks.py").write_text('"""docstring"""\n', encoding="utf-8")
+    assert extract_ast(tmp_path) == []
+
+
+def test_pycache_directory_is_skipped(tmp_path: Path) -> None:
+    pc = tmp_path / "__pycache__"
+    pc.mkdir()
+    (pc / "x.py").write_text('"""docstring"""\n', encoding="utf-8")
+    assert extract_ast(tmp_path) == []
+
+
+def test_venv_directory_is_skipped(tmp_path: Path) -> None:
+    v = tmp_path / ".venv"
+    v.mkdir()
+    (v / "x.py").write_text('"""docstring"""\n', encoding="utf-8")
+    assert extract_ast(tmp_path) == []
+
+
+# --- Recursion + ordering ----------------------------------------------
+
+
+def test_nested_directories_are_walked(tmp_path: Path) -> None:
+    sub = tmp_path / "src" / "pkg"
+    sub.mkdir(parents=True)
+    (sub / "deep.py").write_text('"""docstring"""\n', encoding="utf-8")
+    candidates = extract_ast(tmp_path)
+    assert len(candidates) == 1
+    assert candidates[0].source == "ast:src/pkg/deep.py:module"
+
+
+def test_files_returned_in_sorted_order(tmp_path: Path) -> None:
+    (tmp_path / "b.py").write_text('"""b docs"""\n', encoding="utf-8")
+    (tmp_path / "a.py").write_text('"""a docs"""\n', encoding="utf-8")
+    sources = [c.source for c in extract_ast(tmp_path)]
+    assert sources == ["ast:a.py:module", "ast:b.py:module"]
+
+
+def test_repeated_extraction_is_deterministic(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text(
+        '"""docs"""\n'
+        'def foo():\n'
+        '    """foo docs"""\n'
+        '    pass\n',
+        encoding="utf-8",
+    )
+    one = extract_ast(tmp_path)
+    two = extract_ast(tmp_path)
+    assert [c.source for c in one] == [c.source for c in two]
+    assert [c.text for c in one] == [c.text for c in two]
+
+
+# --- Robustness ---------------------------------------------------------
+
+
+def test_syntax_error_file_is_skipped_others_kept(tmp_path: Path) -> None:
+    (tmp_path / "good.py").write_text('"""good module"""\n', encoding="utf-8")
+    (tmp_path / "bad.py").write_text("def broken(:\n    pass\n", encoding="utf-8")
+    sources = [c.source for c in extract_ast(tmp_path)]
+    assert "ast:good.py:module" in sources
+    assert not any("bad.py" in s for s in sources)
+
+
+def test_results_are_sentence_candidates(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text('"""docs"""\n', encoding="utf-8")
+    candidates = extract_ast(tmp_path)
+    assert all(isinstance(c, SentenceCandidate) for c in candidates)


### PR DESCRIPTION
Third v1.0 extractor. Walks .py files; emits SentenceCandidate per module / top-level function / top-level class docstring. Nested defs skipped per 'simple AST' contract. Source: `ast:<rel-path>:{module|func|class}:<name>`. Pure stdlib, syntax-error files skipped silently.

26 atomic short tests, full suite 242 passed.

- [x] uv run pytest -q → 242 passed
- [x] uv run pyright → 0/0/0
- [x] signed
- [ ] staging-gate green