### PR TITLE
feat: add scan_repo orchestrator combining 3 extractors + classification + store

### DIFF
--- a/src/aelfrice/scanner.py
+++ b/src/aelfrice/scanner.py
@@ -18,10 +18,16 @@ above.
 from __future__ import annotations
 
 import ast
+import hashlib
 import subprocess
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Final
+
+from aelfrice.classification import classify_sentence
+from aelfrice.models import LOCK_NONE, Belief
+from aelfrice.store import Store
 
 # Directories the scanner never descends into. Standard "build artefact"
 # locations and version-control internals.
@@ -70,6 +76,73 @@ class SentenceCandidate:
 
     text: str
     source: str
+
+
+def scan_repo(
+    store: Store,
+    root: Path,
+    now: str | None = None,
+) -> ScanResult:
+    """Run all three extractors on `root`, classify each candidate, and
+    insert persistable results as Beliefs in the store.
+
+    Idempotent: a belief id is `sha256(source\\x00text)[:16]`, so
+    re-scanning the same tree produces no duplicates. Existing beliefs
+    are detected via `Store.get_belief(id)` and skipped.
+
+    Non-persistable candidates (classifier returned `persist=False` —
+    empty paragraphs, question-form sentences) are counted in
+    `skipped_non_persisting` for visibility but never reach the store.
+
+    No new edges are formed by `scan_repo` in v1.0. Edge formation at
+    onboard time is deferred to a later release; for now beliefs land
+    standalone and edges are added by feedback flows or future
+    explicit-edge tools.
+
+    Returns a ScanResult summarizing what happened. Pure-stdlib
+    orchestration: no third-party deps, deterministic for any stable
+    input tree + clock supplied via `now`.
+    """
+    timestamp = now if now is not None else _utc_now_iso()
+    candidates: list[SentenceCandidate] = []
+    candidates.extend(extract_filesystem(root))
+    candidates.extend(extract_git_log(root))
+    candidates.extend(extract_ast(root))
+
+    inserted = 0
+    skipped_existing = 0
+    skipped_non_persisting = 0
+
+    for candidate in candidates:
+        result = classify_sentence(candidate.text, candidate.source)
+        if not result.persist:
+            skipped_non_persisting += 1
+            continue
+        belief_id = _derive_belief_id(candidate.text, candidate.source)
+        if store.get_belief(belief_id) is not None:
+            skipped_existing += 1
+            continue
+        store.insert_belief(Belief(
+            id=belief_id,
+            content=candidate.text,
+            content_hash=_content_hash(candidate.text),
+            alpha=result.alpha,
+            beta=result.beta,
+            type=result.belief_type,
+            lock_level=LOCK_NONE,
+            locked_at=None,
+            demotion_pressure=0,
+            created_at=timestamp,
+            last_retrieved_at=None,
+        ))
+        inserted += 1
+
+    return ScanResult(
+        inserted=inserted,
+        skipped_existing=skipped_existing,
+        skipped_non_persisting=skipped_non_persisting,
+        total_candidates=len(candidates),
+    )
 
 
 def _iter_doc_files(root: Path) -> list[Path]:
@@ -121,6 +194,44 @@ _GIT_LOG_DEFAULT_LIMIT: Final[int] = 100
 _GIT_LOG_TIMEOUT_SECONDS: Final[float] = 5.0
 
 _PY_EXTENSION: Final[str] = ".py"
+
+_BELIEF_ID_HEX_LEN: Final[int] = 16
+
+
+@dataclass
+class ScanResult:
+    """Aggregate outcome of a scan_repo run.
+
+    Fields:
+    - inserted: count of new beliefs added to the store
+    - skipped_existing: count of candidates whose deterministic id was
+      already present (re-scan idempotence)
+    - skipped_non_persisting: count of candidates the classifier
+      flagged persist=False (questions, empty paragraphs)
+    - total_candidates: sum across all extractors before filtering
+    """
+
+    inserted: int
+    skipped_existing: int
+    skipped_non_persisting: int
+    total_candidates: int
+
+
+def _derive_belief_id(text: str, source: str) -> str:
+    """Deterministic id from (text, source). Re-running scan on the same
+    tree yields the same ids — that's how the orchestrator stays
+    idempotent without a separate dedupe table.
+    """
+    h = hashlib.sha256(f"{source}\x00{text}".encode("utf-8")).hexdigest()
+    return h[:_BELIEF_ID_HEX_LEN]
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def extract_git_log(

--- a/tests/test_scanner_scan_repo.py
+++ b/tests/test_scanner_scan_repo.py
@@ -1,0 +1,267 @@
+"""scan_repo: orchestrator combining the 3 extractors + classification + store.
+
+Atomic-short tests use tmp_path for hermetic file-system isolation and
+:memory: SQLite for the store. Each test asserts one property; helpers
+build the tree and run the orchestrator.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aelfrice.models import LOCK_NONE
+from aelfrice.scanner import ScanResult, scan_repo
+from aelfrice.store import Store
+
+_GIT_AVAILABLE = shutil.which("git") is not None
+needs_git = pytest.mark.skipif(not _GIT_AVAILABLE, reason="git binary not on PATH")
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "init.defaultBranch=main",
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=5.0,
+        check=True,
+    )
+
+
+# --- Empty / missing inputs ---------------------------------------------
+
+
+def test_missing_root_yields_no_inserts(tmp_path: Path) -> None:
+    s = Store(":memory:")
+    bogus = tmp_path / "nope"
+    result = scan_repo(s, bogus)
+    assert result.inserted == 0
+
+
+def test_empty_directory_yields_no_inserts(tmp_path: Path) -> None:
+    s = Store(":memory:")
+    result = scan_repo(s, tmp_path)
+    assert result.inserted == 0
+
+
+def test_empty_directory_yields_no_candidates(tmp_path: Path) -> None:
+    s = Store(":memory:")
+    result = scan_repo(s, tmp_path)
+    assert result.total_candidates == 0
+
+
+# --- Single-source extraction --------------------------------------------
+
+
+def test_single_md_paragraph_inserts_one_belief(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    s = Store(":memory:")
+    result = scan_repo(s, tmp_path)
+    assert result.inserted == 1
+
+
+def test_single_md_paragraph_belief_persists_lock_none(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    s = Store(":memory:")
+    scan_repo(s, tmp_path)
+    beliefs = s.search_beliefs("regex")
+    assert len(beliefs) == 1
+    assert beliefs[0].lock_level == LOCK_NONE
+
+
+def test_single_md_paragraph_belief_has_deterministic_id(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    s1 = Store(":memory:")
+    s2 = Store(":memory:")
+    scan_repo(s1, tmp_path, now="2026-04-26T00:00:00Z")
+    scan_repo(s2, tmp_path, now="2026-04-26T00:00:00Z")
+    ids1 = {b.id for b in s1.search_beliefs("regex")}
+    ids2 = {b.id for b in s2.search_beliefs("regex")}
+    assert ids1 == ids2
+
+
+def test_single_md_paragraph_uses_provided_now_timestamp(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    s = Store(":memory:")
+    scan_repo(s, tmp_path, now="2026-04-26T12:34:56Z")
+    beliefs = s.search_beliefs("regex")
+    assert beliefs[0].created_at == "2026-04-26T12:34:56Z"
+
+
+# --- Idempotence --------------------------------------------------------
+
+
+def test_repeat_scan_does_not_duplicate(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    s = Store(":memory:")
+    scan_repo(s, tmp_path)
+    second = scan_repo(s, tmp_path)
+    assert second.inserted == 0
+
+
+def test_repeat_scan_counts_skipped_existing(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    s = Store(":memory:")
+    scan_repo(s, tmp_path)
+    second = scan_repo(s, tmp_path)
+    assert second.skipped_existing >= 1
+
+
+def test_repeat_scan_total_belief_count_matches_first_inserted(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5\n\n"
+        "another paragraph long enough to qualify",
+        encoding="utf-8",
+    )
+    s = Store(":memory:")
+    first = scan_repo(s, tmp_path)
+    scan_repo(s, tmp_path)
+    # Beliefs in the store after two runs == beliefs after one.
+    all_after = s.search_beliefs("paragraph")
+    # cannot search all without query; use specific query that hits both.
+    # Use a more comprehensive search:
+    p1 = s.search_beliefs("regex")
+    p2 = s.search_beliefs("paragraph")
+    total_unique_ids = {b.id for b in p1} | {b.id for b in p2}
+    assert len(total_unique_ids) == first.inserted
+    # Also: re-scan does not silently dedupe wrong thing; same set holds.
+    p1b = s.search_beliefs("regex")
+    p2b = s.search_beliefs("paragraph")
+    total_after_b = {b.id for b in p1b} | {b.id for b in p2b}
+    assert total_after_b == total_unique_ids
+    # tidy unused
+    _ = all_after
+
+
+# --- Multi-source --------------------------------------------------------
+
+
+@needs_git
+def test_md_plus_git_plus_py_inserts_three_or_more(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    (tmp_path / "module.py").write_text(
+        '"""the module ships the regex fallback only at v0.5"""\n',
+        encoding="utf-8",
+    )
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "feat: ship regex fallback for v0.5")
+    s = Store(":memory:")
+    result = scan_repo(s, tmp_path)
+    assert result.inserted >= 3
+
+
+# --- Non-persisting filter ----------------------------------------------
+
+
+def test_question_in_doc_does_not_persist(tmp_path: Path) -> None:
+    """Question-form sentences from any source -> persist=False."""
+    (tmp_path / "FAQ.md").write_text(
+        "what does the project ship at v0.5?",
+        encoding="utf-8",
+    )
+    s = Store(":memory:")
+    result = scan_repo(s, tmp_path)
+    assert result.inserted == 0
+    assert result.skipped_non_persisting >= 1
+
+
+def test_persist_filter_does_not_block_other_paragraphs(tmp_path: Path) -> None:
+    (tmp_path / "FAQ.md").write_text(
+        "what does the project ship at v0.5?\n\n"
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    s = Store(":memory:")
+    result = scan_repo(s, tmp_path)
+    assert result.inserted == 1
+    assert result.skipped_non_persisting >= 1
+
+
+# --- Result type --------------------------------------------------------
+
+
+def test_result_is_scan_result_typed(tmp_path: Path) -> None:
+    s = Store(":memory:")
+    result = scan_repo(s, tmp_path)
+    assert isinstance(result, ScanResult)
+
+
+def test_result_total_candidates_consistent(tmp_path: Path) -> None:
+    (tmp_path / "a.md").write_text(
+        "one paragraph long enough to qualify here",
+        encoding="utf-8",
+    )
+    s = Store(":memory:")
+    result = scan_repo(s, tmp_path)
+    assert (
+        result.inserted
+        + result.skipped_existing
+        + result.skipped_non_persisting
+        == result.total_candidates
+    )
+
+
+# --- Belief properties --------------------------------------------------
+
+
+def test_inserted_belief_alpha_below_user_prior(tmp_path: Path) -> None:
+    """Scanner-extracted beliefs use the deflated alpha (non-user source)."""
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    s = Store(":memory:")
+    scan_repo(s, tmp_path)
+    b = s.search_beliefs("regex")[0]
+    # Factual user-prior alpha is 3.0; deflation factor 0.2 -> 0.6 (above 0.5 floor).
+    assert b.alpha < 3.0
+
+
+def test_inserted_belief_demotion_pressure_zero(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    s = Store(":memory:")
+    scan_repo(s, tmp_path)
+    b = s.search_beliefs("regex")[0]
+    assert b.demotion_pressure == 0


### PR DESCRIPTION
Single onboarding entry point. Walks the 3 v1.0 extractors (filesystem docs, git log, AST), classifies each candidate, inserts persistable results as Beliefs.

Idempotent: belief id = sha256(source + NUL + text)[:16]. Re-scan inserts zero. Non-persisting candidates (questions etc.) counted but never stored. ScanResult invariant: inserted + skipped_existing + skipped_non_persisting == total_candidates.

No edges formed at onboard in v1.0; deferred.

17 atomic short tests, full suite 259 passed in 4.72s.

- [x] uv run pytest -q → 259 passed
- [x] uv run pyright → 0/0/0
- [x] signed
- [ ] staging-gate green