### PR TITLE
feat: add onboard_sessions schema and CRUD

### DIFF
--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -47,6 +47,20 @@ LOCK_USER: Final[str] = "user"
 
 LOCK_LEVELS: Final[frozenset[str]] = frozenset({LOCK_NONE, LOCK_USER})
 
+# --- Onboard-session states ---
+# A polymorphic onboard handshake passes through exactly two persisted
+# states: `pending` after `start_onboard_session` records the scanner
+# candidates, `completed` after the host's classifications have been
+# accepted and beliefs inserted. No `aborted` state in v1.0 — abandoned
+# sessions are simply garbage-collected later by id and timestamp.
+ONBOARD_STATE_PENDING: Final[str] = "pending"
+ONBOARD_STATE_COMPLETED: Final[str] = "completed"
+
+ONBOARD_STATES: Final[frozenset[str]] = frozenset({
+    ONBOARD_STATE_PENDING,
+    ONBOARD_STATE_COMPLETED,
+})
+
 
 @dataclass
 class Belief:
@@ -77,6 +91,25 @@ class Edge:
     dst: str
     type: str
     weight: float
+
+
+@dataclass
+class OnboardSession:
+    """One polymorphic-onboard handshake row.
+
+    `candidates_json` is the JSON-serialized list of scanner candidates
+    awaiting host classification. Stored as a blob (rather than a
+    side-table) because the candidate list is read/written exactly once
+    per session and never queried by field — JSON keeps the schema
+    minimal without imposing a second table.
+    """
+
+    session_id: str
+    repo_path: str
+    state: str
+    candidates_json: str
+    created_at: str
+    completed_at: str | None
 
 
 @dataclass

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -19,9 +19,12 @@ from typing import Iterable
 
 from aelfrice.models import (
     EDGE_VALENCE,
+    ONBOARD_STATE_COMPLETED,
+    ONBOARD_STATE_PENDING,
     Belief,
     Edge,
     FeedbackEvent,
+    OnboardSession,
 )
 
 # --- Schema ---------------------------------------------------------------
@@ -64,9 +67,20 @@ _SCHEMA: tuple[str, ...] = (
         created_at  TEXT NOT NULL
     )
     """,
+    """
+    CREATE TABLE IF NOT EXISTS onboard_sessions (
+        session_id      TEXT PRIMARY KEY,
+        repo_path       TEXT NOT NULL,
+        state           TEXT NOT NULL,
+        candidates_json TEXT NOT NULL,
+        created_at      TEXT NOT NULL,
+        completed_at    TEXT
+    )
+    """,
     "CREATE INDEX IF NOT EXISTS idx_edges_src ON edges(src)",
     "CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst)",
     "CREATE INDEX IF NOT EXISTS idx_feedback_belief ON feedback_history(belief_id)",
+    "CREATE INDEX IF NOT EXISTS idx_onboard_state ON onboard_sessions(state)",
 )
 
 
@@ -125,6 +139,17 @@ def _row_to_feedback(row: sqlite3.Row) -> FeedbackEvent:
         valence=row["valence"],
         source=row["source"],
         created_at=row["created_at"],
+    )
+
+
+def _row_to_onboard_session(row: sqlite3.Row) -> OnboardSession:
+    return OnboardSession(
+        session_id=row["session_id"],
+        repo_path=row["repo_path"],
+        state=row["state"],
+        candidates_json=row["candidates_json"],
+        created_at=row["created_at"],
+        completed_at=row["completed_at"],
     )
 
 
@@ -451,3 +476,80 @@ class Store:
     def insert_edges(self, edges: Iterable[Edge]) -> None:
         for e in edges:
             self.insert_edge(e)
+
+    # --- Onboard sessions -------------------------------------------------
+
+    def insert_onboard_session(self, s: OnboardSession) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO onboard_sessions (
+                session_id, repo_path, state, candidates_json,
+                created_at, completed_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                s.session_id, s.repo_path, s.state, s.candidates_json,
+                s.created_at, s.completed_at,
+            ),
+        )
+        self._conn.commit()
+
+    def get_onboard_session(self, session_id: str) -> OnboardSession | None:
+        cur = self._conn.execute(
+            "SELECT * FROM onboard_sessions WHERE session_id = ?",
+            (session_id,),
+        )
+        row = cur.fetchone()
+        return _row_to_onboard_session(row) if row else None
+
+    def complete_onboard_session(
+        self, session_id: str, completed_at: str,
+    ) -> bool:
+        """Mark a pending session completed. Returns True if a row was
+        updated, False if no pending session with that id existed.
+
+        Idempotent: re-completing an already-completed session updates
+        `completed_at` to the new timestamp but the state stays
+        `completed`. Caller is responsible for ensuring the session
+        wasn't already completed if that matters to it.
+        """
+        cur = self._conn.execute(
+            """
+            UPDATE onboard_sessions
+            SET state = ?, completed_at = ?
+            WHERE session_id = ?
+            """,
+            (ONBOARD_STATE_COMPLETED, completed_at, session_id),
+        )
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    def count_onboard_sessions(self, state: str | None = None) -> int:
+        if state is None:
+            cur = self._conn.execute(
+                "SELECT COUNT(*) AS n FROM onboard_sessions"
+            )
+        else:
+            cur = self._conn.execute(
+                "SELECT COUNT(*) AS n FROM onboard_sessions WHERE state = ?",
+                (state,),
+            )
+        row = cur.fetchone()
+        return int(row["n"]) if row else 0
+
+    def list_pending_onboard_sessions(self) -> list[OnboardSession]:
+        """All sessions in `pending` state, oldest first.
+
+        Used by the polymorphic onboard handshake to expose `aelf:onboard()`
+        with no args as a status call: "what sessions are awaiting host
+        classification?".
+        """
+        cur = self._conn.execute(
+            """
+            SELECT * FROM onboard_sessions
+            WHERE state = ?
+            ORDER BY created_at ASC, session_id ASC
+            """,
+            (ONBOARD_STATE_PENDING,),
+        )
+        return [_row_to_onboard_session(r) for r in cur.fetchall()]

--- a/tests/test_onboard_sessions_store.py
+++ b/tests/test_onboard_sessions_store.py
@@ -1,0 +1,159 @@
+"""Atomic CRUD tests for the onboard_sessions table.
+
+One property per test, deterministic, in-memory store, no fixtures
+beyond a fresh `Store(":memory:")`. The polymorphic onboard state
+machine builds on these primitives in v0.6.0; this file only locks the
+storage layer.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aelfrice.models import (
+    ONBOARD_STATE_COMPLETED,
+    ONBOARD_STATE_PENDING,
+    OnboardSession,
+)
+from aelfrice.store import Store
+
+
+@pytest.fixture
+def store() -> Store:
+    return Store(":memory:")
+
+
+def _session(
+    *,
+    session_id: str = "sess-1",
+    state: str = ONBOARD_STATE_PENDING,
+    completed_at: str | None = None,
+) -> OnboardSession:
+    return OnboardSession(
+        session_id=session_id,
+        repo_path="/tmp/repo",
+        state=state,
+        candidates_json='[{"text": "x", "source_meta": {}}]',
+        created_at="2026-04-26T00:00:00Z",
+        completed_at=completed_at,
+    )
+
+
+def test_insert_then_get_round_trips_all_fields(store: Store) -> None:
+    s = _session()
+    store.insert_onboard_session(s)
+    got = store.get_onboard_session("sess-1")
+    assert got is not None
+    assert got == s
+
+
+def test_get_unknown_session_returns_none(store: Store) -> None:
+    assert store.get_onboard_session("missing") is None
+
+
+def test_insert_duplicate_session_id_raises(store: Store) -> None:
+    store.insert_onboard_session(_session())
+    with pytest.raises(Exception):
+        store.insert_onboard_session(_session())
+
+
+def test_complete_returns_true_for_pending_session(store: Store) -> None:
+    store.insert_onboard_session(_session())
+    assert store.complete_onboard_session("sess-1", "2026-04-26T01:00:00Z") is True
+
+
+def test_complete_returns_false_for_unknown_session(store: Store) -> None:
+    assert store.complete_onboard_session("nope", "2026-04-26T01:00:00Z") is False
+
+
+def test_complete_sets_state_to_completed(store: Store) -> None:
+    store.insert_onboard_session(_session())
+    store.complete_onboard_session("sess-1", "2026-04-26T01:00:00Z")
+    got = store.get_onboard_session("sess-1")
+    assert got is not None
+    assert got.state == ONBOARD_STATE_COMPLETED
+
+
+def test_complete_writes_completed_at_timestamp(store: Store) -> None:
+    store.insert_onboard_session(_session())
+    store.complete_onboard_session("sess-1", "2026-04-26T01:00:00Z")
+    got = store.get_onboard_session("sess-1")
+    assert got is not None
+    assert got.completed_at == "2026-04-26T01:00:00Z"
+
+
+def test_count_no_filter_counts_all_states(store: Store) -> None:
+    store.insert_onboard_session(_session(session_id="a"))
+    store.insert_onboard_session(
+        _session(session_id="b", state=ONBOARD_STATE_COMPLETED,
+                 completed_at="2026-04-26T02:00:00Z")
+    )
+    assert store.count_onboard_sessions() == 2
+
+
+def test_count_filtered_by_pending_excludes_completed(store: Store) -> None:
+    store.insert_onboard_session(_session(session_id="a"))
+    store.insert_onboard_session(
+        _session(session_id="b", state=ONBOARD_STATE_COMPLETED,
+                 completed_at="2026-04-26T02:00:00Z")
+    )
+    assert store.count_onboard_sessions(ONBOARD_STATE_PENDING) == 1
+
+
+def test_count_filtered_by_completed_excludes_pending(store: Store) -> None:
+    store.insert_onboard_session(_session(session_id="a"))
+    store.insert_onboard_session(
+        _session(session_id="b", state=ONBOARD_STATE_COMPLETED,
+                 completed_at="2026-04-26T02:00:00Z")
+    )
+    assert store.count_onboard_sessions(ONBOARD_STATE_COMPLETED) == 1
+
+
+def test_count_on_empty_store_is_zero(store: Store) -> None:
+    assert store.count_onboard_sessions() == 0
+
+
+def test_list_pending_returns_only_pending_sessions(store: Store) -> None:
+    store.insert_onboard_session(_session(session_id="a"))
+    store.insert_onboard_session(
+        _session(session_id="b", state=ONBOARD_STATE_COMPLETED,
+                 completed_at="2026-04-26T02:00:00Z")
+    )
+    result = store.list_pending_onboard_sessions()
+    assert [s.session_id for s in result] == ["a"]
+
+
+def test_list_pending_orders_by_created_at_then_id(store: Store) -> None:
+    store.insert_onboard_session(OnboardSession(
+        session_id="b", repo_path="/r", state=ONBOARD_STATE_PENDING,
+        candidates_json="[]", created_at="2026-04-26T01:00:00Z",
+        completed_at=None,
+    ))
+    store.insert_onboard_session(OnboardSession(
+        session_id="a", repo_path="/r", state=ONBOARD_STATE_PENDING,
+        candidates_json="[]", created_at="2026-04-26T00:00:00Z",
+        completed_at=None,
+    ))
+    result = store.list_pending_onboard_sessions()
+    assert [s.session_id for s in result] == ["a", "b"]
+
+
+def test_list_pending_on_empty_store_is_empty(store: Store) -> None:
+    assert store.list_pending_onboard_sessions() == []
+
+
+def test_complete_then_list_pending_no_longer_returns_session(store: Store) -> None:
+    store.insert_onboard_session(_session())
+    store.complete_onboard_session("sess-1", "2026-04-26T01:00:00Z")
+    assert store.list_pending_onboard_sessions() == []
+
+
+def test_candidates_json_blob_round_trips_unchanged(store: Store) -> None:
+    blob = '[{"text": "alpha", "source_meta": {"path": "x.py", "line": 3}}]'
+    store.insert_onboard_session(OnboardSession(
+        session_id="sess-1", repo_path="/r", state=ONBOARD_STATE_PENDING,
+        candidates_json=blob, created_at="2026-04-26T00:00:00Z",
+        completed_at=None,
+    ))
+    got = store.get_onboard_session("sess-1")
+    assert got is not None
+    assert got.candidates_json == blob


### PR DESCRIPTION
## Summary
- Adds `onboard_sessions` SQLite table — five fields, state index — for the v0.6.0 polymorphic onboard handshake.
- `OnboardSession` dataclass + `ONBOARD_STATE_{PENDING,COMPLETED}` constants in `models.py`.
- `Store.{insert,get,complete,count,list_pending}_onboard_session(s)` CRUD.
- 16 atomic short tests, all deterministic, in-memory store.
- No consumers yet — purely additive foundation for PR #34 (state machine in classification.py) and PR #35 (mcp_server.py).

## Test plan
- [x] `uv run pytest tests/test_onboard_sessions_store.py -q` — 16/16 pass
- [x] `uv run pytest tests/ -q` — 351/351 pass (full suite, +16 from previous main)
- [x] `uv run pyright src/aelfrice tests` — 0 errors, 0 warnings