### PR TITLE
feat: polymorphic onboard state machine in classification.py

### DIFF
--- a/src/aelfrice/classification.py
+++ b/src/aelfrice/classification.py
@@ -25,8 +25,13 @@ catalog if usage data justifies it.
 """
 from __future__ import annotations
 
+import hashlib
+import json
+import secrets
 from dataclasses import dataclass
-from typing import Final
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
 
 from aelfrice.correction import detect_correction
 from aelfrice.models import (
@@ -34,7 +39,15 @@ from aelfrice.models import (
     BELIEF_FACTUAL,
     BELIEF_PREFERENCE,
     BELIEF_REQUIREMENT,
+    BELIEF_TYPES,
+    LOCK_NONE,
+    ONBOARD_STATE_PENDING,
+    Belief,
+    OnboardSession,
 )
+
+if TYPE_CHECKING:
+    from aelfrice.store import Store
 
 # --- Priors (per Exp 61, restricted to v1.0's 4-type catalog) -----------
 
@@ -243,4 +256,263 @@ def classify_sentence(text: str, source: str) -> ClassificationResult:
         beta=beta,
         persist=True,
         pending_classification=True,
+    )
+
+
+# --- Polymorphic onboard handshake (v0.6.0) -----------------------------
+#
+# The host LLM is asked to classify scanner candidates in its own context
+# (where it already has the surrounding repo context loaded), then hands
+# the typed results back. Classifications produced this way carry
+# `pending_classification=False` — they were typed by an actual LLM, not
+# by the regex fallback.
+#
+# Three persisted states transit through onboard_sessions:
+#
+#   start_onboard_session(repo_path)
+#       -> session_id + list of OnboardSentence(index, text, source)
+#       -> row written with state=PENDING, candidates_json populated
+#
+#   accept_classifications(session_id, [HostClassification, ...])
+#       -> beliefs inserted with refined types
+#       -> row updated to state=COMPLETED, completed_at populated
+#
+# A full circular import with scanner is avoided by importing extractors
+# lazily inside `start_onboard_session`; classification.py is imported by
+# scanner.py at module-load, and the reverse import only happens when an
+# onboard session is actually started.
+
+_ONBOARD_SESSION_ID_BYTES: Final[int] = 12
+_ONBOARD_BELIEF_ID_HEX_LEN: Final[int] = 16
+
+
+@dataclass
+class OnboardSentence:
+    """One scanner candidate awaiting host classification.
+
+    `index` is the position used by HostClassification to refer back; it
+    is stable across the JSON round-trip in `onboard_sessions.candidates_json`.
+    """
+
+    index: int
+    text: str
+    source: str
+
+
+@dataclass
+class StartOnboardResult:
+    """Output of `start_onboard_session`.
+
+    `sentences` is what the host needs to classify. `n_already_present`
+    counts candidates that were dropped before the host saw them because
+    a belief with the deterministic id already exists — re-running
+    onboard on a tree the brain has already seen does not re-ask the
+    host to classify the same content.
+    """
+
+    session_id: str
+    sentences: list[OnboardSentence]
+    n_already_present: int
+
+
+@dataclass
+class HostClassification:
+    """One classification result from the host LLM, addressed by index.
+
+    `persist` is the host's verdict: True to insert as a belief, False to
+    drop (questions, meta-commentary, anything ephemeral). Mirrors the
+    `persist` field on ClassificationResult so the regex-fallback and
+    host-handshake paths share semantics.
+    """
+
+    index: int
+    belief_type: str
+    persist: bool
+
+
+@dataclass
+class AcceptOnboardResult:
+    """Output of `accept_classifications`.
+
+    Mirrors `scanner.ScanResult` shape so callers can render either path
+    uniformly.
+    """
+
+    session_id: str
+    inserted: int
+    skipped_non_persisting: int
+    skipped_existing: int
+    skipped_unclassified: int
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _new_session_id() -> str:
+    return secrets.token_hex(_ONBOARD_SESSION_ID_BYTES)
+
+
+def _derive_belief_id(text: str, source: str) -> str:
+    h = hashlib.sha256(f"{source}\x00{text}".encode("utf-8")).hexdigest()
+    return h[:_ONBOARD_BELIEF_ID_HEX_LEN]
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def start_onboard_session(
+    store: "Store",
+    repo_path: Path,
+    *,
+    now: str | None = None,
+) -> StartOnboardResult:
+    """Run the three scanner extractors against `repo_path`, filter out
+    candidates whose deterministic belief id is already in the store,
+    persist the rest as a pending onboard_sessions row, and return the
+    payload the host should classify.
+
+    Idempotent: re-calling against the same tree returns a fresh
+    session_id whose `sentences` list excludes anything already present.
+    The host can answer with an empty list of classifications and the
+    session will close cleanly.
+    """
+    # Lazy import: scanner imports classification at module-load (it
+    # calls `classify_sentence`); importing scanner at top-level here
+    # would form a circular import. Doing it inside the function defers
+    # resolution until the cycle is already broken.
+    from aelfrice.scanner import (
+        extract_ast,
+        extract_filesystem,
+        extract_git_log,
+    )
+
+    timestamp = now if now is not None else _utc_now_iso()
+    candidates = (
+        extract_filesystem(repo_path)
+        + extract_git_log(repo_path)
+        + extract_ast(repo_path)
+    )
+
+    pending_sentences: list[OnboardSentence] = []
+    n_already_present = 0
+    for c in candidates:
+        bid = _derive_belief_id(c.text, c.source)
+        if store.get_belief(bid) is not None:
+            n_already_present += 1
+            continue
+        pending_sentences.append(
+            OnboardSentence(
+                index=len(pending_sentences),
+                text=c.text,
+                source=c.source,
+            )
+        )
+
+    session_id = _new_session_id()
+    candidates_json = json.dumps(
+        [
+            {"index": s.index, "text": s.text, "source": s.source}
+            for s in pending_sentences
+        ]
+    )
+    store.insert_onboard_session(
+        OnboardSession(
+            session_id=session_id,
+            repo_path=str(repo_path),
+            state=ONBOARD_STATE_PENDING,
+            candidates_json=candidates_json,
+            created_at=timestamp,
+            completed_at=None,
+        )
+    )
+    return StartOnboardResult(
+        session_id=session_id,
+        sentences=pending_sentences,
+        n_already_present=n_already_present,
+    )
+
+
+def accept_classifications(
+    store: "Store",
+    session_id: str,
+    classifications: list[HostClassification],
+    *,
+    now: str | None = None,
+) -> AcceptOnboardResult:
+    """Apply host-provided classifications to a pending onboard session.
+
+    Insert one belief per (sentence, classification) pair where the host
+    set `persist=True`. Beliefs land with `pending_classification=False`
+    semantics — they were typed by an actual LLM, not the regex
+    fallback. Sentences with no matching classification index are
+    counted as `skipped_unclassified` (host chose to elide them).
+
+    Raises ValueError on:
+    - unknown session_id
+    - session already in COMPLETED state (re-accepting is rejected so
+      callers can't double-insert by replaying a stale message)
+    - any classification whose `belief_type` is not in BELIEF_TYPES
+    """
+    session = store.get_onboard_session(session_id)
+    if session is None:
+        raise ValueError(f"unknown session: {session_id}")
+    if session.state != ONBOARD_STATE_PENDING:
+        raise ValueError(
+            f"session not pending (state={session.state}): {session_id}"
+        )
+    for c in classifications:
+        if c.belief_type not in BELIEF_TYPES:
+            raise ValueError(f"unknown belief_type: {c.belief_type}")
+
+    timestamp = now if now is not None else _utc_now_iso()
+    sentences_data = json.loads(session.candidates_json)
+    by_index: dict[int, HostClassification] = {c.index: c for c in classifications}
+
+    inserted = 0
+    skipped_non_persisting = 0
+    skipped_existing = 0
+    skipped_unclassified = 0
+
+    for sd in sentences_data:
+        idx = int(sd["index"])
+        text = str(sd["text"])
+        source = str(sd["source"])
+        c = by_index.get(idx)
+        if c is None:
+            skipped_unclassified += 1
+            continue
+        if not c.persist:
+            skipped_non_persisting += 1
+            continue
+        bid = _derive_belief_id(text, source)
+        if store.get_belief(bid) is not None:
+            skipped_existing += 1
+            continue
+        alpha, beta = get_source_adjusted_prior(c.belief_type, source)
+        store.insert_belief(
+            Belief(
+                id=bid,
+                content=text,
+                content_hash=_content_hash(text),
+                alpha=alpha,
+                beta=beta,
+                type=c.belief_type,
+                lock_level=LOCK_NONE,
+                locked_at=None,
+                demotion_pressure=0,
+                created_at=timestamp,
+                last_retrieved_at=None,
+            )
+        )
+        inserted += 1
+
+    store.complete_onboard_session(session_id, timestamp)
+    return AcceptOnboardResult(
+        session_id=session_id,
+        inserted=inserted,
+        skipped_non_persisting=skipped_non_persisting,
+        skipped_existing=skipped_existing,
+        skipped_unclassified=skipped_unclassified,
     )

--- a/tests/test_onboard_handshake.py
+++ b/tests/test_onboard_handshake.py
@@ -1,0 +1,296 @@
+"""Atomic tests for the polymorphic onboard state machine.
+
+`start_onboard_session` produces a session_id + sentences for the host
+to classify; `accept_classifications` applies host verdicts and closes
+the session. One property per test, fixture repos in tmp_path so the
+extractors run on real on-disk content but stay deterministic.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.classification import (
+    HostClassification,
+    accept_classifications,
+    start_onboard_session,
+)
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    BELIEF_PREFERENCE,
+    BELIEF_REQUIREMENT,
+    LOCK_NONE,
+    ONBOARD_STATE_COMPLETED,
+    ONBOARD_STATE_PENDING,
+    Belief,
+)
+from aelfrice.store import Store
+
+
+@pytest.fixture
+def store() -> Store:
+    return Store(":memory:")
+
+
+def _populate_repo(root: Path) -> None:
+    """Write enough content that the three extractors find candidates."""
+    (root / "README.md").write_text(
+        "This project must use uv for environment management.\n\n"
+        "We always prefer atomic commits over batched commits.\n\n"
+        "The system follows a Bayesian feedback loop with locks.\n"
+    )
+    (root / "module.py").write_text(
+        '"""Top-level module docstring describing the module purpose."""\n\n'
+        "def f():\n"
+        '    """A top-level function that returns a constant value."""\n'
+        "    return 1\n"
+    )
+
+
+def test_start_returns_nonempty_session_id(store: Store, tmp_path: Path) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    assert result.session_id
+    assert len(result.session_id) >= 16
+
+
+def test_start_persists_session_in_pending_state(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    session = store.get_onboard_session(result.session_id)
+    assert session is not None
+    assert session.state == ONBOARD_STATE_PENDING
+
+
+def test_start_session_records_repo_path(store: Store, tmp_path: Path) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    session = store.get_onboard_session(result.session_id)
+    assert session is not None
+    assert session.repo_path == str(tmp_path)
+
+
+def test_start_returns_at_least_one_sentence(store: Store, tmp_path: Path) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    assert len(result.sentences) > 0
+
+
+def test_sentences_have_contiguous_indices_from_zero(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    indices = [s.index for s in result.sentences]
+    assert indices == list(range(len(indices)))
+
+
+def test_candidates_json_round_trips_sentences(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    session = store.get_onboard_session(result.session_id)
+    assert session is not None
+    parsed = json.loads(session.candidates_json)
+    assert len(parsed) == len(result.sentences)
+    assert {p["index"] for p in parsed} == {s.index for s in result.sentences}
+
+
+def test_start_on_empty_dir_returns_empty_sentence_list(
+    store: Store, tmp_path: Path
+) -> None:
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    assert result.sentences == []
+
+
+def test_start_on_empty_dir_still_creates_session(
+    store: Store, tmp_path: Path
+) -> None:
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    session = store.get_onboard_session(result.session_id)
+    assert session is not None
+
+
+def test_start_skips_already_present_beliefs(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    first = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    classifications = [
+        HostClassification(index=s.index, belief_type=BELIEF_FACTUAL, persist=True)
+        for s in first.sentences
+    ]
+    accept_classifications(store, first.session_id, classifications,
+                            now="2026-04-26T01:00:00Z")
+    second = start_onboard_session(store, tmp_path, now="2026-04-26T02:00:00Z")
+    assert second.sentences == []
+    assert second.n_already_present > 0
+
+
+def test_accept_unknown_session_raises(store: Store) -> None:
+    with pytest.raises(ValueError, match="unknown session"):
+        accept_classifications(store, "no-such-session", [],
+                                now="2026-04-26T01:00:00Z")
+
+
+def test_accept_already_completed_session_raises(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    accept_classifications(store, result.session_id, [],
+                            now="2026-04-26T01:00:00Z")
+    with pytest.raises(ValueError, match="not pending"):
+        accept_classifications(store, result.session_id, [],
+                                now="2026-04-26T02:00:00Z")
+
+
+def test_accept_invalid_belief_type_raises(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    bad = [HostClassification(index=0, belief_type="not_a_real_type", persist=True)]
+    with pytest.raises(ValueError, match="unknown belief_type"):
+        accept_classifications(store, result.session_id, bad,
+                                now="2026-04-26T01:00:00Z")
+
+
+def test_accept_marks_session_completed(store: Store, tmp_path: Path) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    accept_classifications(store, result.session_id, [],
+                            now="2026-04-26T01:00:00Z")
+    session = store.get_onboard_session(result.session_id)
+    assert session is not None
+    assert session.state == ONBOARD_STATE_COMPLETED
+
+
+def test_accept_writes_completed_at_timestamp(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    accept_classifications(store, result.session_id, [],
+                            now="2026-04-26T01:00:00Z")
+    session = store.get_onboard_session(result.session_id)
+    assert session is not None
+    assert session.completed_at == "2026-04-26T01:00:00Z"
+
+
+def test_accept_inserts_one_belief_per_persisting_classification(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    cls = [
+        HostClassification(index=s.index, belief_type=BELIEF_FACTUAL, persist=True)
+        for s in result.sentences
+    ]
+    outcome = accept_classifications(
+        store, result.session_id, cls, now="2026-04-26T01:00:00Z"
+    )
+    assert outcome.inserted == len(result.sentences)
+
+
+def test_accept_skips_non_persisting_classifications(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    if not result.sentences:
+        pytest.skip("fixture produced no sentences")
+    cls = [HostClassification(
+        index=result.sentences[0].index, belief_type=BELIEF_FACTUAL, persist=False
+    )]
+    outcome = accept_classifications(
+        store, result.session_id, cls, now="2026-04-26T01:00:00Z"
+    )
+    assert outcome.skipped_non_persisting == 1
+    assert outcome.inserted == 0
+
+
+def test_accept_counts_unclassified_sentences(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    if len(result.sentences) < 2:
+        pytest.skip("fixture produced < 2 sentences")
+    # Classify only the first sentence; everything else is "unclassified".
+    cls = [HostClassification(
+        index=result.sentences[0].index, belief_type=BELIEF_FACTUAL, persist=True
+    )]
+    outcome = accept_classifications(
+        store, result.session_id, cls, now="2026-04-26T01:00:00Z"
+    )
+    assert outcome.skipped_unclassified == len(result.sentences) - 1
+
+
+def test_accept_assigns_host_provided_belief_type(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    if not result.sentences:
+        pytest.skip("fixture produced no sentences")
+    s0 = result.sentences[0]
+    cls = [HostClassification(
+        index=s0.index, belief_type=BELIEF_REQUIREMENT, persist=True
+    )]
+    accept_classifications(
+        store, result.session_id, cls, now="2026-04-26T01:00:00Z"
+    )
+    bid = _derive_id_for_sentence(s0.text, s0.source)
+    inserted = store.get_belief(bid)
+    assert inserted is not None
+    assert inserted.type == BELIEF_REQUIREMENT
+
+
+def test_accept_skips_existing_beliefs_inserted_after_session_started(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    if not result.sentences:
+        pytest.skip("fixture produced no sentences")
+    s0 = result.sentences[0]
+    # Pre-insert a belief with the deterministic id that the session
+    # would derive for sentence 0. Race we are protecting against:
+    # session A starts, session B starts and completes for the same
+    # tree, A's accept must skip rather than collide.
+    bid = _derive_id_for_sentence(s0.text, s0.source)
+    store.insert_belief(Belief(
+        id=bid, content=s0.text, content_hash="precomputed",
+        alpha=1.0, beta=1.0, type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE, locked_at=None, demotion_pressure=0,
+        created_at="2026-04-26T00:30:00Z", last_retrieved_at=None,
+    ))
+    cls = [HostClassification(
+        index=s0.index, belief_type=BELIEF_PREFERENCE, persist=True
+    )]
+    outcome = accept_classifications(
+        store, result.session_id, cls, now="2026-04-26T01:00:00Z"
+    )
+    assert outcome.skipped_existing == 1
+    assert outcome.inserted == 0
+
+
+def test_two_starts_produce_distinct_session_ids(
+    store: Store, tmp_path: Path
+) -> None:
+    _populate_repo(tmp_path)
+    a = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    b = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:01Z")
+    assert a.session_id != b.session_id
+
+
+def _derive_id_for_sentence(text: str, source: str) -> str:
+    """Mirror classification._derive_belief_id for the precomputed-id test."""
+    import hashlib
+    return hashlib.sha256(f"{source}\x00{text}".encode("utf-8")).hexdigest()[:16]


### PR DESCRIPTION
## Summary
- \`start_onboard_session(store, repo)\` runs the 3 scanner extractors, filters already-present beliefs, persists pending session, returns indexed sentences for host classification.
- \`accept_classifications(store, session_id, classifications)\` applies host verdicts: insert beliefs with refined types, mark session COMPLETED. Raises ValueError on unknown / non-pending session / bad belief_type.
- Lazy import inside \`start_\` breaks the classification ↔ scanner import cycle.
- 20 atomic short tests; module count unchanged (cap-of-11 holds).

## Test plan
- [x] \`uv run pytest tests/test_onboard_handshake.py -q\` — 20/20
- [x] \`uv run pytest tests/ -q\` — 371/371 (full suite)
- [x] \`uv run pyright src/aelfrice tests\` — 0 errors