### PR TITLE
feat: add slash_commands/ with 8 markdown skill files (closes v0.6.0)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -265,7 +265,7 @@ def _cmd_health(args: argparse.Namespace, out: object) -> int:
 # --- Dispatcher ---------------------------------------------------------
 
 
-def _build_parser() -> argparse.ArgumentParser:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="aelf",
         description="Bayesian memory designed for feedback-driven learning.",
@@ -324,6 +324,6 @@ def main(argv: Sequence[str] | None = None, out: object = None) -> int:
     """
     if out is None:
         out = sys.stdout
-    parser = _build_parser()
+    parser = build_parser()
     args = parser.parse_args(argv)
     return int(args.func(args, out))

--- a/src/aelfrice/slash_commands/demote.md
+++ b/src/aelfrice/slash_commands/demote.md
@@ -1,0 +1,16 @@
+---
+name: aelf:demote
+description: Manually demote a locked belief one tier (user -> none).
+argument-hint: The belief id (16-hex prefix as shown by aelf:locked)
+allowed-tools:
+  - Bash
+---
+<objective>
+Manually drop a user lock. Use this when a previously-locked
+constraint no longer holds and you want it removed from the L0 layer.
+</objective>
+
+<process>
+Run: `uv run aelf demote "$ARGUMENTS"`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/slash_commands/feedback.md
+++ b/src/aelfrice/slash_commands/feedback.md
@@ -1,0 +1,17 @@
+---
+name: aelf:feedback
+description: Apply one Bayesian feedback event to a belief. Signal must be 'used' or 'harmful'.
+argument-hint: <belief_id> <used|harmful>
+allowed-tools:
+  - Bash
+---
+<objective>
+Record one feedback event. `used` increments alpha; `harmful` increments
+beta and contributes demotion pressure to any locked beliefs reached via
+CONTRADICTS edges.
+</objective>
+
+<process>
+Run: `uv run aelf feedback $ARGUMENTS`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/slash_commands/health.md
+++ b/src/aelfrice/slash_commands/health.md
@@ -1,0 +1,15 @@
+---
+name: aelf:health
+description: Run the regime classifier and report the brain's current operating mode.
+allowed-tools:
+  - Bash
+---
+<objective>
+Diagnose the brain's regime — supersede vs. ignore vs. balanced — based
+on aggregate confidence, lock density, and edge density.
+</objective>
+
+<process>
+Run: `uv run aelf health`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/slash_commands/lock.md
+++ b/src/aelfrice/slash_commands/lock.md
@@ -1,0 +1,17 @@
+---
+name: aelf:lock
+description: Insert (or upgrade an existing belief into) a user-locked ground-truth belief.
+argument-hint: The statement text to lock as ground truth
+allowed-tools:
+  - Bash
+---
+<objective>
+Lock a statement as user-asserted ground truth. Locked beliefs auto-load
+above keyword search results (L0 layer) and resist demotion until 5+
+contradicting feedback events arrive.
+</objective>
+
+<process>
+Run: `uv run aelf lock "$ARGUMENTS"`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/slash_commands/locked.md
+++ b/src/aelfrice/slash_commands/locked.md
@@ -1,0 +1,17 @@
+---
+name: aelf:locked
+description: List user-locked beliefs. Pass --pressured to show only locks with nonzero demotion pressure.
+argument-hint: (optional) --pressured
+allowed-tools:
+  - Bash
+---
+<objective>
+Inspect the locked-belief tier. With no arguments, lists every user
+lock; with `--pressured`, lists only locks that have accumulated
+demotion pressure from contradicting feedback.
+</objective>
+
+<process>
+Run: `uv run aelf locked $ARGUMENTS`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/slash_commands/onboard.md
+++ b/src/aelfrice/slash_commands/onboard.md
@@ -1,0 +1,17 @@
+---
+name: aelf:onboard
+description: Scan a project directory and ingest beliefs into aelfrice memory.
+argument-hint: Path to the project directory (e.g. . or ~/projects/myapp)
+allowed-tools:
+  - Bash
+---
+<objective>
+Onboard a project into aelfrice using the synchronous regex-classifier
+pipeline. The polymorphic host-LLM handshake is reached via the MCP
+tool surface; this slash command uses the same code path as the CLI.
+</objective>
+
+<process>
+Run: `uv run aelf onboard "$ARGUMENTS"`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/slash_commands/search.md
+++ b/src/aelfrice/slash_commands/search.md
@@ -1,0 +1,15 @@
+---
+name: aelf:search
+description: Retrieve beliefs by keyword. Locked beliefs come first (L0), then FTS5 BM25 hits (L1).
+argument-hint: Keyword query (e.g. "deployment process")
+allowed-tools:
+  - Bash
+---
+<objective>
+Search the aelfrice memory store for beliefs matching the given query.
+</objective>
+
+<process>
+Run: `uv run aelf search "$ARGUMENTS"`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/slash_commands/stats.md
+++ b/src/aelfrice/slash_commands/stats.md
@@ -1,0 +1,14 @@
+---
+name: aelf:stats
+description: Show summary counts — beliefs, edges, locks, and feedback events.
+allowed-tools:
+  - Bash
+---
+<objective>
+Quick health check: how much memory has aelfrice accumulated?
+</objective>
+
+<process>
+Run: `uv run aelf stats`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -1,0 +1,96 @@
+"""Verify the 8 slash-command markdown files match the CLI surface.
+
+These files ship inside the aelfrice package so `setup.py` (v0.7.0) can
+copy them into `~/.claude/commands/aelf/`. The tests check structural
+properties — frontmatter, required fields, and that each command's
+shell action references the matching CLI subcommand.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# The 8-tool surface — must match cli.py's subparsers exactly.
+EXPECTED_COMMANDS = (
+    "onboard",
+    "search",
+    "lock",
+    "locked",
+    "demote",
+    "feedback",
+    "stats",
+    "health",
+)
+
+
+def _slash_dir() -> Path:
+    """Locate src/aelfrice/slash_commands without importing aelfrice."""
+    import aelfrice
+    return Path(aelfrice.__file__).parent / "slash_commands"
+
+
+@pytest.mark.parametrize("cmd", EXPECTED_COMMANDS)
+def test_slash_command_file_exists(cmd: str) -> None:
+    path = _slash_dir() / f"{cmd}.md"
+    assert path.exists(), f"missing slash command: {path}"
+
+
+@pytest.mark.parametrize("cmd", EXPECTED_COMMANDS)
+def test_slash_command_file_nonempty(cmd: str) -> None:
+    path = _slash_dir() / f"{cmd}.md"
+    assert path.stat().st_size > 0
+
+
+@pytest.mark.parametrize("cmd", EXPECTED_COMMANDS)
+def test_slash_command_has_frontmatter(cmd: str) -> None:
+    text = (_slash_dir() / f"{cmd}.md").read_text()
+    assert text.startswith("---\n"), f"{cmd}.md missing opening frontmatter delimiter"
+    assert "\n---\n" in text[4:], f"{cmd}.md missing closing frontmatter delimiter"
+
+
+@pytest.mark.parametrize("cmd", EXPECTED_COMMANDS)
+def test_slash_command_name_matches_filename(cmd: str) -> None:
+    text = (_slash_dir() / f"{cmd}.md").read_text()
+    m = re.search(r"^name:\s*(\S+)", text, re.MULTILINE)
+    assert m is not None, f"{cmd}.md missing name: line"
+    assert m.group(1) == f"aelf:{cmd}", f"{cmd}.md name mismatch: {m.group(1)}"
+
+
+@pytest.mark.parametrize("cmd", EXPECTED_COMMANDS)
+def test_slash_command_has_description(cmd: str) -> None:
+    text = (_slash_dir() / f"{cmd}.md").read_text()
+    m = re.search(r"^description:\s*(.+)$", text, re.MULTILINE)
+    assert m is not None, f"{cmd}.md missing description: line"
+    assert len(m.group(1).strip()) >= 20, f"{cmd}.md description too short"
+
+
+@pytest.mark.parametrize("cmd", EXPECTED_COMMANDS)
+def test_slash_command_invokes_matching_cli(cmd: str) -> None:
+    text = (_slash_dir() / f"{cmd}.md").read_text()
+    assert f"uv run aelf {cmd}" in text, (
+        f"{cmd}.md does not invoke `uv run aelf {cmd}`"
+    )
+
+
+def test_no_extra_files_in_slash_commands_dir() -> None:
+    """Catches typos like `loocked.md` and accidental .md.bak files."""
+    files = sorted(p.name for p in _slash_dir().iterdir() if p.is_file())
+    expected = sorted(f"{c}.md" for c in EXPECTED_COMMANDS)
+    assert files == expected
+
+
+def test_slash_commands_match_cli_subcommands() -> None:
+    """The 8 markdown files must correspond exactly to the CLI's
+    subparser names. If the CLI grows or shrinks a command, this test
+    forces the slash directory to follow."""
+    from aelfrice.cli import build_parser
+    parser = build_parser()
+    # The first positional sub-action holds the subparsers.
+    sub_actions = [a for a in parser._subparsers._actions  # type: ignore[union-attr]
+                    if a.__class__.__name__ == "_SubParsersAction"]
+    assert sub_actions, "cli has no subparsers"
+    cli_names = sorted(sub_actions[0].choices.keys())  # type: ignore[attr-defined]
+    md_names = sorted(EXPECTED_COMMANDS)
+    assert cli_names == md_names, f"cli subcommands {cli_names} != slash {md_names}"


### PR DESCRIPTION
## Summary
- 8 markdown skill files at \`src/aelfrice/slash_commands/{onboard,search,lock,locked,demote,feedback,stats,health}.md\` — one per CLI subcommand. Frontmatter-shaped, minimal bodies that invoke \`uv run aelf <command>\`.
- Files ship inside the wheel (verified) so v0.7.0's setup.py can copy them into \`~/.claude/commands/aelf/\`.
- \`cli._build_parser\` promoted to \`cli.build_parser\` so the slash-vs-cli mirror test can introspect subcommand names without crossing a private boundary.
- 50 atomic tests covering structure, naming, content, and directory shape.

## v0.6.0 close-out
- 11/11 production modules in place (cap-of-11 holds)
- 8/8 slash commands shipped
- 453 tests passing, pyright strict-clean
- v0.6.0 milestone done

## Test plan
- [x] \`uv run pytest tests/test_slash_commands.py -q\` — 50/50
- [x] \`uv run pytest tests/ -q\` — 453/453
- [x] \`uv run pyright src/aelfrice tests\` — 0 errors
- [x] \`uv build\` then \`unzip -l dist/*.whl | grep slash_commands\` — all 8 ship