### PR TITLE
release: v0.6.0 + sync README roadmap with shipped milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aelfrice
 
-**Bayesian memory designed for feedback-driven learning.** Today: knowledge store with Bayesian priors. Coming in `v0.4.0`: the feedback loop that teaches the store.
+**Bayesian memory designed for feedback-driven learning.** Today: knowledge store, retrieval, feedback loop, scanner, CLI, and MCP server all landed on `main`. Next on the path to `v1.0.0`: Claude Code setup automation, docs/license, and benchmark harness.
 
 > ⚠️ **Status: under active rebuild — do not depend on this for production.** The first installable release is `v1.0.0`; until then, modules land milestone-by-milestone. The previous codebase (`v2.0`) is preserved at [`aelfrice-v0`](https://github.com/robotrocketscience/aelfrice-v0) (archived, read-only).
 
@@ -23,26 +23,28 @@ The rebuild is structured as a sequence of small, atomic milestones.
 |---|---|---|
 | **v0.1.0** | shipped | `models.py` + `config.py` + `store.py` (SQLite WAL + FTS5 + CRUD + broker-attenuated `propagate_valence` + `demotion_pressure` read/write) |
 | **v0.2.0** | shipped | `scoring.py` (Beta-Bernoulli posterior mean, type-specific decay with lock-floor short-circuit, basic relevance combiner) + tests for Bayesian inertia, decay-required, and lock-floor sharpness |
-| **v0.3.0** | next | `retrieval.py` — locked beliefs auto-load + FTS5 keyword search with BM25. Token-budgeted output. No HRR, no BFS multi-hop, no entity-index in v1.0. |
-| **v0.4.0** | planned | `feedback.py` — the central new endpoint (`apply_feedback`, `feedback_history` table, demotion-pressure-acted-on) + `correction.py` |
-| **v0.5.0** | planned | `scanner.py` — onboarding with filesystem walk, git log, simple AST extractors |
-| **v0.6.0** | planned | `cli.py` (8 commands) + `mcp_server.py` (8 MCP tools) + `slash_commands/` |
-| **v0.7.0** | planned | `setup.py` — Claude Code wiring (`UserPromptSubmit` hook for retrieval injection) |
+| **v0.3.0** | shipped | `retrieval.py` — locked beliefs auto-load + FTS5 keyword search with BM25. Token-budgeted output. No HRR, no BFS multi-hop, no entity-index in v1.0. |
+| **v0.4.0** | shipped | `feedback.py` — the central new endpoint (`apply_feedback`, `feedback_history` table, demotion-pressure-acted-on) + `correction.py` |
+| **v0.5.0** | shipped | `scanner.py` — onboarding with filesystem walk, git log, simple AST extractors |
+| **v0.6.0** | shipped | `cli.py` (8 commands) + `mcp_server.py` (8 MCP tools) + `slash_commands/` |
+| **v0.7.0** | next | `setup.py` — Claude Code wiring (`UserPromptSubmit` hook for retrieval injection) |
 | **v0.8.0** | planned | docs, `CHANGELOG.md`, `LICENSE` (MIT), final `pyproject.toml` |
 | **v0.9.0-rc** | planned | minimal benchmark harness producing a publishable score |
 | **v1.0.0** | planned | tag, push, PyPI publish |
 
 After `v1.0.0`, the `v1.x` series recovers `v2.0` features incrementally with evidence justifying each addition.
 
-## What works today (v0.2.0)
+## What works today (v0.6.0)
 
 - SQLite-backed Belief and Edge storage with WAL journaling and FTS5 search
 - Beta-Bernoulli confidence math; per-type half-life decay
 - Lock floor (a `user`-locked belief does not decay)
 - Broker-confidence-attenuated valence propagation through the belief graph
-- 24 tests, including 3 pre-registered property tests (Bayesian inertia, decay necessity, lock-floor sharpness) and 7 type-half-life lockdown tests
+- Retrieval (locked-belief auto-load + BM25 FTS5, token-budgeted) and the `apply_feedback` endpoint (Beta-Bernoulli updates + demotion-pressure auto-demote)
+- Onboarding scanner (filesystem walk + git log + AST extractors) and `cli.py` (8 commands), `mcp_server.py` (8 tools, `[mcp]` extra), and 8 slash commands under `slash_commands/`
+- ~400 test functions across the unit suite, including 3 pre-registered property tests (Bayesian inertia, decay necessity, lock-floor sharpness) and end-to-end regression scenarios for retrieval, feedback, and onboarding
 
-What does NOT work yet: retrieval, the feedback endpoint, the CLI, the MCP server, onboarding, install via `pip`. Wait for `v1.0.0` if you want to use this.
+What does NOT work yet: install via `pip`, the Claude Code `setup.py` wiring (v0.7.0), final docs/CHANGELOG/LICENSE (v0.8.0), and the v0.9.0-rc benchmark harness. Wait for `v1.0.0` if you want a stable release; until then, install editable from source (`uv pip install -e .`).
 
 ## design notes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "0.2.0"
+version = "0.6.0"
 description = "Bayesian memory designed for feedback-driven learning"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version from `0.2.0` → `0.6.0` to match what has actually merged on `main`. v0.3.0 (retrieval, #14), v0.4.0 (feedback + correction, #19–#23), v0.5.0 (scanner, #25–#29), and v0.6.0 (CLI/MCP/slash_commands, #32–#36) all shipped; the version field never followed.
- Update README roadmap table: mark v0.3.0–v0.6.0 as `shipped`, mark v0.7.0 (`setup.py`) as `next`.
- Refresh \"What works today\" to list retrieval, feedback, scanner, CLI (8 commands), MCP server (8 tools), and slash_commands.
- Replace stale \"24 tests\" claim with current count (~400 test functions; verified via `grep -rE \"^def test_|^    def test_\" tests/`).
- Replace the false \"What does NOT work yet: retrieval, the feedback endpoint, the CLI, the MCP server, onboarding\" with what is actually still open: pip install, v0.7.0 setup wiring, v0.8.0 docs/CHANGELOG/LICENSE, v0.9.0-rc benchmark.

## Why

User noticed v1 status was unclear and the pyproject version field was lying about what had shipped. Audit of `git log --oneline` against the README roadmap table confirmed the gap.

## Test plan

- [ ] `cat pyproject.toml | grep version` → `0.6.0`
- [ ] README \"What works today\" header reads `(v0.6.0)` and lists retrieval/feedback/scanner/CLI/MCP/slash_commands
- [ ] No regressions: existing test suite still passes (no source changes in this PR)
- [ ] Roadmap table v0.3.0–v0.6.0 rows say `shipped`