### PR TITLE
fix: sync aelfrice.__version__ to 0.6.0

### DIFF
--- a/src/aelfrice/__init__.py
+++ b/src/aelfrice/__init__.py
@@ -1,2 +1,2 @@
 """aelfrice: Bayesian memory designed for feedback-driven learning."""
-__version__ = "0.2.0"
+__version__ = "0.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aelfrice"
-version = "0.2.0"
+version = "0.6.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- `src/aelfrice/__init__.py` still declared `__version__ = "0.2.0"` after PR #37 bumped `pyproject.toml` to `0.6.0`.
- Anything importing `aelfrice` and inspecting `__version__` was returning a stale value that disagreed with the package metadata and README roadmap.
- Bumps the package string to match.

## Test plan
- [x] CI: pyright strict + pytest 3.12/3.13 + staging-gate (secrets/pattern/history scans)
- [ ] Spot-check: `python -c "import aelfrice; print(aelfrice.__version__)"` returns `0.6.0`