### PR TITLE
feat(v0.7.0): aelfrice.hook — UserPromptSubmit retrieval entry-point

### DIFF
--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -1,0 +1,134 @@
+"""Claude Code hook entry-points for aelfrice.
+
+This module exposes the script-side half of the v0.7.0 wiring: the
+process Claude Code spawns when a `UserPromptSubmit` hook fires. It
+reads the JSON event payload from stdin, pulls the user's prompt out
+of it, runs aelfrice retrieval against that prompt, and writes the
+formatted hits to stdout. Claude Code injects stdout as additional
+context above the user's message.
+
+Non-blocking contract: the hook must never fail in a way that
+prevents the user's prompt from reaching the model. Every failure
+mode (empty payload, malformed JSON, missing prompt field, retrieval
+error) returns exit 0 and emits no stdout. Internal exceptions are
+written to stderr (Claude Code captures and surfaces these in the
+hook log) but do not bubble up.
+
+Output format: a single XML-tag-delimited block. The tag delimiters
+are stable; the contents inside are the same per-belief lines the
+`aelf search` CLI prints, so a future change to the retrieval format
+flows here automatically.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+from typing import IO, Final, cast
+
+from aelfrice.cli import db_path
+from aelfrice.models import LOCK_USER, Belief
+from aelfrice.retrieval import retrieve
+from aelfrice.store import Store
+
+DEFAULT_HOOK_TOKEN_BUDGET: Final[int] = 1500
+"""Conservative default budget for hook-injected context.
+
+Below the CLI default (2000) to leave headroom for the user's
+prompt and other concurrent UserPromptSubmit hooks competing for
+the same context window.
+"""
+
+OPEN_TAG: Final[str] = "<aelfrice-memory>"
+CLOSE_TAG: Final[str] = "</aelfrice-memory>"
+_PROMPT_KEY: Final[str] = "prompt"
+
+
+def user_prompt_submit(
+    *,
+    stdin: IO[str] | None = None,
+    stdout: IO[str] | None = None,
+    stderr: IO[str] | None = None,
+    token_budget: int | None = None,
+) -> int:
+    """Run the UserPromptSubmit hook. Always returns 0.
+
+    Reads a Claude Code UserPromptSubmit JSON payload from `stdin`,
+    runs retrieval against the `prompt` field, and writes the
+    formatted output to `stdout`. Streams default to the process
+    `sys.stdin`/`sys.stdout`/`sys.stderr`.
+    """
+    sin = stdin if stdin is not None else sys.stdin
+    sout = stdout if stdout is not None else sys.stdout
+    serr = stderr if stderr is not None else sys.stderr
+    try:
+        raw = sin.read()
+        prompt = _extract_prompt(raw)
+        if prompt is None:
+            return 0
+        budget = (
+            token_budget
+            if token_budget is not None
+            else DEFAULT_HOOK_TOKEN_BUDGET
+        )
+        body = _retrieve_and_format(prompt, budget)
+        if body:
+            sout.write(body)
+    except Exception:  # non-blocking: surface but do not fail
+        traceback.print_exc(file=serr)
+    return 0
+
+
+def _extract_prompt(raw: str) -> str | None:
+    if not raw.strip():
+        return None
+    try:
+        payload = json.loads(raw)  # pyright: ignore[reportAny]
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    payload_typed = cast(dict[str, object], payload)
+    prompt = payload_typed.get(_PROMPT_KEY)
+    if not isinstance(prompt, str):
+        return None
+    if not prompt.strip():
+        return None
+    return prompt
+
+
+def _retrieve_and_format(prompt: str, token_budget: int) -> str:
+    store = _open_store()
+    try:
+        hits = retrieve(store, prompt, token_budget=token_budget)
+    finally:
+        store.close()
+    if not hits:
+        return ""
+    return _format_hits(hits)
+
+
+def _format_hits(hits: list[Belief]) -> str:
+    lines: list[str] = [OPEN_TAG]
+    for h in hits:
+        prefix = "[locked]" if h.lock_level == LOCK_USER else "        "
+        lines.append(f"{prefix} {h.id}: {h.content}")
+    lines.append(CLOSE_TAG)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _open_store() -> Store:
+    p = db_path()
+    if str(p) != ":memory:":
+        p.parent.mkdir(parents=True, exist_ok=True)
+    return Store(str(p))
+
+
+def main() -> int:
+    """Entry point for `python -m aelfrice.hook`."""
+    return user_prompt_submit()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_hook_user_prompt_submit.py
+++ b/tests/test_hook_user_prompt_submit.py
@@ -1,0 +1,272 @@
+"""UserPromptSubmit hook entry-point: stdin parse, retrieval, output format."""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.hook import (
+    CLOSE_TAG,
+    DEFAULT_HOOK_TOKEN_BUDGET,
+    OPEN_TAG,
+    user_prompt_submit,
+)
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.store import Store
+
+
+def _mk(
+    bid: str,
+    content: str,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _seed_db(db_path: Path, beliefs: list[Belief]) -> None:
+    store = Store(str(db_path))
+    try:
+        for b in beliefs:
+            store.insert_belief(b)
+    finally:
+        store.close()
+
+
+def _payload(prompt: str) -> str:
+    return json.dumps(
+        {
+            "session_id": "s1",
+            "transcript_path": "/dev/null",
+            "cwd": "/tmp",
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": prompt,
+        }
+    )
+
+
+def _set_db(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    monkeypatch.setenv("AELFRICE_DB", str(path))
+
+
+def test_hook_emits_context_when_retrieval_finds_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "the kitchen is full of bananas")])
+    _set_db(monkeypatch, db)
+    sin = io.StringIO(_payload("bananas"))
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = user_prompt_submit(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    out = sout.getvalue()
+    assert out.startswith(OPEN_TAG + "\n")
+    assert CLOSE_TAG in out
+    assert "F1: the kitchen is full of bananas" in out
+    assert serr.getvalue() == ""
+
+
+def test_hook_marks_locked_beliefs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(
+        db,
+        [
+            _mk(
+                "L1",
+                "the user pinned this as ground truth",
+                lock_level=LOCK_USER,
+                locked_at="2026-04-26T01:00:00Z",
+            ),
+        ],
+    )
+    _set_db(monkeypatch, db)
+    sin = io.StringIO(_payload("anything"))
+    sout = io.StringIO()
+    rc = user_prompt_submit(stdin=sin, stdout=sout)
+    assert rc == 0
+    out = sout.getvalue()
+    assert "[locked] L1: the user pinned this as ground truth" in out
+
+
+def test_hook_silent_on_empty_stdin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "anything")])
+    _set_db(monkeypatch, db)
+    sout = io.StringIO()
+    rc = user_prompt_submit(stdin=io.StringIO(""), stdout=sout)
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+def test_hook_silent_on_malformed_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "anything")])
+    _set_db(monkeypatch, db)
+    sout = io.StringIO()
+    rc = user_prompt_submit(stdin=io.StringIO("{not json"), stdout=sout)
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+def test_hook_silent_on_non_object_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "anything")])
+    _set_db(monkeypatch, db)
+    sout = io.StringIO()
+    rc = user_prompt_submit(stdin=io.StringIO('"a string"'), stdout=sout)
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+def test_hook_silent_when_prompt_field_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "anything")])
+    _set_db(monkeypatch, db)
+    sout = io.StringIO()
+    rc = user_prompt_submit(
+        stdin=io.StringIO(json.dumps({"session_id": "s1"})), stdout=sout
+    )
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+def test_hook_silent_when_prompt_field_blank(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "anything")])
+    _set_db(monkeypatch, db)
+    sout = io.StringIO()
+    rc = user_prompt_submit(stdin=io.StringIO(_payload("   ")), stdout=sout)
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+def test_hook_silent_when_prompt_field_wrong_type(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "anything")])
+    _set_db(monkeypatch, db)
+    sout = io.StringIO()
+    rc = user_prompt_submit(
+        stdin=io.StringIO(json.dumps({"prompt": 42})), stdout=sout
+    )
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+def test_hook_silent_when_no_retrieval_hits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "elephants are large")])
+    _set_db(monkeypatch, db)
+    sout = io.StringIO()
+    rc = user_prompt_submit(
+        stdin=io.StringIO(_payload("dogs")), stdout=sout
+    )
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+def test_hook_passes_default_token_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "the kitchen is full of bananas")])
+    _set_db(monkeypatch, db)
+    captured: dict[str, int] = {}
+    import aelfrice.hook as hook_mod
+
+    real_retrieve = hook_mod.retrieve
+
+    def spy_retrieve(
+        store: Store, query: str, token_budget: int = 2000, l1_limit: int = 50
+    ) -> list[Belief]:
+        captured["token_budget"] = token_budget
+        return real_retrieve(store, query, token_budget=token_budget,
+                              l1_limit=l1_limit)
+
+    monkeypatch.setattr(hook_mod, "retrieve", spy_retrieve)
+    user_prompt_submit(
+        stdin=io.StringIO(_payload("bananas")), stdout=io.StringIO()
+    )
+    assert captured["token_budget"] == DEFAULT_HOOK_TOKEN_BUDGET
+
+
+def test_hook_honors_explicit_token_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "the kitchen is full of bananas")])
+    _set_db(monkeypatch, db)
+    captured: dict[str, int] = {}
+    import aelfrice.hook as hook_mod
+
+    real_retrieve = hook_mod.retrieve
+
+    def spy_retrieve(
+        store: Store, query: str, token_budget: int = 2000, l1_limit: int = 50
+    ) -> list[Belief]:
+        captured["token_budget"] = token_budget
+        return real_retrieve(store, query, token_budget=token_budget,
+                              l1_limit=l1_limit)
+
+    monkeypatch.setattr(hook_mod, "retrieve", spy_retrieve)
+    user_prompt_submit(
+        stdin=io.StringIO(_payload("bananas")),
+        stdout=io.StringIO(),
+        token_budget=314,
+    )
+    assert captured["token_budget"] == 314
+
+
+def test_hook_non_blocking_on_internal_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "bananas")])
+    _set_db(monkeypatch, db)
+    import aelfrice.hook as hook_mod
+
+    def boom(
+        _store: Store, _q: str, token_budget: int = 2000, l1_limit: int = 50
+    ) -> list[Belief]:
+        _ = token_budget, l1_limit
+        raise RuntimeError("simulated retrieval failure")
+
+    monkeypatch.setattr(hook_mod, "retrieve", boom)
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = user_prompt_submit(
+        stdin=io.StringIO(_payload("bananas")), stdout=sout, stderr=serr
+    )
+    assert rc == 0
+    assert sout.getvalue() == ""
+    assert "simulated retrieval failure" in serr.getvalue()


### PR DESCRIPTION
## Summary
Second piece of `v0.7.0`. Pairs with `src/aelfrice/setup.py` (landed in #39): `setup.py` writes the hook entry into `settings.json`; this PR adds the process Claude Code spawns when that hook fires.

`aelfrice.hook.user_prompt_submit` reads the `UserPromptSubmit` JSON payload on stdin, pulls the `prompt` field, runs aelfrice retrieval against it, and writes a `<aelfrice-memory>...</aelfrice-memory>` block to stdout. Claude Code injects stdout above the user's message.

## Non-blocking contract
Every failure mode (empty stdin, malformed JSON, missing/blank/wrong-type prompt field, retrieval exceptions) returns exit `0` and emits no stdout. Internal exceptions are written to stderr (Claude Code surfaces these in the hook log) but never bubble up. The user's prompt must always reach the model.

## Defaults
- `DEFAULT_HOOK_TOKEN_BUDGET = 1500` (below the CLI default of 2000) to leave headroom for the prompt itself and for concurrent `UserPromptSubmit` hooks.
- DB path resolves through the existing `aelfrice.cli.db_path()` (`$AELFRICE_DB` or `~/.aelfrice/memory.db`).

## Test plan
- [x] `uv run pytest tests/test_hook_user_prompt_submit.py` — 12/12 pass
- [x] `uv run pyright` — strict mode, 0 errors
- [x] full suite (485 tests) green
- [ ] CI: pytest 3.12 / 3.13, secrets-scan, pattern-scan, history-scan

## Out of scope (next on this milestone)
- `aelf setup` / `aelf unsetup` CLI subcommands wrapping `install_user_prompt_submit_hook` / `uninstall_user_prompt_submit_hook` and pointing the recorded `command` at `python -m aelfrice.hook`.
- `aelf-hook` script entry-point in `[project.scripts]` for a shorter command string.
- End-to-end regression test exercising install → invoke hook → context emitted → uninstall.