### PR TITLE
feat(v0.7.0): aelf setup / unsetup CLI subcommands + slash commands

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -1,4 +1,4 @@
-"""Eight-command CLI matching the MVP user surface.
+"""Ten-command CLI matching the MVP user surface.
 
 Commands:
   onboard <path>                   scan a project and ingest beliefs
@@ -9,6 +9,8 @@ Commands:
   feedback <id> <used|harmful>     apply one Bayesian feedback event
   stats                            summary of belief / lock / history counts
   health                           regime classifier output
+  setup                            install UserPromptSubmit hook in Claude Code
+  unsetup                          remove UserPromptSubmit hook from Claude Code
 
 DB path resolves from AELFRICE_DB environment variable when set,
 otherwise from ~/.aelfrice/memory.db. Callers can run `main(argv=...)`
@@ -39,12 +41,20 @@ from aelfrice.models import (
 )
 from aelfrice.retrieval import DEFAULT_TOKEN_BUDGET, retrieve
 from aelfrice.scanner import scan_repo
+from aelfrice.setup import (
+    SettingsScope,
+    default_settings_path,
+    install_user_prompt_submit_hook,
+    uninstall_user_prompt_submit_hook,
+)
 from aelfrice.store import Store
 
 DEFAULT_DB_DIR: Final[Path] = Path.home() / ".aelfrice"
 DEFAULT_DB_FILENAME: Final[str] = "memory.db"
+DEFAULT_HOOK_COMMAND: Final[str] = "python -m aelfrice.hook"
 _FEEDBACK_VALENCES: Final[dict[str, float]] = {"used": 1.0, "harmful": -1.0}
 _LOCK_ID_LEN: Final[int] = 16
+_VALID_SCOPES: Final[tuple[SettingsScope, ...]] = ("user", "project")
 
 
 def db_path() -> Path:
@@ -236,6 +246,58 @@ def _cmd_stats(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _resolve_settings_path(args: argparse.Namespace) -> Path:
+    if args.settings_path is not None:
+        return Path(args.settings_path)
+    scope: SettingsScope = args.scope
+    project_root = (
+        Path(args.project_root) if args.project_root is not None else None
+    )
+    return default_settings_path(scope, project_root=project_root)
+
+
+def _cmd_setup(args: argparse.Namespace, out: object) -> int:
+    path = _resolve_settings_path(args)
+    result = install_user_prompt_submit_hook(
+        path,
+        command=args.command,
+        timeout=args.timeout,
+        status_message=args.status_message,
+    )
+    if result.already_present:
+        print(
+            f"hook already installed in {result.path} "
+            f"(command={args.command!r})",
+            file=out,  # type: ignore[arg-type]
+        )
+    else:
+        print(
+            f"installed UserPromptSubmit hook in {result.path} "
+            f"(command={args.command!r})",
+            file=out,  # type: ignore[arg-type]
+        )
+    return 0
+
+
+def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
+    path = _resolve_settings_path(args)
+    result = uninstall_user_prompt_submit_hook(path, command=args.command)
+    if result.removed == 0:
+        print(
+            f"no matching hook in {result.path} "
+            f"(command={args.command!r})",
+            file=out,  # type: ignore[arg-type]
+        )
+    else:
+        print(
+            f"removed {result.removed} hook entr"
+            f"{'y' if result.removed == 1 else 'ies'} from {result.path} "
+            f"(command={args.command!r})",
+            file=out,  # type: ignore[arg-type]
+        )
+    return 0
+
+
 def _cmd_health(args: argparse.Namespace, out: object) -> int:
     _ = args
     store = _open_store()
@@ -313,7 +375,61 @@ def build_parser() -> argparse.ArgumentParser:
     p_health = sub.add_parser("health", help="regime classifier output")
     p_health.set_defaults(func=_cmd_health)
 
+    p_setup = sub.add_parser(
+        "setup",
+        help="install the UserPromptSubmit hook in Claude Code settings.json",
+    )
+    _add_hook_scope_args(p_setup)
+    p_setup.add_argument(
+        "--command", default=DEFAULT_HOOK_COMMAND,
+        help=(
+            f"hook command Claude Code will spawn "
+            f"(default {DEFAULT_HOOK_COMMAND!r})"
+        ),
+    )
+    p_setup.add_argument(
+        "--timeout", type=int, default=None,
+        help="hook execution timeout in seconds (default: not set)",
+    )
+    p_setup.add_argument(
+        "--status-message", default=None,
+        help="status message Claude Code shows while the hook runs",
+    )
+    p_setup.set_defaults(func=_cmd_setup)
+
+    p_unsetup = sub.add_parser(
+        "unsetup",
+        help="remove the UserPromptSubmit hook from Claude Code settings.json",
+    )
+    _add_hook_scope_args(p_unsetup)
+    p_unsetup.add_argument(
+        "--command", default=DEFAULT_HOOK_COMMAND,
+        help=(
+            "hook command string to remove "
+            f"(default {DEFAULT_HOOK_COMMAND!r})"
+        ),
+    )
+    p_unsetup.set_defaults(func=_cmd_unsetup)
+
     return parser
+
+
+def _add_hook_scope_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--scope", choices=list(_VALID_SCOPES), default="user",
+        help="settings.json scope (default 'user' = ~/.claude/settings.json)",
+    )
+    parser.add_argument(
+        "--project-root", default=None,
+        help="project root for --scope project (default: current directory)",
+    )
+    parser.add_argument(
+        "--settings-path", default=None,
+        help=(
+            "explicit settings.json path; overrides --scope and "
+            "--project-root when set"
+        ),
+    )
 
 
 def main(argv: Sequence[str] | None = None, out: object = None) -> int:

--- a/src/aelfrice/slash_commands/setup.md
+++ b/src/aelfrice/slash_commands/setup.md
@@ -1,0 +1,25 @@
+---
+name: aelf:setup
+description: Install the aelfrice UserPromptSubmit hook in Claude Code's settings.json.
+allowed-tools:
+  - Bash
+---
+<objective>
+Wire aelfrice's retrieval into Claude Code so that every user prompt is
+augmented with the most relevant locked beliefs and FTS5 hits from the
+local memory store. This adds an entry under
+`hooks.UserPromptSubmit` in Claude Code's `settings.json`.
+</objective>
+
+<process>
+Run: `uv run aelf setup`
+
+By default the hook is installed user-wide
+(`~/.claude/settings.json`) and the recorded command is
+`python -m aelfrice.hook`. Pass `--scope project` for a
+project-scoped install, or `--settings-path PATH` to write to an
+explicit location. The command is idempotent: running it twice
+results in exactly one matching hook entry.
+
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/slash_commands/unsetup.md
+++ b/src/aelfrice/slash_commands/unsetup.md
@@ -1,0 +1,24 @@
+---
+name: aelf:unsetup
+description: Remove the aelfrice UserPromptSubmit hook from Claude Code's settings.json.
+allowed-tools:
+  - Bash
+---
+<objective>
+Reverse `aelf:setup`. Strip the matching `hooks.UserPromptSubmit`
+entry from Claude Code's `settings.json` so prompts are no longer
+augmented with aelfrice retrieval. Other hook events and any
+unrelated `UserPromptSubmit` entries are preserved.
+</objective>
+
+<process>
+Run: `uv run aelf unsetup`
+
+Defaults match `aelf setup`: user scope and command
+`python -m aelfrice.hook`. Pass the same `--scope` /
+`--settings-path` / `--command` flags you used at install time so
+the matching entry is found. The command is idempotent: a second
+invocation is a no-op and reports `no matching hook`.
+
+Display the output verbatim. Do not add commentary.
+</process>

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -1,0 +1,162 @@
+"""`aelf setup` / `aelf unsetup` CLI subcommand integration tests.
+
+Tests drive `cli.main(argv=...)` end-to-end against a tmp settings.json
+chosen via `--scope project --project-root <tmp_path>` so no real
+~/.claude/settings.json is ever touched.
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from aelfrice.cli import DEFAULT_HOOK_COMMAND, main
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AELFRICE_DB", str(tmp_path / "aelf.db"))
+
+
+def _run(*argv: str) -> tuple[int, str]:
+    buf = io.StringIO()
+    code = main(argv=list(argv), out=buf)
+    return code, buf.getvalue()
+
+
+def _read_settings(path: Path) -> dict[str, object]:
+    raw = path.read_text(encoding="utf-8")
+    parsed = json.loads(raw)  # pyright: ignore[reportAny]
+    assert isinstance(parsed, dict)
+    return cast(dict[str, object], parsed)
+
+
+def _project_settings(tmp_path: Path) -> Path:
+    return tmp_path / ".claude" / "settings.json"
+
+
+def _hook_commands(settings_path: Path) -> list[str]:
+    data = _read_settings(settings_path)
+    hooks = data["hooks"]
+    assert isinstance(hooks, dict)
+    hooks_typed = cast(dict[str, object], hooks)
+    entries = hooks_typed["UserPromptSubmit"]
+    assert isinstance(entries, list)
+    out: list[str] = []
+    for entry in cast(list[dict[str, object]], entries):
+        inner = entry["hooks"]
+        assert isinstance(inner, list)
+        inner_typed = cast(list[dict[str, object]], inner)
+        cmd = inner_typed[0]["command"]
+        assert isinstance(cmd, str)
+        out.append(cmd)
+    return out
+
+
+def test_setup_default_command_writes_project_settings(tmp_path: Path) -> None:
+    code, output = _run(
+        "setup", "--scope", "project", "--project-root", str(tmp_path)
+    )
+    assert code == 0
+    settings = _project_settings(tmp_path)
+    assert settings.exists()
+    assert _hook_commands(settings) == [DEFAULT_HOOK_COMMAND]
+    assert "installed" in output
+    assert DEFAULT_HOOK_COMMAND in output
+
+
+def test_setup_idempotent_reports_already_present(tmp_path: Path) -> None:
+    _run("setup", "--scope", "project", "--project-root", str(tmp_path))
+    code, output = _run(
+        "setup", "--scope", "project", "--project-root", str(tmp_path)
+    )
+    assert code == 0
+    assert "already installed" in output
+    assert _hook_commands(_project_settings(tmp_path)) == [DEFAULT_HOOK_COMMAND]
+
+
+def test_setup_custom_command_timeout_and_status_message(
+    tmp_path: Path,
+) -> None:
+    code, _ = _run(
+        "setup",
+        "--scope", "project",
+        "--project-root", str(tmp_path),
+        "--command", "/usr/local/bin/my-hook.sh",
+        "--timeout", "7",
+        "--status-message", "thinking...",
+    )
+    assert code == 0
+    data = _read_settings(_project_settings(tmp_path))
+    hooks = data["hooks"]
+    assert isinstance(hooks, dict)
+    hooks_typed = cast(dict[str, object], hooks)
+    entries = hooks_typed["UserPromptSubmit"]
+    assert isinstance(entries, list)
+    inner = cast(list[dict[str, object]], entries)[0]["hooks"]
+    assert isinstance(inner, list)
+    inner_typed = cast(list[dict[str, object]], inner)
+    assert inner_typed[0] == {
+        "type": "command",
+        "command": "/usr/local/bin/my-hook.sh",
+        "timeout": 7,
+        "statusMessage": "thinking...",
+    }
+
+
+def test_setup_explicit_settings_path_overrides_scope(tmp_path: Path) -> None:
+    explicit = tmp_path / "weird-place" / "claude.json"
+    code, _ = _run("setup", "--settings-path", str(explicit))
+    assert code == 0
+    assert explicit.exists()
+    assert _hook_commands(explicit) == [DEFAULT_HOOK_COMMAND]
+
+
+def test_unsetup_removes_default_command(tmp_path: Path) -> None:
+    _run("setup", "--scope", "project", "--project-root", str(tmp_path))
+    code, output = _run(
+        "unsetup", "--scope", "project", "--project-root", str(tmp_path)
+    )
+    assert code == 0
+    assert "removed 1" in output
+    assert _hook_commands(_project_settings(tmp_path)) == []
+
+
+def test_unsetup_no_op_when_missing_reports_zero(tmp_path: Path) -> None:
+    code, output = _run(
+        "unsetup", "--scope", "project", "--project-root", str(tmp_path)
+    )
+    assert code == 0
+    assert "no matching hook" in output
+
+
+def test_unsetup_keeps_other_entries(tmp_path: Path) -> None:
+    _run(
+        "setup",
+        "--scope", "project",
+        "--project-root", str(tmp_path),
+        "--command", "/keep/me",
+    )
+    _run("setup", "--scope", "project", "--project-root", str(tmp_path))
+    code, output = _run(
+        "unsetup", "--scope", "project", "--project-root", str(tmp_path)
+    )
+    assert code == 0
+    assert "removed 1" in output
+    assert _hook_commands(_project_settings(tmp_path)) == ["/keep/me"]
+
+
+def test_user_scope_writes_into_monkeypatched_user_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_user_settings = tmp_path / "user-claude" / "settings.json"
+    import aelfrice.setup as setup_mod
+
+    monkeypatch.setattr(setup_mod, "USER_SETTINGS_PATH", fake_user_settings)
+    code, _ = _run("setup", "--scope", "user")
+    assert code == 0
+    assert fake_user_settings.exists()
+    assert _hook_commands(fake_user_settings) == [DEFAULT_HOOK_COMMAND]

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -1,4 +1,4 @@
-"""Verify the 8 slash-command markdown files match the CLI surface.
+"""Verify the 10 slash-command markdown files match the CLI surface.
 
 These files ship inside the aelfrice package so `setup.py` (v0.7.0) can
 copy them into `~/.claude/commands/aelf/`. The tests check structural
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-# The 8-tool surface — must match cli.py's subparsers exactly.
+# The 10-tool surface — must match cli.py's subparsers exactly.
 EXPECTED_COMMANDS = (
     "onboard",
     "search",
@@ -22,6 +22,8 @@ EXPECTED_COMMANDS = (
     "feedback",
     "stats",
     "health",
+    "setup",
+    "unsetup",
 )
 
 


### PR DESCRIPTION
## Summary
Third piece of `v0.7.0`. Wraps the install/uninstall functions from `src/aelfrice/setup.py` (#39) and the hook entry-point from #40 with user-facing CLI subcommands so `aelf setup` is a one-shot way to wire aelfrice retrieval into Claude Code.

## New surface
```
aelf setup    [--scope user|project] [--project-root PATH] [--settings-path PATH]
              [--command STR] [--timeout INT] [--status-message STR]
aelf unsetup  [--scope user|project] [--project-root PATH] [--settings-path PATH]
              [--command STR]
```

- Default `--scope user` writes to `~/.claude/settings.json`.
- Default `--command` is `python -m aelfrice.hook` (works with `uv pip install -e .`; once an `aelf-hook` script entry lands in `pyproject.toml` we can switch the default to that).
- `--settings-path` overrides scope when set, useful for non-standard layouts.

## Slash commands
Adds `slash_commands/setup.md` and `slash_commands/unsetup.md` to keep the CLI ↔ slash-command 1:1 invariant green (`test_slash_commands.py::test_slash_commands_match_cli_subcommands`). The expected-commands tuple bumps from 8 to 10.

## Test plan
- [x] `uv run pytest tests/test_cli_setup.py` — 8/8 pass
- [x] `uv run pytest tests/test_slash_commands.py` — 50/50 pass (10 commands × 5 parametrized properties)
- [x] full suite (493 tests) green
- [x] `uv run pyright` — strict mode, 0 errors
- [ ] CI: pytest 3.12 / 3.13, secrets-scan, pattern-scan, history-scan

## Dependency
This PR's default `--command` value is just a string and CI doesn't validate that the command is runnable. End-to-end resolution depends on #40 (`aelfrice.hook`) being merged so that `python -m aelfrice.hook` actually does retrieval. PRs #40 and #41 can land in either order — neither blocks the other at code-review time.

## Out of scope (next on this milestone)
- Add `aelf-hook = "aelfrice.hook:main"` to `[project.scripts]` in `pyproject.toml` and switch the CLI default `--command` to `aelf-hook`.
- End-to-end regression test exercising install → invoke hook → context emitted → uninstall (depends on #40 merging first).