### PR TITLE
feat(v0.7.0): aelf-hook script entry-point + CLI default switch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = []
 
 [project.scripts]
 aelf = "aelfrice.cli:main"
+aelf-hook = "aelfrice.hook:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -51,7 +51,7 @@ from aelfrice.store import Store
 
 DEFAULT_DB_DIR: Final[Path] = Path.home() / ".aelfrice"
 DEFAULT_DB_FILENAME: Final[str] = "memory.db"
-DEFAULT_HOOK_COMMAND: Final[str] = "python -m aelfrice.hook"
+DEFAULT_HOOK_COMMAND: Final[str] = "aelf-hook"
 _FEEDBACK_VALENCES: Final[dict[str, float]] = {"used": 1.0, "harmful": -1.0}
 _LOCK_ID_LEN: Final[int] = 16
 _VALID_SCOPES: Final[tuple[SettingsScope, ...]] = ("user", "project")

--- a/src/aelfrice/slash_commands/setup.md
+++ b/src/aelfrice/slash_commands/setup.md
@@ -16,10 +16,11 @@ Run: `uv run aelf setup`
 
 By default the hook is installed user-wide
 (`~/.claude/settings.json`) and the recorded command is
-`python -m aelfrice.hook`. Pass `--scope project` for a
-project-scoped install, or `--settings-path PATH` to write to an
-explicit location. The command is idempotent: running it twice
-results in exactly one matching hook entry.
+`aelf-hook` (the script entry-point exposed by aelfrice's
+pyproject). Pass `--scope project` for a project-scoped install, or
+`--settings-path PATH` to write to an explicit location. The
+command is idempotent: running it twice results in exactly one
+matching hook entry.
 
 Display the output verbatim. Do not add commentary.
 </process>

--- a/src/aelfrice/slash_commands/unsetup.md
+++ b/src/aelfrice/slash_commands/unsetup.md
@@ -14,11 +14,11 @@ unrelated `UserPromptSubmit` entries are preserved.
 <process>
 Run: `uv run aelf unsetup`
 
-Defaults match `aelf setup`: user scope and command
-`python -m aelfrice.hook`. Pass the same `--scope` /
-`--settings-path` / `--command` flags you used at install time so
-the matching entry is found. The command is idempotent: a second
-invocation is a no-op and reports `no matching hook`.
+Defaults match `aelf setup`: user scope and command `aelf-hook`.
+Pass the same `--scope` / `--settings-path` / `--command` flags you
+used at install time so the matching entry is found. The command
+is idempotent: a second invocation is a no-op and reports
+`no matching hook`.
 
 Display the output verbatim. Do not add commentary.
 </process>


### PR DESCRIPTION
## Summary
Fourth piece of `v0.7.0`. Adds `aelf-hook = "aelfrice.hook:main"` to `[project.scripts]` in `pyproject.toml` so users get a short, stable hook command once aelfrice is installed (editable or PyPI). Switches the CLI default `--command` for both `aelf setup` and `aelf unsetup` from `python -m aelfrice.hook` to `aelf-hook`. The two slash command markdown files are updated in lockstep so the documented invocation matches the new default.

## Why
- `aelf-hook` is the same string a user gets from `which aelf-hook` after install, which is what they're most likely to paste into other tooling. `python -m aelfrice.hook` always works but is bulkier.
- Switching the CLI default keeps `aelf setup` (with no flags) producing settings.json entries that match what users would write by hand.

## Test plan
- [x] `uv run pytest` — 505/505 pass (existing `test_cli_setup.py` assertions follow `DEFAULT_HOOK_COMMAND` automatically; no test edits needed)
- [x] `uv run pyright` — strict mode, 0 errors
- [x] smoke: `uv run aelf-hook < /dev/null` exits 0
- [x] smoke: `echo '{"prompt":"banana"}' | uv run aelf-hook` exits 0 against an empty DB
- [ ] CI: pytest 3.12 / 3.13, secrets-scan, pattern-scan, history-scan

## Out of scope (last item on this milestone)
End-to-end regression test that exercises `aelf setup` → spawn `aelf-hook` subprocess → verify retrieval output → `aelf unsetup`. Will land as a single regression test in a follow-up PR.