### PR TITLE
release: v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aelfrice
 
-**Bayesian memory designed for feedback-driven learning.** Today: knowledge store, retrieval, feedback loop, scanner, CLI, and MCP server all landed on `main`. Next on the path to `v1.0.0`: Claude Code setup automation, docs/license, and benchmark harness.
+**Bayesian memory designed for feedback-driven learning.** Today: knowledge store, retrieval, feedback loop, scanner, CLI, MCP server, and Claude Code wiring all landed on `main`. Next on the path to `v1.0.0`: docs/license and benchmark harness.
 
 > ⚠️ **Status: under active rebuild — do not depend on this for production.** The first installable release is `v1.0.0`; until then, modules land milestone-by-milestone. The previous codebase (`v2.0`) is preserved at [`aelfrice-v0`](https://github.com/robotrocketscience/aelfrice-v0) (archived, read-only).
 
@@ -27,24 +27,25 @@ The rebuild is structured as a sequence of small, atomic milestones.
 | **v0.4.0** | shipped | `feedback.py` — the central new endpoint (`apply_feedback`, `feedback_history` table, demotion-pressure-acted-on) + `correction.py` |
 | **v0.5.0** | shipped | `scanner.py` — onboarding with filesystem walk, git log, simple AST extractors |
 | **v0.6.0** | shipped | `cli.py` (8 commands) + `mcp_server.py` (8 MCP tools) + `slash_commands/` |
-| **v0.7.0** | next | `setup.py` — Claude Code wiring (`UserPromptSubmit` hook for retrieval injection) |
-| **v0.8.0** | planned | docs, `CHANGELOG.md`, `LICENSE` (MIT), final `pyproject.toml` |
+| **v0.7.0** | shipped | `setup.py` — Claude Code wiring (`UserPromptSubmit` hook for retrieval injection) + `aelfrice.hook` entry-point + `aelf setup` / `aelf unsetup` CLI + `aelf-hook` script |
+| **v0.8.0** | next | docs, `CHANGELOG.md`, `LICENSE` (MIT), final `pyproject.toml` |
 | **v0.9.0-rc** | planned | minimal benchmark harness producing a publishable score |
 | **v1.0.0** | planned | tag, push, PyPI publish |
 
 After `v1.0.0`, the `v1.x` series recovers `v2.0` features incrementally with evidence justifying each addition.
 
-## What works today (v0.6.0)
+## What works today (v0.7.0)
 
 - SQLite-backed Belief and Edge storage with WAL journaling and FTS5 search
 - Beta-Bernoulli confidence math; per-type half-life decay
 - Lock floor (a `user`-locked belief does not decay)
 - Broker-confidence-attenuated valence propagation through the belief graph
 - Retrieval (locked-belief auto-load + BM25 FTS5, token-budgeted) and the `apply_feedback` endpoint (Beta-Bernoulli updates + demotion-pressure auto-demote)
-- Onboarding scanner (filesystem walk + git log + AST extractors) and `cli.py` (8 commands), `mcp_server.py` (8 tools, `[mcp]` extra), and 8 slash commands under `slash_commands/`
-- ~400 test functions across the unit suite, including 3 pre-registered property tests (Bayesian inertia, decay necessity, lock-floor sharpness) and end-to-end regression scenarios for retrieval, feedback, and onboarding
+- Onboarding scanner (filesystem walk + git log + AST extractors), `cli.py` (10 commands), `mcp_server.py` (8 tools, `[mcp]` extra), and 10 slash commands under `slash_commands/`
+- Claude Code wiring: `aelf setup` / `aelf unsetup` install or remove a `UserPromptSubmit` hook in Claude Code's `settings.json`; `aelf-hook` is the script entry-point that reads the hook payload, runs retrieval, and emits an `<aelfrice-memory>` block as injected context
+- ~500 test functions across the unit suite, including 3 pre-registered property tests (Bayesian inertia, decay necessity, lock-floor sharpness) and end-to-end regression scenarios for retrieval, feedback, onboarding, and the Claude Code setup→hook→unsetup round-trip
 
-What does NOT work yet: install via `pip`, the Claude Code `setup.py` wiring (v0.7.0), final docs/CHANGELOG/LICENSE (v0.8.0), and the v0.9.0-rc benchmark harness. Wait for `v1.0.0` if you want a stable release; until then, install editable from source (`uv pip install -e .`).
+What does NOT work yet: install via `pip`, final docs/CHANGELOG/LICENSE (v0.8.0), and the v0.9.0-rc benchmark harness. Wait for `v1.0.0` if you want a stable release; until then, install editable from source (`uv pip install -e .`) and run `aelf setup` to wire the hook into Claude Code.
 
 ## design notes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "0.6.0"
+version = "0.7.0"
 description = "Bayesian memory designed for feedback-driven learning"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aelfrice/__init__.py
+++ b/src/aelfrice/__init__.py
@@ -1,2 +1,2 @@
 """aelfrice: Bayesian memory designed for feedback-driven learning."""
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aelfrice"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
Marks the **v0.7.0 — Claude Code wiring** milestone shipped on main.

Bumps:
- `pyproject.toml` `version`: `0.6.0` → `0.7.0`
- `src/aelfrice/__init__.__version__`: `0.6.0` → `0.7.0`
- `uv.lock`: editable entry resynced to 0.7.0

## What landed in v0.7.0
PRs #39, #40, #41, #42, #43:

| PR | Piece |
|---|---|
| #39 | `src/aelfrice/setup.py` — idempotent install/uninstall of `UserPromptSubmit` hook in `settings.json`, atomic on-disk write |
| #40 | `src/aelfrice/hook.py` — `aelfrice.hook:main` reads UserPromptSubmit payload, runs retrieval, emits `<aelfrice-memory>` block. Non-blocking contract |
| #41 | `aelf setup` / `aelf unsetup` CLI subcommands + matching slash commands (10-tool surface, up from 8) |
| #42 | `aelf-hook = "aelfrice.hook:main"` script entry + CLI default switch to `aelf-hook` |
| #43 | End-to-end regression test: `aelf setup` → real `aelf-hook` subprocess spawn → verify retrieval output → `aelf unsetup` |

## README roadmap updates (same commit)
- v0.7.0 row flips `next` → `shipped`.
- v0.8.0 row flips `planned` → `next`.
- "What works today" refreshed: 10 CLI commands, 10 slash commands, ~500 tests, Claude Code wiring listed in the feature bullets.
- Headline tagline updated to reflect the new shipped/next boundary.

## Test plan
- [x] `uv run pytest` — 506/506 pass
- [x] `uv run pyright` — strict mode, 0 errors
- [x] `uv run python -c "import aelfrice; print(aelfrice.__version__)"` returns `0.7.0`
- [ ] CI: pytest 3.12 / 3.13, secrets-scan, pattern-scan, history-scan

## Tag
After this PR merges, tag `v0.7.0`:
```
git tag v0.7.0 && git push github v0.7.0
```
(The publish workflow is gated for v1.0.0 per CLAUDE.md release process; tagging now is informational.)

## Next milestone
**v0.8.0** — `docs/`, `CHANGELOG.md`, `LICENSE` (MIT), final `pyproject.toml`. Now flagged `next` in the roadmap.