### PR TITLE
feat(v0.8.0): add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 robotrocketscience
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ Closed to outside contribution until `v1.0.0` ships. Issues welcome at that poin
 
 ## License
 
-Will land at `v0.8.0` (MIT planned). Until then, all rights reserved by the author.
+[MIT](LICENSE). Copyright (c) 2026 robotrocketscience.


### PR DESCRIPTION
## Summary
First piece of `v0.8.0`. The `pyproject.toml` has declared `license = { text = "MIT" }` since v0.1.0 but no `LICENSE` file existed at the repo root. Adds the standard MIT text — copyright holder `robotrocketscience`, year 2026 — to match the git author.

## Verification
- `uv build` produces `dist/aelfrice-0.7.0-py3-none-any.whl` containing `aelfrice-0.7.0.dist-info/licenses/LICENSE` (hatchling auto-bundling — no manual `[tool.hatch]` plumbing required).
- `dist/aelfrice-0.7.0.tar.gz` contains `aelfrice-0.7.0/LICENSE`.

## README
Replaces the "Will land at `v0.8.0` (MIT planned). Until then, all rights reserved by the author." placeholder with a link to the new LICENSE file.

## Test plan
- [x] `uv build` — wheel + sdist both bundle LICENSE
- [ ] CI: pytest 3.12 / 3.13, secrets-scan, pattern-scan, history-scan

## Out of scope (next on this milestone)
- `CHANGELOG.md` covering v0.1.0 → v0.7.0 retroactively + Unreleased section.
- `docs/` tree (`INSTALL.md`, `ARCHITECTURE.md`, optionally `USAGE.md`).
- Final `pyproject.toml` metadata pass: project URLs, classifiers, keywords.