### PR TITLE
feat(v0.8.0): final pyproject.toml metadata pass for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,49 @@
 [project]
 name = "aelfrice"
 version = "0.7.0"
-description = "Bayesian memory designed for feedback-driven learning"
+description = "Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven."
 readme = "README.md"
 requires-python = ">=3.12"
 license = { text = "MIT" }
+license-files = ["LICENSE"]
+authors = [
+    { name = "robotrocketscience", email = "noreply@robotrocketscience.com" },
+]
+keywords = [
+    "agent",
+    "bayesian",
+    "claude-code",
+    "fts5",
+    "knowledge-graph",
+    "llm",
+    "mcp",
+    "memory",
+    "retrieval",
+    "sqlite",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Database",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
 dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/robotrocketscience/aelfrice"
+Repository = "https://github.com/robotrocketscience/aelfrice"
+Documentation = "https://github.com/robotrocketscience/aelfrice#readme"
+Changelog = "https://github.com/robotrocketscience/aelfrice/blob/main/CHANGELOG.md"
+Issues = "https://github.com/robotrocketscience/aelfrice/issues"
 
 [project.scripts]
 aelf = "aelfrice.cli:main"


### PR DESCRIPTION
## Summary
Final piece of `v0.8.0`. Fills in the metadata fields PyPI uses to render the project page when v1.0.0 publishes.

## Changes
| Field | Before | After |
|---|---|---|
| `description` | `Bayesian memory designed for feedback-driven learning` | `Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven.` |
| `authors` | (missing) | `[{name = "robotrocketscience", email = "noreply@robotrocketscience.com"}]` |
| `license-files` | (missing) | `["LICENSE"]` (explicit, complements the existing implicit bundle) |
| `keywords` | (missing) | 10 terms: `agent`, `bayesian`, `claude-code`, `fts5`, `knowledge-graph`, `llm`, `mcp`, `memory`, `retrieval`, `sqlite` |
| `classifiers` | (missing) | 13 Trove classifiers: dev status Beta, env Console, audience Developers, MIT license, OS Independent, Python 3 / 3.12 / 3.13 / 3-only, topics Database / AI / Library, `Typing :: Typed` |
| `[project.urls]` | (missing) | Homepage, Repository, Documentation, Changelog, Issues |

## Verification
- `uv build` — wheel + sdist build cleanly.
- `unzip -p dist/aelfrice-0.7.0-py3-none-any.whl aelfrice-0.7.0.dist-info/METADATA` confirms every `Project-URL`, `Classifier`, `Keywords`, `Author-email`, and `Summary` line renders correctly.

## Test plan
- [x] `uv build` — both artifacts produced
- [x] `uv run pytest` — 506/506 pass (no code change)
- [x] `uv run pyright` — strict mode, 0 errors
- [ ] CI: pytest 3.12 / 3.13, secrets-scan, pattern-scan, history-scan

## v0.8.0 status after this PR
With #45, #46, #47, and this PR landed, **v0.8.0 is functionally complete**:
- ✅ #45: `LICENSE` (MIT)
- ✅ #46: `CHANGELOG.md` (Keep-a-Changelog, retroactive v0.1.0–v0.7.0)
- ✅ #47: `docs/INSTALL.md` + `docs/ARCHITECTURE.md`
- 🟡 this PR: final `pyproject.toml` metadata

Once all four merge, ready to tag `v0.8.0` and flip the README roadmap row from `next` → `shipped`.