### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,30 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-26
+
+Project-metadata milestone — everything required for PyPI publish (gated
+until v1.0.0) is now present and verified.
+
 ### Added
 
 - `LICENSE` file at repo root (MIT) matching the `pyproject.toml` license
-  declaration. `uv build` now bundles it into both wheel and sdist (#45).
+  declaration. `uv build` bundles it into both wheel and sdist (#45).
+- `CHANGELOG.md` following the [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/)
+  format with retroactive sections for v0.1.0–v0.7.0 (#46).
+- `docs/INSTALL.md` — install, configure, quickstart, Claude Code wiring,
+  development workflow, uninstall (#47).
+- `docs/ARCHITECTURE.md` — design principles, module map, data model,
+  Bayesian update path, retrieval flow with ASCII diagram, Claude Code
+  integration diagram, test layers, explicit "out of scope through v1.0.0"
+  list (#47).
+- README `## docs` section linking to both new files (#47).
+- `pyproject.toml` PyPI-ready metadata pass: sharpened `description`,
+  `authors` with email, explicit `license-files = ["LICENSE"]`, ten
+  `keywords`, thirteen Trove `classifiers` (Beta dev status, Python 3 /
+  3.12 / 3.13, MIT, Topic / Audience / `Typing :: Typed`), and
+  `[project.urls]` (Homepage, Repository, Documentation, Changelog,
+  Issues) (#48).
 
 ## [0.7.0] - 2026-04-26
 
@@ -170,7 +190,8 @@ Foundation milestone — store, models, config.
 - Initial repo scaffold: pyproject, README, GitHub Actions workflows,
   scan configs (commit `67b4343`).
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/robotrocketscience/aelfrice/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/robotrocketscience/aelfrice/releases/tag/v0.7.0
 [0.6.0]: https://github.com/robotrocketscience/aelfrice/compare/8b45b77...c088314
 [0.5.0]: https://github.com/robotrocketscience/aelfrice/compare/8fdee15...a2f6841

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aelfrice
 
-**Bayesian memory designed for feedback-driven learning.** Today: knowledge store, retrieval, feedback loop, scanner, CLI, MCP server, and Claude Code wiring all landed on `main`. Next on the path to `v1.0.0`: docs/license and benchmark harness.
+**Bayesian memory designed for feedback-driven learning.** Today: knowledge store, retrieval, feedback loop, scanner, CLI, MCP server, Claude Code wiring, docs, LICENSE, and CHANGELOG all landed on `main`. Next on the path to `v1.0.0`: benchmark harness.
 
 > ⚠️ **Status: under active rebuild — do not depend on this for production.** The first installable release is `v1.0.0`; until then, modules land milestone-by-milestone. The previous codebase (`v2.0`) is preserved at [`aelfrice-v0`](https://github.com/robotrocketscience/aelfrice-v0) (archived, read-only).
 
@@ -28,13 +28,13 @@ The rebuild is structured as a sequence of small, atomic milestones.
 | **v0.5.0** | shipped | `scanner.py` — onboarding with filesystem walk, git log, simple AST extractors |
 | **v0.6.0** | shipped | `cli.py` (8 commands) + `mcp_server.py` (8 MCP tools) + `slash_commands/` |
 | **v0.7.0** | shipped | `setup.py` — Claude Code wiring (`UserPromptSubmit` hook for retrieval injection) + `aelfrice.hook` entry-point + `aelf setup` / `aelf unsetup` CLI + `aelf-hook` script |
-| **v0.8.0** | next | docs, `CHANGELOG.md`, `LICENSE` (MIT), final `pyproject.toml` |
-| **v0.9.0-rc** | planned | minimal benchmark harness producing a publishable score |
+| **v0.8.0** | shipped | docs (`docs/INSTALL.md`, `docs/ARCHITECTURE.md`), `CHANGELOG.md`, `LICENSE` (MIT), PyPI-ready `pyproject.toml` metadata |
+| **v0.9.0-rc** | next | minimal benchmark harness producing a publishable score |
 | **v1.0.0** | planned | tag, push, PyPI publish |
 
 After `v1.0.0`, the `v1.x` series recovers `v2.0` features incrementally with evidence justifying each addition.
 
-## What works today (v0.7.0)
+## What works today (v0.8.0)
 
 - SQLite-backed Belief and Edge storage with WAL journaling and FTS5 search
 - Beta-Bernoulli confidence math; per-type half-life decay
@@ -43,9 +43,10 @@ After `v1.0.0`, the `v1.x` series recovers `v2.0` features incrementally with ev
 - Retrieval (locked-belief auto-load + BM25 FTS5, token-budgeted) and the `apply_feedback` endpoint (Beta-Bernoulli updates + demotion-pressure auto-demote)
 - Onboarding scanner (filesystem walk + git log + AST extractors), `cli.py` (10 commands), `mcp_server.py` (8 tools, `[mcp]` extra), and 10 slash commands under `slash_commands/`
 - Claude Code wiring: `aelf setup` / `aelf unsetup` install or remove a `UserPromptSubmit` hook in Claude Code's `settings.json`; `aelf-hook` is the script entry-point that reads the hook payload, runs retrieval, and emits an `<aelfrice-memory>` block as injected context
+- Project metadata: `LICENSE` (MIT), `CHANGELOG.md` (Keep-a-Changelog), `docs/INSTALL.md`, `docs/ARCHITECTURE.md`, and PyPI-ready `pyproject.toml` (description, authors, keywords, 13 classifiers, project URLs)
 - ~500 test functions across the unit suite, including 3 pre-registered property tests (Bayesian inertia, decay necessity, lock-floor sharpness) and end-to-end regression scenarios for retrieval, feedback, onboarding, and the Claude Code setup→hook→unsetup round-trip
 
-What does NOT work yet: install via `pip`, final docs/CHANGELOG/LICENSE (v0.8.0), and the v0.9.0-rc benchmark harness. Wait for `v1.0.0` if you want a stable release; until then, install editable from source (`uv pip install -e .`) and run `aelf setup` to wire the hook into Claude Code.
+What does NOT work yet: install via `pip` (PyPI publish gated until v1.0.0), and the v0.9.0-rc benchmark harness. Until then, install editable from source (`uv pip install -e .`) and run `aelf setup` to wire the hook into Claude Code.
 
 ## docs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "0.7.0"
+version = "0.8.0"
 description = "Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aelfrice/__init__.py
+++ b/src/aelfrice/__init__.py
@@ -1,2 +1,2 @@
 """aelfrice: Bayesian memory designed for feedback-driven learning."""
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aelfrice"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
Marks the **v0.8.0 — project metadata** milestone shipped on main.

Bumps `pyproject.toml`, `src/aelfrice/__init__.__version__`, and `uv.lock` 0.7.0 → 0.8.0. Promotes CHANGELOG `[Unreleased]` → `[0.8.0] - 2026-04-26`. Flips README roadmap rows: v0.8.0 → `shipped`, v0.9.0-rc → `next`.

## What landed in v0.8.0
PRs #45, #46, #47, #48 — see CHANGELOG for the full breakdown.

## Test plan
- [x] `uv run pytest` — 506/506 pass
- [x] `uv run pyright` — strict mode, 0 errors
- [x] `uv run python -c "import aelfrice; print(aelfrice.__version__)"` returns `0.8.0`
- [ ] CI: pytest 3.12 / 3.13, secrets-scan, pattern-scan, history-scan

## Tag
After merge: `git tag v0.8.0 && git push github v0.8.0`. Publish workflow stays dormant until v1.0.0.

## Next milestone
**v0.9.0-rc** — minimal benchmark harness producing a publishable score. Last gate before v1.0.0 (tag + PyPI publish).