### PR TITLE
feat(v0.9.0-rc): minimal benchmark harness — aelfrice.benchmark + aelf bench

### DIFF
--- a/src/aelfrice/benchmark.py
+++ b/src/aelfrice/benchmark.py
@@ -1,0 +1,263 @@
+"""Minimal v0.9.0-rc benchmark harness.
+
+Runs aelfrice retrieval against a small deterministic synthetic
+corpus (16 beliefs across 4 topics) and a deterministic query set
+(16 queries with one known correct belief each). Produces a single
+JSON document containing hit@1 / hit@3 / hit@5, MRR, and latency
+percentiles.
+
+This harness is the **measurement instrument**, not a proof of the
+central claim. It does not currently differentiate
+"with-feedback" vs "no-feedback" because retrieval ranking in
+v1.0 is BM25-only (posterior alpha/beta does not factor into
+search_beliefs ordering — see store.py:244). A v1.x retrieval
+upgrade that consumes posterior is the precondition for using this
+harness to claim feedback drives accuracy.
+
+What this harness DOES validate at v0.9.0-rc:
+- The full ingest -> retrieve pipeline runs end-to-end against a
+  fresh on-disk store.
+- A reproducible score is produced. Re-running the harness against
+  an empty store yields identical numbers.
+- Latency stays below a sane ceiling for the size-16 corpus
+  (regression test asserts p99 < 100ms).
+
+Score floor (regression-asserted):
+- hit_at_5 >= 0.75 — at least 12 of 16 queries find their correct
+  belief in the top 5 results. Anything below means BM25 escaping
+  or scoring has regressed.
+
+The corpus, queries, and expected-correct mappings are all
+hand-authored. They live in this module rather than a separate
+data file because (a) we want the harness to ship in the wheel
+without needing package_data plumbing, and (b) review of changes
+is just a regular code-review of this file.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass
+from typing import Final
+
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
+from aelfrice.retrieval import retrieve
+from aelfrice.store import Store
+
+BENCHMARK_NAME: Final[str] = "aelfrice-bench-v1"
+"""Stable identifier for this benchmark configuration.
+
+Bumped (v2, v3, ...) only when corpus / queries / expected mapping
+change in a way that breaks score comparability across releases.
+Within a v1 series, hit@K numbers are directly comparable.
+"""
+
+DEFAULT_TOP_K: Final[int] = 5
+DEFAULT_TOKEN_BUDGET: Final[int] = 4000
+"""Higher than retrieval's default 2000 so the budget doesn't
+cap the harness at fewer than top_k results when belief contents
+are long."""
+
+
+# --- Synthetic corpus -------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _CorpusEntry:
+    id: str
+    content: str
+
+
+# 4 topics * 4 beliefs each = 16 beliefs. Topic key embedded in id
+# prefix so reviewers can sanity-check the expected-mapping table
+# without rerunning the harness.
+_CORPUS: Final[tuple[_CorpusEntry, ...]] = (
+    # Cooking
+    _CorpusEntry("cook_01", "the kitchen knife should be sharpened weekly to maintain a clean cutting edge"),
+    _CorpusEntry("cook_02", "boiling water for pasta needs at least one tablespoon of salt per liter"),
+    _CorpusEntry("cook_03", "cast iron skillets must be seasoned with oil after every wash to prevent rust"),
+    _CorpusEntry("cook_04", "a sourdough starter ferments overnight at room temperature before baking"),
+    # Gardening
+    _CorpusEntry("gard_01", "tomato plants should be staked when the stem reaches knee height to prevent breakage"),
+    _CorpusEntry("gard_02", "compost piles need turning every two weeks to aerate and accelerate decomposition"),
+    _CorpusEntry("gard_03", "drip irrigation delivers water directly to plant roots with minimal evaporation loss"),
+    _CorpusEntry("gard_04", "raised beds drain better than ground-level plots in clay-heavy soil"),
+    # Networking
+    _CorpusEntry("net_01", "TCP retransmits lost packets after a timeout based on the round-trip estimate"),
+    _CorpusEntry("net_02", "BGP announces routes between autonomous systems across the public internet"),
+    _CorpusEntry("net_03", "TLS handshake negotiates a symmetric key using asymmetric certificate exchange"),
+    _CorpusEntry("net_04", "subnet masks partition an IP address space into smaller administrative groups"),
+    # Programming
+    _CorpusEntry("prog_01", "garbage collection reclaims memory from objects no longer reachable from a root set"),
+    _CorpusEntry("prog_02", "B-trees keep database indexes balanced so disk page reads stay logarithmic in row count"),
+    _CorpusEntry("prog_03", "compilers lower high-level code into machine instructions through a sequence of passes"),
+    _CorpusEntry("prog_04", "merge sort recursively splits and combines lists to achieve guaranteed n log n time"),
+)
+
+
+# --- Queries with expected-correct mapping ----------------------------
+
+
+@dataclass(frozen=True)
+class _QueryEntry:
+    query: str
+    correct_id: str
+
+
+# Queries are deliberately constrained to terms present (surface-form,
+# case-insensitive) in their target belief, because FTS5 with the
+# simple tokenizer does not stem and store._escape_fts5_query joins
+# whitespace tokens with implicit AND. Single-keyword queries would
+# match too many beliefs; 2–4 specific terms gives a sharp signal.
+_QUERIES: Final[tuple[_QueryEntry, ...]] = (
+    _QueryEntry("kitchen knife sharpened", "cook_01"),
+    _QueryEntry("salt pasta water", "cook_02"),
+    _QueryEntry("cast iron seasoned", "cook_03"),
+    _QueryEntry("sourdough starter overnight", "cook_04"),
+    _QueryEntry("tomato plants staked", "gard_01"),
+    _QueryEntry("compost turning weeks", "gard_02"),
+    _QueryEntry("drip irrigation roots", "gard_03"),
+    _QueryEntry("raised beds clay", "gard_04"),
+    _QueryEntry("TCP packets timeout", "net_01"),
+    _QueryEntry("BGP routes autonomous", "net_02"),
+    _QueryEntry("TLS handshake certificate", "net_03"),
+    _QueryEntry("subnet masks IP", "net_04"),
+    _QueryEntry("garbage collection memory", "prog_01"),
+    _QueryEntry("database indexes balanced", "prog_02"),
+    _QueryEntry("compilers machine instructions", "prog_03"),
+    _QueryEntry("merge sort recursively", "prog_04"),
+)
+
+
+# --- Scored output ----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BenchmarkReport:
+    """Reproducible single-run summary."""
+
+    benchmark_name: str
+    aelfrice_version: str
+    corpus_size: int
+    query_count: int
+    top_k: int
+    hit_at_1: float
+    hit_at_3: float
+    hit_at_5: float
+    mrr: float
+    p50_latency_ms: float
+    p99_latency_ms: float
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+# --- Harness ----------------------------------------------------------
+
+
+def seed_corpus(store: Store, *, created_at: str = "2026-04-26T00:00:00Z") -> int:
+    """Insert the deterministic benchmark corpus into `store`.
+
+    Inserts each `_CorpusEntry` as an unlocked factual belief with
+    Jeffreys prior (alpha=1, beta=1). Returns the count inserted.
+    """
+    inserted = 0
+    for entry in _CORPUS:
+        store.insert_belief(
+            Belief(
+                id=entry.id,
+                content=entry.content,
+                content_hash=f"bench_{entry.id}",
+                alpha=1.0,
+                beta=1.0,
+                type=BELIEF_FACTUAL,
+                lock_level=LOCK_NONE,
+                locked_at=None,
+                demotion_pressure=0,
+                created_at=created_at,
+                last_retrieved_at=None,
+            )
+        )
+        inserted += 1
+    return inserted
+
+
+def run_benchmark(
+    store: Store,
+    *,
+    aelfrice_version: str,
+    top_k: int = DEFAULT_TOP_K,
+) -> BenchmarkReport:
+    """Run all queries against `store` and return scored results.
+
+    Caller must have seeded the corpus (e.g. via `seed_corpus`) into
+    `store` before calling. The harness does not seed implicitly to
+    keep store ownership explicit and to let benchmark variants
+    layer additional state (e.g. pre-locked beliefs) on top of the
+    base corpus.
+    """
+    if top_k <= 0:
+        raise ValueError(f"top_k must be positive, got {top_k}")
+
+    hits_at_1 = 0
+    hits_at_3 = 0
+    hits_at_5 = 0
+    reciprocal_ranks: list[float] = []
+    latencies_ms: list[float] = []
+
+    for q in _QUERIES:
+        t0 = time.perf_counter()
+        results = retrieve(
+            store, q.query, token_budget=DEFAULT_TOKEN_BUDGET, l1_limit=top_k
+        )
+        latencies_ms.append((time.perf_counter() - t0) * 1000.0)
+
+        rank = _rank_of(q.correct_id, results)
+        if rank is not None:
+            reciprocal_ranks.append(1.0 / rank)
+            if rank == 1:
+                hits_at_1 += 1
+            if rank <= 3:
+                hits_at_3 += 1
+            if rank <= 5:
+                hits_at_5 += 1
+        else:
+            reciprocal_ranks.append(0.0)
+
+    n = len(_QUERIES)
+    return BenchmarkReport(
+        benchmark_name=BENCHMARK_NAME,
+        aelfrice_version=aelfrice_version,
+        corpus_size=len(_CORPUS),
+        query_count=n,
+        top_k=top_k,
+        hit_at_1=hits_at_1 / n,
+        hit_at_3=hits_at_3 / n,
+        hit_at_5=hits_at_5 / n,
+        mrr=sum(reciprocal_ranks) / n,
+        p50_latency_ms=_percentile(latencies_ms, 0.50),
+        p99_latency_ms=_percentile(latencies_ms, 0.99),
+    )
+
+
+def _rank_of(correct_id: str, results: list[Belief]) -> int | None:
+    """1-indexed position of `correct_id` in `results`, or None."""
+    for i, b in enumerate(results, start=1):
+        if b.id == correct_id:
+            return i
+    return None
+
+
+def _percentile(values: list[float], q: float) -> float:
+    """Inclusive percentile with linear interpolation. q in [0, 1]."""
+    if not values:
+        return 0.0
+    if not 0.0 <= q <= 1.0:
+        raise ValueError(f"q must be in [0, 1], got {q}")
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    pos = q * (len(s) - 1)
+    lo = int(pos)
+    hi = min(lo + 1, len(s) - 1)
+    frac = pos - lo
+    return s[lo] + (s[hi] - s[lo]) * frac

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -1,4 +1,4 @@
-"""Ten-command CLI matching the MVP user surface.
+"""Eleven-command CLI matching the MVP user surface.
 
 Commands:
   onboard <path>                   scan a project and ingest beliefs
@@ -11,6 +11,7 @@ Commands:
   health                           regime classifier output
   setup                            install UserPromptSubmit hook in Claude Code
   unsetup                          remove UserPromptSubmit hook from Claude Code
+  bench                            run the v0.9.0-rc benchmark harness
 
 DB path resolves from AELFRICE_DB environment variable when set,
 otherwise from ~/.aelfrice/memory.db. Callers can run `main(argv=...)`
@@ -39,6 +40,8 @@ from aelfrice.models import (
     LOCK_USER,
     Belief,
 )
+from aelfrice import __version__ as _AELFRICE_VERSION
+from aelfrice.benchmark import run_benchmark, seed_corpus
 from aelfrice.retrieval import DEFAULT_TOKEN_BUDGET, retrieve
 from aelfrice.scanner import scan_repo
 from aelfrice.setup import (
@@ -246,6 +249,28 @@ def _cmd_stats(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _cmd_bench(args: argparse.Namespace, out: object) -> int:
+    """Run the v0.9.0-rc benchmark harness; print one JSON document.
+
+    Default: seed an in-memory store with the synthetic corpus and
+    score retrieval. The benchmark is fully reproducible — repeated
+    invocations against fresh in-memory stores produce identical
+    accuracy numbers (latency varies).
+    """
+    import json
+    db = ":memory:" if args.db is None else str(Path(args.db))
+    store = Store(db)
+    try:
+        seed_corpus(store)
+        report = run_benchmark(
+            store, aelfrice_version=_AELFRICE_VERSION, top_k=args.top_k
+        )
+    finally:
+        store.close()
+    print(json.dumps(report.to_dict(), indent=2), file=out)  # type: ignore[arg-type]
+    return 0
+
+
 def _resolve_settings_path(args: argparse.Namespace) -> Path:
     if args.settings_path is not None:
         return Path(args.settings_path)
@@ -410,6 +435,23 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_unsetup.set_defaults(func=_cmd_unsetup)
+
+    p_bench = sub.add_parser(
+        "bench",
+        help="run the v0.9.0-rc benchmark harness and print a JSON report",
+    )
+    p_bench.add_argument(
+        "--db", default=None,
+        help=(
+            "path to an empty SQLite file to seed and benchmark against. "
+            "Default: in-memory store (fully reproducible across runs)."
+        ),
+    )
+    p_bench.add_argument(
+        "--top-k", type=int, default=5,
+        help="retrieval depth used for hit@k accounting (default 5)",
+    )
+    p_bench.set_defaults(func=_cmd_bench)
 
     return parser
 

--- a/src/aelfrice/slash_commands/bench.md
+++ b/src/aelfrice/slash_commands/bench.md
@@ -1,0 +1,25 @@
+---
+name: aelf:bench
+description: Run the aelfrice benchmark harness and print a reproducible JSON score report.
+allowed-tools:
+  - Bash
+---
+<objective>
+Produce a publishable score for the current aelfrice build by
+running the v0.9.0-rc benchmark harness: 16 hand-authored beliefs
+across 4 topics, 16 queries with one known correct answer each,
+scored by hit@1 / hit@3 / hit@5 / MRR plus p50 and p99 retrieval
+latency.
+</objective>
+
+<process>
+Run: `uv run aelf bench`
+
+The default invocation seeds an in-memory SQLite store with the
+synthetic corpus, runs every query, and prints a single JSON
+document. Pass `--db PATH` to seed a real on-disk store instead
+(useful for inspecting the post-run state). Pass `--top-k N` to
+override the retrieval depth used for hit@k accounting.
+
+Display the JSON output verbatim. Do not add commentary.
+</process>

--- a/tests/regression/test_benchmark_cli_end_to_end.py
+++ b/tests/regression/test_benchmark_cli_end_to_end.py
@@ -1,0 +1,63 @@
+"""End-to-end regression: aelf bench produces a JSON report meeting the
+v0.9.0-rc score floor.
+
+Marks the v0.9.0-rc benchmark milestone as observable from outside the
+package: a user with `aelf` on their PATH can run `aelf bench` and
+publish the resulting JSON without touching internals.
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from aelfrice.benchmark import BENCHMARK_NAME
+from aelfrice.cli import main as cli_main
+
+pytestmark = pytest.mark.regression
+
+
+def _run_cli(*argv: str) -> tuple[int, str]:
+    buf = io.StringIO()
+    code = cli_main(argv=list(argv), out=buf)
+    return code, buf.getvalue()
+
+
+def _parse_report(stdout: str) -> dict[str, object]:
+    parsed = json.loads(stdout)  # pyright: ignore[reportAny]
+    assert isinstance(parsed, dict)
+    return cast(dict[str, object], parsed)
+
+
+@pytest.mark.timeout(30)
+def test_aelf_bench_default_in_memory_meets_score_floor() -> None:
+    code, output = _run_cli("bench")
+    assert code == 0
+    report = _parse_report(output)
+    assert report["benchmark_name"] == BENCHMARK_NAME
+    assert report["corpus_size"] == 16
+    assert report["query_count"] == 16
+    hit5 = report["hit_at_5"]
+    assert isinstance(hit5, float)
+    assert hit5 >= 0.75, f"hit_at_5={hit5} below v0.9.0-rc floor 0.75"
+
+
+@pytest.mark.timeout(30)
+def test_aelf_bench_with_explicit_db_writes_file(tmp_path: Path) -> None:
+    db = tmp_path / "bench.db"
+    code, output = _run_cli("bench", "--db", str(db))
+    assert code == 0
+    assert db.exists()
+    report = _parse_report(output)
+    assert report["corpus_size"] == 16
+
+
+@pytest.mark.timeout(30)
+def test_aelf_bench_top_k_override_changes_report_field() -> None:
+    code, output = _run_cli("bench", "--top-k", "3")
+    assert code == 0
+    report = _parse_report(output)
+    assert report["top_k"] == 3

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,215 @@
+"""v0.9.0-rc benchmark harness — unit + score-floor tests."""
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+
+from aelfrice.benchmark import (
+    BENCHMARK_NAME,
+    BenchmarkReport,
+    DEFAULT_TOP_K,
+    run_benchmark,
+    seed_corpus,
+)
+from aelfrice.benchmark import _percentile, _rank_of  # type: ignore[reportPrivateUsage]
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
+from aelfrice.store import Store
+
+
+def _fresh_store(tmp_path: Path) -> Store:
+    return Store(str(tmp_path / "bench.db"))
+
+
+def _mk(bid: str, content: str) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def test_seed_corpus_inserts_16_beliefs(tmp_path: Path) -> None:
+    s = _fresh_store(tmp_path)
+    try:
+        n = seed_corpus(s)
+    finally:
+        s.close()
+    assert n == 16
+    s = _fresh_store(tmp_path)
+    try:
+        # Re-open and confirm round-trip.
+        assert s.count_beliefs() == 16
+    finally:
+        s.close()
+
+
+def test_run_benchmark_returns_well_formed_report(tmp_path: Path) -> None:
+    s = _fresh_store(tmp_path)
+    try:
+        seed_corpus(s)
+        report = run_benchmark(s, aelfrice_version="0.9.0-rc")
+    finally:
+        s.close()
+    assert isinstance(report, BenchmarkReport)
+    assert report.benchmark_name == BENCHMARK_NAME
+    assert report.aelfrice_version == "0.9.0-rc"
+    assert report.corpus_size == 16
+    assert report.query_count == 16
+    assert report.top_k == DEFAULT_TOP_K
+    for f in fields(BenchmarkReport):
+        assert getattr(report, f.name) is not None, f"field {f.name} missing"
+
+
+def test_run_benchmark_score_floor_hit_at_5(tmp_path: Path) -> None:
+    """Locked-in floor: at least 12 of 16 queries find their correct
+    belief in the top-5. Below this means BM25 escaping or scoring has
+    regressed and the harness will produce an unpublishable result."""
+    s = _fresh_store(tmp_path)
+    try:
+        seed_corpus(s)
+        report = run_benchmark(s, aelfrice_version="test")
+    finally:
+        s.close()
+    assert report.hit_at_5 >= 0.75, (
+        f"hit_at_5={report.hit_at_5:.3f} below floor 0.75 "
+        f"({int(report.hit_at_5 * report.query_count)} of "
+        f"{report.query_count} hits)"
+    )
+
+
+def test_run_benchmark_mrr_consistency(tmp_path: Path) -> None:
+    """MRR must be between hit_at_1 (lower bound — missed queries
+    contribute 0) and hit_at_5 (upper bound — at best every hit is
+    rank 1)."""
+    s = _fresh_store(tmp_path)
+    try:
+        seed_corpus(s)
+        report = run_benchmark(s, aelfrice_version="test")
+    finally:
+        s.close()
+    assert report.hit_at_1 <= report.mrr <= report.hit_at_5
+
+
+def test_run_benchmark_latency_percentiles_ordered(tmp_path: Path) -> None:
+    s = _fresh_store(tmp_path)
+    try:
+        seed_corpus(s)
+        report = run_benchmark(s, aelfrice_version="test")
+    finally:
+        s.close()
+    assert report.p50_latency_ms <= report.p99_latency_ms
+
+
+def test_run_benchmark_latency_p99_under_ceiling(tmp_path: Path) -> None:
+    """For a 16-belief corpus on any halfway-modern machine, p99 should
+    be deep below 100ms. If we cross that the harness has a bug."""
+    s = _fresh_store(tmp_path)
+    try:
+        seed_corpus(s)
+        report = run_benchmark(s, aelfrice_version="test")
+    finally:
+        s.close()
+    assert report.p99_latency_ms < 100.0, (
+        f"p99={report.p99_latency_ms:.2f}ms exceeds 100ms ceiling"
+    )
+
+
+def test_run_benchmark_is_deterministic(tmp_path: Path) -> None:
+    """Two runs against fresh stores must produce identical
+    accuracy scores. Latencies will differ; that's expected and
+    handled at the percentile-only assertion above."""
+    s1 = Store(str(tmp_path / "a.db"))
+    s2 = Store(str(tmp_path / "b.db"))
+    try:
+        seed_corpus(s1)
+        seed_corpus(s2)
+        r1 = run_benchmark(s1, aelfrice_version="test")
+        r2 = run_benchmark(s2, aelfrice_version="test")
+    finally:
+        s1.close()
+        s2.close()
+    assert r1.hit_at_1 == r2.hit_at_1
+    assert r1.hit_at_3 == r2.hit_at_3
+    assert r1.hit_at_5 == r2.hit_at_5
+    assert r1.mrr == r2.mrr
+
+
+def test_run_benchmark_rejects_nonpositive_top_k(tmp_path: Path) -> None:
+    s = _fresh_store(tmp_path)
+    try:
+        seed_corpus(s)
+        with pytest.raises(ValueError):
+            run_benchmark(s, aelfrice_version="test", top_k=0)
+        with pytest.raises(ValueError):
+            run_benchmark(s, aelfrice_version="test", top_k=-1)
+    finally:
+        s.close()
+
+
+def test_report_to_dict_round_trip() -> None:
+    """to_dict() output must contain every dataclass field as a
+    JSON-serialisable primitive."""
+    report = BenchmarkReport(
+        benchmark_name="test",
+        aelfrice_version="0.0.0",
+        corpus_size=1,
+        query_count=1,
+        top_k=5,
+        hit_at_1=1.0,
+        hit_at_3=1.0,
+        hit_at_5=1.0,
+        mrr=1.0,
+        p50_latency_ms=0.5,
+        p99_latency_ms=1.5,
+    )
+    d = report.to_dict()
+    assert set(d.keys()) == {f.name for f in fields(BenchmarkReport)}
+    import json
+    assert json.dumps(d)  # serialisable
+
+
+# --- Internal helpers ------------------------------------------------
+
+
+def test_rank_of_returns_one_indexed_position() -> None:
+    results = [_mk("a", "x"), _mk("b", "y"), _mk("c", "z")]
+    assert _rank_of("a", results) == 1
+    assert _rank_of("b", results) == 2
+    assert _rank_of("c", results) == 3
+    assert _rank_of("d", results) is None
+
+
+def test_rank_of_empty_results() -> None:
+    assert _rank_of("anything", []) is None
+
+
+def test_percentile_single_value() -> None:
+    assert _percentile([42.0], 0.5) == 42.0
+    assert _percentile([42.0], 0.99) == 42.0
+
+
+def test_percentile_two_values() -> None:
+    assert _percentile([1.0, 3.0], 0.0) == 1.0
+    assert _percentile([1.0, 3.0], 1.0) == 3.0
+    assert _percentile([1.0, 3.0], 0.5) == 2.0
+
+
+def test_percentile_empty_list_returns_zero() -> None:
+    assert _percentile([], 0.5) == 0.0
+
+
+def test_percentile_rejects_out_of_range_q() -> None:
+    with pytest.raises(ValueError):
+        _percentile([1.0, 2.0], -0.1)
+    with pytest.raises(ValueError):
+        _percentile([1.0, 2.0], 1.1)

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -1,4 +1,4 @@
-"""Verify the 10 slash-command markdown files match the CLI surface.
+"""Verify the 11 slash-command markdown files match the CLI surface.
 
 These files ship inside the aelfrice package so `setup.py` (v0.7.0) can
 copy them into `~/.claude/commands/aelf/`. The tests check structural
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-# The 10-tool surface — must match cli.py's subparsers exactly.
+# The 11-tool surface — must match cli.py's subparsers exactly.
 EXPECTED_COMMANDS = (
     "onboard",
     "search",
@@ -24,6 +24,7 @@ EXPECTED_COMMANDS = (
     "health",
     "setup",
     "unsetup",
+    "bench",
 )
 
 


### PR DESCRIPTION
## Summary
**v0.9.0-rc — minimal benchmark harness producing a publishable score.** Last gate before `v1.0.0` (tag + PyPI publish).

Two atomic commits:
1. `aelfrice.benchmark` module + 15 unit tests.
2. `aelf bench` CLI subcommand + slash command + 3 e2e regression tests.

## What it produces
A single deterministic JSON document. Sample local run on the v0.8.0 codebase:

```json
{
  "benchmark_name": "aelfrice-bench-v1",
  "aelfrice_version": "0.8.0",
  "corpus_size": 16,
  "query_count": 16,
  "top_k": 5,
  "hit_at_1": 1.0,
  "hit_at_3": 1.0,
  "hit_at_5": 1.0,
  "mrr": 1.0,
  "p50_latency_ms": 0.045,
  "p99_latency_ms": 0.234
}
```

## Design
- **16 hand-authored beliefs** across 4 topics (cooking / gardening / networking / programming) embedded in `benchmark.py`. No package-data plumbing required.
- **16 queries** with one known correct belief each. Queries are deliberately constrained to surface-form terms present in their target belief because FTS5's simple tokenizer doesn't stem and `_escape_fts5_query` joins whitespace tokens with implicit AND.
- **Reproducibility**: default `aelf bench` invocation uses an in-memory SQLite store, so two runs against fresh stores produce identical accuracy. Latencies vary; that's expected and only constrained at the percentile level.
- **Score floor regression**: `test_run_benchmark_score_floor_hit_at_5` and the e2e test both assert `hit_at_5 >= 0.75`. Below that means BM25 escaping or scoring has regressed and the harness is producing an unpublishable result.
- **`BENCHMARK_NAME = "aelfrice-bench-v1"`** is bumped only when corpus / queries / expected-mapping change in a way that breaks score comparability across releases. Within the v1 series, hit@K numbers are directly comparable.

## What this harness does NOT do (and why that's fine for v0.9.0-rc)
The README's central claim is "a memory which actually applies feedback outperforms one that doesn't." This harness does **not** currently differentiate "with-feedback" vs "no-feedback" because retrieval ranking in v1.0 is BM25-only — `aelfrice.retrieval.retrieve` does not consume `alpha`/`beta`. A v1.x retrieval upgrade that reads posterior is the precondition for using this harness to claim feedback drives accuracy. The benchmark module's docstring documents this explicitly.

What v0.9.0-rc DOES validate:
- Full ingest → retrieve pipeline runs end-to-end.
- Score is reproducible across runs.
- Latency stays below a sane ceiling for the corpus size.

## Surface change
| | Before | After |
|---|---|---|
| CLI subcommands | 10 | 11 (adds `bench`) |
| Slash commands | 10 | 11 (adds `bench.md`) |

`test_slash_commands.py::test_slash_commands_match_cli_subcommands` keeps the 1:1 invariant green.

## Test plan
- [x] `uv run pytest tests/test_benchmark.py` — 15/15 pass
- [x] `uv run pytest tests/regression/test_benchmark_cli_end_to_end.py` — 3/3 pass
- [x] `uv run pytest tests/test_slash_commands.py` — 55/55 pass (11 commands × 5 parametrized properties)
- [x] full suite — 530/530 pass
- [x] `uv run pyright` — strict mode, 0 errors
- [x] manual: `uv run aelf bench` returns the JSON above
- [ ] CI: pytest 3.12 / 3.13, secrets-scan, pattern-scan, history-scan

## Next
Once this merges and the release commit lands, **v1.0.0** is the only remaining milestone — tag, push, and (per CLAUDE.md release process) the PyPI Trusted Publisher workflow fires off the `v1.0.0` tag.