### PR TITLE
release: v0.9.0rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+## [0.9.0rc0] - 2026-04-26
+
+Benchmark-harness milestone — final gate before `v1.0.0`. The `v0.9.0-rc`
+roadmap row is shipped as PEP 440 release candidate `0.9.0rc0`.
+
+### Added
+
+- `aelfrice.benchmark` module — deterministic 16-belief × 16-query
+  synthetic harness. Public surface: `BENCHMARK_NAME`,
+  `seed_corpus(store)`, `run_benchmark(store, *, aelfrice_version,
+  top_k=5)`, frozen `BenchmarkReport` dataclass with `hit_at_1`,
+  `hit_at_3`, `hit_at_5`, `mrr`, `p50_latency_ms`, `p99_latency_ms`
+  (#50).
+- `aelf bench` CLI subcommand — prints the report as a single JSON
+  document. Defaults to in-memory store for full reproducibility;
+  `--db PATH` for an explicit on-disk SQLite file; `--top-k N` to
+  override hit@k accounting depth (#50).
+- `slash_commands/bench.md` keeping the CLI ↔ slash 1:1 invariant
+  green at 11 commands (#50).
+- `tests/regression/test_benchmark_cli_end_to_end.py` —
+  `@pytest.mark.regression` end-to-end coverage of `aelf bench`
+  default invocation, `--db PATH`, and `--top-k` override (#50).
+
+### Notes
+
+- The harness is the **measurement instrument**, not proof of the
+  central feedback claim. Retrieval ranking in the v1.0 line is
+  BM25-only (`store.search_beliefs` orders by `bm25(beliefs_fts)`,
+  posterior `alpha`/`beta` are not consumed), so `apply_feedback`
+  does not currently move benchmark scores. A v1.x retrieval
+  upgrade that consumes posterior is the precondition for using
+  this harness to claim feedback drives accuracy.
+
 ## [0.8.0] - 2026-04-26
 
 Project-metadata milestone — everything required for PyPI publish (gated
@@ -190,7 +223,8 @@ Foundation milestone — store, models, config.
 - Initial repo scaffold: pyproject, README, GitHub Actions workflows,
   scan configs (commit `67b4343`).
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v0.9.0rc0...HEAD
+[0.9.0rc0]: https://github.com/robotrocketscience/aelfrice/compare/v0.8.0...v0.9.0rc0
 [0.8.0]: https://github.com/robotrocketscience/aelfrice/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/robotrocketscience/aelfrice/releases/tag/v0.7.0
 [0.6.0]: https://github.com/robotrocketscience/aelfrice/compare/8b45b77...c088314

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aelfrice
 
-**Bayesian memory designed for feedback-driven learning.** Today: knowledge store, retrieval, feedback loop, scanner, CLI, MCP server, Claude Code wiring, docs, LICENSE, and CHANGELOG all landed on `main`. Next on the path to `v1.0.0`: benchmark harness.
+**Bayesian memory designed for feedback-driven learning.** Today: knowledge store, retrieval, feedback loop, scanner, CLI, MCP server, Claude Code wiring, docs, LICENSE, CHANGELOG, and benchmark harness all landed on `main`. Next: tag `v1.0.0` and publish to PyPI.
 
 > ⚠️ **Status: under active rebuild — do not depend on this for production.** The first installable release is `v1.0.0`; until then, modules land milestone-by-milestone. The previous codebase (`v2.0`) is preserved at [`aelfrice-v0`](https://github.com/robotrocketscience/aelfrice-v0) (archived, read-only).
 
@@ -29,24 +29,25 @@ The rebuild is structured as a sequence of small, atomic milestones.
 | **v0.6.0** | shipped | `cli.py` (8 commands) + `mcp_server.py` (8 MCP tools) + `slash_commands/` |
 | **v0.7.0** | shipped | `setup.py` — Claude Code wiring (`UserPromptSubmit` hook for retrieval injection) + `aelfrice.hook` entry-point + `aelf setup` / `aelf unsetup` CLI + `aelf-hook` script |
 | **v0.8.0** | shipped | docs (`docs/INSTALL.md`, `docs/ARCHITECTURE.md`), `CHANGELOG.md`, `LICENSE` (MIT), PyPI-ready `pyproject.toml` metadata |
-| **v0.9.0-rc** | next | minimal benchmark harness producing a publishable score |
-| **v1.0.0** | planned | tag, push, PyPI publish |
+| **v0.9.0-rc** (`0.9.0rc0`) | shipped | `aelfrice.benchmark` + `aelf bench` — 16-belief × 16-query reproducible JSON score harness with hit@1 / hit@3 / hit@5 / MRR + p50 / p99 latency |
+| **v1.0.0** | next | tag, push, PyPI publish |
 
 After `v1.0.0`, the `v1.x` series recovers `v2.0` features incrementally with evidence justifying each addition.
 
-## What works today (v0.8.0)
+## What works today (v0.9.0rc0)
 
 - SQLite-backed Belief and Edge storage with WAL journaling and FTS5 search
 - Beta-Bernoulli confidence math; per-type half-life decay
 - Lock floor (a `user`-locked belief does not decay)
 - Broker-confidence-attenuated valence propagation through the belief graph
 - Retrieval (locked-belief auto-load + BM25 FTS5, token-budgeted) and the `apply_feedback` endpoint (Beta-Bernoulli updates + demotion-pressure auto-demote)
-- Onboarding scanner (filesystem walk + git log + AST extractors), `cli.py` (10 commands), `mcp_server.py` (8 tools, `[mcp]` extra), and 10 slash commands under `slash_commands/`
+- Onboarding scanner (filesystem walk + git log + AST extractors), `cli.py` (11 commands), `mcp_server.py` (8 tools, `[mcp]` extra), and 11 slash commands under `slash_commands/`
 - Claude Code wiring: `aelf setup` / `aelf unsetup` install or remove a `UserPromptSubmit` hook in Claude Code's `settings.json`; `aelf-hook` is the script entry-point that reads the hook payload, runs retrieval, and emits an `<aelfrice-memory>` block as injected context
+- Benchmark harness: `aelf bench` runs a deterministic 16-belief × 16-query corpus and prints a single JSON document (`hit_at_1` / `hit_at_3` / `hit_at_5` / `mrr` + `p50_latency_ms` / `p99_latency_ms`). Reproducible across runs against fresh in-memory stores.
 - Project metadata: `LICENSE` (MIT), `CHANGELOG.md` (Keep-a-Changelog), `docs/INSTALL.md`, `docs/ARCHITECTURE.md`, and PyPI-ready `pyproject.toml` (description, authors, keywords, 13 classifiers, project URLs)
-- ~500 test functions across the unit suite, including 3 pre-registered property tests (Bayesian inertia, decay necessity, lock-floor sharpness) and end-to-end regression scenarios for retrieval, feedback, onboarding, and the Claude Code setup→hook→unsetup round-trip
+- ~530 test functions across the unit suite, including 3 pre-registered property tests (Bayesian inertia, decay necessity, lock-floor sharpness) and end-to-end regression scenarios for retrieval, feedback, onboarding, the Claude Code setup→hook→unsetup round-trip, and the `aelf bench` CLI
 
-What does NOT work yet: install via `pip` (PyPI publish gated until v1.0.0), and the v0.9.0-rc benchmark harness. Until then, install editable from source (`uv pip install -e .`) and run `aelf setup` to wire the hook into Claude Code.
+What does NOT work yet: install via `pip` (PyPI publish gated until `v1.0.0` tag). Until then, install editable from source (`uv pip install -e .`) and run `aelf setup` to wire the hook into Claude Code.
 
 ## docs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "0.8.0"
+version = "0.9.0rc0"
 description = "Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aelfrice/__init__.py
+++ b/src/aelfrice/__init__.py
@@ -1,2 +1,2 @@
 """aelfrice: Bayesian memory designed for feedback-driven learning."""
-__version__ = "0.8.0"
+__version__ = "0.9.0rc0"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aelfrice"
-version = "0.8.0"
+version = "0.9.0rc0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
Marks the **v0.9.0-rc — benchmark harness** milestone shipped on main. The roadmap row's "v0.9.0-rc" label maps to PEP 440 canonical `0.9.0rc0` for `pyproject.toml` / `__version__` / git tag, since `0.9.0-rc` is not a valid PEP 440 version.

Bumps:
- `pyproject.toml` `version`: `0.8.0` → `0.9.0rc0`
- `src/aelfrice/__init__.__version__`: `0.8.0` → `0.9.0rc0`
- `uv.lock` editable entry resynced

## What landed in v0.9.0-rc
PR #50 — see CHANGELOG `[0.9.0rc0]` section for the full breakdown.

## Honest constraint on the score
The CHANGELOG `Notes` paragraph (and the benchmark module docstring) records the v1.0-line constraint explicitly: retrieval ranking is BM25-only (`store.search_beliefs` orders by `bm25(beliefs_fts)`; posterior `α`/`β` are not consumed), so `apply_feedback` does not currently move benchmark scores. The harness is the measurement instrument; the v1.x retrieval upgrade is the precondition for using it to claim feedback drives accuracy.

## Test plan
- [x] `uv run pytest` — 530/530 pass
- [x] `uv run pyright` — strict mode, 0 errors
- [x] `uv run python -c "import aelfrice; print(aelfrice.__version__)"` returns `0.9.0rc0`
- [x] `uv run aelf bench` returns a hit@5 = 1.0 / MRR = 1.0 / p99 < 1ms JSON document
- [ ] CI: pytest 3.12 / 3.13, secrets-scan, pattern-scan, history-scan

## Tag
After merge: `git tag v0.9.0rc0 && git push github v0.9.0rc0`. Per CLAUDE.md release process, the publish workflow stays dormant until `v1.0.0`.

## Next
**v1.0.0** is the only remaining milestone. The CLAUDE.md release process is:
1. Bump `pyproject.toml` to `1.0.0` and `uv lock`.
2. Commit on `release/v1.0.0` branch.
3. Open PR, merge once staging-gate passes.
4. `git tag v1.0.0 && git push github v1.0.0` — `.github/workflows/publish.yml` triggers on `v*` tags and publishes to PyPI via Trusted Publishing.

The Trusted Publisher setup is a one-time PyPI web-UI step and is documented as deferred until v1.0.0 in CLAUDE.md. We can do that web-UI step before or after merging the v1.0.0 PR; the workflow only fires on the tag push.