### PR TITLE
release: v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-04-27
+
+First installable PyPI release. The full v1.0 surface is the cumulative
+shipped contents of v0.1.0–v0.9.0rc0; this release tags it, builds the
+sdist + wheel, and publishes via the GitHub Actions Trusted Publisher
+workflow.
+
+### Added
+
+- PyPI publication: `pip install aelfrice` (`pip install "aelfrice[mcp]"`
+  for the MCP server extra).
+
+### Changed
+
+- Trove `Development Status` classifier promoted from `4 - Beta` to
+  `5 - Production/Stable`.
+- README headline and tagline rewritten for a post-rebuild audience:
+  install instruction front-and-centre, "Status: under active rebuild"
+  warning removed, "What works today" section retitled to v1.0.0.
+
 ## [0.9.0rc0] - 2026-04-26
 
 Benchmark-harness milestone — final gate before `v1.0.0`. The `v0.9.0-rc`
@@ -223,7 +243,8 @@ Foundation milestone — store, models, config.
 - Initial repo scaffold: pyproject, README, GitHub Actions workflows,
   scan configs (commit `67b4343`).
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v0.9.0rc0...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/robotrocketscience/aelfrice/compare/v0.9.0rc0...v1.0.0
 [0.9.0rc0]: https://github.com/robotrocketscience/aelfrice/compare/v0.8.0...v0.9.0rc0
 [0.8.0]: https://github.com/robotrocketscience/aelfrice/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/robotrocketscience/aelfrice/releases/tag/v0.7.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # aelfrice
 
-**Bayesian memory designed for feedback-driven learning.** Today: knowledge store, retrieval, feedback loop, scanner, CLI, MCP server, Claude Code wiring, docs, LICENSE, CHANGELOG, and benchmark harness all landed on `main`. Next: tag `v1.0.0` and publish to PyPI.
+**Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven.** v1.0.0 is the first installable release on PyPI: `pip install aelfrice`. The full v1.0 surface is the local SQLite store, retrieval (L0 locked + L1 FTS5 BM25), the `apply_feedback` endpoint, the onboarding scanner, an 11-command CLI, an MCP server, Claude Code wiring, and a reproducible benchmark harness.
 
-> ⚠️ **Status: under active rebuild — do not depend on this for production.** The first installable release is `v1.0.0`; until then, modules land milestone-by-milestone. The previous codebase (`v2.0`) is preserved at [`aelfrice-v0`](https://github.com/robotrocketscience/aelfrice-v0) (archived, read-only).
+> The previous codebase (`v2.0` line) is preserved at [`aelfrice-v0`](https://github.com/robotrocketscience/aelfrice-v0) (archived, read-only). The `v1.x` series will recover `v2.0` features incrementally with evidence justifying each addition.
 
 ## Why aelfrice
 
@@ -13,7 +13,7 @@ LLM agents repeatedly forget what they learned. Vector-RAG remembers documents b
 - Let you **lock** beliefs you trust as ground truth. Lock floor short-circuits decay. Contradicting feedback against a locked belief accumulates `demotion_pressure`; cross a threshold and the lock auto-demotes.
 - Stay local. Pure stdlib SQLite. No vector DB, no embeddings, no cloud sync. Local-only is a feature.
 
-The central claim — that a memory which actually applies feedback outperforms one that doesn't — will be testable end-to-end at `v1.0.0`.
+The central claim — that a memory which actually applies feedback outperforms one that doesn't — is what the post-`v1.0.0` retrieval upgrade will measure end-to-end against the `v0.9.0-rc` benchmark harness. v1.0.0 itself ships the harness as a reproducible measurement instrument; retrieval ranking is BM25-only at this version, so feedback does not yet move benchmark scores.
 
 ## v1.0.0 milestone roadmap
 
@@ -30,11 +30,11 @@ The rebuild is structured as a sequence of small, atomic milestones.
 | **v0.7.0** | shipped | `setup.py` — Claude Code wiring (`UserPromptSubmit` hook for retrieval injection) + `aelfrice.hook` entry-point + `aelf setup` / `aelf unsetup` CLI + `aelf-hook` script |
 | **v0.8.0** | shipped | docs (`docs/INSTALL.md`, `docs/ARCHITECTURE.md`), `CHANGELOG.md`, `LICENSE` (MIT), PyPI-ready `pyproject.toml` metadata |
 | **v0.9.0-rc** (`0.9.0rc0`) | shipped | `aelfrice.benchmark` + `aelf bench` — 16-belief × 16-query reproducible JSON score harness with hit@1 / hit@3 / hit@5 / MRR + p50 / p99 latency |
-| **v1.0.0** | next | tag, push, PyPI publish |
+| **v1.0.0** | shipped | tag, push, PyPI publish — `pip install aelfrice` |
 
 After `v1.0.0`, the `v1.x` series recovers `v2.0` features incrementally with evidence justifying each addition.
 
-## What works today (v0.9.0rc0)
+## What works today (v1.0.0)
 
 - SQLite-backed Belief and Edge storage with WAL journaling and FTS5 search
 - Beta-Bernoulli confidence math; per-type half-life decay
@@ -47,7 +47,7 @@ After `v1.0.0`, the `v1.x` series recovers `v2.0` features incrementally with ev
 - Project metadata: `LICENSE` (MIT), `CHANGELOG.md` (Keep-a-Changelog), `docs/INSTALL.md`, `docs/ARCHITECTURE.md`, and PyPI-ready `pyproject.toml` (description, authors, keywords, 13 classifiers, project URLs)
 - ~530 test functions across the unit suite, including 3 pre-registered property tests (Bayesian inertia, decay necessity, lock-floor sharpness) and end-to-end regression scenarios for retrieval, feedback, onboarding, the Claude Code setup→hook→unsetup round-trip, and the `aelf bench` CLI
 
-What does NOT work yet: install via `pip` (PyPI publish gated until `v1.0.0` tag). Until then, install editable from source (`uv pip install -e .`) and run `aelf setup` to wire the hook into Claude Code.
+Install: `pip install aelfrice` (or `uv pip install aelfrice`). Optional: `pip install "aelfrice[mcp]"` for the MCP server. Run `aelf setup` after install to wire the `UserPromptSubmit` hook into Claude Code.
 
 ## docs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "0.9.0rc0"
+version = "1.0.0"
 description = "Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -22,7 +22,7 @@ keywords = [
     "sqlite",
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",

--- a/src/aelfrice/__init__.py
+++ b/src/aelfrice/__init__.py
@@ -1,2 +1,2 @@
 """aelfrice: Bayesian memory designed for feedback-driven learning."""
-__version__ = "0.9.0rc0"
+__version__ = "1.0.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aelfrice"
-version = "0.9.0rc0"
+version = "1.0.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
**First installable PyPI release.** The full v1.0 surface is the cumulative shipped contents of v0.1.0–v0.9.0rc0; this PR tags it.

## Changes
- `pyproject.toml`: version `0.9.0rc0` → `1.0.0`; Trove `Development Status` `4 - Beta` → `5 - Production/Stable`.
- `src/aelfrice/__init__.__version__` and `uv.lock` synced to `1.0.0`.
- README rewritten for post-rebuild audience: install instruction (`pip install aelfrice`) is now the headline; "Status: under active rebuild" warning removed; central-claim paragraph reframed (v1.0.0 ships the harness as a measurement instrument; the post-v1.0.0 retrieval upgrade is what will score the with-feedback claim end-to-end); v1.0.0 roadmap row flips `next` → `shipped`; "What works today" retitled to v1.0.0; install guidance switches from editable-only to PyPI.
- `CHANGELOG`: new `[1.0.0]` section.

## Verification (local)
- [x] `uv run pytest` — 530/530 pass
- [x] `uv run pyright` — strict mode, 0 errors
- [x] `uv run python -c "import aelfrice; print(aelfrice.__version__)"` returns `1.0.0`
- [x] `uv build` produces `dist/aelfrice-1.0.0.tar.gz` and `dist/aelfrice-1.0.0-py3-none-any.whl`
- [ ] CI: pytest 3.12 / 3.13, secrets-scan, pattern-scan, history-scan

## Tag + publish flow
After this PR merges:

```
git tag v1.0.0 && git push github v1.0.0
```

That fires `.github/workflows/publish.yml`. Repo is public now, so the `actions/attest-build-provenance@v1` step that failed on the v0.7.0 / v0.8.0 tag pushes will succeed. The PyPI Trusted Publisher path is exercised for the first time on this tag — if it's not yet configured at `pypi.org/manage/project/aelfrice/settings/publishing/`, the workflow will fail at the `pypa/gh-action-pypi-publish` step.