### PR TITLE
feat: P2 ingest shim — adapters import cleanly

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -14,33 +14,56 @@ which is a small in-tree corpus that runs in CI on every PR.
 | Synthetic regression | `src/aelfrice/benchmark.py` | Catch retrieval/scoring regressions | <1s | $0 |
 | Academic suite | `benchmarks/` (here) | Reproduce website headline numbers | minutes–hours | LLM API spend |
 
-## Activation status (aelfrice v1.0.0)
+## Activation status (aelfrice v1.0.x post-P2 ingest shim)
 
 The adapters were ported from the private lab repo
-(`aelfrice-lab/benchmarks/`) where they target lab v2.0.0. They
-require modules that have not yet ported into the public v1.0.0
-release. They are present in the public tree as **scaffold for
-future activation**, not because they currently run.
+(`aelfrice-lab/benchmarks/`) where they target lab v2.0.0. P2
+landed an ingest-pipeline shim (`aelfrice.ingest.ingest_turn`,
+`aelfrice.extraction`, `MemoryStore.create_session`) so all five
+academic adapters now **import successfully**. End-to-end runs
+remain blocked on per-adapter issues:
 
-| File | Status | Activates in |
-|---|---|---|
-| `verify_clean.py` | **runnable** | v1.1.0 (P1) |
-| `mab_adapter.py` | inert — needs `aelfrice.ingest`, `MemoryStore` | v1.2.0 (P2) |
-| `mab_reader.py` | runnable (stdlib + `anthropic` only) | v1.1.0 (P1) |
-| `locomo_adapter.py` | inert — needs `aelfrice.ingest`, `MemoryStore` | v1.2.0 (P2) |
-| `locomo_generate.py` | runnable (stdlib only) | v1.1.0 (P1) |
-| `locomo_score.py` | inert — depends on `locomo_adapter` symbols | v1.2.0 (P2) |
-| `locomo_score_protocol.py` | inert — depends on `locomo_adapter` symbols | v1.2.0 (P2) |
-| `longmemeval_adapter.py` | inert — needs `aelfrice.ingest`, `MemoryStore` | v1.2.0 (P2) |
-| `longmemeval_budget_sweep.py` | inert — depends on adapter | v1.2.0 (P2) |
-| `longmemeval_score.py` | runnable (stdlib only) | v1.1.0 (P1) |
-| `structmemeval_adapter.py` | inert — needs `aelfrice.ingest`, `MemoryStore` | v1.2.0 (P2) |
-| `amabench_adapter.py` | inert — needs `aelfrice.ingest`, `MemoryStore` | v1.2.0 (P2) |
+| File | Imports | End-to-end | Notes |
+|---|---|---|---|
+| `verify_clean.py` | OK | runs | stdlib only |
+| `mab_adapter.py` | needs `nltk` + `tiktoken` | blocked | retrieval kwargs `budget`/`use_hrr`/`use_bfs` differ from public `retrieve(token_budget=...)` |
+| `mab_reader.py` | needs `anthropic` (already a dep) | runs | LLM reader; not an aelfrice ingest path |
+| `locomo_adapter.py` | needs `nltk` | blocked | same retrieval-kwarg gap |
+| `locomo_generate.py` | OK | runs | stdlib only |
+| `locomo_score.py` | needs `nltk` (via adapter) | blocked | scoring depends on adapter symbols |
+| `locomo_score_protocol.py` | same | blocked | same |
+| `longmemeval_adapter.py` | OK | blocked | retrieval-kwarg gap |
+| `longmemeval_budget_sweep.py` | OK | blocked | depends on adapter |
+| `longmemeval_score.py` | OK | runs | stdlib only |
+| `structmemeval_adapter.py` | OK | blocked | retrieval-kwarg gap |
+| `amabench_adapter.py` | needs `datasets` (HuggingFace) | blocked | retrieval-kwarg gap |
 
 Three additional adapters from the lab (`mab_triple_adapter.py`,
 `mab_entity_index_adapter.py`, `mab_llm_entity_adapter.py`) are
-**not yet present**; they require triple-extraction (P2) and
-entity-index retrieval (P3) and will land alongside those features.
+**not yet present**; they require triple-extraction (P3) and
+entity-index retrieval (P4) and will land alongside those features.
+
+### Remaining blockers for end-to-end runs
+
+1. **Optional dependencies.** `nltk`, `tiktoken`, `datasets`. Add to
+   `[project.optional-dependencies] benchmarks` and require
+   `pip install aelfrice[benchmarks]` for end-to-end use.
+2. **Retrieval-kwarg gap.** Adapters call:
+
+   ```python
+   result = retrieve(store=store, query=q, budget=N,
+                     include_locked=False, use_hrr=True, use_bfs=True)
+   parts = [b.content for b in result.beliefs]
+   ```
+
+   Public v1.0.x `retrieve` returns `list[Belief]` directly and
+   accepts `token_budget` (not `budget`); has no `include_locked`,
+   `use_hrr`, or `use_bfs`. Two paths to close this:
+   - Patch each adapter to use the public signature (intrusive).
+   - Add `aelfrice.retrieval.retrieve_v2(...)` wrapper with the
+     lab signature; HRR/BFS flags no-op until ported. (Recommended.)
+
+   This wrapper is the next chunk of P2 (or rolled into P3).
 
 ## Missing public-surface dependencies
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -48,9 +48,12 @@ The adapters import the following lab-side modules that have not
 yet ported to the public v1.0.0 release:
 
 - `aelfrice.ingest` — `ingest_turn()` end-to-end ingest pipeline
-- `aelfrice.store.MemoryStore` — public v1.0.0 ships `Store` (rename or alias pending)
 - (transitively) `aelfrice.extraction`, `aelfrice.relationship_detector`,
   `aelfrice.supersession`, `aelfrice.triple_extraction`
+
+The `Store` → `MemoryStore` rename landed in P2 (`feat/p2-ingest-port`)
+ahead of the ingest port itself; adapters now find the class they
+expect.
 
 These ports are scheduled in P2/P3/P4 of the v2.0.0 milestone plan
 (see private `aelfrice-lab/docs/V2_BENCHMARK_MILESTONE_PLAN.md`).

--- a/src/aelfrice/benchmark.py
+++ b/src/aelfrice/benchmark.py
@@ -41,7 +41,7 @@ from typing import Final
 
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
 from aelfrice.retrieval import retrieve
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 BENCHMARK_NAME: Final[str] = "aelfrice-bench-v1"
 """Stable identifier for this benchmark configuration.
@@ -154,7 +154,7 @@ class BenchmarkReport:
 # --- Harness ----------------------------------------------------------
 
 
-def seed_corpus(store: Store, *, created_at: str = "2026-04-26T00:00:00Z") -> int:
+def seed_corpus(store: MemoryStore, *, created_at: str = "2026-04-26T00:00:00Z") -> int:
     """Insert the deterministic benchmark corpus into `store`.
 
     Inserts each `_CorpusEntry` as an unlocked factual belief with
@@ -182,7 +182,7 @@ def seed_corpus(store: Store, *, created_at: str = "2026-04-26T00:00:00Z") -> in
 
 
 def run_benchmark(
-    store: Store,
+    store: MemoryStore,
     *,
     aelfrice_version: str,
     top_k: int = DEFAULT_TOP_K,

--- a/src/aelfrice/classification.py
+++ b/src/aelfrice/classification.py
@@ -47,7 +47,7 @@ from aelfrice.models import (
 )
 
 if TYPE_CHECKING:
-    from aelfrice.store import Store
+    from aelfrice.store import MemoryStore
 
 # --- Priors (per Exp 61, restricted to v1.0's 4-type catalog) -----------
 
@@ -363,7 +363,7 @@ def _content_hash(text: str) -> str:
 
 
 def start_onboard_session(
-    store: "Store",
+    store: "MemoryStore",
     repo_path: Path,
     *,
     now: str | None = None,
@@ -435,7 +435,7 @@ def start_onboard_session(
 
 
 def accept_classifications(
-    store: "Store",
+    store: "MemoryStore",
     session_id: str,
     classifications: list[HostClassification],
     *,

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -50,7 +50,7 @@ from aelfrice.setup import (
     install_user_prompt_submit_hook,
     uninstall_user_prompt_submit_hook,
 )
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 DEFAULT_DB_DIR: Final[Path] = Path.home() / ".aelfrice"
 DEFAULT_DB_FILENAME: Final[str] = "memory.db"
@@ -72,11 +72,11 @@ def _ensure_parent_dir(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
 
-def _open_store() -> Store:
+def _open_store() -> MemoryStore:
     p = db_path()
     if str(p) != ":memory:":
         _ensure_parent_dir(p)
-    return Store(str(p))
+    return MemoryStore(str(p))
 
 
 def _utc_now_iso() -> str:
@@ -283,7 +283,7 @@ def _cmd_bench(args: argparse.Namespace, out: object) -> int:
 
     if target == "synthetic":
         db = ":memory:" if args.db is None else str(Path(args.db))
-        store = Store(db)
+        store = MemoryStore(db)
         try:
             seed_corpus(store)
             report = run_benchmark(

--- a/src/aelfrice/extraction.py
+++ b/src/aelfrice/extraction.py
@@ -1,0 +1,71 @@
+"""Sentence extraction from conversation text.
+
+Implements the Exp 57/61 dumb extraction pipeline: strip noise, split on boundaries,
+discard fragments. No classification, no keyword filtering.
+"""
+from __future__ import annotations
+
+import re
+
+
+# Minimum character length for a sentence fragment to be kept.
+_MIN_LEN: int = 10
+
+
+def extract_sentences(text: str) -> list[str]:
+    """Extract atomic sentences from conversation text.
+
+    Process:
+    1. Strip code blocks (triple-backtick regions)
+    2. Strip inline code backticks but keep surrounding text
+    3. Strip URLs
+    4. Strip markdown formatting (headers, bold, italic, table rows, list markers)
+    5. Split on newlines first
+    6. Within each line, split on sentence-ending punctuation followed by space
+    7. Discard fragments under 10 characters
+
+    Returns list of clean sentences.
+    """
+    # Step 1: strip code blocks (triple-backtick regions, including language tag)
+    cleaned: str = re.sub(r"```[\s\S]*?```", " ", text)
+
+    # Step 2: strip inline code backticks, keep surrounding text
+    cleaned = re.sub(r"`[^`]*`", " ", cleaned)
+
+    # Step 3: strip URLs
+    cleaned = re.sub(r"https?://\S+", " ", cleaned)
+
+    # Step 4: strip markdown formatting
+    # Headers: lines starting with one or more # characters
+    cleaned = re.sub(r"^#{1,6}\s+", "", cleaned, flags=re.MULTILINE)
+    # Bold: **text** or __text__
+    cleaned = re.sub(r"\*{2}([^*]*)\*{2}", r"\1", cleaned)
+    cleaned = re.sub(r"_{2}([^_]*)_{2}", r"\1", cleaned)
+    # Italic: *text* or _text_ (single, not double)
+    cleaned = re.sub(r"\*([^*]+)\*", r"\1", cleaned)
+    cleaned = re.sub(r"_([^_]+)_", r"\1", cleaned)
+    # Markdown table rows: lines containing | characters
+    cleaned = re.sub(r"^\s*\|.*\|\s*$", " ", cleaned, flags=re.MULTILINE)
+    # List markers: leading -, *, +, or numbered list items
+    cleaned = re.sub(r"^[ \t]*[-*+]\s+", "", cleaned, flags=re.MULTILINE)
+    cleaned = re.sub(r"^[ \t]*\d+\.\s+", "", cleaned, flags=re.MULTILINE)
+
+    # Step 5: split on newlines first
+    lines: list[str] = cleaned.splitlines()
+
+    sentences: list[str] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+
+        # Step 6: within each line, split on sentence-ending punctuation followed by space
+        # Use re.split with a lookbehind so the punctuation stays with the preceding sentence.
+        parts: list[str] = re.split(r"(?<=[.!?])\s+", line)
+        for part in parts:
+            part = part.strip()
+            # Step 7: discard fragments under 10 characters
+            if len(part) >= _MIN_LEN:
+                sentences.append(part)
+
+    return sentences

--- a/src/aelfrice/feedback.py
+++ b/src/aelfrice/feedback.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from typing import Final
 
 from aelfrice.models import EDGE_CONTRADICTS, LOCK_NONE, LOCK_USER, Belief
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 DEMOTION_THRESHOLD: int = 5
 
@@ -63,7 +63,7 @@ def _bayesian_update(b: Belief, valence: float) -> tuple[float, float]:
 
 
 def _pressure_and_maybe_demote(
-    store: Store, source_id: str
+    store: MemoryStore, source_id: str
 ) -> tuple[list[str], list[str]]:
     """For each outbound CONTRADICTS edge from source_id whose dst is a
     user-locked belief, increment that belief's demotion_pressure by 1.
@@ -104,7 +104,7 @@ def _pressure_and_maybe_demote(
 
 
 def apply_feedback(
-    store: Store,
+    store: MemoryStore,
     belief_id: str,
     valence: float,
     source: str,

--- a/src/aelfrice/health.py
+++ b/src/aelfrice/health.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 # E43: minimum belief count below which the classifier reports
 # `insufficient_data` instead of forcing a regime label. Lowered from
@@ -103,7 +103,7 @@ def _median(sorted_values: list[float]) -> float:
     return (sorted_values[n // 2 - 1] + sorted_values[n // 2]) / 2.0
 
 
-def compute_features(store: Store) -> HealthFeatures:
+def compute_features(store: MemoryStore) -> HealthFeatures:
     """Roll up the store into the five-feature vector the classifier
     consumes. Pure function of the current store state.
 
@@ -212,7 +212,7 @@ def classify_regime(features: HealthFeatures) -> HealthReport:
     )
 
 
-def assess_health(store: Store) -> HealthReport:
+def assess_health(store: MemoryStore) -> HealthReport:
     """Single-call convenience: compute features then classify.
 
     Pure function over the current store state. Deterministic for any

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -29,7 +29,7 @@ from typing import IO, Final, cast
 from aelfrice.cli import db_path
 from aelfrice.models import LOCK_USER, Belief
 from aelfrice.retrieval import retrieve
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 DEFAULT_HOOK_TOKEN_BUDGET: Final[int] = 1500
 """Conservative default budget for hook-injected context.
@@ -118,11 +118,11 @@ def _format_hits(hits: list[Belief]) -> str:
     return "\n".join(lines)
 
 
-def _open_store() -> Store:
+def _open_store() -> MemoryStore:
     p = db_path()
     if str(p) != ":memory:":
         p.parent.mkdir(parents=True, exist_ok=True)
-    return Store(str(p))
+    return MemoryStore(str(p))
 
 
 def main() -> int:

--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -1,0 +1,106 @@
+"""Ingest pipeline: split a conversation turn into sentences,
+classify each, and insert classified sentences as beliefs.
+
+This module is a deliberate **shim**, not a literal port of lab
+v2.0.0's ingest pipeline. The public v1.0.0 schema does not model
+observations, sessions, evidence, or audit logs as separate
+tables; lab v2.0.0 does. Rather than invert v1.0.0's deliberate
+slim-down, ingest_turn here lowers conversation turns directly to
+the existing `beliefs` table via the public classification API
+(`classify_sentence`, one sentence at a time) instead of lab's
+`classify_sentences_offline` batch path.
+
+The signature is kept compatible with the lab adapters in
+`benchmarks/` so they import successfully without modification:
+
+    ingest_turn(store, text, source, session_id, created_at, source_id)
+
+`session_id` and `source_id` are accepted but not persisted at
+v1.0.x. They reappear as belief metadata when (or if) the schema
+gains source-tracking columns.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+
+from aelfrice.classification import classify_sentence
+from aelfrice.extraction import extract_sentences
+from aelfrice.models import LOCK_NONE, Belief
+from aelfrice.store import MemoryStore
+
+_BELIEF_ID_HEX_LEN: int = 16
+
+
+def _belief_id(text: str, source: str) -> str:
+    """Stable id derived from (source, text). Matches the scheme used
+    by classification._derive_belief_id and scanner._derive_belief_id
+    so re-ingesting an identical (text, source) pair is idempotent."""
+    h = hashlib.sha256(f"{source}\x00{text}".encode("utf-8")).hexdigest()
+    return h[:_BELIEF_ID_HEX_LEN]
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _now_utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ingest_turn(
+    store: MemoryStore,
+    text: str,
+    source: str,
+    session_id: str | None = None,  # noqa: ARG001
+    created_at: str | None = None,
+    source_id: str = "",  # noqa: ARG001
+) -> int:
+    """Ingest a single conversation turn.
+
+    Steps:
+      1. Sentence-split via :func:`aelfrice.extraction.extract_sentences`.
+      2. Classify each sentence via :func:`aelfrice.classification.classify_sentence`.
+      3. Insert classifications with `persist=True` as beliefs.
+
+    Idempotent on (source, sentence) pairs: re-ingesting the same turn
+    triggers `INSERT OR IGNORE` semantics in the store (belief id
+    derives from the sha256 of source + sentence). Sentences whose
+    classification returns `persist=False` (questions, empty text) are
+    skipped.
+
+    `session_id` and `source_id` are accepted for adapter parity with
+    lab v2.0.0 but are not stored at v1.0.x.
+
+    Returns the number of beliefs inserted (or that would have been
+    inserted if not already present).
+    """
+    sentences = extract_sentences(text)
+    if not sentences:
+        return 0
+
+    ts = created_at or _now_utc_iso()
+    inserted = 0
+    for sentence in sentences:
+        result = classify_sentence(sentence, source)
+        if not result.persist:
+            continue
+        belief_id = _belief_id(sentence, source)
+        if store.get_belief(belief_id) is not None:
+            continue  # idempotent: same (source, sentence) already ingested
+        belief = Belief(
+            id=belief_id,
+            content=sentence,
+            content_hash=_content_hash(sentence),
+            alpha=result.alpha,
+            beta=result.beta,
+            type=result.belief_type,
+            lock_level=LOCK_NONE,
+            locked_at=None,
+            demotion_pressure=0,
+            created_at=ts,
+            last_retrieved_at=None,
+        )
+        store.insert_belief(belief)
+        inserted += 1
+    return inserted

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -3,7 +3,7 @@
 
 The same surface as the CLI, accessible from any host that speaks the
 Model Context Protocol. The handlers are pure Python — they take a
-`Store` plus structured args and return JSON-shaped dicts. The thin
+`MemoryStore` plus structured args and return JSON-shaped dicts. The thin
 `serve()` shim opens a per-process store at the default path and
 registers the pure handlers as FastMCP tools.
 
@@ -58,7 +58,7 @@ from aelfrice.models import (
 )
 from aelfrice.retrieval import DEFAULT_TOKEN_BUDGET, retrieve
 from aelfrice.scanner import scan_repo
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 _FEEDBACK_VALENCES: Final[dict[str, float]] = {"used": 1.0, "harmful": -1.0}
 _LOCK_ID_LEN: Final[int] = 16
@@ -83,11 +83,11 @@ def _ensure_parent_dir(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
 
-def _open_default_store() -> Store:
+def _open_default_store() -> MemoryStore:
     p = db_path()
     if str(p) != ":memory:":
         _ensure_parent_dir(p)
-    return Store(str(p))
+    return MemoryStore(str(p))
 
 
 # --- Pure tool handlers (test target) ----------------------------------
@@ -98,7 +98,7 @@ def _open_default_store() -> Store:
 
 
 def tool_onboard(
-    store: Store,
+    store: MemoryStore,
     *,
     path: str | None = None,
     session_id: str | None = None,
@@ -117,7 +117,7 @@ def tool_onboard(
     return _onboard_status(store)
 
 
-def _onboard_start(store: Store, repo_path: str) -> dict[str, Any]:
+def _onboard_start(store: MemoryStore, repo_path: str) -> dict[str, Any]:
     # CI / no-host-agent environments use scan_repo for sync onboarding;
     # the polymorphic state machine is for hosts that can classify in
     # their own context. The MCP server always has a host (that's what
@@ -137,7 +137,7 @@ def _onboard_start(store: Store, repo_path: str) -> dict[str, Any]:
 
 
 def _onboard_accept(
-    store: Store,
+    store: MemoryStore,
     session_id: str,
     classifications: Sequence[dict[str, Any]],
 ) -> dict[str, Any]:
@@ -161,7 +161,7 @@ def _onboard_accept(
     }
 
 
-def _onboard_status(store: Store) -> dict[str, Any]:
+def _onboard_status(store: MemoryStore) -> dict[str, Any]:
     pending = store.list_pending_onboard_sessions()
     return {
         "kind": "onboard.status",
@@ -170,7 +170,7 @@ def _onboard_status(store: Store) -> dict[str, Any]:
     }
 
 
-def tool_onboard_sync(store: Store, *, path: str) -> dict[str, Any]:
+def tool_onboard_sync(store: MemoryStore, *, path: str) -> dict[str, Any]:
     """Synchronous fallback that runs the regex-classifier pipeline
     instead of the host handshake. Exposed for hosts that explicitly
     want the no-LLM onboard path (CI runs, scripted setup). Not a
@@ -187,7 +187,7 @@ def tool_onboard_sync(store: Store, *, path: str) -> dict[str, Any]:
 
 
 def tool_search(
-    store: Store, *, query: str, budget: int = DEFAULT_TOKEN_BUDGET,
+    store: MemoryStore, *, query: str, budget: int = DEFAULT_TOKEN_BUDGET,
 ) -> dict[str, Any]:
     hits = retrieve(store, query, token_budget=budget)
     return {
@@ -205,7 +205,7 @@ def tool_search(
     }
 
 
-def tool_lock(store: Store, *, statement: str) -> dict[str, Any]:
+def tool_lock(store: MemoryStore, *, statement: str) -> dict[str, Any]:
     bid = _lock_id_for(statement)
     existing = store.get_belief(bid)
     now = _utc_now_iso()
@@ -232,7 +232,7 @@ def tool_lock(store: Store, *, statement: str) -> dict[str, Any]:
 
 
 def tool_locked(
-    store: Store, *, pressured: bool = False,
+    store: MemoryStore, *, pressured: bool = False,
 ) -> dict[str, Any]:
     locked = store.list_locked_beliefs()
     if pressured:
@@ -252,7 +252,7 @@ def tool_locked(
     }
 
 
-def tool_demote(store: Store, *, belief_id: str) -> dict[str, Any]:
+def tool_demote(store: MemoryStore, *, belief_id: str) -> dict[str, Any]:
     belief = store.get_belief(belief_id)
     if belief is None:
         return {
@@ -275,7 +275,7 @@ def tool_demote(store: Store, *, belief_id: str) -> dict[str, Any]:
 
 
 def tool_feedback(
-    store: Store,
+    store: MemoryStore,
     *,
     belief_id: str,
     signal: str,
@@ -311,7 +311,7 @@ def tool_feedback(
     }
 
 
-def tool_stats(store: Store) -> dict[str, Any]:
+def tool_stats(store: MemoryStore) -> dict[str, Any]:
     return {
         "kind": "stats.snapshot",
         "beliefs": store.count_beliefs(),
@@ -322,7 +322,7 @@ def tool_stats(store: Store) -> dict[str, Any]:
     }
 
 
-def tool_health(store: Store) -> dict[str, Any]:
+def tool_health(store: MemoryStore) -> dict[str, Any]:
     report = assess_health(store)
     payload: dict[str, Any] = {
         "kind": "health.report",

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -126,3 +126,22 @@ class FeedbackEvent:
     valence: float
     source: str
     created_at: str
+
+
+@dataclass
+class Session:
+    """Ephemeral session identifier produced by MemoryStore.create_session.
+
+    The public v1.0.0 schema does not persist sessions; this dataclass
+    exists so academic-suite benchmark adapters that group ingest calls
+    by session_id (LongMemEval, LoCoMo, MAB, StructMemEval, AMA-Bench)
+    have a stable handle to pass through. Lab v2.0.0 persists this as
+    a full sessions table with token/correction/velocity tracking; the
+    public shim exposes only what the adapters consume.
+    """
+
+    id: str
+    started_at: str
+    completed_at: str | None
+    model: str | None
+    project_context: str | None

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from typing import Final
 
 from aelfrice.models import Belief
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 DEFAULT_TOKEN_BUDGET: Final[int] = 2000
 _CHARS_PER_TOKEN: Final[float] = 4.0
@@ -33,7 +33,7 @@ def _belief_tokens(b: Belief) -> int:
 
 
 def retrieve(
-    store: Store,
+    store: MemoryStore,
     query: str,
     token_budget: int = DEFAULT_TOKEN_BUDGET,
     l1_limit: int = DEFAULT_L1_LIMIT,

--- a/src/aelfrice/scanner.py
+++ b/src/aelfrice/scanner.py
@@ -8,7 +8,7 @@ Three extractors only in v1.0 (pre-commit `MVP_SCOPE.md`):
 Each extractor returns a list of `SentenceCandidate(text, source)`. The
 `scan_repo` orchestrator combines them, classifies each candidate via
 `classification.classify_sentence`, and inserts the persistable results
-as Beliefs into a Store.
+as Beliefs into a MemoryStore.
 
 The other five extractors from the previous codebase (HRR-related,
 doc-cross-reference, citation, sentence-decomposition, structural) are
@@ -27,7 +27,7 @@ from typing import Final
 
 from aelfrice.classification import classify_sentence
 from aelfrice.models import LOCK_NONE, Belief
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 # Directories the scanner never descends into. Standard "build artefact"
 # locations and version-control internals.
@@ -79,7 +79,7 @@ class SentenceCandidate:
 
 
 def scan_repo(
-    store: Store,
+    store: MemoryStore,
     root: Path,
     now: str | None = None,
 ) -> ScanResult:
@@ -88,7 +88,7 @@ def scan_repo(
 
     Idempotent: a belief id is `sha256(source\\x00text)[:16]`, so
     re-scanning the same tree produces no duplicates. Existing beliefs
-    are detected via `Store.get_belief(id)` and skipped.
+    are detected via `MemoryStore.get_belief(id)` and skipped.
 
     Non-persistable candidates (classifier returned `persist=False` —
     empty paragraphs, question-form sentences) are counted in

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -153,7 +153,7 @@ def _row_to_onboard_session(row: sqlite3.Row) -> OnboardSession:
     )
 
 
-class Store:
+class MemoryStore:
     """SQLite store. Pass `:memory:` for tests, a path otherwise."""
 
     def __init__(self, path: str) -> None:

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -14,7 +14,9 @@ suite locks that behaviour in from day one
 """
 from __future__ import annotations
 
+import secrets
 import sqlite3
+from datetime import datetime, timezone
 from typing import Iterable
 
 from aelfrice.models import (
@@ -25,6 +27,7 @@ from aelfrice.models import (
     Edge,
     FeedbackEvent,
     OnboardSession,
+    Session,
 )
 
 # --- Schema ---------------------------------------------------------------
@@ -553,3 +556,34 @@ class MemoryStore:
             (ONBOARD_STATE_PENDING,),
         )
         return [_row_to_onboard_session(r) for r in cur.fetchall()]
+
+    def create_session(
+        self,
+        model: str | None = None,
+        project_context: str | None = None,
+    ) -> Session:
+        """Create an ephemeral Session handle for grouping ingest calls.
+
+        The public v1.0.0 schema does not persist sessions; this returns
+        a Session dataclass with a fresh id but does not write to any
+        table. Academic-suite adapters use the id to tag belief metadata
+        (and call complete_session at the end of a logical group).
+        """
+        return Session(
+            id=secrets.token_hex(16),
+            started_at=datetime.now(timezone.utc).isoformat(),
+            completed_at=None,
+            model=model,
+            project_context=project_context,
+        )
+
+    def complete_session(self, session_id: str) -> None:  # noqa: ARG002
+        """No-op terminator paired with create_session.
+
+        Public v1.0.0 does not persist session lifecycle; this exists so
+        adapters porting from lab v2.0.0 do not need conditional logic.
+        Lab v2.0.0 uses this entry point to write completed_at, summary,
+        and velocity metrics; that behavior lands when (or if) the
+        sessions table ports to public.
+        """
+        return None

--- a/tests/regression/test_feedback_loop_end_to_end.py
+++ b/tests/regression/test_feedback_loop_end_to_end.py
@@ -26,18 +26,18 @@ from aelfrice.models import (
 )
 from aelfrice.retrieval import retrieve
 from aelfrice.scoring import posterior_mean
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 pytestmark = pytest.mark.regression
 
 
-def _seed_store() -> Store:
+def _seed_store() -> MemoryStore:
     """Common fixture: locked belief Y challenged by contradictor X.
 
     X has content matching the search query "main"; Y has content
     matching "master". Edge X -> Y CONTRADICTS. Y is user-locked.
     """
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(Belief(
         id="X",
         content="we always use main as the default branch name",
@@ -68,13 +68,13 @@ def _seed_store() -> Store:
     return s
 
 
-def _y(store: Store) -> Belief:
+def _y(store: MemoryStore) -> Belief:
     got = store.get_belief("Y")
     assert got is not None
     return got
 
 
-def _x(store: Store) -> Belief:
+def _x(store: MemoryStore) -> Belief:
     got = store.get_belief("X")
     assert got is not None
     return got

--- a/tests/regression/test_onboard_to_search_end_to_end.py
+++ b/tests/regression/test_onboard_to_search_end_to_end.py
@@ -27,7 +27,7 @@ import pytest
 from aelfrice.models import LOCK_USER
 from aelfrice.retrieval import retrieve
 from aelfrice.scanner import scan_repo
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 _GIT_AVAILABLE = shutil.which("git") is not None
 needs_git = pytest.mark.skipif(not _GIT_AVAILABLE, reason="git binary not on PATH")
@@ -84,14 +84,14 @@ def _seed_fixture(root: Path, with_git: bool = True) -> None:
 
 def test_scan_inserts_at_least_one_belief(tmp_path: Path) -> None:
     _seed_fixture(tmp_path, with_git=False)
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     result = scan_repo(s, tmp_path)
     assert result.inserted >= 1
 
 
 def test_doc_paragraph_lands_in_store(tmp_path: Path) -> None:
     _seed_fixture(tmp_path, with_git=False)
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     hits = s.search_beliefs("regex")
     assert len(hits) >= 1
@@ -99,7 +99,7 @@ def test_doc_paragraph_lands_in_store(tmp_path: Path) -> None:
 
 def test_module_docstring_lands_in_store(tmp_path: Path) -> None:
     _seed_fixture(tmp_path, with_git=False)
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     hits = s.search_beliefs("scanner")
     assert any("module exposes" in h.content for h in hits)
@@ -108,7 +108,7 @@ def test_module_docstring_lands_in_store(tmp_path: Path) -> None:
 @needs_git
 def test_git_commit_subject_lands_in_store(tmp_path: Path) -> None:
     _seed_fixture(tmp_path, with_git=True)
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     hits = s.search_beliefs("milestone")
     assert any("v0.5 milestone" in h.content for h in hits)
@@ -119,7 +119,7 @@ def test_git_commit_subject_lands_in_store(tmp_path: Path) -> None:
 
 def test_retrieve_finds_doc_belief_via_l1(tmp_path: Path) -> None:
     _seed_fixture(tmp_path, with_git=False)
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     hits = retrieve(s, query="regex", token_budget=10_000)
     contents = " ".join(h.content for h in hits)
@@ -130,7 +130,7 @@ def test_retrieve_query_with_no_match_returns_empty_when_no_locks(
     tmp_path: Path,
 ) -> None:
     _seed_fixture(tmp_path, with_git=False)
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     hits = retrieve(s, query="nonexistentterm12345", token_budget=10_000)
     assert hits == []
@@ -141,7 +141,7 @@ def test_retrieve_query_with_no_match_returns_empty_when_no_locks(
 
 def test_locked_scanned_belief_appears_first(tmp_path: Path) -> None:
     _seed_fixture(tmp_path, with_git=False)
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     docs = s.search_beliefs("regex")
     assert len(docs) >= 1
@@ -159,7 +159,7 @@ def test_locked_scanned_belief_appears_first(tmp_path: Path) -> None:
 
 def test_rescan_inserts_zero_new_beliefs(tmp_path: Path) -> None:
     _seed_fixture(tmp_path, with_git=False)
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     second = scan_repo(s, tmp_path)
     assert second.inserted == 0
@@ -167,7 +167,7 @@ def test_rescan_inserts_zero_new_beliefs(tmp_path: Path) -> None:
 
 def test_rescan_total_belief_set_unchanged(tmp_path: Path) -> None:
     _seed_fixture(tmp_path, with_git=False)
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     ids_one = {b.id for b in s.search_beliefs("regex")} | {
         b.id for b in s.search_beliefs("scanner")
@@ -190,7 +190,7 @@ def test_doc_and_git_with_overlapping_text_remain_distinct(
     text get stored as two distinct beliefs because the source-keyed
     id derivation distinguishes them."""
     _seed_fixture(tmp_path, with_git=True)
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     hits = s.search_beliefs("regex")
     sources_distinct = len({h.id for h in hits})
@@ -205,7 +205,7 @@ def test_question_in_doc_does_not_land(tmp_path: Path) -> None:
         "what is the project shipping at the next milestone?",
         encoding="utf-8",
     )
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     # Use a plain alphanumeric query to avoid FTS5 syntax characters.
     # The FTS5-escape bug surfaced by version-string queries like "v0.5"
@@ -228,7 +228,7 @@ def test_scanned_belief_can_be_locked_and_unlocked_by_demotion(
     from aelfrice.models import EDGE_CONTRADICTS, BELIEF_FACTUAL, Belief, Edge, LOCK_NONE
 
     _seed_fixture(tmp_path, with_git=False)
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     target = s.search_beliefs("regex")[0]
     target.lock_level = LOCK_USER

--- a/tests/regression/test_setup_hook_unsetup_end_to_end.py
+++ b/tests/regression/test_setup_hook_unsetup_end_to_end.py
@@ -37,7 +37,7 @@ import pytest
 from aelfrice.cli import main as cli_main
 from aelfrice.hook import CLOSE_TAG, OPEN_TAG
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 pytestmark = pytest.mark.regression
 
@@ -67,7 +67,7 @@ def _mk(
 def seeded_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """One locked belief + one FTS5-matchable unlocked belief."""
     db = tmp_path / "memory.db"
-    store = Store(str(db))
+    store = MemoryStore(str(db))
     try:
         store.insert_belief(
             _mk(

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -15,11 +15,11 @@ from aelfrice.benchmark import (
 )
 from aelfrice.benchmark import _percentile, _rank_of  # type: ignore[reportPrivateUsage]
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
-def _fresh_store(tmp_path: Path) -> Store:
-    return Store(str(tmp_path / "bench.db"))
+def _fresh_store(tmp_path: Path) -> MemoryStore:
+    return MemoryStore(str(tmp_path / "bench.db"))
 
 
 def _mk(bid: str, content: str) -> Belief:
@@ -128,8 +128,8 @@ def test_run_benchmark_is_deterministic(tmp_path: Path) -> None:
     """Two runs against fresh stores must produce identical
     accuracy scores. Latencies will differ; that's expected and
     handled at the percentile-only assertion above."""
-    s1 = Store(str(tmp_path / "a.db"))
-    s2 = Store(str(tmp_path / "b.db"))
+    s1 = MemoryStore(str(tmp_path / "a.db"))
+    s2 = MemoryStore(str(tmp_path / "b.db"))
     try:
         seed_corpus(s1)
         seed_corpus(s2)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ import pytest
 
 from aelfrice.cli import db_path, main
 from aelfrice.models import LOCK_USER
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 @pytest.fixture(autouse=True)
@@ -70,7 +70,7 @@ def test_onboard_inserts_beliefs_in_db(tmp_path: Path,
     code, out = _run("onboard", str(repo))
     assert code == 0
     assert "added" in out
-    s = Store(str(isolated_db))
+    s = MemoryStore(str(isolated_db))
     try:
         assert s.count_beliefs() >= 1
     finally:
@@ -84,7 +84,7 @@ def test_lock_inserts_locked_belief(isolated_db: Path) -> None:
     code, out = _run("lock", "we always sign commits with ssh")
     assert code == 0
     assert "locked:" in out
-    s = Store(str(isolated_db))
+    s = MemoryStore(str(isolated_db))
     try:
         assert s.count_locked() == 1
     finally:
@@ -106,7 +106,7 @@ def test_locked_pressured_filters_to_pressured_only(isolated_db: Path) -> None:
     assert "no pressured locks" in out
 
     # Manually pressure the lock so the next call sees it.
-    s = Store(str(isolated_db))
+    s = MemoryStore(str(isolated_db))
     try:
         for b in s.list_locked_beliefs():
             b.demotion_pressure = 2
@@ -120,7 +120,7 @@ def test_locked_pressured_filters_to_pressured_only(isolated_db: Path) -> None:
 
 def test_demote_removes_user_lock(isolated_db: Path) -> None:
     _run("lock", "we always sign commits with ssh")
-    s = Store(str(isolated_db))
+    s = MemoryStore(str(isolated_db))
     try:
         bid = s.list_locked_beliefs()[0].id
     finally:
@@ -128,7 +128,7 @@ def test_demote_removes_user_lock(isolated_db: Path) -> None:
     code, out = _run("demote", bid)
     assert code == 0
     assert "demoted" in out
-    s = Store(str(isolated_db))
+    s = MemoryStore(str(isolated_db))
     try:
         b = s.get_belief(bid)
         assert b is not None
@@ -147,7 +147,7 @@ def test_demote_already_unlocked_exits_zero_with_message(
 ) -> None:
     """Demoting a belief that is already unlocked is a no-op success."""
     _run("lock", "the source of truth is the manifest")
-    s = Store(str(isolated_db))
+    s = MemoryStore(str(isolated_db))
     try:
         bid = s.list_locked_beliefs()[0].id
     finally:
@@ -163,7 +163,7 @@ def test_demote_already_unlocked_exits_zero_with_message(
 
 def test_feedback_used_increments_alpha(isolated_db: Path) -> None:
     _run("lock", "the source of truth is the manifest")
-    s = Store(str(isolated_db))
+    s = MemoryStore(str(isolated_db))
     try:
         bid = s.list_locked_beliefs()[0].id
         pre = s.get_belief(bid)
@@ -173,7 +173,7 @@ def test_feedback_used_increments_alpha(isolated_db: Path) -> None:
         s.close()
     code, _ = _run("feedback", bid, "used")
     assert code == 0
-    s = Store(str(isolated_db))
+    s = MemoryStore(str(isolated_db))
     try:
         post = s.get_belief(bid)
         assert post is not None

--- a/tests/test_demotion_pressure.py
+++ b/tests/test_demotion_pressure.py
@@ -7,7 +7,7 @@ having get_belief return it. This test enforces that contract.
 from __future__ import annotations
 
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 def _mk(dp: int) -> Belief:
@@ -27,7 +27,7 @@ def _mk(dp: int) -> Belief:
 
 
 def test_demotion_pressure_initial_zero_persists() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk(0))
     got = s.get_belief("b1")
     assert got is not None
@@ -35,7 +35,7 @@ def test_demotion_pressure_initial_zero_persists() -> None:
 
 
 def test_demotion_pressure_update_to_three_reads_back() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     b = _mk(0)
     s.insert_belief(b)
     b.demotion_pressure = 3
@@ -46,7 +46,7 @@ def test_demotion_pressure_update_to_three_reads_back() -> None:
 
 
 def test_demotion_pressure_update_again_to_seven_reads_back() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     b = _mk(0)
     s.insert_belief(b)
     b.demotion_pressure = 3
@@ -60,7 +60,7 @@ def test_demotion_pressure_update_again_to_seven_reads_back() -> None:
 
 def test_demotion_pressure_inserted_nonzero_persists() -> None:
     """Belt-and-suspenders: insert path also persists nonzero values."""
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk(11))
     got = s.get_belief("b1")
     assert got is not None

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,0 +1,59 @@
+"""Tests for the sentence-extraction utility."""
+from __future__ import annotations
+
+from aelfrice.extraction import extract_sentences
+
+
+def test_extracts_simple_sentences() -> None:
+    text = "The cat sat on the mat. The dog barked loudly. Birds fly south."
+    out = extract_sentences(text)
+    assert len(out) == 3
+    assert out[0].startswith("The cat")
+
+
+def test_strips_code_blocks() -> None:
+    text = "Hello there friend.\n```python\nprint('hi')\n```\nThe end is near."
+    out = extract_sentences(text)
+    assert all("print" not in s for s in out)
+    assert any("Hello there friend" in s for s in out)
+
+
+def test_strips_inline_code() -> None:
+    out = extract_sentences("Use the `foo()` function carefully here.")
+    assert len(out) == 1
+    assert "foo" not in out[0]
+
+
+def test_strips_urls() -> None:
+    out = extract_sentences("See https://example.com/path for the docs page.")
+    assert all("example.com" not in s for s in out)
+
+
+def test_strips_markdown_headers_and_emphasis() -> None:
+    text = "# Section Header\nThis is **bold** important text here."
+    out = extract_sentences(text)
+    assert any("important text" in s for s in out)
+    assert all("**" not in s for s in out)
+    assert all("#" not in s for s in out)
+
+
+def test_discards_short_fragments() -> None:
+    text = "Long enough sentence here. Too short. Another long enough one."
+    out = extract_sentences(text)
+    # "Too short." is 10 chars exactly, kept; shorter would be dropped.
+    # Use clearly-short fragment:
+    text2 = "Long enough sentence here. ok. Another long enough one."
+    out2 = extract_sentences(text2)
+    assert all("ok" != s.strip(".") for s in out2)
+    assert len(out) >= 2
+
+
+def test_empty_text_returns_empty_list() -> None:
+    assert extract_sentences("") == []
+
+
+def test_strips_table_rows_and_list_markers() -> None:
+    text = "Intro paragraph here for context.\n| col1 | col2 |\n- bullet item one"
+    out = extract_sentences(text)
+    assert all("|" not in s for s in out)
+    assert any("Intro paragraph" in s for s in out)

--- a/tests/test_feedback_apply.py
+++ b/tests/test_feedback_apply.py
@@ -10,7 +10,7 @@ import pytest
 from aelfrice.feedback import FeedbackResult, apply_feedback
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
 from aelfrice.scoring import posterior_mean
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 def _mk(bid: str = "b1", alpha: float = 1.0, beta: float = 1.0) -> Belief:
@@ -29,8 +29,8 @@ def _mk(bid: str = "b1", alpha: float = 1.0, beta: float = 1.0) -> Belief:
     )
 
 
-def _store_with(b: Belief) -> Store:
-    s = Store(":memory:")
+def _store_with(b: Belief) -> MemoryStore:
+    s = MemoryStore(":memory:")
     s.insert_belief(b)
     return s
 
@@ -205,13 +205,13 @@ def test_empty_source_raises_value_error() -> None:
 
 
 def test_unknown_belief_id_raises_value_error() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     with pytest.raises(ValueError):
         apply_feedback(s, "nonexistent", valence=1.0, source="user")
 
 
 def test_unknown_belief_id_does_not_write_history() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     with pytest.raises(ValueError):
         apply_feedback(s, "nonexistent", valence=1.0, source="user")
     assert s.count_feedback_events() == 0

--- a/tests/test_feedback_auto_demote.py
+++ b/tests/test_feedback_auto_demote.py
@@ -22,7 +22,7 @@ from aelfrice.models import (
     Belief,
     Edge,
 )
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 def _mk(
@@ -46,8 +46,8 @@ def _mk(
     )
 
 
-def _build(starting_pressure: int = 0) -> Store:
-    s = Store(":memory:")
+def _build(starting_pressure: int = 0) -> MemoryStore:
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("X"))
     s.insert_belief(_mk("Y", lock_level=LOCK_USER,
                         locked_at="2026-04-26T01:00:00Z",
@@ -56,7 +56,7 @@ def _build(starting_pressure: int = 0) -> Store:
     return s
 
 
-def _y(store: Store) -> Belief:
+def _y(store: MemoryStore) -> Belief:
     got = store.get_belief("Y")
     assert got is not None
     return got
@@ -194,7 +194,7 @@ def test_at_threshold_pressured_and_demoted_both_contain_target() -> None:
 
 
 def test_only_at_threshold_target_demotes_others_remain_locked() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("X"))
     s.insert_belief(_mk("Y_high", lock_level=LOCK_USER,
                         locked_at="2026-04-26T01:00:00Z",

--- a/tests/test_feedback_demotion_pressure.py
+++ b/tests/test_feedback_demotion_pressure.py
@@ -25,7 +25,7 @@ from aelfrice.models import (
     Belief,
     Edge,
 )
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 def _mk(
@@ -50,8 +50,8 @@ def _mk(
 
 
 def _build(source_id: str, target_id: str, edge_type: str,
-           target_lock: str = LOCK_USER) -> Store:
-    s = Store(":memory:")
+           target_lock: str = LOCK_USER) -> MemoryStore:
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk(source_id))
     s.insert_belief(_mk(target_id, lock_level=target_lock,
                         locked_at="2026-04-26T01:00:00Z"))
@@ -59,7 +59,7 @@ def _build(source_id: str, target_id: str, edge_type: str,
     return s
 
 
-def _pressure(store: Store, bid: str) -> int:
+def _pressure(store: MemoryStore, bid: str) -> int:
     got = store.get_belief(bid)
     assert got is not None
     return got.demotion_pressure
@@ -122,7 +122,7 @@ def test_negative_valence_does_not_increment_pressure() -> None:
 def test_inbound_contradicts_edge_does_not_increment_pressure() -> None:
     """Edge Y->X CONTRADICTS means Y contradicts X. Feedback on X should
     not pressure Y under the 1-hop outbound semantics."""
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("X"))
     s.insert_belief(_mk("Y", lock_level=LOCK_USER,
                         locked_at="2026-04-26T01:00:00Z"))
@@ -143,7 +143,7 @@ def test_pressure_accumulates_across_repeated_positive_calls() -> None:
 
 
 def test_pressure_starts_from_existing_value_not_zero() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("X"))
     s.insert_belief(_mk("Y", lock_level=LOCK_USER,
                         locked_at="2026-04-26T01:00:00Z",
@@ -157,7 +157,7 @@ def test_pressure_starts_from_existing_value_not_zero() -> None:
 
 
 def test_two_locked_contradicted_targets_both_pressured() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("X"))
     s.insert_belief(_mk("Y1", lock_level=LOCK_USER,
                         locked_at="2026-04-26T01:00:00Z"))
@@ -171,7 +171,7 @@ def test_two_locked_contradicted_targets_both_pressured() -> None:
 
 
 def test_mix_of_locked_and_unlocked_targets_only_locked_pressured() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("X"))
     s.insert_belief(_mk("Y_locked", lock_level=LOCK_USER,
                         locked_at="2026-04-26T01:00:00Z"))
@@ -201,7 +201,7 @@ def test_result_reports_no_pressured_locks_when_no_contradiction() -> None:
 
 
 def test_result_reports_multiple_pressured_locks_sorted() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("X"))
     s.insert_belief(_mk("Yb", lock_level=LOCK_USER,
                         locked_at="2026-04-26T01:00:00Z"))

--- a/tests/test_feedback_history_schema.py
+++ b/tests/test_feedback_history_schema.py
@@ -1,4 +1,4 @@
-"""Smoke tests for the feedback_history schema and Store helpers.
+"""Smoke tests for the feedback_history schema and MemoryStore helpers.
 
 The audit table records every apply_feedback call so a project's
 feedback regime is recoverable after the fact. Pre-commit #5 in scope.
@@ -9,17 +9,17 @@ property per test, each :memory: store, all run in milliseconds.
 from __future__ import annotations
 
 from aelfrice.models import FeedbackEvent
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 def test_feedback_history_starts_empty() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     assert s.list_feedback_events() == []
     assert s.count_feedback_events() == 0
 
 
 def test_insert_feedback_event_returns_positive_rowid() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     rowid = s.insert_feedback_event(
         belief_id="b1",
         valence=1.0,
@@ -30,14 +30,14 @@ def test_insert_feedback_event_returns_positive_rowid() -> None:
 
 
 def test_insert_two_events_yields_two_distinct_rowids() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     r1 = s.insert_feedback_event("b1", 1.0, "user", "2026-04-26T18:00:00Z")
     r2 = s.insert_feedback_event("b1", -1.0, "system", "2026-04-26T18:01:00Z")
     assert r1 != r2
 
 
 def test_count_feedback_events_total_after_three_inserts() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_feedback_event("b1", 1.0, "user", "2026-04-26T18:00:00Z")
     s.insert_feedback_event("b1", -1.0, "system", "2026-04-26T18:01:00Z")
     s.insert_feedback_event("b2", 1.0, "user", "2026-04-26T18:02:00Z")
@@ -45,7 +45,7 @@ def test_count_feedback_events_total_after_three_inserts() -> None:
 
 
 def test_count_feedback_events_per_belief_filter() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_feedback_event("b1", 1.0, "user", "2026-04-26T18:00:00Z")
     s.insert_feedback_event("b1", -1.0, "system", "2026-04-26T18:01:00Z")
     s.insert_feedback_event("b2", 1.0, "user", "2026-04-26T18:02:00Z")
@@ -55,7 +55,7 @@ def test_count_feedback_events_per_belief_filter() -> None:
 
 
 def test_list_feedback_events_round_trip_returns_typed_object() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_feedback_event("b1", 0.7, "user", "2026-04-26T18:00:00Z")
     events = s.list_feedback_events()
     assert len(events) == 1
@@ -68,7 +68,7 @@ def test_list_feedback_events_round_trip_returns_typed_object() -> None:
 
 
 def test_list_feedback_events_orders_by_id_desc() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     r1 = s.insert_feedback_event("b1", 1.0, "user", "2026-04-26T18:00:00Z")
     r2 = s.insert_feedback_event("b1", -1.0, "user", "2026-04-26T18:01:00Z")
     r3 = s.insert_feedback_event("b2", 1.0, "user", "2026-04-26T18:02:00Z")
@@ -78,7 +78,7 @@ def test_list_feedback_events_orders_by_id_desc() -> None:
 
 
 def test_list_feedback_events_limit_caps_result_size() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     for i in range(7):
         s.insert_feedback_event("b1", 1.0, "user", f"2026-04-26T18:0{i}:00Z")
     events = s.list_feedback_events(limit=3)
@@ -86,7 +86,7 @@ def test_list_feedback_events_limit_caps_result_size() -> None:
 
 
 def test_list_feedback_events_belief_filter_excludes_others() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_feedback_event("b1", 1.0, "user", "2026-04-26T18:00:00Z")
     s.insert_feedback_event("b2", 1.0, "user", "2026-04-26T18:01:00Z")
     s.insert_feedback_event("b1", -1.0, "user", "2026-04-26T18:02:00Z")

--- a/tests/test_fts5_query_escaping.py
+++ b/tests/test_fts5_query_escaping.py
@@ -12,7 +12,7 @@ Atomic short tests: one property each, all use :memory: SQLite.
 from __future__ import annotations
 
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 def _mk(bid: str, content: str) -> Belief:
@@ -35,28 +35,28 @@ def _mk(bid: str, content: str) -> Belief:
 
 
 def test_search_with_dot_in_query_does_not_raise() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", "the project ships at v0.5 with the regex fallback"))
     hits = s.search_beliefs("v0.5")
     assert any(h.id == "b1" for h in hits)
 
 
 def test_search_with_hyphen_does_not_raise() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", "we use multi-hop retrieval at scale"))
     hits = s.search_beliefs("multi-hop")
     assert any(h.id == "b1" for h in hits)
 
 
 def test_search_with_parens_does_not_raise() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", "the function is called foo(bar) for legacy reasons"))
     hits = s.search_beliefs("foo(bar)")
     assert any(h.id == "b1" for h in hits)
 
 
 def test_search_with_slash_does_not_raise() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", "documented at docs/install.md as the canonical path"))
     hits = s.search_beliefs("docs/install.md")
     assert any(h.id == "b1" for h in hits)
@@ -65,14 +65,14 @@ def test_search_with_slash_does_not_raise() -> None:
 def test_search_with_fts5_keyword_does_not_raise() -> None:
     """FTS5 reserves AND, OR, NEAR, NOT as boolean operators. The escape
     wrapper quotes them as literal words so they don't hit a syntax error."""
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", "the rule is AND not OR for this branch"))
     hits = s.search_beliefs("AND")
     assert isinstance(hits, list)
 
 
 def test_search_with_quote_bearing_query_does_not_raise() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(
         _mk("b1", 'the docstring says "use this only when stable" verbatim')
     )
@@ -81,7 +81,7 @@ def test_search_with_quote_bearing_query_does_not_raise() -> None:
 
 
 def test_search_with_colon_in_query_does_not_raise() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", "the source format is doc:README.md:p0 for provenance"))
     hits = s.search_beliefs("doc:README.md:p0")
     assert isinstance(hits, list)
@@ -91,13 +91,13 @@ def test_search_with_colon_in_query_does_not_raise() -> None:
 
 
 def test_empty_query_returns_empty_list() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", "any content here at all"))
     assert s.search_beliefs("") == []
 
 
 def test_whitespace_only_query_returns_empty_list() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", "any content here at all"))
     assert s.search_beliefs("   \n\t  ") == []
 
@@ -106,7 +106,7 @@ def test_whitespace_only_query_returns_empty_list() -> None:
 
 
 def test_single_word_query_still_finds_match() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", "bananas are yellow"))
     s.insert_belief(_mk("b2", "apples are red"))
     hits = s.search_beliefs("bananas")
@@ -115,7 +115,7 @@ def test_single_word_query_still_finds_match() -> None:
 
 def test_multi_word_query_implicit_and() -> None:
     """Two tokens AND together: only beliefs containing both match."""
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", "bananas are yellow"))
     s.insert_belief(_mk("b2", "yellow submarines are common"))
     s.insert_belief(_mk("b3", "bananas are tasty"))
@@ -125,13 +125,13 @@ def test_multi_word_query_implicit_and() -> None:
 
 
 def test_no_match_returns_empty_list() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", "the cat sat on the mat"))
     assert s.search_beliefs("xenomorph") == []
 
 
 def test_limit_clamp_still_honored() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     for i in range(7):
         s.insert_belief(_mk(f"b{i}", "shared keyword bananas across all"))
     hits = s.search_beliefs("bananas", limit=3)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -28,7 +28,7 @@ from aelfrice.models import (
     Belief,
     Edge,
 )
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 def _mk(
@@ -57,7 +57,7 @@ def _mk(
 
 
 def test_empty_store_features_zero() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     f = compute_features(s)
     assert f.n_beliefs == 0
     assert f.confidence_mean == 0.0
@@ -65,7 +65,7 @@ def test_empty_store_features_zero() -> None:
 
 
 def test_single_belief_features_match_belief() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", alpha=3.0, beta=1.0))
     f = compute_features(s)
     assert f.n_beliefs == 1
@@ -74,7 +74,7 @@ def test_single_belief_features_match_belief() -> None:
 
 
 def test_three_beliefs_confidence_mean_is_average() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", alpha=4.0, beta=1.0))  # 0.8
     s.insert_belief(_mk("b2", alpha=2.0, beta=2.0))  # 0.5
     s.insert_belief(_mk("b3", alpha=1.0, beta=4.0))  # 0.2
@@ -83,7 +83,7 @@ def test_three_beliefs_confidence_mean_is_average() -> None:
 
 
 def test_odd_count_median_is_middle_element() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", alpha=4.0, beta=1.0))  # 0.8
     s.insert_belief(_mk("b2", alpha=2.0, beta=2.0))  # 0.5
     s.insert_belief(_mk("b3", alpha=1.0, beta=4.0))  # 0.2
@@ -92,7 +92,7 @@ def test_odd_count_median_is_middle_element() -> None:
 
 
 def test_even_count_median_averages_middle_two() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", alpha=4.0, beta=1.0))  # 0.8
     s.insert_belief(_mk("b2", alpha=2.0, beta=2.0))  # 0.5
     s.insert_belief(_mk("b3", alpha=1.0, beta=4.0))  # 0.2
@@ -103,14 +103,14 @@ def test_even_count_median_averages_middle_two() -> None:
 
 
 def test_lock_per_1000_zero_when_no_locks() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", alpha=1.0, beta=1.0))
     f = compute_features(s)
     assert f.lock_per_1000 == 0.0
 
 
 def test_lock_per_1000_scaled_correctly() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     # 1 of 4 locked -> 250 per 1000.
     s.insert_belief(_mk("b1", 1.0, 1.0))
     s.insert_belief(_mk("b2", 1.0, 1.0))
@@ -122,14 +122,14 @@ def test_lock_per_1000_scaled_correctly() -> None:
 
 
 def test_edge_per_belief_zero_when_no_edges() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("b1", 1.0, 1.0))
     f = compute_features(s)
     assert f.edge_per_belief == 0.0
 
 
 def test_edge_per_belief_one_when_one_edge_per_belief() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("a", 1.0, 1.0))
     s.insert_belief(_mk("b", 1.0, 1.0))
     s.insert_edge(Edge(src="a", dst="b", type=EDGE_SUPPORTS, weight=1.0))
@@ -258,19 +258,19 @@ def test_classification_confidence_in_unit_range() -> None:
 
 
 def test_assess_health_empty_store_insufficient_data() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     r = assess_health(s)
     assert r.regime == REGIME_INSUFFICIENT_DATA
 
 
 def test_assess_health_returns_health_report_typed() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     r = assess_health(s)
     assert isinstance(r, HealthReport)
 
 
 def test_assess_health_n_beliefs_matches_store() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     for i in range(7):
         s.insert_belief(_mk(f"b{i}", 1.0, 1.0))
     r = assess_health(s)
@@ -278,7 +278,7 @@ def test_assess_health_n_beliefs_matches_store() -> None:
 
 
 def test_assess_health_under_threshold_yields_insufficient_data() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     for i in range(MIN_BELIEFS - 1):
         s.insert_belief(_mk(f"b{i}", 1.0, 1.0))
     r = assess_health(s)
@@ -286,7 +286,7 @@ def test_assess_health_under_threshold_yields_insufficient_data() -> None:
 
 
 def test_assess_health_at_threshold_yields_a_real_regime() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     for i in range(MIN_BELIEFS):
         s.insert_belief(_mk(f"b{i}", 4.0, 1.0))  # supersede-shaped
     r = assess_health(s)
@@ -297,7 +297,7 @@ def test_assess_health_at_threshold_yields_a_real_regime() -> None:
 
 
 def test_repeated_assessment_returns_same_regime() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     for i in range(MIN_BELIEFS):
         s.insert_belief(_mk(f"b{i}", 4.0, 1.0))
     one = assess_health(s)

--- a/tests/test_hook_user_prompt_submit.py
+++ b/tests/test_hook_user_prompt_submit.py
@@ -14,7 +14,7 @@ from aelfrice.hook import (
     user_prompt_submit,
 )
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 def _mk(
@@ -39,7 +39,7 @@ def _mk(
 
 
 def _seed_db(db_path: Path, beliefs: list[Belief]) -> None:
-    store = Store(str(db_path))
+    store = MemoryStore(str(db_path))
     try:
         for b in beliefs:
             store.insert_belief(b)
@@ -207,7 +207,7 @@ def test_hook_passes_default_token_budget(
     real_retrieve = hook_mod.retrieve
 
     def spy_retrieve(
-        store: Store, query: str, token_budget: int = 2000, l1_limit: int = 50
+        store: MemoryStore, query: str, token_budget: int = 2000, l1_limit: int = 50
     ) -> list[Belief]:
         captured["token_budget"] = token_budget
         return real_retrieve(store, query, token_budget=token_budget,
@@ -232,7 +232,7 @@ def test_hook_honors_explicit_token_budget(
     real_retrieve = hook_mod.retrieve
 
     def spy_retrieve(
-        store: Store, query: str, token_budget: int = 2000, l1_limit: int = 50
+        store: MemoryStore, query: str, token_budget: int = 2000, l1_limit: int = 50
     ) -> list[Belief]:
         captured["token_budget"] = token_budget
         return real_retrieve(store, query, token_budget=token_budget,
@@ -256,7 +256,7 @@ def test_hook_non_blocking_on_internal_error(
     import aelfrice.hook as hook_mod
 
     def boom(
-        _store: Store, _q: str, token_budget: int = 2000, l1_limit: int = 50
+        _store: MemoryStore, _q: str, token_budget: int = 2000, l1_limit: int = 50
     ) -> list[Belief]:
         _ = token_budget, l1_limit
         raise RuntimeError("simulated retrieval failure")

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,101 @@
+"""End-to-end smoke tests for the v1.0.x ingest_turn shim."""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from aelfrice.ingest import ingest_turn
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Iterator[MemoryStore]:
+    s = MemoryStore(str(tmp_path / "ingest.db"))
+    yield s
+    s.close()
+
+
+def test_ingest_turn_returns_zero_for_empty_text(store: MemoryStore) -> None:
+    assert ingest_turn(store, "", source="user") == 0
+
+
+def test_ingest_turn_inserts_factual_sentences(store: MemoryStore) -> None:
+    text = (
+        "The configuration file lives at /etc/aelfrice/conf. "
+        "The default port is 8080 for the dashboard."
+    )
+    n = ingest_turn(store, text, source="user")
+    assert n == 2
+    assert store.count_beliefs() == 2
+
+
+def test_ingest_turn_skips_questions(store: MemoryStore) -> None:
+    text = (
+        "What is the default port for the dashboard service? "
+        "The answer lives in the configuration file at /etc."
+    )
+    n = ingest_turn(store, text, source="user")
+    # Question is skipped (persist=False); statement is kept.
+    assert n == 1
+
+
+def test_ingest_turn_search_finds_ingested_content(store: MemoryStore) -> None:
+    ingest_turn(
+        store,
+        "The Hubble telescope observes galactic supernovae nightly. "
+        "Astronomers process the imagery using cluster computing.",
+        source="user",
+    )
+    hits = store.search_beliefs("Hubble", limit=10)
+    assert len(hits) == 1
+    assert "Hubble" in hits[0].content
+
+
+def test_ingest_turn_idempotent_on_same_text(store: MemoryStore) -> None:
+    text = "The configuration file lives at the default location here."
+    ingest_turn(store, text, source="user")
+    before = store.count_beliefs()
+    ingest_turn(store, text, source="user")
+    after = store.count_beliefs()
+    assert before == after  # INSERT OR IGNORE prevents duplicates
+
+
+def test_ingest_turn_accepts_session_id_and_source_id(store: MemoryStore) -> None:
+    """session_id and source_id are accepted for adapter parity but
+    not persisted at v1.0.x — calls must succeed without error."""
+    n = ingest_turn(
+        store,
+        "A meaningful statement here that should be classified factual.",
+        source="user",
+        session_id="some-session-uuid",
+        source_id="S0:turn:3",
+    )
+    assert n == 1
+
+
+def test_ingest_turn_uses_provided_created_at(store: MemoryStore) -> None:
+    ingest_turn(
+        store,
+        "A meaningful statement here that should be classified factual.",
+        source="user",
+        created_at="2026-04-27T08:00:00+00:00",
+    )
+    beliefs = store.search_beliefs("meaningful", limit=10)
+    assert len(beliefs) == 1
+    assert beliefs[0].created_at == "2026-04-27T08:00:00+00:00"
+
+
+def test_create_session_returns_handle_with_id(store: MemoryStore) -> None:
+    session = store.create_session(model="test", project_context="ctx")
+    assert session.id  # non-empty
+    assert session.completed_at is None
+    assert session.model == "test"
+
+
+def test_complete_session_is_no_op(store: MemoryStore) -> None:
+    """Public v1.0.x complete_session is a terminator with no schema effect."""
+    session = store.create_session()
+    # Should not raise even though the session is not in any table.
+    store.complete_session(session.id)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -34,16 +34,16 @@ from aelfrice.models import (
     LOCK_USER,
     Belief,
 )
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 @pytest.fixture
-def store() -> Store:
-    return Store(":memory:")
+def store() -> MemoryStore:
+    return MemoryStore(":memory:")
 
 
 def _put_belief(
-    store: Store,
+    store: MemoryStore,
     *,
     id: str = "b1",
     content: str = "hello world",
@@ -99,13 +99,13 @@ def test_serve_raises_clear_error_when_fastmcp_missing() -> None:
 # --- search ------------------------------------------------------------
 
 
-def test_search_returns_results_kind(store: Store) -> None:
+def test_search_returns_results_kind(store: MemoryStore) -> None:
     _put_belief(store, content="the quick brown fox")
     out = tool_search(store, query="brown")
     assert out["kind"] == "search.results"
 
 
-def test_search_returns_hit_payload_shape(store: Store) -> None:
+def test_search_returns_hit_payload_shape(store: MemoryStore) -> None:
     _put_belief(store, content="the quick brown fox")
     out = tool_search(store, query="brown")
     assert out["n_hits"] == 1
@@ -113,7 +113,7 @@ def test_search_returns_hit_payload_shape(store: Store) -> None:
     assert set(hit.keys()) == {"id", "content", "lock_level", "type"}
 
 
-def test_search_no_match_returns_zero_hits(store: Store) -> None:
+def test_search_no_match_returns_zero_hits(store: MemoryStore) -> None:
     out = tool_search(store, query="zzznonexistent")
     assert out["n_hits"] == 0
 
@@ -121,7 +121,7 @@ def test_search_no_match_returns_zero_hits(store: Store) -> None:
 # --- lock --------------------------------------------------------------
 
 
-def test_lock_creates_new_belief(store: Store) -> None:
+def test_lock_creates_new_belief(store: MemoryStore) -> None:
     out = tool_lock(store, statement="we always sign commits with ssh")
     assert out["action"] == "locked"
     bid = out["id"]
@@ -130,7 +130,7 @@ def test_lock_creates_new_belief(store: Store) -> None:
     assert inserted.lock_level == LOCK_USER
 
 
-def test_lock_upgrades_existing_unlocked_belief(store: Store) -> None:
+def test_lock_upgrades_existing_unlocked_belief(store: MemoryStore) -> None:
     first = tool_lock(store, statement="claude is my friend")
     bid = first["id"]
     # demote then re-lock to exercise the upgrade path
@@ -147,20 +147,20 @@ def test_lock_upgrades_existing_unlocked_belief(store: Store) -> None:
 # --- locked ------------------------------------------------------------
 
 
-def test_locked_lists_user_locks(store: Store) -> None:
+def test_locked_lists_user_locks(store: MemoryStore) -> None:
     tool_lock(store, statement="alpha")
     tool_lock(store, statement="beta")
     out = tool_locked(store)
     assert out["n"] == 2
 
 
-def test_locked_pressured_filter_excludes_unpressured(store: Store) -> None:
+def test_locked_pressured_filter_excludes_unpressured(store: MemoryStore) -> None:
     tool_lock(store, statement="alpha")
     out = tool_locked(store, pressured=True)
     assert out["n"] == 0
 
 
-def test_locked_pressured_filter_includes_pressured(store: Store) -> None:
+def test_locked_pressured_filter_includes_pressured(store: MemoryStore) -> None:
     tool_lock(store, statement="alpha")
     bid = tool_locked(store)["locked"][0]["id"]
     b = store.get_belief(bid)
@@ -174,7 +174,7 @@ def test_locked_pressured_filter_includes_pressured(store: Store) -> None:
 # --- demote ------------------------------------------------------------
 
 
-def test_demote_unlocks_a_locked_belief(store: Store) -> None:
+def test_demote_unlocks_a_locked_belief(store: MemoryStore) -> None:
     bid = tool_lock(store, statement="x")["id"]
     out = tool_demote(store, belief_id=bid)
     assert out["demoted"] is True
@@ -183,13 +183,13 @@ def test_demote_unlocks_a_locked_belief(store: Store) -> None:
     assert b.lock_level == LOCK_NONE
 
 
-def test_demote_unknown_belief_returns_not_found(store: Store) -> None:
+def test_demote_unknown_belief_returns_not_found(store: MemoryStore) -> None:
     out = tool_demote(store, belief_id="deadbeef")
     assert out["kind"] == "demote.not_found"
     assert out["demoted"] is False
 
 
-def test_demote_unlocked_belief_is_no_op(store: Store) -> None:
+def test_demote_unlocked_belief_is_no_op(store: MemoryStore) -> None:
     _put_belief(store, id="b1", lock_level=LOCK_NONE)
     out = tool_demote(store, belief_id="b1")
     assert out["kind"] == "demote.not_locked"
@@ -199,27 +199,27 @@ def test_demote_unlocked_belief_is_no_op(store: Store) -> None:
 # --- feedback ----------------------------------------------------------
 
 
-def test_feedback_used_increments_alpha(store: Store) -> None:
+def test_feedback_used_increments_alpha(store: MemoryStore) -> None:
     _put_belief(store, id="b1", alpha=2.0, beta=1.0)
     out = tool_feedback(store, belief_id="b1", signal="used")
     assert out["kind"] == "feedback.applied"
     assert out["new_alpha"] > out["prior_alpha"]
 
 
-def test_feedback_harmful_increments_beta(store: Store) -> None:
+def test_feedback_harmful_increments_beta(store: MemoryStore) -> None:
     _put_belief(store, id="b1", alpha=2.0, beta=1.0)
     out = tool_feedback(store, belief_id="b1", signal="harmful")
     assert out["new_beta"] > out["prior_beta"]
 
 
-def test_feedback_bad_signal_returns_error(store: Store) -> None:
+def test_feedback_bad_signal_returns_error(store: MemoryStore) -> None:
     _put_belief(store, id="b1")
     out = tool_feedback(store, belief_id="b1", signal="bogus")
     assert out["kind"] == "feedback.bad_signal"
     assert "error" in out
 
 
-def test_feedback_unknown_belief_returns_error(store: Store) -> None:
+def test_feedback_unknown_belief_returns_error(store: MemoryStore) -> None:
     out = tool_feedback(store, belief_id="nope", signal="used")
     assert out["kind"] == "feedback.unknown_belief"
 
@@ -227,7 +227,7 @@ def test_feedback_unknown_belief_returns_error(store: Store) -> None:
 # --- stats / health ----------------------------------------------------
 
 
-def test_stats_returns_count_keys(store: Store) -> None:
+def test_stats_returns_count_keys(store: MemoryStore) -> None:
     out = tool_stats(store)
     assert {
         "beliefs", "edges", "locked", "feedback_events",
@@ -235,20 +235,20 @@ def test_stats_returns_count_keys(store: Store) -> None:
     }.issubset(out.keys())
 
 
-def test_stats_counts_match_after_inserts(store: Store) -> None:
+def test_stats_counts_match_after_inserts(store: MemoryStore) -> None:
     _put_belief(store, id="a")
     _put_belief(store, id="b")
     out = tool_stats(store)
     assert out["beliefs"] == 2
 
 
-def test_health_returns_regime_field(store: Store) -> None:
+def test_health_returns_regime_field(store: MemoryStore) -> None:
     out = tool_health(store)
     assert "regime" in out
     assert "description" in out
 
 
-def test_health_insufficient_data_omits_features(store: Store) -> None:
+def test_health_insufficient_data_omits_features(store: MemoryStore) -> None:
     """Empty store -> insufficient_data regime; features must not be
     reported (they would be undefined)."""
     out = tool_health(store)
@@ -259,7 +259,7 @@ def test_health_insufficient_data_omits_features(store: Store) -> None:
 # --- onboard (polymorphic) --------------------------------------------
 
 
-def test_onboard_path_starts_session(store: Store, tmp_path: Path) -> None:
+def test_onboard_path_starts_session(store: MemoryStore, tmp_path: Path) -> None:
     _populate_repo(tmp_path)
     out = tool_onboard(store, path=str(tmp_path))
     assert out["kind"] == "onboard.session_started"
@@ -267,14 +267,14 @@ def test_onboard_path_starts_session(store: Store, tmp_path: Path) -> None:
     assert isinstance(out["sentences"], list)
 
 
-def test_onboard_status_no_pending_returns_zero(store: Store) -> None:
+def test_onboard_status_no_pending_returns_zero(store: MemoryStore) -> None:
     out = tool_onboard(store)
     assert out["kind"] == "onboard.status"
     assert out["n_pending"] == 0
 
 
 def test_onboard_status_lists_started_session(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     started = tool_onboard(store, path=str(tmp_path))
@@ -284,7 +284,7 @@ def test_onboard_status_lists_started_session(
 
 
 def test_onboard_accept_completes_session(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     started = tool_onboard(store, path=str(tmp_path))
@@ -299,7 +299,7 @@ def test_onboard_accept_completes_session(
 
 
 def test_onboard_accept_with_no_classifications_completes_empty(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     started = tool_onboard(store, path=str(tmp_path))
@@ -309,7 +309,7 @@ def test_onboard_accept_with_no_classifications_completes_empty(
 
 
 def test_onboard_after_complete_no_longer_pending(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     started = tool_onboard(store, path=str(tmp_path))
@@ -319,7 +319,7 @@ def test_onboard_after_complete_no_longer_pending(
 
 
 def test_onboard_sync_falls_back_to_regex_classifier(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     out = tool_onboard_sync(store, path=str(tmp_path))
@@ -330,7 +330,7 @@ def test_onboard_sync_falls_back_to_regex_classifier(
 # --- end-to-end smoke ---------------------------------------------------
 
 
-def test_end_to_end_lock_search_feedback_demote(store: Store) -> None:
+def test_end_to_end_lock_search_feedback_demote(store: MemoryStore) -> None:
     locked = tool_lock(store, statement="we use uv exclusively")
     bid = locked["id"]
 
@@ -349,7 +349,7 @@ def test_end_to_end_lock_search_feedback_demote(store: Store) -> None:
 
 
 def test_end_to_end_polymorphic_onboard_then_search(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     started = tool_onboard(store, path=str(tmp_path))
@@ -367,7 +367,7 @@ def test_end_to_end_polymorphic_onboard_then_search(
 
 
 def test_polymorphic_onboard_handlers_share_state_with_classification_module(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     """Round-trip via the bare classification API should match the MCP
     tool's view of the world. Catches drift between the two surfaces."""
@@ -388,7 +388,7 @@ def test_polymorphic_onboard_handlers_share_state_with_classification_module(
 
 
 def test_unused_classification_import_does_not_drift(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     via_classification = start_onboard_session(

--- a/tests/test_onboard_handshake.py
+++ b/tests/test_onboard_handshake.py
@@ -26,12 +26,12 @@ from aelfrice.models import (
     ONBOARD_STATE_PENDING,
     Belief,
 )
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 @pytest.fixture
-def store() -> Store:
-    return Store(":memory:")
+def store() -> MemoryStore:
+    return MemoryStore(":memory:")
 
 
 def _populate_repo(root: Path) -> None:
@@ -49,7 +49,7 @@ def _populate_repo(root: Path) -> None:
     )
 
 
-def test_start_returns_nonempty_session_id(store: Store, tmp_path: Path) -> None:
+def test_start_returns_nonempty_session_id(store: MemoryStore, tmp_path: Path) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
     assert result.session_id
@@ -57,7 +57,7 @@ def test_start_returns_nonempty_session_id(store: Store, tmp_path: Path) -> None
 
 
 def test_start_persists_session_in_pending_state(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
@@ -66,7 +66,7 @@ def test_start_persists_session_in_pending_state(
     assert session.state == ONBOARD_STATE_PENDING
 
 
-def test_start_session_records_repo_path(store: Store, tmp_path: Path) -> None:
+def test_start_session_records_repo_path(store: MemoryStore, tmp_path: Path) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
     session = store.get_onboard_session(result.session_id)
@@ -74,14 +74,14 @@ def test_start_session_records_repo_path(store: Store, tmp_path: Path) -> None:
     assert session.repo_path == str(tmp_path)
 
 
-def test_start_returns_at_least_one_sentence(store: Store, tmp_path: Path) -> None:
+def test_start_returns_at_least_one_sentence(store: MemoryStore, tmp_path: Path) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
     assert len(result.sentences) > 0
 
 
 def test_sentences_have_contiguous_indices_from_zero(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
@@ -90,7 +90,7 @@ def test_sentences_have_contiguous_indices_from_zero(
 
 
 def test_candidates_json_round_trips_sentences(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
@@ -102,14 +102,14 @@ def test_candidates_json_round_trips_sentences(
 
 
 def test_start_on_empty_dir_returns_empty_sentence_list(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
     assert result.sentences == []
 
 
 def test_start_on_empty_dir_still_creates_session(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
     session = store.get_onboard_session(result.session_id)
@@ -117,7 +117,7 @@ def test_start_on_empty_dir_still_creates_session(
 
 
 def test_start_skips_already_present_beliefs(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     first = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
@@ -132,14 +132,14 @@ def test_start_skips_already_present_beliefs(
     assert second.n_already_present > 0
 
 
-def test_accept_unknown_session_raises(store: Store) -> None:
+def test_accept_unknown_session_raises(store: MemoryStore) -> None:
     with pytest.raises(ValueError, match="unknown session"):
         accept_classifications(store, "no-such-session", [],
                                 now="2026-04-26T01:00:00Z")
 
 
 def test_accept_already_completed_session_raises(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
@@ -151,7 +151,7 @@ def test_accept_already_completed_session_raises(
 
 
 def test_accept_invalid_belief_type_raises(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
@@ -161,7 +161,7 @@ def test_accept_invalid_belief_type_raises(
                                 now="2026-04-26T01:00:00Z")
 
 
-def test_accept_marks_session_completed(store: Store, tmp_path: Path) -> None:
+def test_accept_marks_session_completed(store: MemoryStore, tmp_path: Path) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
     accept_classifications(store, result.session_id, [],
@@ -172,7 +172,7 @@ def test_accept_marks_session_completed(store: Store, tmp_path: Path) -> None:
 
 
 def test_accept_writes_completed_at_timestamp(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
@@ -184,7 +184,7 @@ def test_accept_writes_completed_at_timestamp(
 
 
 def test_accept_inserts_one_belief_per_persisting_classification(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
@@ -199,7 +199,7 @@ def test_accept_inserts_one_belief_per_persisting_classification(
 
 
 def test_accept_skips_non_persisting_classifications(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
@@ -216,7 +216,7 @@ def test_accept_skips_non_persisting_classifications(
 
 
 def test_accept_counts_unclassified_sentences(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
@@ -233,7 +233,7 @@ def test_accept_counts_unclassified_sentences(
 
 
 def test_accept_assigns_host_provided_belief_type(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
@@ -253,7 +253,7 @@ def test_accept_assigns_host_provided_belief_type(
 
 
 def test_accept_skips_existing_beliefs_inserted_after_session_started(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
@@ -282,7 +282,7 @@ def test_accept_skips_existing_beliefs_inserted_after_session_started(
 
 
 def test_two_starts_produce_distinct_session_ids(
-    store: Store, tmp_path: Path
+    store: MemoryStore, tmp_path: Path
 ) -> None:
     _populate_repo(tmp_path)
     a = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")

--- a/tests/test_onboard_sessions_store.py
+++ b/tests/test_onboard_sessions_store.py
@@ -1,7 +1,7 @@
 """Atomic CRUD tests for the onboard_sessions table.
 
 One property per test, deterministic, in-memory store, no fixtures
-beyond a fresh `Store(":memory:")`. The polymorphic onboard state
+beyond a fresh `MemoryStore(":memory:")`. The polymorphic onboard state
 machine builds on these primitives in v0.6.0; this file only locks the
 storage layer.
 """
@@ -14,12 +14,12 @@ from aelfrice.models import (
     ONBOARD_STATE_PENDING,
     OnboardSession,
 )
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 @pytest.fixture
-def store() -> Store:
-    return Store(":memory:")
+def store() -> MemoryStore:
+    return MemoryStore(":memory:")
 
 
 def _session(
@@ -38,7 +38,7 @@ def _session(
     )
 
 
-def test_insert_then_get_round_trips_all_fields(store: Store) -> None:
+def test_insert_then_get_round_trips_all_fields(store: MemoryStore) -> None:
     s = _session()
     store.insert_onboard_session(s)
     got = store.get_onboard_session("sess-1")
@@ -46,26 +46,26 @@ def test_insert_then_get_round_trips_all_fields(store: Store) -> None:
     assert got == s
 
 
-def test_get_unknown_session_returns_none(store: Store) -> None:
+def test_get_unknown_session_returns_none(store: MemoryStore) -> None:
     assert store.get_onboard_session("missing") is None
 
 
-def test_insert_duplicate_session_id_raises(store: Store) -> None:
+def test_insert_duplicate_session_id_raises(store: MemoryStore) -> None:
     store.insert_onboard_session(_session())
     with pytest.raises(Exception):
         store.insert_onboard_session(_session())
 
 
-def test_complete_returns_true_for_pending_session(store: Store) -> None:
+def test_complete_returns_true_for_pending_session(store: MemoryStore) -> None:
     store.insert_onboard_session(_session())
     assert store.complete_onboard_session("sess-1", "2026-04-26T01:00:00Z") is True
 
 
-def test_complete_returns_false_for_unknown_session(store: Store) -> None:
+def test_complete_returns_false_for_unknown_session(store: MemoryStore) -> None:
     assert store.complete_onboard_session("nope", "2026-04-26T01:00:00Z") is False
 
 
-def test_complete_sets_state_to_completed(store: Store) -> None:
+def test_complete_sets_state_to_completed(store: MemoryStore) -> None:
     store.insert_onboard_session(_session())
     store.complete_onboard_session("sess-1", "2026-04-26T01:00:00Z")
     got = store.get_onboard_session("sess-1")
@@ -73,7 +73,7 @@ def test_complete_sets_state_to_completed(store: Store) -> None:
     assert got.state == ONBOARD_STATE_COMPLETED
 
 
-def test_complete_writes_completed_at_timestamp(store: Store) -> None:
+def test_complete_writes_completed_at_timestamp(store: MemoryStore) -> None:
     store.insert_onboard_session(_session())
     store.complete_onboard_session("sess-1", "2026-04-26T01:00:00Z")
     got = store.get_onboard_session("sess-1")
@@ -81,7 +81,7 @@ def test_complete_writes_completed_at_timestamp(store: Store) -> None:
     assert got.completed_at == "2026-04-26T01:00:00Z"
 
 
-def test_count_no_filter_counts_all_states(store: Store) -> None:
+def test_count_no_filter_counts_all_states(store: MemoryStore) -> None:
     store.insert_onboard_session(_session(session_id="a"))
     store.insert_onboard_session(
         _session(session_id="b", state=ONBOARD_STATE_COMPLETED,
@@ -90,7 +90,7 @@ def test_count_no_filter_counts_all_states(store: Store) -> None:
     assert store.count_onboard_sessions() == 2
 
 
-def test_count_filtered_by_pending_excludes_completed(store: Store) -> None:
+def test_count_filtered_by_pending_excludes_completed(store: MemoryStore) -> None:
     store.insert_onboard_session(_session(session_id="a"))
     store.insert_onboard_session(
         _session(session_id="b", state=ONBOARD_STATE_COMPLETED,
@@ -99,7 +99,7 @@ def test_count_filtered_by_pending_excludes_completed(store: Store) -> None:
     assert store.count_onboard_sessions(ONBOARD_STATE_PENDING) == 1
 
 
-def test_count_filtered_by_completed_excludes_pending(store: Store) -> None:
+def test_count_filtered_by_completed_excludes_pending(store: MemoryStore) -> None:
     store.insert_onboard_session(_session(session_id="a"))
     store.insert_onboard_session(
         _session(session_id="b", state=ONBOARD_STATE_COMPLETED,
@@ -108,11 +108,11 @@ def test_count_filtered_by_completed_excludes_pending(store: Store) -> None:
     assert store.count_onboard_sessions(ONBOARD_STATE_COMPLETED) == 1
 
 
-def test_count_on_empty_store_is_zero(store: Store) -> None:
+def test_count_on_empty_store_is_zero(store: MemoryStore) -> None:
     assert store.count_onboard_sessions() == 0
 
 
-def test_list_pending_returns_only_pending_sessions(store: Store) -> None:
+def test_list_pending_returns_only_pending_sessions(store: MemoryStore) -> None:
     store.insert_onboard_session(_session(session_id="a"))
     store.insert_onboard_session(
         _session(session_id="b", state=ONBOARD_STATE_COMPLETED,
@@ -122,7 +122,7 @@ def test_list_pending_returns_only_pending_sessions(store: Store) -> None:
     assert [s.session_id for s in result] == ["a"]
 
 
-def test_list_pending_orders_by_created_at_then_id(store: Store) -> None:
+def test_list_pending_orders_by_created_at_then_id(store: MemoryStore) -> None:
     store.insert_onboard_session(OnboardSession(
         session_id="b", repo_path="/r", state=ONBOARD_STATE_PENDING,
         candidates_json="[]", created_at="2026-04-26T01:00:00Z",
@@ -137,17 +137,17 @@ def test_list_pending_orders_by_created_at_then_id(store: Store) -> None:
     assert [s.session_id for s in result] == ["a", "b"]
 
 
-def test_list_pending_on_empty_store_is_empty(store: Store) -> None:
+def test_list_pending_on_empty_store_is_empty(store: MemoryStore) -> None:
     assert store.list_pending_onboard_sessions() == []
 
 
-def test_complete_then_list_pending_no_longer_returns_session(store: Store) -> None:
+def test_complete_then_list_pending_no_longer_returns_session(store: MemoryStore) -> None:
     store.insert_onboard_session(_session())
     store.complete_onboard_session("sess-1", "2026-04-26T01:00:00Z")
     assert store.list_pending_onboard_sessions() == []
 
 
-def test_candidates_json_blob_round_trips_unchanged(store: Store) -> None:
+def test_candidates_json_blob_round_trips_unchanged(store: MemoryStore) -> None:
     blob = '[{"text": "alpha", "source_meta": {"path": "x.py", "line": 3}}]'
     store.insert_onboard_session(OnboardSession(
         session_id="sess-1", repo_path="/r", state=ONBOARD_STATE_PENDING,

--- a/tests/test_propagate_valence.py
+++ b/tests/test_propagate_valence.py
@@ -12,7 +12,7 @@ from aelfrice.models import (
     Belief,
     Edge,
 )
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 def _mk(bid: str, alpha: float, beta: float) -> Belief:
@@ -31,8 +31,8 @@ def _mk(bid: str, alpha: float, beta: float) -> Belief:
     )
 
 
-def _build_chain(broker_alpha: float, broker_beta: float) -> Store:
-    s = Store(":memory:")
+def _build_chain(broker_alpha: float, broker_beta: float) -> MemoryStore:
+    s = MemoryStore(":memory:")
     # A is source; broker confidence at A doesn't matter for downstream
     # because propagation multiplier uses dst broker, but give it neutral.
     s.insert_belief(_mk("A", alpha=5.0, beta=5.0))
@@ -66,7 +66,7 @@ def test_low_broker_confidence_attenuates_vs_high() -> None:
 
 
 def test_propagate_returns_empty_for_isolated_source() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("solo", alpha=5.0, beta=5.0))
     out = s.propagate_valence("solo", valence=1.0)
     assert out == {}

--- a/tests/test_retrieval_l0_first.py
+++ b/tests/test_retrieval_l0_first.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
 from aelfrice.retrieval import retrieve
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 def _mk(
@@ -33,8 +33,8 @@ def _mk(
     )
 
 
-def _populate_mixed_store() -> Store:
-    s = Store(":memory:")
+def _populate_mixed_store() -> MemoryStore:
+    s = MemoryStore(":memory:")
     # 3 locked beliefs (L0), 5 unlocked beliefs (L1 candidates).
     s.insert_belief(_mk("L_a", "the user pinned a strong opinion about coffee",
                         lock_level=LOCK_USER, locked_at="2026-04-26T03:00:00Z"))

--- a/tests/test_retrieval_smoke.py
+++ b/tests/test_retrieval_smoke.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
 from aelfrice.retrieval import retrieve
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 def _mk(
@@ -33,7 +33,7 @@ def _mk(
 
 
 def test_retrieval_returns_l0_locked_beliefs_for_unrelated_query() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("L1", "user pinned a fact about cats",
                         lock_level=LOCK_USER, locked_at="2026-04-26T01:00:00Z"))
     s.insert_belief(_mk("F1", "an unrelated fact about elephants"))
@@ -47,7 +47,7 @@ def test_retrieval_returns_l0_locked_beliefs_for_unrelated_query() -> None:
 
 
 def test_retrieval_returns_l1_fts5_match_when_present() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("F1", "the kitchen is full of bananas"))
     s.insert_belief(_mk("F2", "the garage is full of tools"))
 
@@ -57,7 +57,7 @@ def test_retrieval_returns_l1_fts5_match_when_present() -> None:
 
 
 def test_retrieval_empty_query_returns_locked_only() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("L1", "locked truth",
                         lock_level=LOCK_USER, locked_at="2026-04-26T01:00:00Z"))
     s.insert_belief(_mk("F1", "free-floating fact"))
@@ -68,7 +68,7 @@ def test_retrieval_empty_query_returns_locked_only() -> None:
 
 
 def test_retrieval_dedupes_locked_belief_appearing_in_fts5_match() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("L1", "the user pinned a banana fact",
                         lock_level=LOCK_USER, locked_at="2026-04-26T01:00:00Z"))
     s.insert_belief(_mk("F1", "the kitchen is full of bananas"))
@@ -82,7 +82,7 @@ def test_retrieval_dedupes_locked_belief_appearing_in_fts5_match() -> None:
 
 
 def test_retrieval_returns_pure_belief_objects() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk("F1", "a fact"))
     hits = retrieve(s, query="fact")
     assert len(hits) == 1

--- a/tests/test_retrieval_token_budget.py
+++ b/tests/test_retrieval_token_budget.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
 from aelfrice.retrieval import retrieve
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 _CHARS_PER_TOKEN = 4.0
 
@@ -53,9 +53,9 @@ def _mk(
     )
 
 
-def _store_with_n_facts(n: int, content_len: int = 200) -> Store:
+def _store_with_n_facts(n: int, content_len: int = 200) -> MemoryStore:
     """N unlocked beliefs, each with content_len chars matching 'fact'."""
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     body = "fact " * (content_len // 5)
     for i in range(n):
         s.insert_belief(_mk(f"F{i}", body[:content_len]))
@@ -74,7 +74,7 @@ def test_output_tokens_at_or_below_budget_when_l0_fits() -> None:
 def test_l0_returned_in_full_even_when_l0_alone_exceeds_budget() -> None:
     """Three locked beliefs, each ~50 tokens; budget 10. All three survive,
     L1 is empty in the output."""
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     big_content = "x" * 200  # ~50 tokens
     s.insert_belief(_mk("L1", big_content, lock_level=LOCK_USER,
                         locked_at="2026-04-26T03:00:00Z"))

--- a/tests/test_scanner_scan_repo.py
+++ b/tests/test_scanner_scan_repo.py
@@ -14,7 +14,7 @@ import pytest
 
 from aelfrice.models import LOCK_NONE
 from aelfrice.scanner import ScanResult, scan_repo
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 _GIT_AVAILABLE = shutil.which("git") is not None
 needs_git = pytest.mark.skipif(not _GIT_AVAILABLE, reason="git binary not on PATH")
@@ -47,20 +47,20 @@ def _git(repo: Path, *args: str) -> None:
 
 
 def test_missing_root_yields_no_inserts(tmp_path: Path) -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     bogus = tmp_path / "nope"
     result = scan_repo(s, bogus)
     assert result.inserted == 0
 
 
 def test_empty_directory_yields_no_inserts(tmp_path: Path) -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     result = scan_repo(s, tmp_path)
     assert result.inserted == 0
 
 
 def test_empty_directory_yields_no_candidates(tmp_path: Path) -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     result = scan_repo(s, tmp_path)
     assert result.total_candidates == 0
 
@@ -73,7 +73,7 @@ def test_single_md_paragraph_inserts_one_belief(tmp_path: Path) -> None:
         "the project ships only the regex fallback at v0.5",
         encoding="utf-8",
     )
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     result = scan_repo(s, tmp_path)
     assert result.inserted == 1
 
@@ -83,7 +83,7 @@ def test_single_md_paragraph_belief_persists_lock_none(tmp_path: Path) -> None:
         "the project ships only the regex fallback at v0.5",
         encoding="utf-8",
     )
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     beliefs = s.search_beliefs("regex")
     assert len(beliefs) == 1
@@ -95,8 +95,8 @@ def test_single_md_paragraph_belief_has_deterministic_id(tmp_path: Path) -> None
         "the project ships only the regex fallback at v0.5",
         encoding="utf-8",
     )
-    s1 = Store(":memory:")
-    s2 = Store(":memory:")
+    s1 = MemoryStore(":memory:")
+    s2 = MemoryStore(":memory:")
     scan_repo(s1, tmp_path, now="2026-04-26T00:00:00Z")
     scan_repo(s2, tmp_path, now="2026-04-26T00:00:00Z")
     ids1 = {b.id for b in s1.search_beliefs("regex")}
@@ -109,7 +109,7 @@ def test_single_md_paragraph_uses_provided_now_timestamp(tmp_path: Path) -> None
         "the project ships only the regex fallback at v0.5",
         encoding="utf-8",
     )
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path, now="2026-04-26T12:34:56Z")
     beliefs = s.search_beliefs("regex")
     assert beliefs[0].created_at == "2026-04-26T12:34:56Z"
@@ -123,7 +123,7 @@ def test_repeat_scan_does_not_duplicate(tmp_path: Path) -> None:
         "the project ships only the regex fallback at v0.5",
         encoding="utf-8",
     )
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     second = scan_repo(s, tmp_path)
     assert second.inserted == 0
@@ -134,7 +134,7 @@ def test_repeat_scan_counts_skipped_existing(tmp_path: Path) -> None:
         "the project ships only the regex fallback at v0.5",
         encoding="utf-8",
     )
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     second = scan_repo(s, tmp_path)
     assert second.skipped_existing >= 1
@@ -148,7 +148,7 @@ def test_repeat_scan_total_belief_count_matches_first_inserted(
         "another paragraph long enough to qualify",
         encoding="utf-8",
     )
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     first = scan_repo(s, tmp_path)
     scan_repo(s, tmp_path)
     # Beliefs in the store after two runs == beliefs after one.
@@ -184,7 +184,7 @@ def test_md_plus_git_plus_py_inserts_three_or_more(tmp_path: Path) -> None:
     _git(tmp_path, "init", "-q")
     _git(tmp_path, "add", ".")
     _git(tmp_path, "commit", "-q", "-m", "feat: ship regex fallback for v0.5")
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     result = scan_repo(s, tmp_path)
     assert result.inserted >= 3
 
@@ -198,7 +198,7 @@ def test_question_in_doc_does_not_persist(tmp_path: Path) -> None:
         "what does the project ship at v0.5?",
         encoding="utf-8",
     )
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     result = scan_repo(s, tmp_path)
     assert result.inserted == 0
     assert result.skipped_non_persisting >= 1
@@ -210,7 +210,7 @@ def test_persist_filter_does_not_block_other_paragraphs(tmp_path: Path) -> None:
         "the project ships only the regex fallback at v0.5",
         encoding="utf-8",
     )
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     result = scan_repo(s, tmp_path)
     assert result.inserted == 1
     assert result.skipped_non_persisting >= 1
@@ -220,7 +220,7 @@ def test_persist_filter_does_not_block_other_paragraphs(tmp_path: Path) -> None:
 
 
 def test_result_is_scan_result_typed(tmp_path: Path) -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     result = scan_repo(s, tmp_path)
     assert isinstance(result, ScanResult)
 
@@ -230,7 +230,7 @@ def test_result_total_candidates_consistent(tmp_path: Path) -> None:
         "one paragraph long enough to qualify here",
         encoding="utf-8",
     )
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     result = scan_repo(s, tmp_path)
     assert (
         result.inserted
@@ -249,7 +249,7 @@ def test_inserted_belief_alpha_below_user_prior(tmp_path: Path) -> None:
         "the project ships only the regex fallback at v0.5",
         encoding="utf-8",
     )
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     b = s.search_beliefs("regex")[0]
     # Factual user-prior alpha is 3.0; deflation factor 0.2 -> 0.6 (above 0.5 floor).
@@ -261,7 +261,7 @@ def test_inserted_belief_demotion_pressure_zero(tmp_path: Path) -> None:
         "the project ships only the regex fallback at v0.5",
         encoding="utf-8",
     )
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     scan_repo(s, tmp_path)
     b = s.search_beliefs("regex")[0]
     assert b.demotion_pressure == 0

--- a/tests/test_store_crud.py
+++ b/tests/test_store_crud.py
@@ -8,7 +8,7 @@ from aelfrice.models import (
     Belief,
     Edge,
 )
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 
 
 def _mk_belief(
@@ -34,7 +34,7 @@ def _mk_belief(
 
 
 def test_belief_insert_and_get_roundtrip() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     b = _mk_belief()
     s.insert_belief(b)
     got = s.get_belief("b1")
@@ -53,7 +53,7 @@ def test_belief_insert_and_get_roundtrip() -> None:
 
 
 def test_belief_update_persists_alpha_beta_and_demotion() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     b = _mk_belief()
     s.insert_belief(b)
     b.alpha = 5.5
@@ -68,14 +68,14 @@ def test_belief_update_persists_alpha_beta_and_demotion() -> None:
 
 
 def test_belief_delete_returns_none() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk_belief())
     s.delete_belief("b1")
     assert s.get_belief("b1") is None
 
 
 def test_edge_insert_get_update_delete() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk_belief("a"))
     s.insert_belief(_mk_belief("b", content="thing two"))
     e = Edge(src="a", dst="b", type=EDGE_SUPPORTS, weight=0.7)
@@ -95,7 +95,7 @@ def test_edge_insert_get_update_delete() -> None:
 
 
 def test_fts5_search_finds_belief_by_keyword() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     s.insert_belief(_mk_belief("b1", content="apples are red and crunchy"))
     s.insert_belief(_mk_belief("b2", content="bananas are yellow"))
     s.insert_belief(_mk_belief("b3", content="grapes are purple"))
@@ -110,7 +110,7 @@ def test_fts5_search_finds_belief_by_keyword() -> None:
 
 
 def test_fts5_search_after_update_reflects_new_content() -> None:
-    s = Store(":memory:")
+    s = MemoryStore(":memory:")
     b = _mk_belief("b1", content="initial wording about cats")
     s.insert_belief(b)
     assert {h.id for h in s.search_beliefs("cats")} == {"b1"}


### PR DESCRIPTION
## Summary

P2 of the v2.0 reproducibility milestone. Stacks on PR #54 (P1 scaffold). Five atomic commits that take the academic-suite adapters from \"all imports fail\" to \"all imports succeed.\"

- **Renames `Store` → `MemoryStore`** consistently across 32 files (266 occurrences). Pure rename, no behavior change. Picked over the alias path for long-term consistency with lab v2.0.0 and to align the public surface with what every academic adapter expects.
- **Ports `aelfrice.extraction`** from lab — 71-LOC regex sentence splitter, no aelfrice dependencies. First piece of the ingest pipeline.
- **Adds `Session` shim** + `MemoryStore.create_session()` / `complete_session()`. Session is a 5-field dataclass; create returns a fresh handle, complete is a no-op. The public schema deliberately does not persist sessions at v1.0.x; this is the minimal API parity with lab so adapters compile without conditionals.
- **Adds `aelfrice.ingest.ingest_turn`** as a thin shim against the public schema rather than a literal port of lab's 440-LOC pipeline. Sentence-split → classify (public `classify_sentence`) → insert as belief, idempotent on (source, sentence) pairs. `session_id` and `source_id` are accepted for adapter parity but not persisted at v1.0.x.
- **Updates `benchmarks/README.md`** activation matrix to reflect the new state.

## Adapter import status after this PR

| Adapter | Imports? | Why end-to-end still blocks |
|---|---|---|
| `longmemeval_adapter` | OK (stdlib only) | retrieval-kwarg gap |
| `structmemeval_adapter` | OK (stdlib only) | retrieval-kwarg gap |
| `mab_adapter` | needs `nltk` + `tiktoken` | + retrieval-kwarg gap |
| `locomo_adapter` | needs `nltk` | + retrieval-kwarg gap |
| `amabench_adapter` | needs `datasets` (HF) | + retrieval-kwarg gap |

The retrieval-kwarg gap (lab adapters call `retrieve(budget=…, include_locked=False, use_hrr=True, use_bfs=True)` and consume `result.beliefs`; public `retrieve(token_budget=…)` returns `list[Belief]`) is not addressed in this PR. It is the natural next chunk — the shape of the wrapper is documented in `benchmarks/README.md`.

## Why path (b) — shim, not port

Lab v2.0.0's ingest pipeline pulls in `extraction`, `relationship_detector`, `supersession`, `triple_extraction`, `correction_detection`, plus 8 schema tables (sessions, observations, evidence, checkpoints, tests, audit_log, graph_edges, confidence_history) that public v1.0.0 deliberately does not have. Lifting the lab pipeline as-is would invert v1.0.0's slim-down. The shim approach keeps the public schema intact and only reaches into lab-side modules when the public API is genuinely insufficient. Lab features port later as their own phases driven by website-claim demand, not by ingest.

## Test plan

- [x] All existing tests pass: 546 → 563 (added 17 new across `test_extraction.py` + `test_ingest.py`).
- [x] `pyright --strict` clean over `src/aelfrice` and `tests`.
- [x] All 5 academic adapters now satisfy `import benchmarks.<adapter>` after their third-party deps are installed.
- [ ] End-to-end smoke against any one adapter on a 5-question subset — deferred to follow-up PR after retrieval-kwarg wrapper lands.

## Out of scope (next phases)

- `aelfrice.retrieval.retrieve_v2` lab-compat wrapper (next PR).
- Optional `[benchmarks]` extras for `nltk` / `tiktoken` / `datasets`.
- First end-to-end activation on a tiny subset.
- Triple extraction, entity-index retrieval, HRR vocabulary bridge (P3 / P4).
- Internal eval harnesses for non-academic claims (P5).

## Stacking

This PR's base is `feat/benchmarks-foundation` (PR #54), not `main`. Merge order: #54 first, then this. After #54 merges, GitHub will automatically retarget this to `main`.