### PR TITLE
chore: repo polish — workflow trim + live README badges

### DIFF
--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -1,8 +1,6 @@
 name: Staging Gate
 
 on:
-  push:
-    branches: [staging]
   pull_request:
     branches: [main]
 
@@ -106,10 +104,3 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --frozen --extra dev
       - run: uv run pytest tests/ -q
-
-  auto-pr-to-main:
-    if: false
-    needs: [secrets-scan, pattern-scan, history-scan, pytest]
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'true'

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 > Bayesian memory for AI coding agents. Local-only. Auditable.
 
-[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![CI](https://github.com/robotrocketscience/aelfrice/actions/workflows/ci.yml/badge.svg)](https://github.com/robotrocketscience/aelfrice/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/aelfrice.svg)](https://pypi.org/project/aelfrice/)
+[![Python](https://img.shields.io/pypi/pyversions/aelfrice.svg)](https://pypi.org/project/aelfrice/)
+[![License](https://img.shields.io/pypi/l/aelfrice.svg)](LICENSE)
+[![CI](https://github.com/robotrocketscience/aelfrice/actions/workflows/ci.yml/badge.svg)](https://github.com/robotrocketscience/aelfrice/actions/workflows/ci.yml)
+[![Staging Gate](https://github.com/robotrocketscience/aelfrice/actions/workflows/staging-gate.yml/badge.svg)](https://github.com/robotrocketscience/aelfrice/actions/workflows/staging-gate.yml)
+[![Downloads](https://img.shields.io/pypi/dm/aelfrice.svg)](https://pypi.org/project/aelfrice/)
 
 > [!NOTE]
 > v1.0 ships the surface — local SQLite store, retrieval, the `apply_feedback` endpoint, the onboarding scanner, an 11-command CLI, an MCP server, Claude Code wiring, and a reproducible benchmark harness. **Retrieval ranking is BM25-only at v1.0** — feedback updates the math but doesn't yet move ranking. The v1.x line wires posterior into ranking and closes [known issues](docs/LIMITATIONS.md#known-issues-at-v10).


### PR DESCRIPTION
## Summary

Cleanup pass to align the public-facing repo with v1.0 launch quality.

- **ci**: Drop dead \`push: branches: [staging]\` trigger and the permanently-disabled \`auto-pr-to-main\` stub from \`staging-gate.yml\`. Real flow is feature-branch -> PR -> main; the staging path was never exercised.
- **docs**: Replace static \"Python 3.12+\" / \"MIT\" badges with dynamic shields.io PyPI sources so they track \`pyproject.toml\` automatically. Add Staging Gate workflow status alongside CI, and PyPI monthly-downloads as a relevance signal.

Pairs with out-of-band repo-settings hardening already applied: secret scanning + push protection enabled, Dependabot security updates enabled, ruleset bypass tightened to \`pull_request\` only, single-merge-method (squash) policy, \`delete_branch_on_merge\` on, 11 stale remote branches pruned, topics + homepage set.

## Test plan

- [ ] Staging Gate runs on this PR (secrets-scan, pattern-scan, history-scan, pytest 3.12 + 3.13)
- [ ] CI workflow runs green
- [ ] After merge: README badges render correctly on github.com/robotrocketscience/aelfrice