### PR TITLE
docs: lead with determinism + traceability across README, PHILOSOPHY, ARCHITECTURE

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ No GPU. No network. No telemetry. No cloud.
 SQLite at ~/.aelfrice/memory.db. That's the whole runtime.
 ```
 
+Every retrieval result is traceable to the beliefs and rules that produced it. Every state of the system is reproducible from its write log. We are not aware of another agent-memory system that combines bit-level reproducibility, named-rule traceability, write-log historical reconstruction, and audit comprehensible to a non-technical reviewer as a single system property. See [PHILOSOPHY § Determinism is the property](docs/PHILOSOPHY.md#determinism-is-the-property).
+
 ## 60 seconds
 
 ```bash

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,11 +4,22 @@ Module map, data flow, design decisions. Maps directly to source under `src/aelf
 
 ## Principles
 
-1. **Stdlib + SQLite only.** No vector DB, no embeddings, no cloud, no LLM in the hot path. The `[mcp]` extra is the only non-stdlib runtime dependency, and it's optional.
-2. **Bayesian, not vibes.** Confidence is `α / (α + β)`. Every update has a closed-form rule. (Note: at v1.0 this score does not yet drive retrieval ranking — see [LIMITATIONS](LIMITATIONS.md#known-issues-at-v10).)
-3. **`apply_feedback` is the central endpoint.** One writer of `(α, β)`. One audit row per successful update.
-4. **Locks are user-asserted ground truth.** A `user`-locked belief short-circuits decay (lock floor) and bypasses L1 budgeting on retrieval. Contradicting positive feedback accumulates `demotion_pressure`; ≥ 5 ⇒ auto-demote.
-5. **Clean by construction, not clean by audit.** Filtering is a tripwire, not a gate.
+1. **Determinism end to end.** Every retrieval result is bit-identical given the same write log and the same code. Every result traces to named beliefs and named rules. The four-property commitment (bit-level reproducibility, named-rule traceability, write-log historical reconstruction, non-technical audit) is documented in [PHILOSOPHY § Determinism is the property](PHILOSOPHY.md#determinism-is-the-property). New components must preserve it; non-deterministic steps either run as one-time enrichment whose outputs are stored as deterministic content (see § Enrichment-step boundary below) or are clearly marked as opt-in non-deterministic paths.
+2. **Stdlib + SQLite only.** No vector DB, no embeddings, no cloud, no LLM in the hot path. The `[mcp]` extra is the only non-stdlib runtime dependency, and it's optional.
+3. **Bayesian, not vibes.** Confidence is `α / (α + β)`. Every update has a closed-form rule. (Note: at v1.0 this score does not yet drive retrieval ranking — see [LIMITATIONS](LIMITATIONS.md#known-issues-at-v10).)
+4. **`apply_feedback` is the central endpoint.** One writer of `(α, β)`. One audit row per successful update.
+5. **Locks are user-asserted ground truth.** A `user`-locked belief short-circuits decay (lock floor) and bypasses L1 budgeting on retrieval. Contradicting positive feedback accumulates `demotion_pressure`; ≥ 5 ⇒ auto-demote.
+6. **Clean by construction, not clean by audit.** Filtering is a tripwire, not a gate.
+
+### Enrichment-step boundary
+
+The determinism contract applies to retrieval — every read is reproducible from the inputs. Some write-side operations (LLM-driven sentence classification on the v1.3 polymorphic onboard path; future `wonder` / `reason` capabilities in v2.0) involve non-deterministic upstream steps. The boundary is explicit:
+
+- **Inputs to enrichment** (raw sentence, source path, host-LLM model id and version, prompt template hash) are recorded deterministically.
+- **Outputs of enrichment** (assigned belief type, type prior, derived edges) are stored as deterministic content with provenance: classifier version, rule-set hash, timestamp.
+- **All retrieval and feedback math downstream** of the enriched store is deterministic. Replaying retrieval against the same enriched corpus produces bit-identical results.
+
+The contract is *deterministic substrate + bounded, audited enrichment layer*, not "no model ever touches the data." A reviewer can identify, for any belief, exactly which step was bounded-non-deterministic and inspect the model id, prompt, and output. Replay-from-raw-text reproducibility requires re-running the enrichment with the same model version; replay-from-enriched-corpus reproducibility is unconditional.
 
 ## Modules
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -10,6 +10,31 @@ The failure modes are predictable: the agent reads the rule and ignores it; cros
 
 aelfrice is a different mechanism, not a tidier file layout. It finds context itself and injects it into the prompt before the agent answers. The agent never has to remember to check a file or follow a cross-reference. Knowledge is already there.
 
+## Determinism is the property
+
+The architectural commitment that organizes everything else.
+
+aelfrice commits to four things, and the commitments interlock:
+
+1. **Bit-level reproducibility.** Given the same write log and the same code, every retrieval result is bit-identical across runs, machines, and time. No model checkpoint, no learned representation that drifts between releases.
+2. **Named-rule traceability.** Every retrieval result is a function of named beliefs and named rules. Asking *"why did this directive surface for this query?"* produces a chain that bottoms out in specific user actions at specific timestamps via specific extraction patterns. The chain is finite, inspectable, and human-readable at every step.
+3. **Write-log historical reconstruction.** Because the log of writes is the source of truth and the queryable structure is derived, any past state of the system is reconstructible. *"What would the agent have retrieved on this query last March, before that lock was set?"* is an answerable question.
+4. **Audit comprehensible to a non-technical reviewer.** "BM25 matched these terms, which retrieved these beliefs, which were filtered by these locked directives, which were created by these user actions at these timestamps" — the chain holds for a regulator, an auditor, or a user, not just for the developer.
+
+These properties hold compositionally only if every component preserves them. A single non-deterministic step in any retrieval path destroys the property for the whole pipeline. There is no "mostly deterministic" — either the property holds end to end or it does not. Embeddings, learned re-rankers, and LLM-driven retrieval steps trade this property for retrieval-quality gains on certain query categories. aelfrice trades the other way, deliberately.
+
+We are not aware of another agent-memory system that combines all four of these guarantees as a single system property.
+
+What it buys, beyond the obvious:
+
+- **Debugging is bounded.** A wrong retrieval is the result of a specific rule that can be identified and fixed. Compare with embedding systems where "wrong result" gets answered with similarity scores.
+- **Provenance composes.** Every belief carries provenance; every retrieval result is a deterministic function of beliefs and rules; every retrieval result therefore inherits provenance from its sources.
+- **Acceptance tests are precise behavioural specifications, not regression detectors with tolerances.**
+- **Counterfactual evaluation becomes tractable.** Replay history with and without specific corrections; measure the differential. Determinism is what makes the differential meaningful.
+- **High-stakes deployment is structurally admitted.** Medical, legal, financial contexts need explainability that survives an audit. Most agent-memory systems are structurally locked out of these settings; aelfrice is structurally admitted.
+
+There are categories of query — multi-session aggregation, fuzzy semantic recall — where the deterministic stack underperforms an embedding system. We treat that as a clarification of what aelfrice is for, not a gap to close at the cost of the property. See [LIMITATIONS](LIMITATIONS.md) for the current scope.
+
 ## Bayesian, not vector
 
 Vector RAG remembers documents. It doesn't remember _outcomes_ — which retrievals helped, which hurt, which were corrected. Two beliefs with similar embeddings rank equally even when one has been right ten times and the other was retrieved once and harmful.
@@ -22,9 +47,9 @@ used    ⟹ α += 1
 harmful ⟹ β += 1
 ```
 
-No embedding model. No hyperparameter search. No opaque ranking. Every score is one division and the audit trail is one table.
+No embedding model. No hyperparameter search. No opaque ranking. Every score is one division and the audit trail is one table. The Bayesian update is itself one of the named rules that traceability bottoms out in.
 
-The cost: dense semantic similarity is gone. The benefit: a learning loop that converges on what _works for you_, not what's textually similar.
+The cost: dense semantic similarity is gone. The benefit: a learning loop that converges on what _works for you_, not what's textually similar — and a retrieval pipeline that preserves the determinism property end to end.
 
 ## Locks, not just decay
 
@@ -55,7 +80,7 @@ Every dependency is maintenance debt and attack surface. Heavier machinery — v
 - **Continuity.** Close the terminal, come back next week, "where were we?" — the memory restores it.
 - **Compounding (by design).** At v1.0 the graph fills during explicit `onboard`/`lock`/`feedback` calls. v1.0.1 closes the hook→feedback-history loop so retrievals leave an audit trail. v1.2.0 adds the commit-ingest hook for automatic capture. v1.3 wires the posterior into retrieval ranking. See [LIMITATIONS](LIMITATIONS.md#known-issues-at-v10).
 - **Self-correction.** Stale rules decay. Wrong locks demote. The mechanism notices when reality has moved.
-- **Auditability.** Every belief has a content hash and timestamp. Every feedback event has an audit row. Every score is `α / (α + β)`. Read the database; reproduce the system's claims about itself.
+- **Auditability.** Every belief has a content hash and timestamp. Every feedback event has an audit row. Every score is `α / (α + β)`. Every retrieval result is reproducible bit-for-bit from the write log and the code. Read the database; reproduce the system's claims about itself. See [Determinism is the property](#determinism-is-the-property).
 - **Locality.** No service to fail, no account to lose, no quota to exceed.
 
 ## What it isn't


### PR DESCRIPTION
## Summary

- README gets a four-property determinism claim (bit-level reproducibility, named-rule traceability, write-log historical reconstruction, audit comprehensible to a non-technical reviewer) above the fold.
- PHILOSOPHY adds a new \"Determinism is the property\" section before \"Bayesian, not vector\". Sharpens the existing \"Auditability\" bullet to reference it.
- ARCHITECTURE promotes determinism to principle 1 and adds an explicit \"Enrichment-step boundary\" sub-section that distinguishes the deterministic substrate from bounded, audited non-deterministic enrichment paths (v1.3 LLM classification on the polymorphic onboard path; v2.0 wonder/reason).

The \"we are not aware of another system that combines all four as a single system property\" wording is verified against a private-side field survey of nine comparator systems (Mem0, Zep/Graphiti, Letta, MIRIX, A-MEM, MemMachine, LangGraph, LlamaIndex, Cognee). Partial overlaps exist — Graphiti documents source-lineage, LangGraph supports checkpoint replay — but neither commits to the conjunction.

## Test plan

- [ ] Render README on github.com/robotrocketscience/aelfrice; confirm new paragraph reads above the fold and the link to \`docs/PHILOSOPHY.md#determinism-is-the-property\` resolves.
- [ ] Render PHILOSOPHY.md; confirm new section anchor \`#determinism-is-the-property\` works.
- [ ] Render ARCHITECTURE.md; confirm \"Enrichment-step boundary\" sub-section is reachable from the principles list.
- [ ] No code changed; pytest is unaffected. Spot-check: \`uv run pytest -m regression\` should still pass on this branch.