### PR TITLE
feat(v1.1.0): LRU query cache for retrieve()

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,6 +36,7 @@ The first patch closes the highest-visibility gaps from launch. Each item is tra
 - **Onboard performance.** A regression test verifying < 60s on a 50k-LOC project.
 - **Contradiction tie-breaker.** Default precedence `user_stated > user_corrected > document_recent > agent_inferred`, with ISO timestamp as the deciding fallback. The loser is auto-superseded; the audit row records which rule fired.
 - **`aelf --version`.** Reads from `aelfrice.__version__`. Trivial, but currently raises an argparse error.
+- **Query result cache.** A bounded LRU cache wrapping `aelfrice.retrieval.retrieve()`, keyed on a canonicalized form of `(query, token_budget, l1_limit)` and invalidated on every store mutation. Skips a full L0+L1 pass when an agent loop re-issues the same query. Spec: [`lru_query_cache.md`](lru_query_cache.md).
 
 ## v1.1.0 — project identity and cosmetic surface
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,7 +36,6 @@ The first patch closes the highest-visibility gaps from launch. Each item is tra
 - **Onboard performance.** A regression test verifying < 60s on a 50k-LOC project.
 - **Contradiction tie-breaker.** Default precedence `user_stated > user_corrected > document_recent > agent_inferred`, with ISO timestamp as the deciding fallback. The loser is auto-superseded; the audit row records which rule fired.
 - **`aelf --version`.** Reads from `aelfrice.__version__`. Trivial, but currently raises an argparse error.
-- **Query result cache.** A bounded LRU cache wrapping `aelfrice.retrieval.retrieve()`, keyed on a canonicalized form of `(query, token_budget, l1_limit)` and invalidated on every store mutation. Skips a full L0+L1 pass when an agent loop re-issues the same query. Spec: [`lru_query_cache.md`](lru_query_cache.md).
 
 ## v1.1.0 — project identity and cosmetic surface
 
@@ -47,6 +46,7 @@ The first patch closes the highest-visibility gaps from launch. Each item is tra
 - **`aelf health` vs `aelf status` split.** `status` becomes a counts snapshot; `health` becomes a real graph auditor — orphan edges, isolated clusters, FTS5 sync, locked-belief contradictions, decay anomalies.
 - **`edges` → `threads`.** User-facing rename in CLI output and MCP tool descriptions. Internal schema is unchanged.
 - **Onboard improvements.** Git-recency weighting for source files; explicit `agent_inferred` → `user_validated` promotion path so onboard-derived beliefs can graduate without being re-locked.
+- **Query result cache.** A bounded LRU cache wrapping `aelfrice.retrieval.retrieve()`, keyed on a canonicalized form of `(query, token_budget, l1_limit)` and invalidated on every store mutation. Skips a full L0+L1 pass when an agent loop re-issues the same query. Spec: [`lru_query_cache.md`](lru_query_cache.md).
 
 ## v1.2.0 — auto-capture and triple extraction
 

--- a/docs/lru_query_cache.md
+++ b/docs/lru_query_cache.md
@@ -1,0 +1,136 @@
+# LRU query cache for `aelfrice.retrieval.retrieve()`
+
+**Status:** spec.
+**Target milestone:** v1.0.1.
+**Dependencies:** stdlib only (`collections.OrderedDict`).
+**Risk:** low. Pure addition to `aelfrice/retrieval.py`. No schema
+change. No `models.py` change.
+
+## Summary
+
+Add a bounded-size LRU cache in front of `aelfrice.retrieval.retrieve()`
+keyed on a canonicalized form of `(query, token_budget, l1_limit)`. On
+hit, return the cached result list directly without re-running L0
+listing or L1 FTS5 search. On miss, run the full retrieval pipeline and
+store the result.
+
+Memoization on canonicalized queries is a standard optimization for
+agent workflows where the same logical question is issued repeatedly
+across a session.
+
+## Motivation
+
+Agent loops re-issue identical or near-identical queries (re-checking
+"what's the database?", retrying after partial failures, exploring the
+same neighborhood from different code paths). The current `retrieve()`
+runs `list_locked_beliefs()` plus an FTS5 BM25 query on every call —
+fast at the scales aelfrice targets, but not free. A cached lookup
+shaves the entire pipeline cost on repeat queries.
+
+This is the only sub-millisecond latency band available to the
+retrieval surface — every other optimization stays above the FTS5
+floor.
+
+The same cache becomes more valuable as later releases extend
+`retrieve()` (v1.3.0 partial Bayesian-weighted ranking; v2.0.0 full
+feedback-into-retrieval loop): the same hit short-circuits each
+addition.
+
+## Design
+
+### Cache key
+
+```python
+def canonicalize(query: str) -> str:
+    """Lowercase, strip punctuation, sort tokens, rejoin.
+
+    Two queries that differ only in word order or punctuation hit
+    the same cache entry. This is correct for FTS5 BM25, which is
+    bag-of-words.
+    """
+```
+
+The full cache key is a tuple `(canonicalized_query, token_budget,
+l1_limit)` so a `token_budget=2000` call does not return cached
+`token_budget=500` results.
+
+### Cache structure
+
+`OrderedDict[tuple[str, int, int], list[Belief]]` with `move_to_end`
+on access. Default capacity: 256 entries.
+
+### Implementation choice
+
+Two options:
+
+- **A (cache on store).** `MemoryStore` owns an internal cache plus a
+  `cached_retrieve()` method. Single source of truth for invalidation.
+  Cons: store now holds retrieval state.
+- **B (cache class subscribes to store).** New `RetrievalCache` in
+  `retrieval.py` wraps a store reference and registers an invalidation
+  callback. Keeps store as pure storage. Cons: callback plumbing.
+
+This release ships **Option B**. Adds a tiny callback registry to
+`MemoryStore` (`add_invalidation_callback(fn)`) and a
+`RetrievalCache(store)` class that subscribes its `invalidate()`
+method on construction. Free-function `retrieve()` keeps working
+unchanged for callers that don't want caching.
+
+### Invalidation
+
+Wipe the entire cache on any state change that could alter retrieval
+results. Cheapest correct policy.
+
+Mutators that fire invalidation: `insert_belief`, `update_belief`,
+`delete_belief`, `insert_edge`, `update_edge`, `delete_edge`. That
+covers lock-state changes (locks flow through `update_belief`) and
+posterior updates from `apply_feedback` (also through
+`update_belief`).
+
+A finer-grained policy (only invalidate cache entries whose result set
+contains the modified belief) is a later optimization. v1.0.1 ships
+the wipe-on-write version.
+
+### Forward compatibility with `retrieve_v2`
+
+`retrieve_v2` is a wrapper for academic-suite adapters. It calls
+`retrieve()` internally, so it inherits caching once `retrieve()` is
+cached — no separate code path needed. The `use_hrr` and `use_bfs`
+flags are no-ops at v1.0.x and don't enter the cache key.
+
+## Acceptance criteria
+
+1. Cache hit returns identical result list to a fresh pipeline run for
+   the same canonicalized query and key tuple.
+2. Cache hit costs ≤ 50 µs on commodity hardware (warm interpreter,
+   N=256 cache entries). Verified by a deterministic micro-benchmark.
+3. Cache miss runs the full pipeline and stores the result.
+4. Each of the six store mutators above invalidates the cache.
+   Verified by inserting beliefs → caching a query → mutating store →
+   reissuing query → asserting the second call returns updated results,
+   not stale cache.
+5. Cache eviction is LRU: the least-recently-accessed entry is dropped
+   when capacity is exceeded.
+6. Two queries that differ only in word order or punctuation hit the
+   same cache entry.
+7. Two queries that differ in `token_budget` or `l1_limit` use distinct
+   cache entries.
+8. The cache is per-store-instance. Multiple `MemoryStore` instances
+   do not share state.
+
+## Test plan
+
+`tests/test_retrieval_cache.py` covers all 8 acceptance criteria. All
+tests deterministic (fixed seeds, in-memory `:memory:` store). Wall
+clock per test < 100 ms.
+
+## Out of scope
+
+- Cross-session cache persistence. Cache is in-memory only.
+- Distributed cache invalidation. Single-process only.
+- Per-belief invalidation (wipe-on-write is sufficient at this
+  milestone).
+- Cache statistics / hit-rate metrics endpoint. Add when there is a
+  consumer that needs them.
+- Configurable canonicalization strategy. Single canonicalizer is
+  correct for FTS5 BM25; revisit if a non-bag-of-words ranker lands.

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -8,9 +8,17 @@ survive retrieval.
 NO HRR, NO BFS multi-hop, NO entity-index in v1.0 (pre-commit #6). Those
 land in a later release once the retrieval upgrade R&D is validated against
 a real corpus.
+
+A `RetrievalCache` wrapper provides bounded LRU memoization over the free
+function `retrieve()`. Cache invalidation is wired through the store's
+callback registry (wipe-on-write across the six mutators). Use the
+free function for single calls; use `RetrievalCache(store)` for agent
+loops that re-issue the same query.
 """
 from __future__ import annotations
 
+import re
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Final
 
@@ -20,6 +28,22 @@ from aelfrice.store import MemoryStore
 DEFAULT_TOKEN_BUDGET: Final[int] = 2000
 _CHARS_PER_TOKEN: Final[float] = 4.0
 DEFAULT_L1_LIMIT: Final[int] = 50
+DEFAULT_CACHE_CAPACITY: Final[int] = 256
+
+_CANONICALIZE_PUNCT: Final[re.Pattern[str]] = re.compile(r"[^\w\s]")
+
+
+def canonicalize_query(query: str) -> str:
+    """Return a deterministic key for cache lookup.
+
+    Lowercase, replace punctuation with whitespace, split on whitespace,
+    sort tokens, rejoin with single spaces. Two queries that differ only
+    in word order or punctuation map to the same key — correct for FTS5
+    BM25, which is bag-of-words.
+    """
+    cleaned = _CANONICALIZE_PUNCT.sub(" ", query.lower()).strip()
+    tokens = sorted(cleaned.split())
+    return " ".join(tokens)
 
 
 @dataclass(frozen=True)
@@ -120,3 +144,62 @@ def retrieve_v2(
     else:
         beliefs = [b for b in raw if b.lock_level == LOCK_NONE]
     return RetrievalResult(beliefs=beliefs)
+
+
+class RetrievalCache:
+    """Bounded LRU cache wrapping `retrieve()` for an attached store.
+
+    Subscribes to the store's invalidation callback registry on
+    construction, so any belief or edge mutation wipes the cache.
+    Per-instance: two `RetrievalCache` objects pointing at different
+    stores never share state.
+
+    Usage:
+
+        cache = RetrievalCache(store)
+        beliefs = cache.retrieve("what database do we use?")
+        # Later in the same agent loop — second call is a cache hit.
+        beliefs = cache.retrieve("what database do we use?")
+    """
+
+    def __init__(
+        self,
+        store: MemoryStore,
+        capacity: int = DEFAULT_CACHE_CAPACITY,
+    ) -> None:
+        if capacity < 1:
+            raise ValueError("capacity must be >= 1")
+        self._store = store
+        self._capacity = capacity
+        self._entries: OrderedDict[
+            tuple[str, int, int], list[Belief]
+        ] = OrderedDict()
+        store.add_invalidation_callback(self.invalidate)
+
+    def retrieve(
+        self,
+        query: str,
+        token_budget: int = DEFAULT_TOKEN_BUDGET,
+        l1_limit: int = DEFAULT_L1_LIMIT,
+    ) -> list[Belief]:
+        """Cached `retrieve()`. Identical contract to the free function."""
+        key = (canonicalize_query(query), token_budget, l1_limit)
+        cached = self._entries.get(key)
+        if cached is not None:
+            self._entries.move_to_end(key)
+            return list(cached)
+        result = retrieve(
+            self._store, query,
+            token_budget=token_budget, l1_limit=l1_limit,
+        )
+        self._entries[key] = list(result)
+        if len(self._entries) > self._capacity:
+            self._entries.popitem(last=False)
+        return result
+
+    def invalidate(self) -> None:
+        """Drop every cached entry. Wired to the store's mutation hook."""
+        self._entries.clear()
+
+    def __len__(self) -> int:
+        return len(self._entries)

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import secrets
 import sqlite3
 from datetime import datetime, timezone
-from typing import Iterable
+from typing import Callable, Iterable
 
 from aelfrice.models import (
     EDGE_VALENCE,
@@ -171,9 +171,27 @@ class MemoryStore:
         for stmt in _SCHEMA:
             self._conn.execute(stmt)
         self._conn.commit()
+        self._invalidation_callbacks: list[Callable[[], None]] = []
 
     def close(self) -> None:
         self._conn.close()
+
+    # --- Invalidation callbacks ------------------------------------------
+    #
+    # External components (e.g. RetrievalCache) register a zero-arg callback
+    # that is fired on every belief/edge mutation. Used to wipe derived
+    # state — query result caches, materialized views — that depends on the
+    # store's contents. Callback order is registration order; exceptions
+    # raised by a callback propagate (better to fail loudly than silently
+    # serve stale data).
+
+    def add_invalidation_callback(self, fn: Callable[[], None]) -> None:
+        """Register a zero-arg callback fired after every store mutation."""
+        self._invalidation_callbacks.append(fn)
+
+    def _fire_invalidation(self) -> None:
+        for fn in self._invalidation_callbacks:
+            fn()
 
     # --- Belief CRUD ------------------------------------------------------
 
@@ -197,6 +215,7 @@ class MemoryStore:
             (b.id, b.content),
         )
         self._conn.commit()
+        self._fire_invalidation()
 
     def get_belief(self, belief_id: str) -> Belief | None:
         cur = self._conn.execute(
@@ -234,6 +253,7 @@ class MemoryStore:
             (b.id, b.content),
         )
         self._conn.commit()
+        self._fire_invalidation()
 
     def delete_belief(self, belief_id: str) -> None:
         self._conn.execute("DELETE FROM beliefs WHERE id = ?", (belief_id,))
@@ -243,6 +263,7 @@ class MemoryStore:
             (belief_id, belief_id),
         )
         self._conn.commit()
+        self._fire_invalidation()
 
     def search_beliefs(self, query: str, limit: int = 20) -> list[Belief]:
         """FTS5 keyword search over belief content. Ranked by bm25.
@@ -387,6 +408,7 @@ class MemoryStore:
             (e.src, e.dst, e.type, e.weight),
         )
         self._conn.commit()
+        self._fire_invalidation()
 
     def get_edge(self, src: str, dst: str, type_: str) -> Edge | None:
         cur = self._conn.execute(
@@ -402,6 +424,7 @@ class MemoryStore:
             (e.weight, e.src, e.dst, e.type),
         )
         self._conn.commit()
+        self._fire_invalidation()
 
     def delete_edge(self, src: str, dst: str, type_: str) -> None:
         self._conn.execute(
@@ -409,6 +432,7 @@ class MemoryStore:
             (src, dst, type_),
         )
         self._conn.commit()
+        self._fire_invalidation()
 
     def edges_from(self, src: str) -> list[Edge]:
         cur = self._conn.execute(

--- a/tests/test_retrieval_cache.py
+++ b/tests/test_retrieval_cache.py
@@ -1,0 +1,232 @@
+"""Acceptance tests for `RetrievalCache` (docs/lru_query_cache.md).
+
+Eight tests, one per acceptance criterion. All deterministic, in-memory
+SQLite, < 100 ms wall clock per test.
+"""
+from __future__ import annotations
+
+import time
+
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_RELATES_TO,
+    LOCK_NONE,
+    LOCK_USER,
+    Belief,
+    Edge,
+)
+from aelfrice.retrieval import (
+    DEFAULT_CACHE_CAPACITY,
+    RetrievalCache,
+    canonicalize_query,
+    retrieve,
+)
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    bid: str,
+    content: str,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _seeded_store() -> MemoryStore:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("F1", "the kitchen is full of bananas"))
+    s.insert_belief(_mk("F2", "the garage is full of tools"))
+    s.insert_belief(_mk(
+        "L1", "user pinned a fact about cats",
+        lock_level=LOCK_USER, locked_at="2026-04-26T01:00:00Z",
+    ))
+    return s
+
+
+# --- AC1: cache hit returns identical results to a fresh pipeline run -----
+
+def test_ac1_cache_hit_matches_fresh_pipeline() -> None:
+    s = _seeded_store()
+    cache = RetrievalCache(s)
+    fresh = retrieve(s, "bananas")
+    cached_first = cache.retrieve("bananas")  # miss → store
+    cached_second = cache.retrieve("bananas")  # hit
+    assert [b.id for b in cached_first] == [b.id for b in fresh]
+    assert [b.id for b in cached_second] == [b.id for b in fresh]
+
+
+# --- AC2: cache hit ≤ 50 µs ------------------------------------------------
+
+def test_ac2_cache_hit_under_fifty_microseconds() -> None:
+    s = _seeded_store()
+    cache = RetrievalCache(s)
+    cache.retrieve("bananas")  # warm
+    # Best-of-many to dampen scheduler jitter.
+    best = float("inf")
+    for _ in range(50):
+        t0 = time.perf_counter()
+        cache.retrieve("bananas")
+        elapsed = time.perf_counter() - t0
+        if elapsed < best:
+            best = elapsed
+    assert best <= 50e-6, f"best-of-50 cache hit was {best * 1e6:.1f} us"
+
+
+# --- AC3: cache miss runs the full pipeline and stores the result --------
+
+def test_ac3_cache_miss_runs_pipeline_and_stores() -> None:
+    s = _seeded_store()
+    cache = RetrievalCache(s)
+    assert len(cache) == 0
+    cache.retrieve("bananas")
+    assert len(cache) == 1
+    cache.retrieve("tools")
+    assert len(cache) == 2
+
+
+# --- AC4: every store mutator invalidates the cache ----------------------
+
+def test_ac4_every_mutator_invalidates_cache() -> None:
+    s = _seeded_store()
+    cache = RetrievalCache(s)
+
+    # Helper: prime cache, mutate, assert wiped.
+    def assert_invalidates(label: str, mutate: callable) -> None:
+        cache.retrieve("bananas")
+        assert len(cache) >= 1, f"{label}: cache failed to populate"
+        mutate()
+        assert len(cache) == 0, f"{label}: cache not invalidated"
+
+    new_belief = _mk("F3", "the basement is full of crates")
+
+    assert_invalidates(
+        "insert_belief",
+        lambda: s.insert_belief(new_belief),
+    )
+
+    fetched = s.get_belief("F3")
+    assert fetched is not None
+    fetched.content = "the basement holds crates and ropes"
+    assert_invalidates(
+        "update_belief",
+        lambda: s.update_belief(fetched),
+    )
+
+    assert_invalidates(
+        "delete_belief",
+        lambda: s.delete_belief("F3"),
+    )
+
+    edge = Edge(src="F1", dst="F2", type=EDGE_RELATES_TO, weight=1.0)
+    assert_invalidates(
+        "insert_edge",
+        lambda: s.insert_edge(edge),
+    )
+
+    edge2 = Edge(src="F1", dst="F2", type=EDGE_RELATES_TO, weight=0.5)
+    assert_invalidates(
+        "update_edge",
+        lambda: s.update_edge(edge2),
+    )
+
+    assert_invalidates(
+        "delete_edge",
+        lambda: s.delete_edge("F1", "F2", EDGE_RELATES_TO),
+    )
+
+
+# --- AC5: LRU eviction at capacity ---------------------------------------
+
+def test_ac5_lru_eviction_at_capacity() -> None:
+    s = _seeded_store()
+    cache = RetrievalCache(s, capacity=3)
+    cache.retrieve("query_a")
+    cache.retrieve("query_b")
+    cache.retrieve("query_c")
+    assert len(cache) == 3
+    # Touch query_a so it becomes most-recently-used; query_b is now LRU.
+    cache.retrieve("query_a")
+    cache.retrieve("query_d")  # evicts query_b
+    assert len(cache) == 3
+    # query_b should now miss (re-storing it brings cache to capacity again,
+    # which would evict the next LRU — this confirms it was actually gone).
+    keys = list(cache._entries.keys())
+    canon_b = canonicalize_query("query_b")
+    assert all(k[0] != canon_b for k in keys), \
+        f"query_b should have been evicted; entries = {keys}"
+
+
+# --- AC6: punctuation/word-order canonicalization ------------------------
+
+def test_ac6_punctuation_and_word_order_canonicalize() -> None:
+    s = _seeded_store()
+    cache = RetrievalCache(s)
+    cache.retrieve("bananas kitchen")
+    assert len(cache) == 1
+    # Same tokens, different order + punctuation — must hit existing entry.
+    cache.retrieve("KITCHEN, bananas!")
+    assert len(cache) == 1, \
+        "punctuation + word-order variants should hit the same cache entry"
+
+
+# --- AC7: distinct token_budget / l1_limit are distinct cache entries ---
+
+def test_ac7_budget_and_limit_are_part_of_key() -> None:
+    s = _seeded_store()
+    cache = RetrievalCache(s)
+    cache.retrieve("bananas", token_budget=2000)
+    cache.retrieve("bananas", token_budget=500)
+    assert len(cache) == 2, "different token_budget must produce distinct entries"
+    cache.retrieve("bananas", token_budget=2000, l1_limit=10)
+    assert len(cache) == 3, "different l1_limit must produce distinct entries"
+
+
+# --- AC8: cache is per-store-instance ------------------------------------
+
+def test_ac8_cache_is_per_instance() -> None:
+    s1 = _seeded_store()
+    s2 = _seeded_store()
+    c1 = RetrievalCache(s1)
+    c2 = RetrievalCache(s2)
+    c1.retrieve("bananas")
+    assert len(c1) == 1
+    assert len(c2) == 0, "second cache must not see first cache's entries"
+    # Mutating s1 must not affect c2.
+    s1.insert_belief(_mk("F9", "extra fact"))
+    assert len(c1) == 0, "c1 should have invalidated"
+    assert len(c2) == 0, "c2 was already empty; nothing to assert beyond independence"
+
+
+# --- Sanity: defaults are sensible ---------------------------------------
+
+def test_default_capacity_is_positive() -> None:
+    assert DEFAULT_CACHE_CAPACITY >= 1
+
+
+def test_canonicalize_is_deterministic() -> None:
+    assert canonicalize_query("Hello, world!") == "hello world"
+    assert canonicalize_query("World hello") == "hello world"
+    assert canonicalize_query("  HELLO   WORLD  ") == "hello world"
+
+
+def test_capacity_must_be_positive() -> None:
+    s = _seeded_store()
+    try:
+        RetrievalCache(s, capacity=0)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("capacity=0 should have raised ValueError")


### PR DESCRIPTION
## Summary

- Adds a bounded LRU cache wrapping `aelfrice.retrieval.retrieve()`, keyed on `(canonicalized_query, token_budget, l1_limit)` with default capacity 256.
- Adds a tiny invalidation callback registry to `MemoryStore` (`add_invalidation_callback`); fired from each of the six belief/edge mutators. `RetrievalCache` subscribes its `invalidate()` method on construction. Wipe-on-write across all writes.
- **Slotted into v1.1.0** (project identity / cosmetic surface), per scope review. Originally pitched against v1.0.1; moved out because v1.0.1 ships narrow launch-defect fixes and the cache is a performance optimisation. Per-feature spec at `docs/lru_query_cache.md`.

`retrieve()` and `retrieve_v2()` keep their existing free-function contracts. Caching is opt-in via `RetrievalCache(store)`. No public-API breaks. No schema change. No new dependency. CHANGELOG update intentionally deferred to the v1.1.0 release commit.

## Acceptance criteria

All 8 from `docs/lru_query_cache.md` covered by `tests/test_retrieval_cache.py::test_ac{1..8}_*`, plus 3 sanity tests for defaults, canonicalization, and capacity validation.

## Test plan

- [x] `pytest tests/test_retrieval_cache.py` — 11/11 passing.
- [x] `pytest tests/` — 581 passing (570 baseline + 11 new). No regressions on existing retrieval / store / propagation / feedback tests.
- [x] Best-of-50 cache hit latency on laptop: ~3 µs (acceptance threshold 50 µs).
- [ ] Reviewer to spot-check the wipe-on-write coverage in \`test_ac4_every_mutator_invalidates_cache\` against the six mutators in \`src/aelfrice/store.py\`.
- [ ] Reviewer to confirm Option B (RetrievalCache subscriber) is preferred over Option A (cache-on-store) per the spec — both options are documented, this PR ships Option B.

## Merge ordering

Hold this PR open until v1.0.1 has tagged. The latest commit on this branch (\`a912be0\`) re-pitches the ROADMAP slot to v1.1.0; merging before v1.0.1 ships would land cache code on a v1.0.x line where ROADMAP no longer references it, which is fine semantically but reads as scope creep on the patch. Cleaner sequence: tag v1.0.1 first, then merge this and bundle into the v1.1.0 line item set.