### PR TITLE
feat(v1.0.1): hook_search — close the retrieval-side feedback-loop gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,29 @@ installable release; see the roadmap in [README.md](README.md).
 
 ### Added
 
+- `aelfrice.hook_search` module: `search_for_prompt(store, prompt, ...)`
+  and `record_retrieval(store, beliefs, ...)`. Closes the v1.0.1
+  retrieval-side feedback-loop gap: every UserPromptSubmit hook
+  retrieval now writes one `feedback_history` row per returned belief,
+  tagged `source='hook'` with `HOOK_RETRIEVAL_VALENCE` (0.1) positive
+  valence (#70).
+- `propagate: bool = True` kwarg on `aelfrice.feedback.apply_feedback`.
+  Default preserves the corrective-feedback contract (positive signal
+  on a contradictor pressures the contradicted user lock); pass `False`
+  for non-corrective signals (hook-driven retrievals) to update the
+  posterior without pressure-walking locked beliefs (#70).
 - `aelf --version` flag prints `aelf <__version__>` and exits 0.
   Closes the long-standing argparse error users hit when probing the
   installed version (#71).
+
+### Changed
+
+- `aelfrice.hook.user_prompt_submit` now routes through
+  `aelfrice.hook_search.search_for_prompt` instead of calling
+  `aelfrice.retrieval.retrieve()` directly. Same non-blocking contract,
+  same OPEN_TAG/CLOSE_TAG output envelope, same payload schema; the
+  behavioural difference is the audit-row write per returned belief
+  (#70).
 
 ## [1.0.0] - 2026-04-27
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -22,7 +22,7 @@ Tracked openly. Each item is mapped to its target version below.
 
 - ✅ **`aelf --version` (v1.0.1).** Prints `aelf <__version__>` and exits 0. Short-circuits the required-subcommand check via argparse's standard version action.
 - **The `aelf-hook` UserPromptSubmit hook may return empty results despite a populated FTS5 index.** Hook fires; no `<aelfrice-memory>` block appears. Workaround: drop to CLI.
-- **Hook bypasses `aelfrice.retrieval.retrieve()` and does not record retrievals as feedback events.** Highest-impact gap. The hook uses an inline FTS5 shim, skipping L0 locked-belief auto-load and feedback-history logging. The "feedback-driven learning" claim depends on this loop closing. v1.0.1 introduces `src/aelfrice/hook_search.py` (`search_for_prompt` + `record_retrieval`) and replaces the shim.
+- ✅ **Hook records retrievals as feedback events (v1.0.1).** The `aelf-hook` UserPromptSubmit entry-point now routes through `aelfrice.hook_search.search_for_prompt`, which wraps `aelfrice.retrieval.retrieve()` and writes one `feedback_history` row per returned belief, tagged `source='hook'` with valence `HOOK_RETRIEVAL_VALENCE` (0.1) and `propagate=False` so implicit retrieval-time exposure does not pressure-walk locked beliefs. The "feedback updates the math" loop is closed on the retrieval side; ranking still uses BM25 only at v1.0.1 (the v1.3 retrieval wave wires posterior into ranking).
 
 ### Onboarding — v1.0.1 + v1.1.0
 

--- a/src/aelfrice/feedback.py
+++ b/src/aelfrice/feedback.py
@@ -109,6 +109,7 @@ def apply_feedback(
     valence: float,
     source: str,
     now: str | None = None,
+    propagate: bool = True,
 ) -> FeedbackResult:
     """Apply one feedback event to one belief.
 
@@ -120,6 +121,16 @@ def apply_feedback(
     4. Persist the new posterior on the belief row.
     5. Append one row to feedback_history (created_at = `now` or UTC now).
     6. Return a FeedbackResult with prior + new posteriors and the row id.
+
+    `propagate` controls the demotion-pressure walk on positive valence.
+    Default True preserves the corrective-feedback contract: a positive
+    signal on a contradictor counts as evidence the contradicted lock is
+    wrong, and the walk increments the lock's pressure. Pass False for
+    non-corrective positive signals (e.g., implicit retrieval-time exposure
+    from the UserPromptSubmit hook) where the caller updates posteriors
+    on the retrieved belief but does not wish to pressure neighbouring
+    locked beliefs. Negative valence is unaffected — the pressure walk
+    only fires on positive valence regardless of `propagate`.
     """
     if valence == 0.0:
         raise ValueError("valence must be nonzero")
@@ -148,7 +159,7 @@ def apply_feedback(
 
     pressured_locks: list[str] = []
     demoted_locks: list[str] = []
-    if valence > 0.0:
+    if valence > 0.0 and propagate:
         pressured_locks, demoted_locks = _pressure_and_maybe_demote(
             store, belief_id
         )

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -27,8 +27,8 @@ import traceback
 from typing import IO, Final, cast
 
 from aelfrice.cli import db_path
+from aelfrice.hook_search import search_for_prompt
 from aelfrice.models import LOCK_USER, Belief
-from aelfrice.retrieval import retrieve
 from aelfrice.store import MemoryStore
 
 DEFAULT_HOOK_TOKEN_BUDGET: Final[int] = 1500
@@ -100,7 +100,7 @@ def _extract_prompt(raw: str) -> str | None:
 def _retrieve_and_format(prompt: str, token_budget: int) -> str:
     store = _open_store()
     try:
-        hits = retrieve(store, prompt, token_budget=token_budget)
+        hits = search_for_prompt(store, prompt, token_budget=token_budget)
     finally:
         store.close()
     if not hits:

--- a/src/aelfrice/hook_search.py
+++ b/src/aelfrice/hook_search.py
@@ -1,0 +1,118 @@
+"""Hook-driven retrieval audit: route the UserPromptSubmit hook through
+`aelfrice.retrieval.retrieve()` and record every retrieval to
+`feedback_history` so the "feedback updates the math" loop closes for
+beliefs surfaced during normal session activity.
+
+This module exists because:
+
+1. The retrieval-side of the feedback loop needs an audit row for every
+   belief the hook injects. Without it, `apply_feedback`'s posterior
+   moves only on explicit `aelf feedback` calls and never on the
+   high-volume implicit signal of "this belief was retrieved and shown
+   to the agent". The README's Bayesian-memory claim depends on this
+   loop closing.
+
+2. Hook-driven retrievals are *non-corrective* signals. A retrieved
+   belief is evidence of relevance, not evidence that any neighbouring
+   user-locked belief is wrong. Calling `apply_feedback` with the default
+   propagate=True would pressure-walk locked beliefs on every prompt,
+   silently auto-demoting them. The hook passes `propagate=False` so the
+   posterior moves but the lock graph is left alone.
+
+3. Hook-driven valence is implicit and weaker than explicit user
+   feedback. A retrieval is exposure, not endorsement. Use a small
+   positive valence (`HOOK_RETRIEVAL_VALENCE = 0.1`) so a thousand
+   retrievals over a few months don't dominate the posterior the way a
+   handful of explicit user thumbs-up should.
+
+The module exposes two functions: `search_for_prompt`, the hook's
+top-level call (retrieve + record), and `record_retrieval`, the audit
+half on its own. Both are best-effort on the write side: a failure to
+record does not prevent the retrieved beliefs from being returned.
+
+Non-blocking guarantee: `record_retrieval` swallows write-side failures
+with a stderr trace; the caller still gets the retrieval results. The
+read side (retrieve) is allowed to raise; `aelfrice.hook` catches at
+the outer try/except and degrades to "no memory injected" per the
+hook contract.
+"""
+from __future__ import annotations
+
+import sys
+import traceback
+from typing import IO, Final, Iterable
+
+from aelfrice.feedback import apply_feedback
+from aelfrice.models import Belief
+from aelfrice.retrieval import DEFAULT_TOKEN_BUDGET, retrieve
+from aelfrice.store import MemoryStore
+
+HOOK_FEEDBACK_SOURCE: Final[str] = "hook"
+"""`source` value written into feedback_history for every hook-driven
+retrieval row. LIMITATIONS.md commits this string publicly; downstream
+analysis (e.g. `SELECT ... WHERE source = 'hook'`) depends on it."""
+
+HOOK_RETRIEVAL_VALENCE: Final[float] = 0.1
+"""Per-belief positive valence written for each hook-driven retrieval.
+
+Smaller than the conventional ±1.0 because a hook retrieval is implicit
+exposure, not explicit user endorsement. Tuned conservatively at v1.0.1
+to keep posterior drift slow under high-volume hook activity. v1.x may
+introduce source-weighted decay or per-source valence calibration; this
+is the simplest defensible value."""
+
+
+def search_for_prompt(
+    store: MemoryStore,
+    prompt: str,
+    token_budget: int = DEFAULT_TOKEN_BUDGET,
+    *,
+    stderr: IO[str] | None = None,
+) -> list[Belief]:
+    """Retrieve hits for a hook prompt and record them to feedback_history.
+
+    Wraps `retrieve(store, prompt, token_budget=...)` and, after the read,
+    calls `record_retrieval` to write one audit row per returned belief.
+    Returns the retrieval result; recording failures are caught and logged
+    so the hook's read path is never blocked by a write-side error.
+    """
+    hits: list[Belief] = retrieve(store, prompt, token_budget=token_budget)
+    record_retrieval(store, hits, stderr=stderr)
+    return hits
+
+
+def record_retrieval(
+    store: MemoryStore,
+    beliefs: Iterable[Belief],
+    *,
+    valence: float = HOOK_RETRIEVAL_VALENCE,
+    source: str = HOOK_FEEDBACK_SOURCE,
+    stderr: IO[str] | None = None,
+) -> int:
+    """Write one feedback_history row per belief; return rows written.
+
+    For each belief, calls `apply_feedback(store, belief.id, valence,
+    source, propagate=False)`. propagate=False suppresses the
+    demotion-pressure walk so implicit hook exposure does not pressure
+    user-locked beliefs.
+
+    Best-effort: any per-belief failure is logged to `stderr` (defaults
+    to `sys.stderr`) and the loop continues. Returns the number of
+    successful writes — callers can use this as a smoke metric without
+    needing to inspect the audit log.
+    """
+    serr: IO[str] = stderr if stderr is not None else sys.stderr
+    written: int = 0
+    for b in beliefs:
+        try:
+            apply_feedback(
+                store,
+                b.id,
+                valence,
+                source,
+                propagate=False,
+            )
+            written += 1
+        except Exception:  # non-blocking: log and continue
+            traceback.print_exc(file=serr)
+    return written

--- a/tests/regression/test_hook_to_feedback_history_end_to_end.py
+++ b/tests/regression/test_hook_to_feedback_history_end_to_end.py
@@ -1,0 +1,209 @@
+"""Regression: hook firing → feedback_history grows.
+
+End-to-end coverage of the v1.0.1 hook→feedback-history loop closure.
+A UserPromptSubmit payload is fed to user_prompt_submit() against an
+on-disk DB seeded with three matching beliefs. After the call:
+
+  - feedback_history contains rows tagged source='hook'.
+  - Each row has positive valence.
+  - Per-belief alpha increased; beta unchanged.
+  - User-locked beliefs in the surrounding graph are not auto-demoted
+    (propagate=False semantics through the hook path).
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.hook import user_prompt_submit
+from aelfrice.hook_search import HOOK_FEEDBACK_SOURCE, HOOK_RETRIEVAL_VALENCE
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CONTRADICTS,
+    LOCK_NONE,
+    LOCK_USER,
+    Belief,
+    Edge,
+)
+from aelfrice.store import MemoryStore
+
+
+pytestmark = pytest.mark.regression
+
+
+def _mk(
+    bid: str,
+    content: str,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _payload(prompt: str) -> str:
+    return json.dumps(
+        {
+            "session_id": "s1",
+            "transcript_path": "/dev/null",
+            "cwd": "/tmp",
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": prompt,
+        }
+    )
+
+
+def _set_db(monkeypatch: pytest.MonkeyPatch, db: Path) -> None:
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+
+
+def test_hook_fire_writes_feedback_rows_tagged_hook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    s = MemoryStore(str(db))
+    s.insert_belief(_mk("F1", "the kitchen is full of bananas"))
+    s.insert_belief(_mk("F2", "bananas ripen on the counter"))
+    s.insert_belief(_mk("F3", "unrelated content about coffee"))
+    s.close()
+    _set_db(monkeypatch, db)
+
+    rc = user_prompt_submit(
+        stdin=io.StringIO(_payload("bananas")), stdout=io.StringIO()
+    )
+    assert rc == 0
+
+    s2 = MemoryStore(str(db))
+    try:
+        events = s2.list_feedback_events()
+    finally:
+        s2.close()
+
+    hook_events = [e for e in events if e.source == HOOK_FEEDBACK_SOURCE]
+    assert len(hook_events) >= 2
+    assert all(e.valence == HOOK_RETRIEVAL_VALENCE for e in hook_events)
+    assert {e.belief_id for e in hook_events} >= {"F1", "F2"}
+
+
+def test_hook_fire_increments_alpha_not_beta(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    s = MemoryStore(str(db))
+    s.insert_belief(_mk("F1", "the kitchen is full of bananas"))
+    s.close()
+    _set_db(monkeypatch, db)
+
+    user_prompt_submit(
+        stdin=io.StringIO(_payload("bananas")), stdout=io.StringIO()
+    )
+
+    s2 = MemoryStore(str(db))
+    try:
+        b = s2.get_belief("F1")
+    finally:
+        s2.close()
+    assert b is not None
+    assert b.alpha == 1.0 + HOOK_RETRIEVAL_VALENCE
+    assert b.beta == 1.0
+
+
+def test_hook_fire_does_not_pressure_locked_contradictors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The non-corrective contract: hook exposure of a belief that
+    contradicts a locked belief must NOT pressure the locked belief.
+    Otherwise every prompt that mentions the contradictor silently
+    erodes the lock."""
+    db = tmp_path / "memory.db"
+    s = MemoryStore(str(db))
+    s.insert_belief(_mk("CONTRADICTOR", "alpha is greater than beta"))
+    s.insert_belief(
+        _mk("LOCKED", "beta is greater than alpha",
+            lock_level=LOCK_USER, locked_at="2026-04-26T01:00:00Z")
+    )
+    s.insert_edge(
+        Edge(src="CONTRADICTOR", dst="LOCKED",
+             type=EDGE_CONTRADICTS, weight=1.0)
+    )
+    s.close()
+    _set_db(monkeypatch, db)
+
+    # Fire 10 prompts that all hit CONTRADICTOR.
+    for _ in range(10):
+        user_prompt_submit(
+            stdin=io.StringIO(_payload("alpha greater")),
+            stdout=io.StringIO(),
+        )
+
+    s2 = MemoryStore(str(db))
+    try:
+        locked = s2.get_belief("LOCKED")
+    finally:
+        s2.close()
+    assert locked is not None
+    assert locked.demotion_pressure == 0
+    assert locked.lock_level == LOCK_USER
+
+
+def test_hook_fire_records_locked_hits_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Locked beliefs auto-loaded by L0 are recorded just like L1 hits."""
+    db = tmp_path / "memory.db"
+    s = MemoryStore(str(db))
+    s.insert_belief(
+        _mk("L1", "always use scripts/publish.sh",
+            lock_level=LOCK_USER, locked_at="2026-04-26T01:00:00Z")
+    )
+    s.close()
+    _set_db(monkeypatch, db)
+
+    user_prompt_submit(
+        stdin=io.StringIO(_payload("anything")), stdout=io.StringIO()
+    )
+
+    s2 = MemoryStore(str(db))
+    try:
+        events = s2.list_feedback_events()
+    finally:
+        s2.close()
+    assert any(
+        e.belief_id == "L1" and e.source == HOOK_FEEDBACK_SOURCE
+        for e in events
+    )
+
+
+def test_hook_fire_no_match_writes_no_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    s = MemoryStore(str(db))
+    s.insert_belief(_mk("F1", "the kitchen is full of bananas"))
+    s.close()
+    _set_db(monkeypatch, db)
+
+    user_prompt_submit(
+        stdin=io.StringIO(_payload("xyzzyzzz")), stdout=io.StringIO()
+    )
+
+    s2 = MemoryStore(str(db))
+    try:
+        events = s2.list_feedback_events()
+    finally:
+        s2.close()
+    assert events == []

--- a/tests/test_feedback_demotion_pressure.py
+++ b/tests/test_feedback_demotion_pressure.py
@@ -217,3 +217,46 @@ def test_negative_valence_result_pressured_locks_empty() -> None:
     s = _build("X", "Y", EDGE_CONTRADICTS)
     result = apply_feedback(s, "X", valence=-1.0, source="user")
     assert result.pressured_locks == []
+
+
+# --- propagate=False suppresses the walk (non-corrective signals) --------
+
+
+def test_propagate_false_does_not_increment_pressure() -> None:
+    """Hook-driven retrievals pass propagate=False so that implicit
+    exposure does not pressure-walk locked beliefs on every prompt."""
+    s = _build("X", "Y", EDGE_CONTRADICTS)
+    apply_feedback(s, "X", valence=1.0, source="hook", propagate=False)
+    assert _pressure(s, "Y") == 0
+
+
+def test_propagate_false_still_updates_posterior() -> None:
+    """propagate=False suppresses the walk, not the Bayesian update."""
+    s = _build("X", "Y", EDGE_CONTRADICTS)
+    result = apply_feedback(s, "X", valence=0.5, source="hook",
+                            propagate=False)
+    assert result.new_alpha == 1.5
+    assert result.new_beta == 1.0
+
+
+def test_propagate_false_still_writes_audit_row() -> None:
+    s = _build("X", "Y", EDGE_CONTRADICTS)
+    result = apply_feedback(s, "X", valence=1.0, source="hook",
+                            propagate=False)
+    assert result.event_id > 0
+    assert s.count_feedback_events() == 1
+
+
+def test_propagate_false_result_pressured_locks_empty() -> None:
+    s = _build("X", "Y", EDGE_CONTRADICTS)
+    result = apply_feedback(s, "X", valence=1.0, source="hook",
+                            propagate=False)
+    assert result.pressured_locks == []
+    assert result.demoted_locks == []
+
+
+def test_propagate_default_true_preserves_corrective_walk() -> None:
+    """Existing callers without the kwarg get the same pressure walk."""
+    s = _build("X", "Y", EDGE_CONTRADICTS)
+    apply_feedback(s, "X", valence=1.0, source="user")
+    assert _pressure(s, "Y") == 1

--- a/tests/test_hook_search.py
+++ b/tests/test_hook_search.py
@@ -1,0 +1,220 @@
+"""hook_search: search_for_prompt + record_retrieval contract.
+
+Closes the v1.0.1 retrieval-side feedback-loop gap (LIMITATIONS § Hook
+layer). Every hook-driven retrieval writes one feedback_history row
+tagged source='hook' with a small positive valence and propagate=False
+so locked beliefs are not pressured by implicit exposure.
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from aelfrice.hook_search import (
+    HOOK_FEEDBACK_SOURCE,
+    HOOK_RETRIEVAL_VALENCE,
+    record_retrieval,
+    search_for_prompt,
+)
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CONTRADICTS,
+    LOCK_NONE,
+    LOCK_USER,
+    Belief,
+    Edge,
+)
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    bid: str,
+    content: str = "",
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content or f"belief {bid}",
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _seed(*beliefs: Belief) -> MemoryStore:
+    s = MemoryStore(":memory:")
+    for b in beliefs:
+        s.insert_belief(b)
+    return s
+
+
+# --- Constants -----------------------------------------------------------
+
+
+def test_hook_feedback_source_constant_is_hook() -> None:
+    """LIMITATIONS.md commits to source='hook'; downstream analysis
+    depends on this exact string."""
+    assert HOOK_FEEDBACK_SOURCE == "hook"
+
+
+def test_hook_retrieval_valence_is_small_positive() -> None:
+    """Implicit signal — should be smaller than the explicit ±1.0 default
+    so high-volume hook activity does not dominate the posterior."""
+    assert 0.0 < HOOK_RETRIEVAL_VALENCE <= 1.0
+
+
+# --- record_retrieval: audit rows ----------------------------------------
+
+
+def test_record_retrieval_writes_one_row_per_belief() -> None:
+    s = _seed(_mk("b1"), _mk("b2"), _mk("b3"))
+    written = record_retrieval(s, [s.get_belief("b1"), s.get_belief("b2")])  # type: ignore[list-item]
+    assert written == 2
+    assert s.count_feedback_events() == 2
+
+
+def test_record_retrieval_tags_rows_with_hook_source() -> None:
+    s = _seed(_mk("b1"))
+    record_retrieval(s, [s.get_belief("b1")])  # type: ignore[list-item]
+    events = s.list_feedback_events()
+    assert len(events) == 1
+    assert events[0].source == "hook"
+
+
+def test_record_retrieval_uses_default_valence() -> None:
+    s = _seed(_mk("b1"))
+    record_retrieval(s, [s.get_belief("b1")])  # type: ignore[list-item]
+    events = s.list_feedback_events()
+    assert events[0].valence == HOOK_RETRIEVAL_VALENCE
+
+
+def test_record_retrieval_empty_iterable_writes_no_rows() -> None:
+    s = _seed(_mk("b1"))
+    written = record_retrieval(s, [])
+    assert written == 0
+    assert s.count_feedback_events() == 0
+
+
+def test_record_retrieval_updates_alpha_not_beta() -> None:
+    s = _seed(_mk("b1"))
+    record_retrieval(s, [s.get_belief("b1")])  # type: ignore[list-item]
+    b = s.get_belief("b1")
+    assert b is not None
+    assert b.alpha == 1.0 + HOOK_RETRIEVAL_VALENCE
+    assert b.beta == 1.0
+
+
+# --- record_retrieval: propagate=False (no pressure walk) ----------------
+
+
+def test_record_retrieval_does_not_pressure_locked_contradictors() -> None:
+    """Hook exposure of a contradictor must not pressure-walk the locked
+    target — that would auto-demote locks on every prompt that surfaces
+    a contradicting belief in the FTS5 layer."""
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("X"))
+    s.insert_belief(_mk("Y", lock_level=LOCK_USER,
+                        locked_at="2026-04-26T01:00:00Z"))
+    s.insert_edge(Edge(src="X", dst="Y", type=EDGE_CONTRADICTS, weight=1.0))
+    record_retrieval(s, [s.get_belief("X")])  # type: ignore[list-item]
+    y_after = s.get_belief("Y")
+    assert y_after is not None
+    assert y_after.demotion_pressure == 0
+    assert y_after.lock_level == LOCK_USER
+
+
+# --- record_retrieval: failure isolation ---------------------------------
+
+
+def test_record_retrieval_skips_missing_belief_logs_and_continues() -> None:
+    """If a belief's id no longer exists at write time (e.g. raced
+    deletion), the row write fails. The loop must continue for the
+    remaining beliefs and the failure must hit stderr."""
+    s = _seed(_mk("b1"), _mk("b2"))
+    ghost = _mk("ghost")  # not inserted
+    err = io.StringIO()
+    written = record_retrieval(
+        s, [s.get_belief("b1"), ghost, s.get_belief("b2")], stderr=err,  # type: ignore[list-item]
+    )
+    assert written == 2
+    assert s.count_feedback_events() == 2
+    assert "ghost" in err.getvalue() or "ValueError" in err.getvalue()
+
+
+# --- search_for_prompt: full read+write path -----------------------------
+
+
+def test_search_for_prompt_returns_retrieval_hits() -> None:
+    s = _seed(_mk("b1", "the quick brown fox"))
+    hits = search_for_prompt(s, "quick fox")
+    assert any(h.id == "b1" for h in hits)
+
+
+def test_search_for_prompt_records_each_hit() -> None:
+    s = _seed(_mk("b1", "the quick brown fox"))
+    hits = search_for_prompt(s, "quick fox")
+    assert s.count_feedback_events() == len(hits)
+
+
+def test_search_for_prompt_empty_query_returns_locked_only() -> None:
+    """Empty/whitespace query: retrieval returns L0 (locked) only.
+    record_retrieval still writes audit rows for what was returned."""
+    s = _seed(_mk("L1", lock_level=LOCK_USER,
+                  locked_at="2026-04-26T01:00:00Z"),
+              _mk("U1", "unlocked content"))
+    hits = search_for_prompt(s, "")
+    assert [h.id for h in hits] == ["L1"]
+    assert s.count_feedback_events() == 1
+
+
+def test_search_for_prompt_no_hits_writes_no_rows() -> None:
+    """A query that hits nothing produces zero audit rows."""
+    s = _seed(_mk("b1", "the quick brown fox"))
+    hits = search_for_prompt(s, "xyzzy")
+    assert hits == []
+    assert s.count_feedback_events() == 0
+
+
+def test_search_for_prompt_record_failure_does_not_block_read() -> None:
+    """If recording somehow fails entirely, the function still returns
+    the retrieval result — the hook contract is non-blocking on the
+    audit side."""
+    s = _seed(_mk("b1", "the quick brown fox"))
+    err = io.StringIO()
+    # Pollute the store so apply_feedback fails: close the connection
+    # before record_retrieval runs. retrieve() ran already; its hits
+    # are already in memory.
+    hits = search_for_prompt(s, "quick fox", stderr=err)
+    # Read happened.
+    assert any(h.id == "b1" for h in hits)
+    # Now manually exercise record on a closed store to force the
+    # error path; verify record_retrieval logs and returns 0.
+    s.close()
+    written = record_retrieval(s, hits, stderr=err)
+    assert written == 0
+
+
+# --- Locked beliefs are still recorded -----------------------------------
+
+
+def test_search_for_prompt_records_locked_hits_too() -> None:
+    """L0 hits (locks auto-loaded) get audit rows just like L1 hits.
+    The 'feedback updates the math' loop covers locks."""
+    s = _seed(_mk("L1", "locked content",
+                  lock_level=LOCK_USER,
+                  locked_at="2026-04-26T01:00:00Z"))
+    _ = search_for_prompt(s, "locked")
+    events = s.list_feedback_events()
+    assert any(ev.belief_id == "L1" for ev in events)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_hook_user_prompt_submit.py
+++ b/tests/test_hook_user_prompt_submit.py
@@ -204,16 +204,18 @@ def test_hook_passes_default_token_budget(
     captured: dict[str, int] = {}
     import aelfrice.hook as hook_mod
 
-    real_retrieve = hook_mod.retrieve
+    real = hook_mod.search_for_prompt
 
-    def spy_retrieve(
-        store: MemoryStore, query: str, token_budget: int = 2000, l1_limit: int = 50
+    def spy(
+        store: MemoryStore,
+        prompt: str,
+        token_budget: int = 2000,
+        **kwargs: object,
     ) -> list[Belief]:
         captured["token_budget"] = token_budget
-        return real_retrieve(store, query, token_budget=token_budget,
-                              l1_limit=l1_limit)
+        return real(store, prompt, token_budget=token_budget, **kwargs)  # type: ignore[arg-type]
 
-    monkeypatch.setattr(hook_mod, "retrieve", spy_retrieve)
+    monkeypatch.setattr(hook_mod, "search_for_prompt", spy)
     user_prompt_submit(
         stdin=io.StringIO(_payload("bananas")), stdout=io.StringIO()
     )
@@ -229,16 +231,18 @@ def test_hook_honors_explicit_token_budget(
     captured: dict[str, int] = {}
     import aelfrice.hook as hook_mod
 
-    real_retrieve = hook_mod.retrieve
+    real = hook_mod.search_for_prompt
 
-    def spy_retrieve(
-        store: MemoryStore, query: str, token_budget: int = 2000, l1_limit: int = 50
+    def spy(
+        store: MemoryStore,
+        prompt: str,
+        token_budget: int = 2000,
+        **kwargs: object,
     ) -> list[Belief]:
         captured["token_budget"] = token_budget
-        return real_retrieve(store, query, token_budget=token_budget,
-                              l1_limit=l1_limit)
+        return real(store, prompt, token_budget=token_budget, **kwargs)  # type: ignore[arg-type]
 
-    monkeypatch.setattr(hook_mod, "retrieve", spy_retrieve)
+    monkeypatch.setattr(hook_mod, "search_for_prompt", spy)
     user_prompt_submit(
         stdin=io.StringIO(_payload("bananas")),
         stdout=io.StringIO(),
@@ -256,12 +260,15 @@ def test_hook_non_blocking_on_internal_error(
     import aelfrice.hook as hook_mod
 
     def boom(
-        _store: MemoryStore, _q: str, token_budget: int = 2000, l1_limit: int = 50
+        _store: MemoryStore,
+        _prompt: str,
+        token_budget: int = 2000,
+        **_kwargs: object,
     ) -> list[Belief]:
-        _ = token_budget, l1_limit
+        _ = token_budget
         raise RuntimeError("simulated retrieval failure")
 
-    monkeypatch.setattr(hook_mod, "retrieve", boom)
+    monkeypatch.setattr(hook_mod, "search_for_prompt", boom)
     sout = io.StringIO()
     serr = io.StringIO()
     rc = user_prompt_submit(


### PR DESCRIPTION
## Summary

Closes the v1.0.1 retrieval-side feedback-loop gap (LIMITATIONS § Hook layer — the highest-impact item). The UserPromptSubmit hook now writes one \`feedback_history\` row per returned belief, tagged \`source='hook'\`, so \`apply_feedback\` posteriors move on the high-volume implicit signal of \"this belief was retrieved and shown to the agent\" — not only on explicit \`aelf feedback\` calls.

### What changed

- **New module \`aelfrice.hook_search\`** — \`search_for_prompt(store, prompt, ...)\` wraps \`retrieve()\` and writes audit rows. \`record_retrieval(store, beliefs, ...)\` is the audit half on its own. \`HOOK_RETRIEVAL_VALENCE = 0.1\` (small implicit signal); \`HOOK_FEEDBACK_SOURCE = 'hook'\` (committed publicly per LIMITATIONS).
- **New \`propagate: bool = True\` kwarg on \`apply_feedback\`** — default preserves the corrective-feedback pressure walk; \`propagate=False\` is the non-corrective path used by hook retrievals so implicit exposure does not auto-demote locked beliefs whenever the FTS5 layer surfaces a contradictor.
- **\`aelfrice.hook\` re-routed** through \`hook_search.search_for_prompt\`. Same non-blocking contract, same OPEN_TAG/CLOSE_TAG envelope, same payload schema. Only behavioural difference: audit rows now flow.

### Tests

- \`tests/test_hook_search.py\` — 15 new unit tests: constants, audit-row contract, alpha increment, propagate=False (no pressure walk on locked contradictors), failure isolation, full search_for_prompt path, empty-query L0-only behaviour, locked-belief rows.
- \`tests/test_feedback_demotion_pressure.py\` — 5 new tests for the propagate=False semantics on apply_feedback.
- \`tests/regression/test_hook_to_feedback_history_end_to_end.py\` — 5 new regression tests over the on-disk DB end-to-end path: source tagging, alpha vs beta increment, no-pressure-on-locked-contradictors over 10 fires, L0 locked hits getting rows, and zero-match writing zero rows.
- 3 existing hook tests updated to monkeypatch \`hook_mod.search_for_prompt\` instead of \`retrieve\`.

**Suite: 595 passed in 6.6s.**

### Docs

- LIMITATIONS § Hook layer: the load-bearing bullet now reads as ✅ resolved with the positive-state description naming the module, constants, and note that ranking is still BM25-only (v1.3 will wire posterior into ranking).
- CHANGELOG.md \`[Unreleased]\`: Added (hook_search, propagate kwarg) + Changed (hook routing) entries.

### Test plan

- [x] \`uv run pytest -q\` — 595/595 pass on Python 3.14.
- [x] \`uv run pytest -m regression\` — full regression suite green.
- [ ] Manual: install on a real project, fire the hook, inspect \`SELECT * FROM feedback_history WHERE source='hook'\` after a few prompts.
- [ ] Confirm the hook continues to emit \`<aelfrice-memory>\` correctly for users with existing v1.0.0 stores (no migration needed).

### Notes for the v1.0.1 release

This is the load-bearing PR for v1.0.1. The remaining v1.0.1 items (\`aelf --version\`, noise filter, contradiction tie-breaker, onboard 60s regression) follow as separate atomic PRs.