### PR TITLE
feat(v1.0.1): aelf --version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+### Added
+
+- `aelf --version` flag prints `aelf <__version__>` and exits 0.
+  Closes the long-standing argparse error users hit when probing the
+  installed version (#71).
+
 ## [1.0.0] - 2026-04-27
 
 First installable PyPI release. The full v1.0 surface is the cumulative

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -20,7 +20,7 @@ Tracked openly. Each item is mapped to its target version below.
 
 ### Hook layer — v1.0.1
 
-- **`aelf --version` does not exist.** Argparse error today. ~5 LOC + unit test.
+- ✅ **`aelf --version` (v1.0.1).** Prints `aelf <__version__>` and exits 0. Short-circuits the required-subcommand check via argparse's standard version action.
 - **The `aelf-hook` UserPromptSubmit hook may return empty results despite a populated FTS5 index.** Hook fires; no `<aelfrice-memory>` block appears. Workaround: drop to CLI.
 - **Hook bypasses `aelfrice.retrieval.retrieve()` and does not record retrievals as feedback events.** Highest-impact gap. The hook uses an inline FTS5 shim, skipping L0 locked-belief auto-load and feedback-history logging. The "feedback-driven learning" claim depends on this loop closing. v1.0.1 introduces `src/aelfrice/hook_search.py` (`search_for_prompt` + `record_retrieval`) and replaces the shim.
 

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -437,6 +437,12 @@ def build_parser() -> argparse.ArgumentParser:
         prog="aelf",
         description="Bayesian memory designed for feedback-driven learning.",
     )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"aelf {_AELFRICE_VERSION}",
+        help="print the installed aelfrice version and exit",
+    )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     p_onboard = sub.add_parser("onboard", help="scan a project and ingest beliefs")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -270,3 +270,29 @@ def test_no_subcommand_exits_nonzero() -> None:
     """argparse `required=True` rejects empty subcommand path."""
     with pytest.raises(SystemExit):
         _run()
+
+
+# --- --version ----------------------------------------------------------
+
+
+def test_version_flag_prints_package_version(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`aelf --version` prints `aelf <__version__>` to stdout and
+    exits 0. argparse's version action raises SystemExit with code 0
+    after writing; we catch and inspect captured stdout."""
+    from aelfrice import __version__ as version
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(argv=["--version"])
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert f"aelf {version}" in captured.out
+
+
+def test_version_flag_short_circuits_required_subcommand() -> None:
+    """`--version` must short-circuit the required-subcommand check
+    (otherwise argparse exits 2 demanding a subcommand)."""
+    with pytest.raises(SystemExit) as excinfo:
+        main(argv=["--version"])
+    assert excinfo.value.code == 0


### PR DESCRIPTION
## Summary

Adds the standard \`--version\` flag to the \`aelf\` CLI. Prints \`aelf <aelfrice.__version__>\` to stdout and exits 0; short-circuits the \`required=True\` subcommand check via argparse's built-in version action.

Closes the LIMITATIONS § Hook layer bullet *\"aelf --version does not exist. Argparse error today.\"*

## Test plan

- [x] \`uv run pytest tests/test_cli.py\` — 24 pass on Python 3.13.
- [x] Manual: \`uv run aelf --version\` prints \`aelf 1.0.0\`.

## Notes

Trivial PR. Stacks under v1.0.1 with #70 (hook_search).