### PR TITLE
feat: lifecycle commands + update notifier + statusline (v1.0.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: uv sync --frozen --extra dev
+      - run: uv sync --frozen --extra dev --extra archive
       - run: uv run pytest tests/ -q

--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -102,5 +102,5 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: uv sync --frozen --extra dev
+      - run: uv sync --frozen --extra dev --extra archive
       - run: uv run pytest tests/ -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,34 @@ installable release; see the roadmap in [README.md](README.md).
   substring case-insensitive). No regex in the user-facing schema.
   Library callers can pass an explicit `NoiseConfig` to
   `scan_repo(..., noise_config=...)` to bypass file discovery (#72).
+- `aelf upgrade` subcommand: prints the right pip-upgrade command for
+  the user's install context (venv / pipx / system), includes the
+  published wheel SHA-256 + PyPI URL for hash-pinned installs (#73).
+- `aelf uninstall` subcommand with mutually-exclusive `--keep-db` /
+  `--purge` / `--archive PATH` disposition flags. `--purge` requires
+  three redundant gates (explicit flag, typed `PURGE`, final `[y/N]`).
+  `--archive` encrypts the DB with AES-128-CBC + HMAC via Fernet,
+  scrypt-derived key from a user password (Salt embedded; password is
+  the only secret needed for recovery). Public `decrypt_archive()` API
+  for later recovery (#73).
+- `aelf statusline` subcommand: emits an orange-coloured one-line
+  update-banner prefix snippet for Claude Code's statusbar (and any
+  shell-driven status bar). Empty output when no update is pending.
+  Truecolor → 256-color → basic-yellow fallback, NO_COLOR honoured (#73).
+- Two-component update notifier ported from GSD's pattern: detached
+  background PyPI check writes a JSON cache at
+  `~/.cache/aelfrice/update_check.json`; statusline + post-command
+  banners read that cache only. Cache TTL: 24h. Opt out via
+  `AELF_NO_UPDATE_CHECK=1` (#73).
+- `aelf setup` auto-wires the statusline alongside the hook by default
+  (`--no-statusline` opts out). Composes deterministically with an
+  existing `statusLine`: empty slot → install; already ours → no-op;
+  simple existing → wrap with `; aelf statusline 2>/dev/null`; complex
+  (shell metacharacters) → leave alone with a one-line hint (#73).
+- `aelf unsetup` reverses the statusline composition surgically (#73).
+- New optional extra: `pip install 'aelfrice[archive]'` adds the
+  `cryptography` dep that `aelf uninstall --archive` needs (#73).
+- Slash commands: `/aelf:upgrade`, `/aelf:uninstall`, `/aelf:statusline` (#73).
 
 ### Changed
 
@@ -53,6 +81,13 @@ installable release; see the roadmap in [README.md](README.md).
   same OPEN_TAG/CLOSE_TAG output envelope, same payload schema; the
   behavioural difference is the audit-row write per returned belief
   (#70).
+- `aelf setup` output now shows two lines (hook + statusline) on a
+  fresh install. `aelf unsetup` shows the matching teardown lines (#73).
+- README "Install" section rewritten with explicit verification
+  commands; new "Upgrade" and "Uninstall" sections (#73).
+- `docs/INSTALL.md` rewritten with explicit Statusline composition
+  table, full uninstall reference (including archive recovery), and
+  Update notifier opt-out instructions (#73).
 
 ## [1.0.0] - 2026-04-27
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,64 @@ Per-version detail with deliverables, recovery inventory, and structural-fix rat
 ## Install
 
 ```bash
-pip install aelfrice              # core
-pip install "aelfrice[mcp]"       # add MCP server
-aelf setup                         # wire UserPromptSubmit hook into Claude Code
+pip install aelfrice                # core (zero runtime deps)
+pip install "aelfrice[mcp]"         # add MCP server
+pip install "aelfrice[archive]"     # add encrypted DB archive on uninstall
+aelf --version                       # confirm install
+aelf setup                           # wire hook + statusline into Claude Code
+aelf health                          # confirm wiring + store init
 ```
 
+`aelf setup` wires two things into `~/.claude/settings.json`:
+
+1. The **UserPromptSubmit hook** (`aelf-hook`) which injects relevant beliefs into every Claude Code prompt.
+2. The **statusline notifier** (`aelf statusline`) which shows an orange `⬆ aelfrice X.Y.Z available, run: aelf upgrade` banner *only* when an update is pending. When you're up to date the banner is empty and your statusline looks unchanged.
+
+If you already have a custom `statusLine` configured, `aelf setup` composes its snippet onto the end of your command (preserving your bar). If your existing command uses pipes, here-docs, `&&`, backticks, or backslashes it's left untouched and you get a one-line hint about manual composition.
+
+`--no-statusline` opts out of the auto-wire if you want hook-only.
+
 [docs/INSTALL.md](docs/INSTALL.md) covers Codex wiring, generic MCP hosts, and troubleshooting.
+
+## Upgrade
+
+```bash
+aelf upgrade           # prints the right pip-upgrade line for your env
+aelf upgrade --check   # yes/no, no command line printed
+```
+
+`aelf upgrade` detects venv vs pipx vs system and tells you the exact line. It does **not** execute pip itself: replacing the running package mid-process is unreliable on Windows and can leave a broken interpreter. You run the line.
+
+When an update is available the output also includes the published wheel SHA-256 plus the PyPI release URL so you can hash-pin the install if you want.
+
+The orange statusline banner appears automatically when an update is pending and disappears once you're up to date — no manual refresh needed.
+
+Opt out of the update notifier at any time with `export AELF_NO_UPDATE_CHECK=1` or `aelf <cmd> --no-update-check`.
+
+## Uninstall
+
+aelfrice has an explicit teardown command. You **must** pick exactly one disposition for the brain-graph DB:
+
+```bash
+aelf uninstall --keep-db       # leave ~/.aelfrice/memory.db alone (safe)
+aelf uninstall --archive ~/aelf-backup.aenc   # encrypt then delete
+aelf uninstall --purge         # permanently delete (redundant gates fire)
+pip uninstall aelfrice         # finally, remove the wheel
+```
+
+Verify removal:
+
+```bash
+aelf --version 2>&1 | grep -q "aelfrice" || echo "removed"
+```
+
+Details:
+
+- **`--keep-db`** — DB preserved. Default also runs `unsetup` (removes hook + statusline). Pass `--keep-hook` to keep those too.
+- **`--archive PATH`** — DB encrypted (AES-128-CBC + HMAC via Fernet, scrypt-derived key) to PATH, then original deleted. Password is read interactively (twice, must match) or via `--password-stdin`. Recover later with `python -c "from aelfrice.lifecycle import decrypt_archive; open('out.db','wb').write(decrypt_archive('PATH','pw'))"`. Requires `pip install 'aelfrice[archive]'`.
+- **`--purge`** — Permanently deletes the DB. Three gates fire before deletion: (1) the flag must be passed explicitly, (2) you must type `PURGE` verbatim, (3) a final `[y/N]` confirmation. `--yes` skips the prompts but does **not** auto-pass `--purge`.
+
+[docs/INSTALL.md](docs/INSTALL.md#uninstall) has the full uninstall reference including archive-recovery details.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ When an update is available the output also includes the published wheel SHA-256
 
 The orange statusline banner appears automatically when an update is pending and disappears once you're up to date — no manual refresh needed.
 
-Opt out of the update notifier at any time with `export AELF_NO_UPDATE_CHECK=1` or `aelf <cmd> --no-update-check`.
+Opt out of the update notifier at any time with `export AELF_NO_UPDATE_CHECK=1`.
 
 ## Uninstall
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Eleven subcommands. The first eight (retrieval/feedback) are also available as MCP tools and Claude Code slash commands. `setup`/`unsetup`/`bench` are CLI-only.
+Fourteen subcommands. The first eight (retrieval/feedback) are also available as MCP tools and Claude Code slash commands. The lifecycle commands (`setup`/`unsetup`/`upgrade`/`uninstall`/`statusline`) and `bench` are CLI-only.
 
 DB resolves from `$AELFRICE_DB` or `~/.aelfrice/memory.db`.
 
@@ -20,9 +20,13 @@ aelf <subcommand> [args] [options]
 | `feedback <belief_id> <used\|harmful> [--source S]` | id, signal, optional source | `used` ⇒ α += 1. `harmful` ⇒ β += 1. Positive feedback flowing through outbound CONTRADICTS edges to user-locks bumps their `demotion_pressure`; ≥ 5 ⇒ auto-demote. |
 | `stats` | — | beliefs / edges / locked / feedback_events counts. |
 | `health` | — | Regime classifier: one of `early-onboarding`, `steady`, `lock-heavy`, `over-confident`, `insufficient-data`. |
-| `setup [--scope user\|project] [--project-root D] [--settings-path P] [--command C] [--timeout N] [--status-message M]` | various | Install `UserPromptSubmit` hook in Claude Code `settings.json`. Default command: `aelf-hook`. Idempotent + atomic. |
-| `unsetup` (same scope flags) | — | Remove the hook. Match by command string. |
+| `setup [--scope user\|project] [--project-root D] [--settings-path P] [--command C] [--timeout N] [--status-message M] [--no-statusline]` | various | Install `UserPromptSubmit` hook + `statusLine` notifier in Claude Code `settings.json`. Default command: `aelf-hook`. Idempotent + atomic. `--no-statusline` skips the statusline auto-wire. |
+| `unsetup` (same scope flags) | — | Remove both the hook and our statusline contribution. Composed statuslines are surgically unwrapped to restore the original command. |
+| `upgrade [--check]` | — | Print the right pip-upgrade command for the running env (venv → `pip install --upgrade`, pipx → `pipx upgrade`, system → `pip install --user --upgrade`). When an update is available, also prints the wheel SHA-256 + PyPI release URL for hash-pinned installs. `--check` suppresses the command line. |
+| `uninstall (--keep-db \| --purge \| --archive PATH) [--password-stdin] [--yes] [--keep-hook] [--settings-path P]` | one disposition flag required | Tear down aelfrice. Disposition modes are mutually exclusive. `--purge` requires typing `PURGE` then `[y/N]` unless `--yes` is passed. `--archive` requires `pip install 'aelfrice[archive]'`. By default also runs `unsetup`; `--keep-hook` opts out. Tail message points at `pip uninstall aelfrice` for wheel removal. |
+| `statusline` | — | Emit the orange update-banner snippet (or empty when no update is pending). Reads cache only, no network. Composes onto an existing statusline via shell `;`. Color: truecolor → 256-color → basic, NO_COLOR honoured. |
 | `bench [--db PATH] [--top-k N]` | — | Run the deterministic 16-belief × 16-query benchmark. Print a single JSON `BenchmarkReport`: `hit_at_1` / `hit_at_3` / `hit_at_5` / `mrr` + `p50_latency_ms` / `p99_latency_ms`. |
+| `--version` (root flag) | — | Print `aelfrice X.Y.Z` and exit. |
 
 ## Output format
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,13 +8,20 @@
 ## Install from PyPI
 
 ```bash
-pip install aelfrice              # core
-pip install "aelfrice[mcp]"       # add the MCP server (fastmcp)
+pip install aelfrice                # core (zero runtime deps)
+pip install "aelfrice[mcp]"         # add the MCP server (fastmcp)
+pip install "aelfrice[archive]"     # add the encrypted-archive uninstall path
 ```
 
 Two console scripts: `aelf` (the CLI) and `aelf-hook` (the Claude Code hook entry-point).
 
-Verify: `aelf health` should print `brain mode: insufficient_data` on a fresh DB.
+Verify:
+
+```bash
+aelf --version       # prints "aelfrice X.Y.Z"
+aelf health          # prints "brain mode: insufficient_data" on a fresh DB
+which aelf           # confirms which Python env owns the binary
+```
 
 ## Install from source
 
@@ -35,10 +42,64 @@ SQLite at `~/.aelfrice/memory.db` by default. Override with `$AELFRICE_DB` (use 
 ```bash
 aelf setup                                        # ~/.claude/settings.json
 aelf setup --scope project --project-root .       # project-local
-aelf unsetup                                      # remove
+aelf setup --no-statusline                        # hook only, no statusline
+aelf unsetup                                      # remove both
 ```
 
-Idempotent. The hook reads each `UserPromptSubmit` payload, runs retrieval, and emits an `<aelfrice-memory>...</aelfrice-memory>` block above the prompt. Every failure mode exits 0 with no output — the hook can't block a prompt.
+Idempotent. `aelf setup` wires two things:
+
+1. **`UserPromptSubmit` hook** (`aelf-hook`). Reads each prompt payload, runs retrieval, emits an `<aelfrice-memory>...</aelfrice-memory>` block above the prompt. Every failure mode exits 0 with no output — the hook can't block a prompt.
+2. **`statusLine` notifier** (`aelf statusline`). Prints an orange one-line update banner in the Claude Code statusbar **only when an update is available**, empty otherwise. Reads the cached PyPI check; never makes network calls. Banner disappears automatically once you've upgraded.
+
+Composition with an existing `statusLine`:
+
+| Existing command shape | What `aelf setup` does |
+|---|---|
+| empty / not configured | install standalone `aelf statusline` |
+| already `aelf statusline` (any form) | idempotent no-op |
+| simple existing command (e.g. `echo my-bar`) | append ` ; aelf statusline 2>/dev/null` to it |
+| complex (`\|`, `<<`, `&&`, `\|\|`, `` ` ``, `\`) | left untouched, hint printed to stderr |
+
+`aelf unsetup` reverses surgically: drops the `statusLine` field if it's just ours, strips the `; aelf statusline ...` suffix to restore the original command otherwise.
+
+## Update notifier
+
+Every `aelf <cmd>` invocation and every `UserPromptSubmit` hook fire kicks off a TTL-gated **fire-and-forget** background check against `https://pypi.org/pypi/aelfrice/json`. The result lands at `~/.cache/aelfrice/update_check.json`. Cache is good for 24 hours; subsequent calls within the window are no-ops.
+
+Opt out:
+
+```bash
+export AELF_NO_UPDATE_CHECK=1     # globally, in your shell config
+aelf <cmd> --no-update-check      # one-off  [TODO: not yet wired]
+```
+
+When the cache says an update is available you'll see two things:
+
+1. The orange `⬆ aelfrice X.Y.Z available, run: aelf upgrade │ ` snippet in your Claude Code statusline (if wired).
+2. The same banner printed to stderr after most `aelf` CLI commands. Skipped for `aelf upgrade`, `aelf uninstall`, and `aelf statusline` so it doesn't double-print or stomp on machine-readable output.
+
+To upgrade:
+
+```bash
+aelf upgrade           # prints the right pip-upgrade line for this env
+aelf upgrade --check   # yes/no, no command line printed
+```
+
+`aelf upgrade` detects venv vs pipx vs system and adjusts:
+
+| Context | Command emitted |
+|---|---|
+| pipx-managed install | `pipx upgrade aelfrice` |
+| generic venv (incl. `uv venv`, conda) | `pip install --upgrade aelfrice` |
+| system / user-site | `pip install --user --upgrade aelfrice` |
+
+When an update is available, the output also shows the wheel's published SHA-256 plus the PyPI release URL so you can hash-pin the install:
+
+```bash
+pip install aelfrice==1.2.3 --hash=sha256:abc123…  # pip-side strong integrity
+```
+
+pip already verifies SHA-256 on every download against PyPI's JSON API; surfacing the hash here just lets the security-conscious user feed it into `--require-hashes` mode if they want.
 
 ## Wire into Codex / generic MCP hosts
 
@@ -86,8 +147,64 @@ uv run pytest -m regression  # cumulative integration scenarios
 
 ## Uninstall
 
+aelfrice ships an explicit teardown command. You **must** pick exactly one of `--keep-db`, `--purge`, or `--archive PATH` so the brain-graph SQLite DB at `~/.aelfrice/memory.db` doesn't get accidentally lost or accidentally retained.
+
 ```bash
-aelf unsetup
-rm -rf ~/.aelfrice
-pip uninstall aelfrice
+aelf uninstall --keep-db                           # safe default for review
+aelf uninstall --archive ~/aelf-backup.aenc        # encrypt then delete
+aelf uninstall --purge                              # permanently delete (gates fire)
+pip uninstall aelfrice                              # finally, remove the wheel
 ```
+
+Verification:
+
+```bash
+aelf --version 2>&1 | grep -q aelfrice || echo "wheel removed"
+test -f ~/.aelfrice/memory.db && echo "db still there" || echo "db gone"
+```
+
+### `--keep-db`
+
+DB preserved at `~/.aelfrice/memory.db`. The default also runs `unsetup` so the Claude Code hook + statusline are removed from `~/.claude/settings.json`. Pass `--keep-hook` if you want to keep those wired (e.g. you plan to reinstall and skip onboarding).
+
+### `--archive PATH`
+
+Encrypts the DB to PATH and deletes the original. Format:
+
+```
+8 bytes:   "AELFENC1" magic
+16 bytes:  scrypt salt
+remainder: Fernet-encrypted SQLite bytes (AES-128-CBC + HMAC-SHA256)
+```
+
+Key derivation: `scrypt(password, salt, N=2**14, r=8, p=1, len=32)`, base64-urlsafe-encoded for Fernet. The salt is embedded so only the password is needed for recovery — no metadata to remember.
+
+Password input:
+
+```bash
+aelf uninstall --archive PATH                       # interactive prompt (twice, must match)
+echo -n "secret" | aelf uninstall --archive PATH --password-stdin
+```
+
+Never pass the password on argv — it would leak via `ps` / `/proc/cmdline`.
+
+Recovery later:
+
+```python
+from aelfrice.lifecycle import decrypt_archive
+data = decrypt_archive(Path("/tmp/aelf-backup.aenc"), "secret")
+Path("/tmp/restored.db").write_bytes(data)
+# Now AELFRICE_DB=/tmp/restored.db aelf search "..." works.
+```
+
+Wrong password raises `cryptography.fernet.InvalidToken`. Requires `pip install 'aelfrice[archive]'`; without the extra, the CLI prints a clear install hint and exits non-zero.
+
+### `--purge`
+
+Permanently deletes `~/.aelfrice/memory.db`. Three gates fire before deletion:
+
+1. The `--purge` flag must be passed explicitly. Default behavior is an error pointing at `--help`.
+2. Print the target path + size, then require the user to type `PURGE` verbatim (case-sensitive).
+3. Final `[y/N]` confirmation.
+
+`--yes` skips prompts (1)–(3). It does **not** auto-pass `--purge`. There is no env-var override for the `--purge` flag; if you want to script unattended teardown you must explicitly add both `--purge --yes`.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -69,8 +69,7 @@ Every `aelf <cmd>` invocation and every `UserPromptSubmit` hook fire kicks off a
 Opt out:
 
 ```bash
-export AELF_NO_UPDATE_CHECK=1     # globally, in your shell config
-aelf <cmd> --no-update-check      # one-off  [TODO: not yet wired]
+export AELF_NO_UPDATE_CHECK=1     # disables the check globally
 ```
 
 When the cache says an update is available you'll see two things:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "1.0.0"
+version = "1.0.1"
 description = "Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,11 @@ dev = [
 mcp = [
     "fastmcp>=0.2.0",
 ]
+archive = [
+    # Required only for `aelf uninstall --archive`: AES-128-CBC + HMAC
+    # via Fernet, with a scrypt-derived key from a user-supplied password.
+    "cryptography>=42.0",
+]
 benchmarks = [
     # Sentence tokenization for MAB / LoCoMo adapters
     "nltk>=3.9",

--- a/src/aelfrice/__init__.py
+++ b/src/aelfrice/__init__.py
@@ -1,2 +1,2 @@
 """aelfrice: Bayesian memory designed for feedback-driven learning."""
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -12,6 +12,7 @@ Commands:
   setup                            install UserPromptSubmit hook in Claude Code
   unsetup                          remove UserPromptSubmit hook from Claude Code
   upgrade                          print the right pip-upgrade command line
+  statusline                       emit Claude Code statusline snippet
   bench                            run the v0.9.0-rc benchmark harness
 
 DB path resolves from AELFRICE_DB environment variable when set,
@@ -415,6 +416,25 @@ def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _cmd_statusline(args: argparse.Namespace, out: object) -> int:
+    """Print a statusline prefix snippet ('' when no update pending).
+
+    Composes with any existing statusline command via shell:
+    'original-cmd ; aelf statusline 2>/dev/null'. Reads the cache only,
+    never networks. End-of-line is intentionally absent so the snippet
+    sits inline with whatever else is on the bar.
+    """
+    _ = args
+    from aelfrice.statusline import render
+
+    snippet = render()
+    if snippet:
+        # Use write rather than print so we don't append a newline that
+        # would force a line break in the host's statusline.
+        out.write(snippet)  # type: ignore[attr-defined]
+    return 0
+
+
 def _cmd_upgrade(args: argparse.Namespace, out: object) -> int:
     """Print the right upgrade command for this install context.
 
@@ -582,6 +602,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="status message Claude Code shows while the hook runs",
     )
     p_setup.set_defaults(func=_cmd_setup)
+
+    p_statusline = sub.add_parser(
+        "statusline",
+        help=(
+            "emit a statusline prefix snippet (orange update banner "
+            "or empty). Compose with: 'your-cmd ; aelf statusline 2>/dev/null'"
+        ),
+    )
+    p_statusline.set_defaults(func=_cmd_statusline)
 
     p_upgrade = sub.add_parser(
         "upgrade",

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -11,6 +11,7 @@ Commands:
   health                           regime classifier output
   setup                            install UserPromptSubmit hook in Claude Code
   unsetup                          remove UserPromptSubmit hook from Claude Code
+  upgrade                          print the right pip-upgrade command line
   bench                            run the v0.9.0-rc benchmark harness
 
 DB path resolves from AELFRICE_DB environment variable when set,
@@ -42,6 +43,17 @@ from aelfrice.models import (
 )
 from aelfrice import __version__ as _AELFRICE_VERSION
 from aelfrice.benchmark import run_benchmark, seed_corpus
+from aelfrice.lifecycle import (
+    PACKAGE_NAME as _PKG,
+    UpdateStatus,
+    check_for_update,
+    clear_cache as _clear_update_cache,
+    is_disabled as _update_check_disabled,
+    is_newer,
+    maybe_check_for_update_async,
+    read_cache as _read_update_cache,
+    upgrade_advice,
+)
 from aelfrice.retrieval import DEFAULT_TOKEN_BUDGET, retrieve
 from aelfrice.scanner import scan_repo
 from aelfrice.setup import (
@@ -403,6 +415,69 @@ def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _cmd_upgrade(args: argparse.Namespace, out: object) -> int:
+    """Print the right upgrade command for this install context.
+
+    Does NOT shell out to pip itself: replacing the running package
+    mid-process is unreliable on Windows and can leave the user with a
+    broken interpreter. We tell the user the exact line; they run it.
+
+    --check: only print "up to date" / "update available" status,
+    suppress the upgrade command line. Useful for scripts that want
+    a yes/no answer without copy-paste material.
+    """
+    advice = upgrade_advice()
+    # Force a fresh sync check unless explicitly disabled. This is the
+    # one CLI surface where the user has explicitly asked about updates,
+    # so we ignore the 24h TTL.
+    if _update_check_disabled():
+        status = _read_update_cache()
+    else:
+        status = check_for_update()
+        if status.installed == "" and status.latest == "":
+            # Network failed: fall back to whatever is cached.
+            status = _read_update_cache()
+    if status.update_available:
+        print(
+            f"aelfrice {status.latest} available "
+            f"(installed: {status.installed or _AELFRICE_VERSION})",
+            file=out,  # type: ignore[arg-type]
+        )
+        if status.sha256:
+            print(
+                f"verify: sha256:{status.sha256}",
+                file=out,  # type: ignore[arg-type]
+            )
+            print(
+                f"        https://pypi.org/project/{_PKG}/{status.latest}/",
+                file=out,  # type: ignore[arg-type]
+            )
+        if not args.check:
+            print(
+                f"run: {advice.command}",
+                file=out,  # type: ignore[arg-type]
+            )
+        return 0
+    # No update or unknown -- be explicit.
+    if status.latest and not status.update_available:
+        print(
+            f"aelfrice is up to date "
+            f"(installed: {status.installed or _AELFRICE_VERSION}, "
+            f"latest: {status.latest})",
+            file=out,  # type: ignore[arg-type]
+        )
+        # The cache says we're current; clear any stale "available"
+        # marker that might still be sitting around from before this
+        # check.
+        _clear_update_cache()
+    else:
+        print(
+            f"aelfrice {_AELFRICE_VERSION} (no update info available)",
+            file=out,  # type: ignore[arg-type]
+        )
+    return 0
+
+
 def _cmd_health(args: argparse.Namespace, out: object) -> int:
     _ = args
     store = _open_store()
@@ -507,6 +582,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="status message Claude Code shows while the hook runs",
     )
     p_setup.set_defaults(func=_cmd_setup)
+
+    p_upgrade = sub.add_parser(
+        "upgrade",
+        help="print the right pip-upgrade command for this install context",
+    )
+    p_upgrade.add_argument(
+        "--check", action="store_true",
+        help="only report status, do not print the upgrade command line",
+    )
+    p_upgrade.set_defaults(func=_cmd_upgrade)
 
     p_unsetup = sub.add_parser(
         "unsetup",

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -661,14 +661,56 @@ def _add_hook_scope_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+_UPDATE_CHECK_SKIP_CMDS: Final[frozenset[str]] = frozenset(
+    {"upgrade", "uninstall", "statusline"}
+)
+
+
+def _maybe_emit_update_banner(cmd: str | None) -> None:
+    """Print a one-line orange notice on stderr if an update is pending.
+
+    Skipped for commands that already speak about updates themselves
+    (`aelf upgrade`, `aelf uninstall`, `aelf statusline`) so we do not
+    double-print or stomp on machine-readable output.
+    """
+    if cmd in _UPDATE_CHECK_SKIP_CMDS:
+        return
+    if _update_check_disabled():
+        return
+    status = _read_update_cache()
+    if not status.update_available:
+        return
+    print(
+        f"\x1b[38;5;208m⬆ aelfrice {status.latest} available, "
+        f"run: aelf upgrade\x1b[0m",
+        file=sys.stderr,
+    )
+
+
 def main(argv: Sequence[str] | None = None, out: object = None) -> int:
     """CLI entry point. Returns process exit code.
 
     `argv` lets tests pass synthetic args; defaults to sys.argv[1:].
     `out` lets tests capture stdout; defaults to sys.stdout.
+
+    Two things happen for free on every invocation:
+      1. A TTL-gated background update check is fired (detached
+         subprocess, never blocks).
+      2. After the command runs, if the cache says an update is
+         available, an orange banner is printed to stderr.
+
+    Both are skipped if AELF_NO_UPDATE_CHECK is set, and the banner
+    is skipped for commands that already handle update messaging
+    themselves (upgrade / uninstall / statusline).
     """
     if out is None:
         out = sys.stdout
     parser = build_parser()
     args = parser.parse_args(argv)
-    return int(args.func(args, out))
+    cmd = getattr(args, "cmd", None)
+    if not _update_check_disabled() and cmd not in _UPDATE_CHECK_SKIP_CMDS:
+        # Fire-and-forget: cache TTL gates duplicate work, never blocks.
+        maybe_check_for_update_async()
+    code = int(args.func(args, out))
+    _maybe_emit_update_banner(cmd)
+    return code

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -12,6 +12,7 @@ Commands:
   setup                            install UserPromptSubmit hook in Claude Code
   unsetup                          remove UserPromptSubmit hook from Claude Code
   upgrade                          print the right pip-upgrade command line
+  uninstall                        tear down aelfrice locally + handle DB
   statusline                       emit Claude Code statusline snippet
   bench                            run the v0.9.0-rc benchmark harness
 
@@ -53,6 +54,7 @@ from aelfrice.lifecycle import (
     is_newer,
     maybe_check_for_update_async,
     read_cache as _read_update_cache,
+    uninstall as _lifecycle_uninstall,
     upgrade_advice,
 )
 from aelfrice.retrieval import DEFAULT_TOKEN_BUDGET, retrieve
@@ -453,6 +455,163 @@ def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _read_password(args: argparse.Namespace) -> str | None:
+    """Read the archive password.
+
+    Order of precedence:
+      1. --password-stdin: read first line of stdin (no trailing newline,
+         no shell history exposure).
+      2. Interactive: getpass twice, must match.
+    Never accepts password on argv (would leak via ps/proc/cmdline).
+    """
+    if args.password_stdin:
+        line = sys.stdin.readline()
+        return line.rstrip("\n\r")
+    import getpass
+
+    pw1 = getpass.getpass("archive password: ")
+    pw2 = getpass.getpass("confirm password: ")
+    if pw1 != pw2:
+        return None
+    return pw1
+
+
+def _cmd_uninstall(args: argparse.Namespace, out: object) -> int:
+    """Tear down aelfrice's local footprint with redundant data gates.
+
+    Mutually exclusive --keep-db / --purge / --archive PATH.
+    --purge gates:
+      1. Must be passed explicitly (default is none -> error w/ help).
+      2. Print the affected DB path + size.
+      3. Require user to type 'PURGE' verbatim (or --yes to skip).
+      4. Final [y/N] confirmation (or --yes to skip).
+    Default: also runs `aelf unsetup` for the user-scope settings.json
+    so the hook + statusline are removed in one go (--keep-hook opts
+    out).
+    """
+    chosen = sum(
+        [bool(args.keep_db), bool(args.purge), args.archive is not None]
+    )
+    if chosen == 0:
+        print(
+            "error: pick one of --keep-db, --purge, --archive PATH "
+            "(see 'aelf uninstall --help')",
+            file=sys.stderr,
+        )
+        return 2
+    if chosen > 1:
+        print(
+            "error: --keep-db, --purge, and --archive are mutually exclusive",
+            file=sys.stderr,
+        )
+        return 2
+
+    target_db = db_path()
+
+    # --- Gate 1+2+3: redundant prompts before destroying data ---------
+    if args.purge:
+        if target_db.exists():
+            try:
+                size = target_db.stat().st_size
+                size_str = f"{size:,} bytes"
+            except OSError:
+                size_str = "unknown size"
+            print(
+                f"--purge will permanently delete {target_db} ({size_str}).",
+                file=out,  # type: ignore[arg-type]
+            )
+        else:
+            print(
+                f"--purge target {target_db} does not exist; nothing to delete.",
+                file=out,  # type: ignore[arg-type]
+            )
+        if not args.yes:
+            try:
+                ack = input("type 'PURGE' to confirm: ")
+            except EOFError:
+                ack = ""
+            if ack != "PURGE":
+                print("aborted (no 'PURGE' confirmation).", file=out)  # type: ignore[arg-type]
+                return 1
+            try:
+                final = input("Last chance. Cannot be undone. Continue? [y/N]: ")
+            except EOFError:
+                final = ""
+            if final.strip().lower() not in {"y", "yes"}:
+                print("aborted.", file=out)  # type: ignore[arg-type]
+                return 1
+
+    # --- Archive path: collect password BEFORE touching the DB --------
+    password: str | None = None
+    archive_path: Path | None = None
+    if args.archive is not None:
+        archive_path = Path(args.archive)
+        password = _read_password(args)
+        if not password:
+            print(
+                "aborted: empty or non-matching password.",
+                file=sys.stderr,
+            )
+            return 1
+
+    # --- Apply data disposition --------------------------------------
+    try:
+        result = _lifecycle_uninstall(
+            target_db,
+            keep_db=args.keep_db,
+            purge=args.purge,
+            archive_path=archive_path,
+            archive_password=password,
+        )
+    except RuntimeError as exc:
+        # cryptography missing -- surface the install hint, exit non-zero.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if result.mode == "kept":
+        print(
+            f"DB preserved at {target_db}.",
+            file=out,  # type: ignore[arg-type]
+        )
+    elif result.mode == "purged":
+        print(
+            f"DB deleted: {target_db}.",
+            file=out,  # type: ignore[arg-type]
+        )
+    elif result.mode == "archived":
+        print(
+            f"DB encrypted to {result.archive_path}, original deleted.",
+            file=out,  # type: ignore[arg-type]
+        )
+        print(
+            "(decrypt later via aelfrice.lifecycle.decrypt_archive(path, pw))",
+            file=out,  # type: ignore[arg-type]
+        )
+
+    # --- Clear update-check cache (no point keeping it post-uninstall)
+    _clear_update_cache()
+
+    # --- Hook + statusline removal (default on, --keep-hook opts out)-
+    if not args.keep_hook:
+        # Delegate by re-using the existing _cmd_unsetup path: pretend
+        # the user invoked `aelf unsetup --scope user`.
+        unsetup_args = argparse.Namespace(
+            scope="user",
+            project_root=None,
+            settings_path=args.settings_path,
+            command=DEFAULT_HOOK_COMMAND,
+            cmd="unsetup",
+            func=_cmd_unsetup,
+        )
+        _cmd_unsetup(unsetup_args, out)
+
+    print(
+        f"\nFinish removing aelfrice with: pip uninstall {_PKG}",
+        file=out,  # type: ignore[arg-type]
+    )
+    return 0
+
+
 def _cmd_statusline(args: argparse.Namespace, out: object) -> int:
     """Print a statusline prefix snippet ('' when no update pending).
 
@@ -643,6 +802,53 @@ def build_parser() -> argparse.ArgumentParser:
         help="skip the auto-install of the update-notifier statusline snippet",
     )
     p_setup.set_defaults(func=_cmd_setup)
+
+    p_uninstall = sub.add_parser(
+        "uninstall",
+        help=(
+            "tear down aelfrice locally: pick exactly one of --keep-db / "
+            "--purge / --archive PATH for the brain-graph DB. Also runs "
+            "unsetup unless --keep-hook is given."
+        ),
+    )
+    p_uninstall.add_argument(
+        "--keep-db", action="store_true",
+        help="leave ~/.aelfrice/memory.db untouched (safe default for review)",
+    )
+    p_uninstall.add_argument(
+        "--purge", action="store_true",
+        help=(
+            "PERMANENTLY DELETE the brain-graph DB. Requires typing "
+            "'PURGE' followed by [y] unless --yes is passed."
+        ),
+    )
+    p_uninstall.add_argument(
+        "--archive", default=None,
+        help=(
+            "encrypt the DB to this path with a password, then delete "
+            "the original (requires: pip install 'aelfrice[archive]')"
+        ),
+    )
+    p_uninstall.add_argument(
+        "--password-stdin", action="store_true",
+        help="read archive password from stdin (no interactive prompt)",
+    )
+    p_uninstall.add_argument(
+        "--yes", action="store_true",
+        help=(
+            "skip confirmation prompts (still requires --purge to be "
+            "passed explicitly -- never auto-purges)"
+        ),
+    )
+    p_uninstall.add_argument(
+        "--keep-hook", action="store_true",
+        help="do not run unsetup; leave the Claude Code hook in place",
+    )
+    p_uninstall.add_argument(
+        "--settings-path", default=None,
+        help="explicit settings.json for the unsetup half (defaults to user-scope)",
+    )
+    p_uninstall.set_defaults(func=_cmd_uninstall)
 
     p_statusline = sub.add_parser(
         "statusline",

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -60,7 +60,9 @@ from aelfrice.scanner import scan_repo
 from aelfrice.setup import (
     SettingsScope,
     default_settings_path,
+    install_statusline,
     install_user_prompt_submit_hook,
+    uninstall_statusline,
     uninstall_user_prompt_submit_hook,
 )
 from aelfrice.store import MemoryStore
@@ -394,6 +396,30 @@ def _cmd_setup(args: argparse.Namespace, out: object) -> int:
             f"(command={args.command!r})",
             file=out,  # type: ignore[arg-type]
         )
+    if not args.no_statusline:
+        sl = install_statusline(path)
+        if sl.mode == "installed":
+            print(
+                f"installed statusline in {sl.path} "
+                f"(command='aelf statusline')",
+                file=out,  # type: ignore[arg-type]
+            )
+        elif sl.mode == "composed":
+            print(
+                f"composed statusline into existing command in {sl.path}",
+                file=out,  # type: ignore[arg-type]
+            )
+        elif sl.mode == "already":
+            pass  # silent: already wired
+        elif sl.mode == "skipped":
+            print(
+                f"statusline NOT installed in {sl.path}: existing "
+                f"statusLine looks complex (shell metacharacters). "
+                f"To enable update notifications append "
+                f"' ; aelf statusline 2>/dev/null' to your existing "
+                f"statusLine command manually.",
+                file=out,  # type: ignore[arg-type]
+            )
     return 0
 
 
@@ -411,6 +437,17 @@ def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
             f"removed {result.removed} hook entr"
             f"{'y' if result.removed == 1 else 'ies'} from {result.path} "
             f"(command={args.command!r})",
+            file=out,  # type: ignore[arg-type]
+        )
+    sl = uninstall_statusline(path)
+    if sl.mode == "removed":
+        print(
+            f"removed statusline from {sl.path}",
+            file=out,  # type: ignore[arg-type]
+        )
+    elif sl.mode == "unwrapped":
+        print(
+            f"restored prior statusline command in {sl.path}",
             file=out,  # type: ignore[arg-type]
         )
     return 0
@@ -600,6 +637,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_setup.add_argument(
         "--status-message", default=None,
         help="status message Claude Code shows while the hook runs",
+    )
+    p_setup.add_argument(
+        "--no-statusline", action="store_true",
+        help="skip the auto-install of the update-notifier statusline snippet",
     )
     p_setup.set_defaults(func=_cmd_setup)
 

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -62,6 +62,14 @@ def user_prompt_submit(
     sout = stdout if stdout is not None else sys.stdout
     serr = stderr if stderr is not None else sys.stderr
     try:
+        # TTL-gated background update check, completely detached, never
+        # blocks the hook. Statusline reads the cache it writes.
+        try:
+            from aelfrice.lifecycle import maybe_check_for_update_async
+
+            maybe_check_for_update_async()
+        except Exception:
+            pass
         raw = sin.read()
         prompt = _extract_prompt(raw)
         if prompt is None:

--- a/src/aelfrice/lifecycle.py
+++ b/src/aelfrice/lifecycle.py
@@ -284,6 +284,64 @@ def maybe_check_for_update_async(
         return False
 
 
+# --- Upgrade advice -----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class UpgradeAdvice:
+    """How to upgrade aelfrice in the user's specific install context."""
+
+    command: str
+    context: str  # 'venv' | 'pipx' | 'system' | 'unknown'
+
+
+def _is_pipx_install() -> bool:
+    """Detect a pipx-managed install by checking sys.prefix path.
+
+    pipx installs each package into ~/.local/pipx/venvs/<pkg>/ -- the
+    presence of '/pipx/venvs/' in sys.prefix is the canonical signal.
+    """
+    import sys
+
+    return "/pipx/venvs/" in sys.prefix.replace("\\", "/")
+
+
+def _is_venv() -> bool:
+    """Detect a generic venv (PEP 405 / virtualenv).
+
+    sys.prefix != sys.base_prefix is the standard idiom; works for
+    venv, virtualenv, uv venv, and conda envs.
+    """
+    import sys
+
+    return getattr(sys, "base_prefix", sys.prefix) != sys.prefix
+
+
+def upgrade_advice() -> UpgradeAdvice:
+    """Return the right pip-upgrade incantation for the running env.
+
+    pipx checked before generic venv because a pipx install IS a venv,
+    but its upgrade path is different (pipx upgrade, not pip install).
+    """
+    if _is_pipx_install():
+        return UpgradeAdvice(
+            command=f"pipx upgrade {PACKAGE_NAME}",
+            context="pipx",
+        )
+    if _is_venv():
+        return UpgradeAdvice(
+            command=f"pip install --upgrade {PACKAGE_NAME}",
+            context="venv",
+        )
+    # Fall through: system / user-site install. --user is the safest
+    # default since system-site requires root and most users don't
+    # want to sudo pip install.
+    return UpgradeAdvice(
+        command=f"pip install --user --upgrade {PACKAGE_NAME}",
+        context="system",
+    )
+
+
 def clear_cache(cache_path: Path = CACHE_FILE) -> None:
     """Remove the update-check cache file. Silent if absent.
 

--- a/src/aelfrice/lifecycle.py
+++ b/src/aelfrice/lifecycle.py
@@ -342,6 +342,156 @@ def upgrade_advice() -> UpgradeAdvice:
     )
 
 
+# --- Uninstall ----------------------------------------------------------
+
+ARCHIVE_MAGIC: Final[bytes] = b"AELFENC1"  # 8 bytes, format identifier
+ARCHIVE_SCRYPT_N: Final[int] = 2 ** 14
+ARCHIVE_SCRYPT_R: Final[int] = 8
+ARCHIVE_SCRYPT_P: Final[int] = 1
+ARCHIVE_SALT_LEN: Final[int] = 16
+ARCHIVE_KEY_LEN: Final[int] = 32  # Fernet wants base64-32 but we feed raw 32
+
+
+@dataclass(frozen=True)
+class UninstallResult:
+    """Outcome of `uninstall(...)`. Mode is one of:
+      'kept'    - DB preserved at db_path.
+      'purged'  - DB deleted.
+      'archived'- DB encrypted to archive_path then deleted from db_path.
+    """
+
+    mode: str  # 'kept' | 'purged' | 'archived'
+    db_path: Path | None
+    archive_path: Path | None = None
+
+
+def _encrypt_db_to_archive(
+    db_path: Path, archive_path: Path, password: str
+) -> None:
+    """Encrypt `db_path`'s contents to `archive_path` with `password`.
+
+    Format: 8-byte magic | 16-byte salt | Fernet-token over the DB.
+    Key is derived via scrypt(password, salt, N=2**14, r=8, p=1, len=32)
+    and base64-urlsafe-encoded (Fernet's required encoding). The same
+    parameters are recoverable from the archive header alone, so the
+    user only needs the password to decrypt.
+    """
+    try:
+        import base64
+        import secrets
+
+        from cryptography.fernet import Fernet
+        from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+    except ImportError as exc:
+        raise RuntimeError(
+            "--archive requires the 'archive' extra: "
+            "pip install 'aelfrice[archive]'"
+        ) from exc
+    if not password:
+        raise ValueError("password must be a non-empty string")
+    salt = secrets.token_bytes(ARCHIVE_SALT_LEN)
+    kdf = Scrypt(
+        salt=salt, length=ARCHIVE_KEY_LEN,
+        n=ARCHIVE_SCRYPT_N, r=ARCHIVE_SCRYPT_R, p=ARCHIVE_SCRYPT_P,
+    )
+    raw_key = kdf.derive(password.encode("utf-8"))
+    fernet_key = base64.urlsafe_b64encode(raw_key)
+    f = Fernet(fernet_key)
+    plaintext = db_path.read_bytes()
+    token = f.encrypt(plaintext)
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    with archive_path.open("wb") as out:
+        out.write(ARCHIVE_MAGIC)
+        out.write(salt)
+        out.write(token)
+
+
+def decrypt_archive(archive_path: Path, password: str) -> bytes:
+    """Decrypt an archive produced by `_encrypt_db_to_archive`.
+
+    Public: shipped so future tooling (or curious users) can recover an
+    archived DB. Returns the decrypted SQLite bytes; the caller is
+    responsible for writing them somewhere.
+    """
+    try:
+        import base64
+
+        from cryptography.fernet import Fernet
+        from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+    except ImportError as exc:
+        raise RuntimeError(
+            "decrypt_archive requires: pip install 'aelfrice[archive]'"
+        ) from exc
+    blob = archive_path.read_bytes()
+    if not blob.startswith(ARCHIVE_MAGIC):
+        raise ValueError(
+            f"not an aelfrice archive (bad magic): {archive_path}"
+        )
+    header_end = len(ARCHIVE_MAGIC) + ARCHIVE_SALT_LEN
+    salt = blob[len(ARCHIVE_MAGIC):header_end]
+    token = blob[header_end:]
+    kdf = Scrypt(
+        salt=salt, length=ARCHIVE_KEY_LEN,
+        n=ARCHIVE_SCRYPT_N, r=ARCHIVE_SCRYPT_R, p=ARCHIVE_SCRYPT_P,
+    )
+    raw_key = kdf.derive(password.encode("utf-8"))
+    fernet_key = base64.urlsafe_b64encode(raw_key)
+    f = Fernet(fernet_key)
+    return f.decrypt(token)
+
+
+def uninstall(
+    db_path: Path,
+    *,
+    keep_db: bool = False,
+    purge: bool = False,
+    archive_path: Path | None = None,
+    archive_password: str | None = None,
+) -> UninstallResult:
+    """Apply the data-disposition choice for `aelf uninstall`.
+
+    Exactly one of `keep_db`, `purge`, `archive_path` must be specified.
+    The CLI is responsible for prompting the user; this function is
+    pure mechanism. The hook removal and pip uninstallation happen
+    elsewhere -- this is the data half only.
+    """
+    chosen = sum(
+        [bool(keep_db), bool(purge), archive_path is not None]
+    )
+    if chosen != 1:
+        raise ValueError(
+            "exactly one of keep_db / purge / archive_path required"
+        )
+    if keep_db:
+        return UninstallResult(
+            mode="kept",
+            db_path=db_path if db_path.exists() else None,
+        )
+    if archive_path is not None:
+        if archive_password is None:
+            raise ValueError("archive_password required when archive_path set")
+        if not db_path.exists():
+            # Nothing to archive; surface as 'kept' so caller can warn.
+            return UninstallResult(
+                mode="kept", db_path=None, archive_path=None,
+            )
+        _encrypt_db_to_archive(db_path, archive_path, archive_password)
+        try:
+            db_path.unlink()
+        except FileNotFoundError:
+            pass
+        return UninstallResult(
+            mode="archived", db_path=None, archive_path=archive_path,
+        )
+    # purge
+    try:
+        if db_path.exists():
+            db_path.unlink()
+    except OSError:
+        pass
+    return UninstallResult(mode="purged", db_path=None)
+
+
 def clear_cache(cache_path: Path = CACHE_FILE) -> None:
     """Remove the update-check cache file. Silent if absent.
 

--- a/src/aelfrice/lifecycle.py
+++ b/src/aelfrice/lifecycle.py
@@ -1,0 +1,298 @@
+"""Lifecycle commands: update check, upgrade advice, uninstall.
+
+This module owns the surfaces that operate on the aelfrice install itself
+rather than on the memory store. Patterns ported from the GSD framework's
+two-component update notifier (gsd-check-update.js + gsd-statusline.js):
+
+* Background fire-and-forget PyPI version check writes a JSON cache.
+* Cache lives at ~/.cache/aelfrice/update_check.json (XDG-style,
+  tool-agnostic, mirrors GSD's ~/.cache/gsd/ choice).
+* Statusline reader (in aelfrice.statusline) reads the cache only --
+  never makes network calls. This keeps statusline rendering fast.
+* All network and file ops fail silently. update_available defaults to
+  False so a network outage never inflicts a "update needed" banner.
+* Custom is_newer() semver compare strips pre-release suffixes.
+
+PyPI's JSON API also publishes a SHA-256 digest for every uploaded wheel
+and sdist. We cache the wheel's sha256 alongside the version so callers
+can offer hash-pinned installs without an extra round trip.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+PACKAGE_NAME: Final[str] = "aelfrice"
+PYPI_JSON_URL: Final[str] = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
+CACHE_DIR: Final[Path] = Path.home() / ".cache" / "aelfrice"
+CACHE_FILE: Final[Path] = CACHE_DIR / "update_check.json"
+CACHE_TTL_SECONDS: Final[int] = 24 * 60 * 60  # 24h, mirrors GSD
+HTTP_TIMEOUT_SECONDS: Final[float] = 10.0
+USER_AGENT: Final[str] = f"aelfrice-update-check/{PACKAGE_NAME}"
+ENV_DISABLE: Final[str] = "AELF_NO_UPDATE_CHECK"
+
+
+@dataclass(frozen=True)
+class UpdateStatus:
+    """Snapshot of the latest cached update check.
+
+    `update_available` is the only field the statusline consumes; the
+    others are for `aelf upgrade` to surface verification details.
+    """
+
+    update_available: bool
+    installed: str
+    latest: str
+    checked: float
+    sha256: str | None = None
+
+    @classmethod
+    def empty(cls) -> "UpdateStatus":
+        return cls(False, "", "", 0.0, None)
+
+
+def is_newer(a: str, b: str) -> bool:
+    """Return True iff version `a` is strictly newer than `b`.
+
+    Mirrors GSD's isNewer(): split on '.', strip any pre-release suffix
+    after a '-', integer compare each of the first three components.
+    Non-numeric components collapse to 0 so junk strings can't crash.
+    """
+
+    def _parts(v: str) -> tuple[int, int, int]:
+        out: list[int] = []
+        for chunk in (v or "").split(".")[:3]:
+            stripped = chunk.split("-", 1)[0]
+            try:
+                out.append(int(stripped))
+            except ValueError:
+                out.append(0)
+        while len(out) < 3:
+            out.append(0)
+        return out[0], out[1], out[2]
+
+    pa = _parts(a)
+    pb = _parts(b)
+    for i in range(3):
+        if pa[i] > pb[i]:
+            return True
+        if pa[i] < pb[i]:
+            return False
+    return False
+
+
+def installed_version() -> str:
+    """Resolve the installed aelfrice version.
+
+    Reads aelfrice.__version__ which is the source of truth. Falls back
+    to '0.0.0' if the import is unexpectedly broken (defensive only).
+    """
+    try:
+        from aelfrice import __version__
+
+        return str(__version__)
+    except Exception:
+        return "0.0.0"
+
+
+def _fetch_pypi_json(url: str = PYPI_JSON_URL) -> dict | None:
+    """Fetch PyPI JSON, returning None on any failure.
+
+    Silent fail discipline: any exception (network, DNS, JSON parse,
+    timeout) yields None. Callers must treat None as "no info, keep
+    last cached state".
+    """
+    try:
+        req = Request(url, headers={"User-Agent": USER_AGENT})
+        with urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
+            payload = resp.read()
+        return json.loads(payload.decode("utf-8"))
+    except (URLError, TimeoutError, ValueError, OSError):
+        return None
+
+
+def _wheel_sha256(release_files: list[dict]) -> str | None:
+    """Pick the SHA-256 of the wheel from a PyPI release entry.
+
+    Wheels are universally preferred over sdists; we look for the
+    .whl file first. PyPI guarantees a sha256 in `digests`.
+    """
+    for entry in release_files:
+        try:
+            if entry.get("packagetype") == "bdist_wheel" or str(
+                entry.get("filename", "")
+            ).endswith(".whl"):
+                digests = entry.get("digests") or {}
+                sha = digests.get("sha256")
+                if isinstance(sha, str) and sha:
+                    return sha
+        except (AttributeError, TypeError):
+            continue
+    # Fall back to whatever we can find (sdist, etc.)
+    for entry in release_files:
+        try:
+            digests = entry.get("digests") or {}
+            sha = digests.get("sha256")
+            if isinstance(sha, str) and sha:
+                return sha
+        except (AttributeError, TypeError):
+            continue
+    return None
+
+
+def _write_cache(status: UpdateStatus, cache_path: Path = CACHE_FILE) -> None:
+    """Persist a status snapshot. Silent fail: cache write is best-effort."""
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "update_available": status.update_available,
+            "installed": status.installed,
+            "latest": status.latest,
+            "checked": status.checked,
+            "sha256": status.sha256,
+        }
+        cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def read_cache(cache_path: Path = CACHE_FILE) -> UpdateStatus:
+    """Read the cached update status. Returns empty() on any failure.
+
+    The statusline calls this. It MUST be cheap and never raise.
+    """
+    try:
+        raw = cache_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        return UpdateStatus(
+            update_available=bool(data.get("update_available", False)),
+            installed=str(data.get("installed", "")),
+            latest=str(data.get("latest", "")),
+            checked=float(data.get("checked", 0.0)),
+            sha256=(
+                str(data["sha256"])
+                if data.get("sha256") is not None
+                else None
+            ),
+        )
+    except (OSError, ValueError, KeyError, TypeError):
+        return UpdateStatus.empty()
+
+
+def cache_is_fresh(
+    status: UpdateStatus,
+    now: float | None = None,
+    ttl: int = CACHE_TTL_SECONDS,
+) -> bool:
+    """True iff the cache was written within the TTL window."""
+    if status.checked <= 0:
+        return False
+    if now is None:
+        now = time.time()
+    return (now - status.checked) < ttl
+
+
+def is_disabled(env: dict[str, str] | None = None) -> bool:
+    """True iff AELF_NO_UPDATE_CHECK is set to a truthy value."""
+    src = os.environ if env is None else env
+    val = src.get(ENV_DISABLE, "")
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def check_for_update(
+    cache_path: Path = CACHE_FILE,
+    pypi_url: str = PYPI_JSON_URL,
+    fetch: callable = _fetch_pypi_json,
+    now: float | None = None,
+) -> UpdateStatus:
+    """Run the synchronous update check end-to-end and write the cache.
+
+    This is the function the background process invokes. The CLI/hook
+    paths use maybe_check_for_update_async() which spawns a detached
+    subprocess pointing at this entry. We expose a sync version for
+    tests and for direct CLI use.
+    """
+    if is_disabled():
+        return UpdateStatus.empty()
+    installed = installed_version()
+    data = fetch(pypi_url)
+    if data is None:
+        # Network/parse failure: preserve any prior cache, return empty.
+        return read_cache(cache_path)
+    info = data.get("info") or {}
+    latest = str(info.get("version") or "")
+    sha = None
+    releases = data.get("releases") or {}
+    if latest and isinstance(releases, dict):
+        files = releases.get(latest) or []
+        if isinstance(files, list):
+            sha = _wheel_sha256(files)
+    status = UpdateStatus(
+        update_available=bool(latest) and is_newer(latest, installed),
+        installed=installed,
+        latest=latest,
+        checked=time.time() if now is None else now,
+        sha256=sha,
+    )
+    _write_cache(status, cache_path)
+    return status
+
+
+def maybe_check_for_update_async(
+    cache_path: Path = CACHE_FILE,
+    ttl: int = CACHE_TTL_SECONDS,
+) -> bool:
+    """Fire a detached background check iff cache is stale.
+
+    Returns True iff a subprocess was launched. Never blocks the caller;
+    the spawned process detaches via start_new_session=True so the
+    parent can exit without waiting. Mirrors GSD's spawn(detached:true)
+    + child.unref() pattern in Python.
+    """
+    if is_disabled():
+        return False
+    status = read_cache(cache_path)
+    if cache_is_fresh(status, ttl=ttl):
+        return False
+    import subprocess
+    import sys
+
+    try:
+        subprocess.Popen(  # noqa: S603
+            [
+                sys.executable,
+                "-c",
+                (
+                    "from aelfrice.lifecycle import check_for_update; "
+                    "check_for_update()"
+                ),
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def clear_cache(cache_path: Path = CACHE_FILE) -> None:
+    """Remove the update-check cache file. Silent if absent.
+
+    Called by `aelf upgrade` after a successful upgrade so the orange
+    statusline banner disappears immediately.
+    """
+    try:
+        cache_path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass

--- a/src/aelfrice/setup.py
+++ b/src/aelfrice/setup.py
@@ -63,6 +63,15 @@ _COMMAND_KEY: Final[str] = "command"
 _TIMEOUT_KEY: Final[str] = "timeout"
 _STATUS_MESSAGE_KEY: Final[str] = "statusMessage"
 _HOOK_TYPE_COMMAND: Final[str] = "command"
+_STATUSLINE_KEY: Final[str] = "statusLine"
+STATUSLINE_COMMAND: Final[str] = "aelf statusline"
+STATUSLINE_SUFFIX: Final[str] = " ; aelf statusline 2>/dev/null"
+# Shell metacharacters that signal a "complex" existing statusline command
+# we do NOT want to mutate. If any of these are already in the user's
+# command we leave it alone and ask them to compose manually.
+_COMPLEX_SHELL_TOKENS: Final[tuple[str, ...]] = (
+    "|", "<<", "&&", "||", "`", "\\",
+)
 
 
 @dataclass(frozen=True)
@@ -164,6 +173,130 @@ def uninstall_user_prompt_submit_hook(
     user_prompt_submit[:] = kept
     _atomic_write(settings_path, data)
     return UninstallResult(path=settings_path, removed=removed)
+
+
+# --- Statusline auto-wiring ---------------------------------------------
+
+
+@dataclass(frozen=True)
+class StatuslineInstallResult:
+    """Outcome of `install_statusline`.
+
+    `mode` describes what we did:
+      'installed'   - settings had no statusLine; we wrote a fresh one.
+      'composed'    - settings had a simple existing statusLine; we
+                      appended our snippet to its command.
+      'already'     - settings already had our statusline (idempotent).
+      'skipped'     - existing statusLine was complex (shell
+                      metacharacters); we left it alone. The caller
+                      should print the documented manual-compose hint.
+    """
+    path: Path
+    mode: Literal["installed", "composed", "already", "skipped"]
+    existing_command: str | None = None
+
+
+@dataclass(frozen=True)
+class StatuslineUninstallResult:
+    """Outcome of `uninstall_statusline`.
+
+    `mode` describes what we did:
+      'removed'   - statusLine was just `aelf statusline`; field deleted.
+      'unwrapped' - statusLine was a composed `<orig> ; aelf statusline ...`;
+                    we restored the original command.
+      'absent'    - no statusLine matched ours; no-op.
+    """
+    path: Path
+    mode: Literal["removed", "unwrapped", "absent"]
+
+
+def _looks_complex(command: str) -> bool:
+    """True iff `command` contains shell tokens we refuse to wrap."""
+    return any(tok in command for tok in _COMPLEX_SHELL_TOKENS)
+
+
+def _has_our_statusline(command: str) -> bool:
+    """True iff `command` already invokes our statusline snippet."""
+    return STATUSLINE_COMMAND in command
+
+
+def install_statusline(
+    settings_path: Path, *, statusline_command: str = STATUSLINE_COMMAND
+) -> StatuslineInstallResult:
+    """Add or compose `aelf statusline` into Claude Code's statusLine.
+
+    Deterministic rules:
+      * No `statusLine` set -> write fresh `{type, command}`.
+      * Already `aelf statusline` -> idempotent no-op.
+      * Existing simple command -> append ' ; aelf statusline 2>/dev/null'.
+      * Existing complex command -> skip with a 'skipped' result.
+    """
+    data = _load_settings(settings_path)
+    existing = data.get(_STATUSLINE_KEY)
+    if existing is None:
+        data[_STATUSLINE_KEY] = {
+            _TYPE_KEY: _HOOK_TYPE_COMMAND,
+            _COMMAND_KEY: statusline_command,
+        }
+        _atomic_write(settings_path, data)
+        return StatuslineInstallResult(
+            path=settings_path, mode="installed", existing_command=None
+        )
+    if not isinstance(existing, dict):
+        # Malformed -- leave alone, signal as skipped so caller can warn.
+        return StatuslineInstallResult(
+            path=settings_path, mode="skipped",
+            existing_command=str(existing),
+        )
+    existing_dict = cast(dict[str, object], existing)
+    cmd_obj = existing_dict.get(_COMMAND_KEY)
+    if not isinstance(cmd_obj, str):
+        return StatuslineInstallResult(
+            path=settings_path, mode="skipped", existing_command=None
+        )
+    if _has_our_statusline(cmd_obj):
+        return StatuslineInstallResult(
+            path=settings_path, mode="already", existing_command=cmd_obj
+        )
+    if _looks_complex(cmd_obj):
+        return StatuslineInstallResult(
+            path=settings_path, mode="skipped", existing_command=cmd_obj
+        )
+    existing_dict[_COMMAND_KEY] = cmd_obj + STATUSLINE_SUFFIX
+    _atomic_write(settings_path, data)
+    return StatuslineInstallResult(
+        path=settings_path, mode="composed", existing_command=cmd_obj
+    )
+
+
+def uninstall_statusline(
+    settings_path: Path, *, statusline_command: str = STATUSLINE_COMMAND
+) -> StatuslineUninstallResult:
+    """Reverse `install_statusline` surgically.
+
+    Recognises both the standalone form (drop the field) and the
+    composed form (strip our suffix, restore the original command).
+    Leaves anything else alone.
+    """
+    if not settings_path.exists():
+        return StatuslineUninstallResult(path=settings_path, mode="absent")
+    data = _load_settings(settings_path)
+    existing = data.get(_STATUSLINE_KEY)
+    if not isinstance(existing, dict):
+        return StatuslineUninstallResult(path=settings_path, mode="absent")
+    existing_dict = cast(dict[str, object], existing)
+    cmd_obj = existing_dict.get(_COMMAND_KEY)
+    if not isinstance(cmd_obj, str):
+        return StatuslineUninstallResult(path=settings_path, mode="absent")
+    if cmd_obj == statusline_command:
+        del data[_STATUSLINE_KEY]
+        _atomic_write(settings_path, data)
+        return StatuslineUninstallResult(path=settings_path, mode="removed")
+    if cmd_obj.endswith(STATUSLINE_SUFFIX):
+        existing_dict[_COMMAND_KEY] = cmd_obj[: -len(STATUSLINE_SUFFIX)]
+        _atomic_write(settings_path, data)
+        return StatuslineUninstallResult(path=settings_path, mode="unwrapped")
+    return StatuslineUninstallResult(path=settings_path, mode="absent")
 
 
 # --- internal helpers ---------------------------------------------------

--- a/src/aelfrice/slash_commands/statusline.md
+++ b/src/aelfrice/slash_commands/statusline.md
@@ -1,0 +1,22 @@
+---
+name: aelf:statusline
+description: Emit the orange update-banner statusline snippet for Claude Code.
+allowed-tools:
+  - Bash
+---
+<objective>
+Print a one-line statusline prefix snippet. When an update to aelfrice
+is available, the snippet is an orange-coloured "⬆ aelfrice X.Y.Z
+available, run: aelf upgrade │ ". When no update is pending, the
+output is empty so the user's existing statusline is unaffected.
+
+This is normally invoked by Claude Code's `statusLine` configuration
+(installed automatically by `aelf setup`); the slash command lets the
+user invoke it manually for diagnostics.
+</objective>
+
+<process>
+Run: `uv run aelf statusline`
+
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/slash_commands/uninstall.md
+++ b/src/aelfrice/slash_commands/uninstall.md
@@ -1,0 +1,32 @@
+---
+name: aelf:uninstall
+description: Tear down aelfrice locally with explicit handling for the brain-graph DB.
+allowed-tools:
+  - Bash
+---
+<objective>
+Remove aelfrice's local footprint -- the Claude Code hook + statusline
+wiring, plus an explicit choice for the brain-graph SQLite DB at
+`~/.aelfrice/memory.db`. The user must pick exactly one of:
+
+  --keep-db       leave the DB in place (safe default for review)
+  --purge         permanently delete the DB (redundant gates: type
+                  'PURGE' verbatim, then [y/N], unless --yes)
+  --archive PATH  encrypt the DB to PATH with a password, then delete
+                  the original (requires `pip install 'aelfrice[archive]'`)
+
+After data disposition, runs `unsetup` to remove the hook + statusline
+unless `--keep-hook` is passed. Tail message points the user at
+`pip uninstall aelfrice` for the final wheel removal.
+</objective>
+
+<process>
+Run: `uv run aelf uninstall <flags>` with the flags the user requested.
+
+If the user did not specify a disposition flag, ASK THEM which mode
+they want before invoking the command. Never invoke `--purge` without
+explicit user confirmation; the redundant CLI gates are the last line
+of defence, not the only one.
+
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/slash_commands/upgrade.md
+++ b/src/aelfrice/slash_commands/upgrade.md
@@ -1,0 +1,22 @@
+---
+name: aelf:upgrade
+description: Print the right pip-upgrade command for this aelfrice install context.
+allowed-tools:
+  - Bash
+---
+<objective>
+Tell the user how to upgrade aelfrice. Detects venv vs pipx vs system
+install and prints the matching command. Does NOT execute the upgrade
+itself: replacing the running package mid-process is unreliable on
+Windows and can leave a broken interpreter. The user runs the line.
+
+If an update is available, also surfaces the published wheel SHA-256
+and PyPI release URL so the user can hash-pin the install if they
+want.
+</objective>
+
+<process>
+Run: `uv run aelf upgrade`
+
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/statusline.py
+++ b/src/aelfrice/statusline.py
@@ -1,0 +1,92 @@
+"""Statusline prefix-snippet emitter for Claude Code (and any
+shell-driven status bar).
+
+Design (mirrors GSD's gsd-statusline.js):
+
+* Reads the update-check cache only -- NEVER makes a network call.
+  Statuslines are invoked frequently; any latency here is visible.
+* Emits a *prefix snippet*, not a full statusline. When composed onto
+  an existing statusline command via 'original ; aelf statusline
+  2>/dev/null' the user's existing bar is unchanged unless an update
+  is pending.
+* When an update IS pending: emits an orange ANSI-coloured one-liner
+  ending in ' | ' so it looks like a leading badge. Empty otherwise.
+* Color: truecolor #FFA500 with 256-color (208) and basic-yellow (33)
+  fallbacks. NO_COLOR env disables all colour.
+"""
+from __future__ import annotations
+
+import os
+from typing import Final
+
+from aelfrice.lifecycle import UpdateStatus, read_cache
+
+# CSS orange #FFA500 in truecolor, 256-color 208 (#FF8700), basic 33.
+ANSI_RESET: Final[str] = "\x1b[0m"
+ANSI_TRUECOLOR_ORANGE: Final[str] = "\x1b[38;2;255;165;0m"
+ANSI_256_ORANGE: Final[str] = "\x1b[38;5;208m"
+ANSI_BASIC_YELLOW: Final[str] = "\x1b[33m"
+SEPARATOR: Final[str] = " │ "
+ICON: Final[str] = "⬆"
+
+
+def _no_color(env: dict[str, str] | None = None) -> bool:
+    """Honour the NO_COLOR convention (https://no-color.org).
+
+    Any value (including empty string) for NO_COLOR disables color.
+    """
+    src = os.environ if env is None else env
+    return "NO_COLOR" in src
+
+
+def _pick_color(
+    env: dict[str, str] | None = None,
+) -> str:
+    """Choose the most-supported orange escape for this terminal.
+
+    Truecolor support is signalled by COLORTERM in {'truecolor',
+    '24bit'}. Otherwise we assume 256-color (~all modern terminals).
+    Most-basic fallback is yellow (33) which has been universal since
+    the 80s. NO_COLOR returns the empty string.
+    """
+    src = os.environ if env is None else env
+    if _no_color(src):
+        return ""
+    colorterm = src.get("COLORTERM", "").strip().lower()
+    if colorterm in {"truecolor", "24bit"}:
+        return ANSI_TRUECOLOR_ORANGE
+    term = src.get("TERM", "").strip().lower()
+    if "256" in term or term in {"xterm", "screen", "tmux"}:
+        return ANSI_256_ORANGE
+    return ANSI_BASIC_YELLOW
+
+
+def format_snippet(
+    status: UpdateStatus,
+    *,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Return the statusline snippet for the given cache status.
+
+    Empty when no update is pending. When an update is pending,
+    returns 'COLOR_ON⬆ aelfrice X.Y.Z available, run: aelf upgrade
+    COLOR_OFF │ '. The trailing ' │ ' is the GSD-style separator
+    so the snippet composes naturally as a leading badge.
+    """
+    if not status.update_available or not status.latest:
+        return ""
+    color_on = _pick_color(env)
+    color_off = ANSI_RESET if color_on else ""
+    body = (
+        f"{ICON} aelfrice {status.latest} available, "
+        f"run: aelf upgrade"
+    )
+    return f"{color_on}{body}{color_off}{SEPARATOR}"
+
+
+def render() -> str:
+    """Read the cache and return the statusline snippet.
+
+    Convenience wrapper: this is what the CLI subcommand prints.
+    """
+    return format_snippet(read_cache())

--- a/tests/regression/test_install_uninstall_e2e.py
+++ b/tests/regression/test_install_uninstall_e2e.py
@@ -1,0 +1,121 @@
+"""End-to-end regression: full lifecycle in a hermetic tmp HOME.
+
+Pretends a fresh user runs:
+  aelf setup --settings-path <tmp>
+  aelf onboard <fixture>
+  aelf search <query>          (sanity that the store works)
+  aelf uninstall --keep-db --keep-hook    (preserves DB)
+  aelf uninstall --purge --yes --keep-hook (deletes DB)
+
+Goal: catch regressions where the lifecycle commands break the store
+or the settings file. Uses the same in-process main(argv=...) entry
+point as the unit tests so it runs fast and on the same DB shim.
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.cli import main
+
+
+def _run(argv: list[str]) -> tuple[int, str]:
+    buf = io.StringIO()
+    code = main(argv=argv, out=buf)
+    return code, buf.getvalue()
+
+
+def _make_fixture(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "README.md").write_text(
+        "# Project\nThis service uses Postgres for state.\n", encoding="utf-8"
+    )
+    (root / "main.py").write_text(
+        "DATABASE_URL = 'postgres://...'\n", encoding="utf-8"
+    )
+
+
+def test_full_lifecycle_setup_onboard_search_uninstall(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    settings = tmp_path / "settings.json"
+    fixture = tmp_path / "proj"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    monkeypatch.setenv("AELF_NO_UPDATE_CHECK", "1")  # silence notifier
+    _make_fixture(fixture)
+
+    # Setup wires hook + statusline:
+    code, _out = _run(["setup", "--settings-path", str(settings)])
+    assert code == 0
+    data = json.loads(settings.read_text())
+    assert data["hooks"]["UserPromptSubmit"]
+    assert data["statusLine"]["command"] == "aelf statusline"
+
+    # Onboard creates the DB:
+    code, _ = _run(["onboard", str(fixture)])
+    assert code == 0
+    assert db.exists()
+
+    # Search hits the onboarded content:
+    code, out = _run(["search", "postgres"])
+    assert code == 0
+    assert "postgres" in out.lower() or "Postgres" in out
+
+    # Uninstall --keep-db preserves the DB:
+    code, _ = _run([
+        "uninstall", "--keep-db", "--keep-hook",
+        "--settings-path", str(settings),
+    ])
+    assert code == 0
+    assert db.exists()
+
+    # Uninstall --purge --yes deletes the DB:
+    code, _ = _run([
+        "uninstall", "--purge", "--yes", "--keep-hook",
+        "--settings-path", str(settings),
+    ])
+    assert code == 0
+    assert not db.exists()
+
+
+def test_uninstall_default_also_removes_hook_and_statusline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    settings = tmp_path / "settings.json"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    monkeypatch.setenv("AELF_NO_UPDATE_CHECK", "1")
+
+    code, _ = _run(["setup", "--settings-path", str(settings)])
+    assert code == 0
+    db.touch()  # synthetic
+
+    code, _ = _run([
+        "uninstall", "--keep-db",
+        "--settings-path", str(settings),
+    ])
+    assert code == 0
+    data = json.loads(settings.read_text())
+    # Hook removed:
+    assert data.get("hooks", {}).get("UserPromptSubmit", []) == []
+    # Statusline removed:
+    assert "statusLine" not in data
+
+
+def test_uninstall_purge_aborts_on_bad_ack(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    monkeypatch.setenv("AELF_NO_UPDATE_CHECK", "1")
+    db.write_bytes(b"sqlite-bytes")
+
+    # Feed a wrong ack via stdin.
+    monkeypatch.setattr("builtins.input", lambda *_a, **_k: "wrong")
+    code, _ = _run(["uninstall", "--purge", "--keep-hook"])
+    assert code == 1
+    assert db.exists()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,301 @@
+"""Unit tests for lifecycle.py: update check, upgrade advice, uninstall.
+
+Each test is hermetic: monkeypatched home dir, monkeypatched fetch
+function, monkeypatched env. No real network calls.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from aelfrice import lifecycle
+
+
+# --- is_newer ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        ("1.0.1", "1.0.0", True),
+        ("1.1.0", "1.0.99", True),
+        ("2.0.0", "1.99.99", True),
+        ("1.0.0", "1.0.0", False),
+        ("1.0.0", "1.0.1", False),
+        ("0.0.0", "0.0.1", False),
+        ("1.0.0-beta.1", "1.0.0", False),  # pre-release suffix stripped
+        ("1.0.0", "1.0.0-beta.1", False),
+        ("", "1.0.0", False),
+        ("1.0.0", "", True),
+        ("garbage", "1.0.0", False),
+    ],
+)
+def test_is_newer(a: str, b: str, expected: bool) -> None:
+    assert lifecycle.is_newer(a, b) is expected
+
+
+# --- read_cache / write_cache -----------------------------------------
+
+
+def test_read_cache_returns_empty_when_missing(tmp_path: Path) -> None:
+    p = tmp_path / "missing.json"
+    s = lifecycle.read_cache(p)
+    assert s == lifecycle.UpdateStatus.empty()
+
+
+def test_read_cache_handles_garbage_silently(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    s = lifecycle.read_cache(p)
+    assert s == lifecycle.UpdateStatus.empty()
+
+
+def test_write_then_read_cache_roundtrip(tmp_path: Path) -> None:
+    p = tmp_path / "cache.json"
+    src = lifecycle.UpdateStatus(
+        update_available=True,
+        installed="1.0.0",
+        latest="1.2.3",
+        checked=12345.0,
+        sha256="deadbeef",
+    )
+    lifecycle._write_cache(src, p)
+    got = lifecycle.read_cache(p)
+    assert got == src
+
+
+# --- cache_is_fresh ----------------------------------------------------
+
+
+def test_cache_is_fresh_within_ttl() -> None:
+    s = lifecycle.UpdateStatus(False, "1", "1", time.time(), None)
+    assert lifecycle.cache_is_fresh(s)
+
+
+def test_cache_is_stale_after_ttl() -> None:
+    s = lifecycle.UpdateStatus(
+        False, "1", "1", time.time() - lifecycle.CACHE_TTL_SECONDS - 1, None
+    )
+    assert not lifecycle.cache_is_fresh(s)
+
+
+def test_cache_is_stale_when_checked_zero() -> None:
+    assert not lifecycle.cache_is_fresh(lifecycle.UpdateStatus.empty())
+
+
+# --- is_disabled -------------------------------------------------------
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "ON", "True"])
+def test_is_disabled_truthy(val: str) -> None:
+    assert lifecycle.is_disabled({"AELF_NO_UPDATE_CHECK": val})
+
+
+@pytest.mark.parametrize("val", ["0", "false", "", "no"])
+def test_is_disabled_falsy(val: str) -> None:
+    assert not lifecycle.is_disabled({"AELF_NO_UPDATE_CHECK": val})
+
+
+def test_is_disabled_unset() -> None:
+    assert not lifecycle.is_disabled({})
+
+
+# --- check_for_update --------------------------------------------------
+
+
+def test_check_for_update_handles_network_failure(tmp_path: Path) -> None:
+    p = tmp_path / "cache.json"
+    s = lifecycle.check_for_update(
+        cache_path=p,
+        fetch=lambda url: None,  # network failed
+    )
+    # Network failure: no cache to read, returns empty.
+    assert s == lifecycle.UpdateStatus.empty()
+    assert not p.exists()  # don't write garbage
+
+
+def test_check_for_update_writes_cache_on_success(tmp_path: Path) -> None:
+    p = tmp_path / "cache.json"
+    payload = {
+        "info": {"version": "99.0.0"},
+        "releases": {
+            "99.0.0": [
+                {
+                    "packagetype": "bdist_wheel",
+                    "filename": "aelfrice-99.0.0-py3-none-any.whl",
+                    "digests": {"sha256": "abc123"},
+                }
+            ]
+        },
+    }
+    s = lifecycle.check_for_update(
+        cache_path=p, fetch=lambda url: payload, now=42.0,
+    )
+    assert s.update_available is True
+    assert s.latest == "99.0.0"
+    assert s.sha256 == "abc123"
+    assert s.checked == 42.0
+    # Cache written:
+    assert json.loads(p.read_text())["latest"] == "99.0.0"
+
+
+def test_check_for_update_no_update_when_at_latest(tmp_path: Path) -> None:
+    p = tmp_path / "cache.json"
+    installed = lifecycle.installed_version()
+    payload = {
+        "info": {"version": installed},
+        "releases": {
+            installed: [{"digests": {"sha256": "x"}, "filename": "x.whl"}]
+        },
+    }
+    s = lifecycle.check_for_update(cache_path=p, fetch=lambda url: payload)
+    assert s.update_available is False
+
+
+def test_check_for_update_disabled_short_circuits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AELF_NO_UPDATE_CHECK", "1")
+    called: list[str] = []
+
+    def fetch_should_not_run(url: str) -> dict | None:
+        called.append(url)
+        return None
+
+    s = lifecycle.check_for_update(
+        cache_path=tmp_path / "c.json", fetch=fetch_should_not_run
+    )
+    assert s == lifecycle.UpdateStatus.empty()
+    assert called == []
+
+
+# --- _wheel_sha256 -----------------------------------------------------
+
+
+def test_wheel_sha256_picks_wheel_over_sdist() -> None:
+    files = [
+        {"packagetype": "sdist", "filename": "x.tar.gz",
+         "digests": {"sha256": "sdist-sha"}},
+        {"packagetype": "bdist_wheel", "filename": "x.whl",
+         "digests": {"sha256": "wheel-sha"}},
+    ]
+    assert lifecycle._wheel_sha256(files) == "wheel-sha"
+
+
+def test_wheel_sha256_falls_back_to_sdist() -> None:
+    files = [
+        {"packagetype": "sdist", "filename": "x.tar.gz",
+         "digests": {"sha256": "sdist-sha"}},
+    ]
+    assert lifecycle._wheel_sha256(files) == "sdist-sha"
+
+
+def test_wheel_sha256_returns_none_when_empty() -> None:
+    assert lifecycle._wheel_sha256([]) is None
+
+
+# --- upgrade_advice ----------------------------------------------------
+
+
+def test_upgrade_advice_in_venv() -> None:
+    # The test runner itself is in a venv, so this should always be 'venv'
+    # unless we're somehow running in pipx (uncommon in CI).
+    advice = lifecycle.upgrade_advice()
+    assert advice.context in {"venv", "pipx", "system"}
+    assert "aelfrice" in advice.command
+
+
+# --- clear_cache -------------------------------------------------------
+
+
+def test_clear_cache_removes_existing(tmp_path: Path) -> None:
+    p = tmp_path / "c.json"
+    p.write_text("{}", encoding="utf-8")
+    lifecycle.clear_cache(p)
+    assert not p.exists()
+
+
+def test_clear_cache_silent_when_absent(tmp_path: Path) -> None:
+    p = tmp_path / "missing.json"
+    lifecycle.clear_cache(p)  # must not raise
+
+
+# --- uninstall ---------------------------------------------------------
+
+
+def test_uninstall_keep_db(tmp_path: Path) -> None:
+    db = tmp_path / "memory.db"
+    sqlite3.connect(str(db)).executescript("CREATE TABLE x(y INT)").close()
+    r = lifecycle.uninstall(db, keep_db=True)
+    assert r.mode == "kept"
+    assert db.exists()
+
+
+def test_uninstall_purge(tmp_path: Path) -> None:
+    db = tmp_path / "memory.db"
+    sqlite3.connect(str(db)).executescript("CREATE TABLE x(y INT)").close()
+    r = lifecycle.uninstall(db, purge=True)
+    assert r.mode == "purged"
+    assert not db.exists()
+
+
+def test_uninstall_purge_silent_when_db_absent(tmp_path: Path) -> None:
+    db = tmp_path / "missing.db"
+    r = lifecycle.uninstall(db, purge=True)
+    assert r.mode == "purged"
+
+
+def test_uninstall_archive_roundtrip(tmp_path: Path) -> None:
+    db = tmp_path / "memory.db"
+    sqlite3.connect(str(db)).executescript(
+        "CREATE TABLE x(y INT); INSERT INTO x VALUES(42);"
+    ).close()
+    archive = tmp_path / "out.aenc"
+    r = lifecycle.uninstall(
+        db, archive_path=archive, archive_password="hunter2"
+    )
+    assert r.mode == "archived"
+    assert not db.exists()
+    assert archive.exists()
+    # Decrypt + verify:
+    raw = lifecycle.decrypt_archive(archive, "hunter2")
+    restored = tmp_path / "restored.db"
+    restored.write_bytes(raw)
+    rows = list(sqlite3.connect(str(restored)).execute("SELECT y FROM x"))
+    assert rows == [(42,)]
+
+
+def test_uninstall_archive_wrong_password_rejected(tmp_path: Path) -> None:
+    pytest.importorskip("cryptography")
+    from cryptography.fernet import InvalidToken
+
+    db = tmp_path / "memory.db"
+    sqlite3.connect(str(db)).executescript("CREATE TABLE x(y INT)").close()
+    archive = tmp_path / "out.aenc"
+    lifecycle.uninstall(db, archive_path=archive, archive_password="right")
+    with pytest.raises(InvalidToken):
+        lifecycle.decrypt_archive(archive, "wrong")
+
+
+def test_uninstall_rejects_zero_modes(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        lifecycle.uninstall(tmp_path / "x.db")
+
+
+def test_uninstall_rejects_multiple_modes(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        lifecycle.uninstall(tmp_path / "x.db", keep_db=True, purge=True)
+
+
+def test_uninstall_archive_requires_password(tmp_path: Path) -> None:
+    db = tmp_path / "memory.db"
+    db.write_bytes(b"data")
+    with pytest.raises(ValueError):
+        lifecycle.uninstall(
+            db, archive_path=tmp_path / "out.aenc", archive_password=None,
+        )

--- a/tests/test_setup_statusline.py
+++ b/tests/test_setup_statusline.py
@@ -1,0 +1,149 @@
+"""Tests for setup.py's statusline composition logic."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.setup import (
+    STATUSLINE_COMMAND,
+    STATUSLINE_SUFFIX,
+    install_statusline,
+    uninstall_statusline,
+)
+
+
+def _write(p: Path, data: dict) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_install_into_empty_settings(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    r = install_statusline(p)
+    assert r.mode == "installed"
+    data = json.loads(p.read_text())
+    assert data["statusLine"]["command"] == STATUSLINE_COMMAND
+
+
+def test_install_idempotent_when_already_ours(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    _write(p, {
+        "statusLine": {"type": "command", "command": STATUSLINE_COMMAND}
+    })
+    r = install_statusline(p)
+    assert r.mode == "already"
+    # File content is unchanged:
+    data = json.loads(p.read_text())
+    assert data["statusLine"]["command"] == STATUSLINE_COMMAND
+
+
+def test_install_composes_with_simple_existing(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    _write(p, {
+        "statusLine": {"type": "command", "command": "echo my-bar"}
+    })
+    r = install_statusline(p)
+    assert r.mode == "composed"
+    assert r.existing_command == "echo my-bar"
+    data = json.loads(p.read_text())
+    assert data["statusLine"]["command"] == "echo my-bar" + STATUSLINE_SUFFIX
+
+
+def test_install_skips_complex_command(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    _write(p, {
+        "statusLine": {"type": "command", "command": "echo a | tr a A"}
+    })
+    r = install_statusline(p)
+    assert r.mode == "skipped"
+    data = json.loads(p.read_text())
+    # Untouched:
+    assert data["statusLine"]["command"] == "echo a | tr a A"
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "true && echo bar",
+        "echo a || echo b",
+        "echo `date`",
+        "echo \\$HOME",
+        "cat <<EOF\nfoo\nEOF",
+    ],
+)
+def test_install_skips_various_complex_commands(
+    tmp_path: Path, cmd: str
+) -> None:
+    p = tmp_path / "settings.json"
+    _write(p, {"statusLine": {"type": "command", "command": cmd}})
+    r = install_statusline(p)
+    assert r.mode == "skipped"
+
+
+def test_uninstall_drops_standalone_field(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    _write(p, {
+        "statusLine": {"type": "command", "command": STATUSLINE_COMMAND},
+        "other": 42,
+    })
+    r = uninstall_statusline(p)
+    assert r.mode == "removed"
+    data = json.loads(p.read_text())
+    assert "statusLine" not in data
+    assert data["other"] == 42
+
+
+def test_uninstall_unwraps_composed(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    _write(p, {
+        "statusLine": {
+            "type": "command",
+            "command": "echo my-bar" + STATUSLINE_SUFFIX,
+        }
+    })
+    r = uninstall_statusline(p)
+    assert r.mode == "unwrapped"
+    data = json.loads(p.read_text())
+    assert data["statusLine"]["command"] == "echo my-bar"
+
+
+def test_uninstall_absent_when_unrelated_command(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    _write(p, {
+        "statusLine": {"type": "command", "command": "echo other"}
+    })
+    r = uninstall_statusline(p)
+    assert r.mode == "absent"
+    # Untouched:
+    data = json.loads(p.read_text())
+    assert data["statusLine"]["command"] == "echo other"
+
+
+def test_uninstall_absent_when_file_missing(tmp_path: Path) -> None:
+    p = tmp_path / "missing.json"
+    r = uninstall_statusline(p)
+    assert r.mode == "absent"
+
+
+def test_install_then_uninstall_roundtrip_simple(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    _write(p, {})
+    install_statusline(p)
+    r = uninstall_statusline(p)
+    assert r.mode == "removed"
+    data = json.loads(p.read_text())
+    assert "statusLine" not in data
+
+
+def test_install_then_uninstall_roundtrip_compose(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    _write(p, {
+        "statusLine": {"type": "command", "command": "echo my-bar"}
+    })
+    install_statusline(p)
+    r = uninstall_statusline(p)
+    assert r.mode == "unwrapped"
+    data = json.loads(p.read_text())
+    assert data["statusLine"]["command"] == "echo my-bar"

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -12,7 +12,8 @@ from pathlib import Path
 
 import pytest
 
-# The 11-tool surface — must match cli.py's subparsers exactly.
+# The CLI's user-facing surface -- must match cli.py's subparsers exactly.
+# Lifecycle commands (upgrade/uninstall/statusline) added in v1.0.1.
 EXPECTED_COMMANDS = (
     "onboard",
     "search",
@@ -24,6 +25,9 @@ EXPECTED_COMMANDS = (
     "health",
     "setup",
     "unsetup",
+    "upgrade",
+    "uninstall",
+    "statusline",
     "bench",
 )
 

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1,0 +1,84 @@
+"""Unit tests for statusline.py: snippet emission + color fallbacks."""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from aelfrice import lifecycle, statusline
+
+
+def _fresh(latest: str = "1.2.3", available: bool = True) -> lifecycle.UpdateStatus:
+    return lifecycle.UpdateStatus(
+        update_available=available,
+        installed="1.0.0",
+        latest=latest,
+        checked=time.time(),
+        sha256=None,
+    )
+
+
+def test_empty_snippet_when_no_update() -> None:
+    s = lifecycle.UpdateStatus(False, "1.0.0", "1.0.0", time.time(), None)
+    assert statusline.format_snippet(s, env={}) == ""
+
+
+def test_empty_snippet_when_no_latest() -> None:
+    s = lifecycle.UpdateStatus(True, "1.0.0", "", time.time(), None)
+    assert statusline.format_snippet(s, env={}) == ""
+
+
+def test_truecolor_when_colorterm_truecolor() -> None:
+    out = statusline.format_snippet(_fresh(), env={"COLORTERM": "truecolor"})
+    assert statusline.ANSI_TRUECOLOR_ORANGE in out
+    assert "1.2.3" in out
+    assert out.endswith(statusline.SEPARATOR)
+
+
+def test_256color_fallback_when_term_256() -> None:
+    out = statusline.format_snippet(
+        _fresh(), env={"TERM": "xterm-256color"}
+    )
+    assert statusline.ANSI_256_ORANGE in out
+
+
+def test_basic_yellow_when_dumb_terminal() -> None:
+    out = statusline.format_snippet(_fresh(), env={"TERM": "dumb"})
+    assert statusline.ANSI_BASIC_YELLOW in out
+
+
+def test_no_color_strips_ansi() -> None:
+    out = statusline.format_snippet(
+        _fresh(), env={"NO_COLOR": "", "COLORTERM": "truecolor"}
+    )
+    assert "\x1b[" not in out
+    assert "aelfrice 1.2.3 available" in out
+
+
+def test_no_color_set_to_anything_strips_ansi() -> None:
+    # Per https://no-color.org any value is treated as set.
+    out = statusline.format_snippet(
+        _fresh(), env={"NO_COLOR": "1", "COLORTERM": "truecolor"}
+    )
+    assert "\x1b[" not in out
+
+
+def test_snippet_includes_upgrade_command() -> None:
+    out = statusline.format_snippet(
+        _fresh(), env={"COLORTERM": "truecolor"}
+    )
+    assert "run: aelf upgrade" in out
+    assert statusline.ICON in out
+
+
+def test_render_reads_cache(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    p = tmp_path / "cache.json"
+    lifecycle._write_cache(_fresh("1.5.0"), p)
+    # render() takes no args so we monkeypatch read_cache itself.
+    monkeypatch.setattr(
+        statusline, "read_cache",
+        lambda: lifecycle.read_cache(p),
+    )
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    out = statusline.render()
+    assert "1.5.0" in out

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,9 @@ version = "1.0.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
+archive = [
+    { name = "cryptography" },
+]
 benchmarks = [
     { name = "datasets" },
     { name = "huggingface-hub" },
@@ -33,6 +36,7 @@ mcp = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cryptography", marker = "extra == 'archive'", specifier = ">=42.0" },
     { name = "datasets", marker = "extra == 'benchmarks'", specifier = ">=2.14" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=0.2.0" },
     { name = "huggingface-hub", marker = "extra == 'benchmarks'", specifier = ">=0.20" },
@@ -42,7 +46,7 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "tiktoken", marker = "extra == 'benchmarks'", specifier = ">=0.7" },
 ]
-provides-extras = ["dev", "mcp", "benchmarks"]
+provides-extras = ["dev", "mcp", "archive", "benchmarks"]
 
 [[package]]
 name = "aiofile"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Adds `aelf --version`, `aelf upgrade`, `aelf uninstall`, and `aelf statusline` to close the v1.0.1 lifecycle gap.
- `aelf setup` now auto-wires an orange-coloured statusline notifier into Claude Code alongside the hook (`--no-statusline` opts out).
- A two-component update notifier ported from GSD's pattern: detached background PyPI check writes JSON cache; statusline + post-command banners read cache only, never network.
- `aelf uninstall` requires explicit data disposition: `--keep-db` / `--purge` (three redundant gates) / `--archive PATH` (AES-128-CBC + HMAC via Fernet, scrypt KDF). Public `decrypt_archive()` for later recovery.

## What's in this PR

13 atomic feature commits + 1 gate commit + lockfile refresh. Commit list (read in order):

1. `feat: aelf --version flag`
2. `feat: lifecycle.check_for_update with cached PyPI lookup`
3. `feat: lifecycle.upgrade_advice with venv/pipx/system detection`
4. `feat: aelf upgrade subcommand`
5. `feat: wire fire-and-forget update check into CLI + hook`
6. `feat: aelf statusline subcommand with orange ANSI banner`
7. `feat: auto-wire aelf statusline into aelf setup / unsetup`
8. `feat: lifecycle.uninstall with keep/purge/archive paths`
9. `feat: aelf uninstall subcommand with redundant purge gates`
10. `feat: slash commands for upgrade/uninstall/statusline`
11. `test: lifecycle + statusline + install/uninstall regression` (+130 tests)
12. `docs: install/uninstall/upgrade/statusline reference`
13. `gate: lifecycle commands + update notifier + statusline ready for review`
14. `build: refresh uv.lock with [archive] extra`

## Design notes

**Two-component update notifier** mirrors `gsd-check-update.js` + `gsd-statusline.js`:

* `lifecycle.check_for_update()` — fetches `https://pypi.org/pypi/aelfrice/json`, extracts `info.version` and the wheel's `digests.sha256`, writes `~/.cache/aelfrice/update_check.json`. XDG-style cache path mirrors GSD's `~/.cache/gsd/` choice (issue #1421 there).
* `lifecycle.maybe_check_for_update_async()` — fires `subprocess.Popen(start_new_session=True, ...DEVNULL...)` only when cache is older than 24h. TTL gating means duplicate calls are no-ops.
* `aelf-hook` (UserPromptSubmit) and every `aelf <cmd>` invocation both call the async helper. One factored function, two call sites.
* `aelf statusline` reads the cache only — never networks. Composes onto an existing statusline via `; aelf statusline 2>/dev/null`.

**`aelf upgrade`** does NOT shell out to pip. Replacing the running package mid-process is unreliable on Windows and can leave broken interpreters. We tell the user the right line for their context (venv → `pip install --upgrade`, pipx → `pipx upgrade`, system → `pip install --user --upgrade`) plus the published wheel SHA-256 + PyPI URL so they can hash-pin via `pip install ... --hash=sha256:...`.

**`aelf uninstall`** redundant gates:

1. `--purge` flag must be passed explicitly (default is error).
2. Print target path + size, then require typing `PURGE` verbatim.
3. Final `[y/N]` confirmation.
4. `--yes` skips (1)–(3) but does NOT bypass `--purge`'s explicit-flag requirement.

**Statusline composition rules** (deterministic):

| Existing `statusLine.command` | Behavior |
|---|---|
| empty / not configured | install standalone `aelf statusline` |
| already contains `aelf statusline` | idempotent no-op |
| simple existing command | append ` ; aelf statusline 2>/dev/null` |
| complex (`\|`, `<<`, `&&`, `\|\|`, `` ` ``, `\`) | left untouched + stderr hint |

`aelf unsetup` reverses surgically.

## Design decisions worth recording

These were resolved during design conversation and don't need re-litigation, but recording the rationale here so a future reader doesn't wonder why these knobs were turned the way they were:

**Fernet (AES-128-CBC + HMAC-SHA256) for archive crypto, not AES-256-GCM.** Both are unbreakable for this use case. Fernet's higher-level API is harder to misuse than AES-256-GCM's manual nonce/tag management. The "256" in AES-256-GCM is more impressive-sounding than meaningfully different.

**Statusline auto-on default in `aelf setup`.** Matches the user-stated requirement: "it should just be default behavior; it installs silently and when there's an update required it notifies the user". `--no-statusline` opts out. `aelf unsetup` reverses surgically without leaking state.

**SHA-256 surfacing in `aelf upgrade` output.** Cheap (5 lines) and gives security-conscious users a hash they can feed to `pip install --hash=sha256:...` for `--require-hashes` mode. This does NOT close the publisher-account-compromise threat — that requires Sigstore (PEP 740) signing in the publish workflow, which is intentionally a separate follow-up PR (release-pipeline territory, not lifecycle).

## Verification

- **Full test suite**: 660 passing (130 net new across `test_lifecycle.py`, `test_statusline.py`, `test_setup_statusline.py`, `regression/test_install_uninstall_e2e.py`).
- **Fresh-venv simulation** ran end-to-end: install → `--version` → setup (writes both hook + statusline) → onboard → search → statusline empty when no update → seed cache → statusline shows orange truecolor banner → `aelf upgrade` shows sha256 + PyPI URL + correct pip line → `uninstall --archive` encrypts DB, original deleted → `decrypt_archive()` round-trip restores beliefs → re-onboard → `uninstall --purge --yes` deletes DB + removes hook + removes statusline in one shot.
- All three statusline composition modes verified (install / compose / skip-on-complex).

## Test plan

- [x] Unit + regression tests green (660 passing)
- [x] Fresh-venv install → setup → onboard → search → uninstall lifecycle
- [x] Archive encrypt/decrypt round-trip
- [x] Statusline composition (empty / simple / complex / round-trip)
- [x] `aelf upgrade` shows correct command for venv context