### PR TITLE
feat(v1.0.1): contradiction tie-breaker + aelf resolve CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,23 @@ adds a no-config noise filter (with a TOML escape hatch), and ships
 
 ### Added
 
+- `aelfrice.contradiction` module: `resolve_contradiction`,
+  `find_unresolved_contradictions`, `auto_resolve_all_contradictions`.
+  When the graph holds a CONTRADICTS edge, the tie-breaker picks a
+  winner via precedence (`user_stated > user_corrected >
+  document_recent`; ties broken by recency, then by id), creates a
+  SUPERSEDES edge from winner to loser, and writes a
+  `feedback_history` audit row tagged
+  `source='contradiction_tiebreaker:<rule>'`. v1.0.1 collapses to
+  three precedence classes (the fourth `agent_inferred` class needs
+  a `Belief.origin` field landing in v1.1.0) (#NN).
+- `aelf resolve` CLI subcommand (12th) — sweeps unresolved
+  CONTRADICTS edges in the store and runs the tie-breaker on each.
+  Matching `slash_commands/resolve.md`. The 1:1 CLI ↔ slash
+  invariant is preserved at 12/12 (#NN).
+
+### Added
+
 - `aelfrice.hook_search` module: `search_for_prompt(store, prompt, ...)`
   and `record_retrieval(store, beliefs, ...)`. Closes the v1.0.1
   retrieval-side feedback-loop gap: every UserPromptSubmit hook

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,12 +33,13 @@ One-directional imports — lower in the table imports from higher.
 | `retrieval.py` | `retrieve(store, query, token_budget=2000)` — L0 locked auto-load + L1 FTS5 BM25. L0 never trimmed. |
 | `feedback.py` | `apply_feedback(store, belief_id, valence, source)` — the only Bayesian-update path. Writes `feedback_history`. Drives demotion-pressure increment + auto-demote. |
 | `correction.py` | No-LLM heuristic correction detector. |
+| `contradiction.py` | `resolve_contradiction` — picks a winner per precedence (user_stated > user_corrected > document_recent; ties broken by recency, then by id), creates a SUPERSEDES edge from winner to loser, writes a `feedback_history` audit row tagged `source='contradiction_tiebreaker:<rule>'`. `auto_resolve_all_contradictions` sweeps the graph. v1.0.1. |
 | `classification.py` | `TYPE_PRIORS` + regex fallback. Polymorphic onboard state machine. |
 | `noise_filter.py` | `is_noise(text, config)` — drops markdown heading blocks, checklist blocks, three-word fragments, and license boilerplate before classification. `NoiseConfig` dataclass + `.aelfrice.toml` discovery via `discover()` walk-up. Power-user surface documented in [CONFIG.md](CONFIG.md). |
 | `scanner.py` | `scan_repo` — filesystem + git log + Python AST extractors, noise filter, classification, persistence. Idempotent against `content_hash`. |
 | `health.py` | Regime classifier (`insufficient_data` / `early-onboarding` / `steady` / `lock-heavy` / `over-confident`) over confidence, mass, lock density, edge density. |
 | `benchmark.py` | `seed_corpus(store)` + `run_benchmark(store, *, aelfrice_version, top_k=5)` — deterministic 16-belief × 16-query synthetic harness. Frozen `BenchmarkReport` with `hit_at_1` / `hit_at_3` / `hit_at_5` / `mrr` + `p50_latency_ms` / `p99_latency_ms`. |
-| `cli.py` | argparse 11-subcommand CLI. DB resolves from `$AELFRICE_DB` or `~/.aelfrice/memory.db`. Entry: `aelf`. |
+| `cli.py` | argparse 12-subcommand CLI (added `aelf resolve` at v1.0.1 alongside the contradiction tie-breaker). DB resolves from `$AELFRICE_DB` or `~/.aelfrice/memory.db`. Entry: `aelf`. |
 | `mcp_server.py` | FastMCP server, 8 tools. `[mcp]` optional extra. |
 | `setup.py` | Idempotent install/uninstall of the Claude Code `UserPromptSubmit` hook. Atomic write via tempfile + `os.replace`. |
 | `hook.py` | `aelfrice.hook:main` — process Claude Code spawns when the hook fires. Reads JSON from stdin, calls `retrieve()`, emits `<aelfrice-memory>...</aelfrice-memory>` on stdout. Non-blocking by contract. Entry: `aelf-hook`. |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -17,6 +17,7 @@ aelf <subcommand> [args] [options]
 | `lock <statement>` | `statement` | Insert at `(α, β) = (9.0, 0.5)` with `lock_level=user`. Idempotent — re-lock of identical text upgrades existing. |
 | `locked [--pressured]` | `--pressured` | List locks. With flag, only those with `demotion_pressure > 0`. |
 | `demote <belief_id>` | `belief_id` | `lock_level → none`, `locked_at → null`, `demotion_pressure → 0`. Belief itself remains. |
+| `resolve` | — | Sweep unresolved CONTRADICTS edges. For each pair, pick a winner per precedence (`user_stated > user_corrected > document_recent`; ties broken by recency, then by id) and create a SUPERSEDES edge from winner to loser. Writes one `feedback_history` row per resolution with `source='contradiction_tiebreaker:<rule>'`. Idempotent. |
 | `feedback <belief_id> <used\|harmful> [--source S]` | id, signal, optional source | `used` ⇒ α += 1. `harmful` ⇒ β += 1. Positive feedback flowing through outbound CONTRADICTS edges to user-locks bumps their `demotion_pressure`; ≥ 5 ⇒ auto-demote. |
 | `stats` | — | beliefs / edges / locked / feedback_events counts. |
 | `health` | — | Regime classifier: one of `early-onboarding`, `steady`, `lock-heavy`, `over-confident`, `insufficient-data`. |

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -33,7 +33,7 @@ Tracked openly. Each item is mapped to its target version below.
 
 ### Feedback semantics — v1.0.1
 
-- **Contradictions detected but not auto-resolved.** Search output prints `WARNING: CONTRADICTS [X] vs [Y]` and continues. v1.0.1 adds a default tie-breaker (`user_stated > user_corrected > document_recent > agent_inferred`, then ISO timestamp) that auto-supersedes the loser. Until then: review with `aelf locked --pressured`.
+- ✅ **Contradiction tie-breaker (v1.0.1).** New `aelfrice.contradiction` module: `resolve_contradiction(store, a_id, b_id)` picks a winner per precedence — `user_stated` (lock_level=user) > `user_corrected` (type=correction) > `document_recent` (everything else). Ties within a class break by `created_at` recency; final tiebreak by belief id (deterministic). Inserts a SUPERSEDES edge from winner to loser and writes one `feedback_history` row tagged `source='contradiction_tiebreaker:<rule>'`. `aelf resolve` (CLI) sweeps all unresolved CONTRADICTS edges in the store. Idempotent — re-running the command on a resolved store does no edge work but writes no audit rows either. The fourth class named in the original spec (`agent_inferred`) requires a `Belief.origin` field not in the v1.0 schema; in practice no v1.0 path produces beliefs that map to it, so v1.0.1 collapses to three classes. v1.1.0 adds the `origin` field alongside project-identity work and the four-class split becomes faithful.
 
 ### Project identity — v1.1.0
 

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -220,6 +220,38 @@ def _cmd_demote(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _cmd_resolve(args: argparse.Namespace, out: object) -> int:
+    """Resolve all unresolved CONTRADICTS edges via the v1.0.1 tie-breaker."""
+    _ = args
+    from aelfrice.contradiction import (
+        auto_resolve_all_contradictions,
+        find_unresolved_contradictions,
+    )
+
+    store = _open_store()
+    try:
+        unresolved = find_unresolved_contradictions(store)
+        if not unresolved:
+            print("no unresolved contradictions", file=out)  # type: ignore[arg-type]
+            return 0
+        results = auto_resolve_all_contradictions(store)
+    finally:
+        store.close()
+    for r in results:
+        print(
+            f"resolved: {r.winner_id} supersedes {r.loser_id} "
+            f"({r.rule_fired})",
+            file=out,  # type: ignore[arg-type]
+        )
+    skipped = len(unresolved) - len(results)
+    if skipped > 0:
+        print(
+            f"skipped {skipped} pair(s) with missing endpoints",
+            file=out,  # type: ignore[arg-type]
+        )
+    return 0
+
+
 def _cmd_feedback(args: argparse.Namespace, out: object) -> int:
     valence = _FEEDBACK_VALENCES.get(args.signal)
     if valence is None:
@@ -820,6 +852,20 @@ def build_parser() -> argparse.ArgumentParser:
     p_demote = sub.add_parser("demote", help="manually demote a lock to none")
     p_demote.add_argument("belief_id", help="id of the belief to demote")
     p_demote.set_defaults(func=_cmd_demote)
+
+    p_resolve = sub.add_parser(
+        "resolve",
+        help="resolve unresolved CONTRADICTS edges via the v1.0.1 tie-breaker",
+        epilog=(
+            "Picks a winner per precedence (user_stated > user_corrected "
+            "> document_recent; ties broken by recency, then id) and "
+            "creates a SUPERSEDES edge from winner to loser. Each "
+            "resolution writes an audit row to feedback_history with "
+            "source='contradiction_tiebreaker:<rule>'. Idempotent — "
+            "already-resolved pairs are skipped."
+        ),
+    )
+    p_resolve.set_defaults(func=_cmd_resolve)
 
     p_feedback = sub.add_parser("feedback", help="apply one feedback event")
     p_feedback.add_argument("belief_id", help="id of the belief")

--- a/src/aelfrice/contradiction.py
+++ b/src/aelfrice/contradiction.py
@@ -1,0 +1,320 @@
+"""Contradiction tie-breaker for v1.0.1.
+
+When the graph holds a `CONTRADICTS` edge between two beliefs, the
+tie-breaker picks one as the winner via a deterministic precedence
+rule and supersedes the loser. The result is a normal `SUPERSEDES`
+edge from winner → loser, plus an audit row in `feedback_history`
+recording which rule fired.
+
+## Precedence
+
+Three classes at v1.0.1 (down from the four named in the LIMITATIONS
+spec — see "Why three not four" below):
+
+1. **`user_stated`** — `lock_level == LOCK_USER`. The user explicitly
+   asserted this belief as ground truth via `aelf lock` or
+   `aelf:lock`. Highest precedence.
+2. **`user_corrected`** — `type == BELIEF_CORRECTION`. The belief was
+   inserted as an explicit correction signal. The classifier's
+   correction-detector path produces these.
+3. **`document_recent`** — anything else. Inserted by `scan_repo`
+   from a doc/git/AST source, or by an unmarked path. Within this
+   class, more recent timestamp wins.
+
+When two beliefs have the same precedence class, **more recent
+`created_at` wins**. When created_at also matches (rare; collision
+implies identical-second insertion), **higher `id` wins** as a
+deterministic tie-breaker — this gates against subtle non-determinism
+in test harnesses that share a clock.
+
+## Why three not four
+
+The original spec named four classes (`user_stated > user_corrected >
+document_recent > agent_inferred`). The fourth — `agent_inferred` —
+needs a `Belief.origin` field that the v1.0 schema does not have; in
+practice no v1.0 code path produces beliefs that would map to
+agent_inferred (every insert path is one of: user lock, MCP remember,
+scan_repo, or correction detection). Adding the field requires a
+schema migration that's out of scope for a patch release; v1.1.0 will
+add it alongside the project-identity work. Until then, the
+`document_recent` class absorbs any belief that isn't user-locked or
+type=correction. This is a faithful approximation for v1.0.1 —
+expanding to the full four-class split is forward-compatible.
+
+## When this fires
+
+The function `resolve_contradiction(store, a, b)` runs on demand;
+the v1.0.1 integration is a CLI command (`aelf resolve`) and direct
+library use. v1.0 has no automatic write path that creates
+CONTRADICTS edges, so there is no existing trigger to integrate with.
+Hooks into `scan_repo`, retrieval, and the relationship-detector
+land in v1.x once the corresponding write paths exist.
+
+## Audit
+
+Every successful resolution writes one row to `feedback_history`:
+
+- `belief_id` = loser's id (the belief being demoted)
+- `valence` = `0.0` (bookkeeping; not a real feedback signal — this
+  is intentional and replay logic should ignore zero-valence rows)
+- `source` = `f"contradiction_tiebreaker:{rule}"` where `rule`
+  encodes the winner's class, e.g.
+  `"contradiction_tiebreaker:user_stated_beats_document_recent"`.
+- `created_at` = now (or supplied)
+
+Reading the audit log answers "which rule fired and against what?"
+without needing to recompute precedence at query time.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Final
+
+from aelfrice.models import (
+    BELIEF_CORRECTION,
+    EDGE_CONTRADICTS,
+    EDGE_SUPERSEDES,
+    LOCK_USER,
+    Belief,
+    Edge,
+)
+from aelfrice.store import MemoryStore
+
+# Precedence classes. Higher value wins. Names are stable wire-format
+# strings — they appear in feedback_history.source — so do not rename
+# without a migration.
+PRECEDENCE_USER_STATED: Final[int] = 3
+PRECEDENCE_USER_CORRECTED: Final[int] = 2
+PRECEDENCE_DOCUMENT_RECENT: Final[int] = 1
+
+CLASS_NAMES: Final[dict[int, str]] = {
+    PRECEDENCE_USER_STATED: "user_stated",
+    PRECEDENCE_USER_CORRECTED: "user_corrected",
+    PRECEDENCE_DOCUMENT_RECENT: "document_recent",
+}
+
+# Audit-row source prefix. Anything written to feedback_history by the
+# tie-breaker has this prefix; the suffix is the rule that fired.
+SOURCE_PREFIX: Final[str] = "contradiction_tiebreaker"
+
+# Edge weight for SUPERSEDES edges created by the tie-breaker. Per
+# `models.EDGE_VALENCE`, SUPERSEDES has valence 0.0 (structural, no
+# propagation), so the weight is informational only — kept at 1.0 by
+# convention to match other structural-edge insert paths.
+SUPERSEDES_WEIGHT: Final[float] = 1.0
+
+
+@dataclass(frozen=True)
+class ResolutionResult:
+    """Outcome of one tie-breaker call.
+
+    `rule_fired` is the wire-format string written to the audit row;
+    callers can read it without re-computing precedence. Format:
+    `<winner_class>_beats_<loser_class>` — e.g.
+    `user_stated_beats_document_recent`,
+    `user_stated_beats_user_stated_by_recency`,
+    `document_recent_beats_document_recent_by_id` for the
+    final-tiebreak case.
+
+    `supersedes_created` is True when the function inserted a new
+    SUPERSEDES edge; False when an equivalent edge already existed
+    (idempotent re-resolve). The audit row is written regardless.
+
+    `audit_event_id` is the rowid of the feedback_history row.
+    """
+    winner_id: str
+    loser_id: str
+    rule_fired: str
+    supersedes_created: bool
+    audit_event_id: int
+
+
+def precedence_class(belief: Belief) -> int:
+    """Return the precedence class for `belief`.
+
+    Three classes at v1.0.1: USER_STATED (lock_level=user),
+    USER_CORRECTED (type=correction), DOCUMENT_RECENT (anything else).
+    """
+    if belief.lock_level == LOCK_USER:
+        return PRECEDENCE_USER_STATED
+    if belief.type == BELIEF_CORRECTION:
+        return PRECEDENCE_USER_CORRECTED
+    return PRECEDENCE_DOCUMENT_RECENT
+
+
+def precedence_class_name(belief: Belief) -> str:
+    """Return the human-readable class name for `belief`."""
+    return CLASS_NAMES[precedence_class(belief)]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _pick_winner(a: Belief, b: Belief) -> tuple[Belief, Belief, str]:
+    """Return (winner, loser, rule_fired_suffix).
+
+    Class wins first; if tied, more recent `created_at` wins; if also
+    tied, higher `id` wins (deterministic). The rule_fired string
+    encodes which axis decided.
+    """
+    a_cls = precedence_class(a)
+    b_cls = precedence_class(b)
+    if a_cls != b_cls:
+        if a_cls > b_cls:
+            return (
+                a, b,
+                f"{CLASS_NAMES[a_cls]}_beats_{CLASS_NAMES[b_cls]}",
+            )
+        return (
+            b, a,
+            f"{CLASS_NAMES[b_cls]}_beats_{CLASS_NAMES[a_cls]}",
+        )
+
+    # Same class — break by recency.
+    if a.created_at != b.created_at:
+        if a.created_at > b.created_at:
+            return (
+                a, b,
+                f"{CLASS_NAMES[a_cls]}_beats_"
+                f"{CLASS_NAMES[a_cls]}_by_recency",
+            )
+        return (
+            b, a,
+            f"{CLASS_NAMES[a_cls]}_beats_"
+            f"{CLASS_NAMES[a_cls]}_by_recency",
+        )
+
+    # Same class, same timestamp — break by id (alphabetical).
+    if a.id > b.id:
+        return (
+            a, b,
+            f"{CLASS_NAMES[a_cls]}_beats_"
+            f"{CLASS_NAMES[a_cls]}_by_id",
+        )
+    return (
+        b, a,
+        f"{CLASS_NAMES[a_cls]}_beats_"
+        f"{CLASS_NAMES[a_cls]}_by_id",
+    )
+
+
+def resolve_contradiction(
+    store: MemoryStore,
+    a_id: str,
+    b_id: str,
+    *,
+    now: str | None = None,
+) -> ResolutionResult:
+    """Resolve a contradiction between two beliefs.
+
+    Picks a winner via the precedence rules (see module docstring),
+    inserts a SUPERSEDES edge from winner → loser if not already
+    present, and writes one audit row to feedback_history tagged
+    `source=f"{SOURCE_PREFIX}:{rule_fired}"`.
+
+    Raises ValueError if either belief is missing. Idempotent: a
+    second call with the same args inserts no new SUPERSEDES edge
+    but still writes a fresh audit row (so re-resolves leave a
+    visible trace).
+    """
+    a = store.get_belief(a_id)
+    if a is None:
+        raise ValueError(f"belief not found: {a_id}")
+    b = store.get_belief(b_id)
+    if b is None:
+        raise ValueError(f"belief not found: {b_id}")
+
+    winner, loser, rule = _pick_winner(a, b)
+
+    existing = store.get_edge(
+        winner.id, loser.id, EDGE_SUPERSEDES,
+    )
+    if existing is None:
+        store.insert_edge(Edge(
+            src=winner.id,
+            dst=loser.id,
+            type=EDGE_SUPERSEDES,
+            weight=SUPERSEDES_WEIGHT,
+        ))
+        supersedes_created = True
+    else:
+        supersedes_created = False
+
+    timestamp = now if now is not None else _utc_now_iso()
+    audit_id = store.insert_feedback_event(
+        belief_id=loser.id,
+        valence=0.0,  # bookkeeping; replay logic ignores zero-valence
+        source=f"{SOURCE_PREFIX}:{rule}",
+        created_at=timestamp,
+    )
+
+    return ResolutionResult(
+        winner_id=winner.id,
+        loser_id=loser.id,
+        rule_fired=rule,
+        supersedes_created=supersedes_created,
+        audit_event_id=audit_id,
+    )
+
+
+def find_unresolved_contradictions(
+    store: MemoryStore,
+) -> list[tuple[str, str]]:
+    """Find CONTRADICTS edges that lack a matching SUPERSEDES edge.
+
+    Returns a deduplicated list of (a_id, b_id) pairs ordered for
+    determinism (lexicographic on the smaller id, then larger).
+    A CONTRADICTS edge in either direction (A→B or B→A) is treated
+    as the same logical pair. A pair is "resolved" when a SUPERSEDES
+    edge exists between the two beliefs in either direction.
+    """
+    pairs: set[tuple[str, str]] = set()
+    for b in store.list_beliefs() if hasattr(store, "list_beliefs") else []:
+        # Defensive: list_beliefs is not in the v1.0 store. Iterate via SQL.
+        _ = b  # never reached; placeholder for future API
+    # Fall through to direct SQL since list_beliefs is not exposed
+    rows = store._conn.execute(  # type: ignore[attr-defined]
+        "SELECT src, dst FROM edges WHERE type = ?",
+        (EDGE_CONTRADICTS,),
+    ).fetchall()
+    for row in rows:
+        a, b = row["src"], row["dst"]
+        # Canonicalise pair (lower id first) so A→B and B→A dedupe.
+        if a < b:
+            pairs.add((a, b))
+        else:
+            pairs.add((b, a))
+    out: list[tuple[str, str]] = []
+    for a, b in sorted(pairs):
+        if (
+            store.get_edge(a, b, EDGE_SUPERSEDES) is not None
+            or store.get_edge(b, a, EDGE_SUPERSEDES) is not None
+        ):
+            continue
+        out.append((a, b))
+    return out
+
+
+def auto_resolve_all_contradictions(
+    store: MemoryStore,
+    *,
+    now: str | None = None,
+) -> list[ResolutionResult]:
+    """Resolve every unresolved CONTRADICTS edge in the store.
+
+    Returns the list of ResolutionResult objects in the order they
+    were resolved. Already-resolved pairs (those with an existing
+    SUPERSEDES edge between them) are skipped — no audit row written.
+    Pairs whose endpoint beliefs no longer exist are silently
+    skipped.
+    """
+    out: list[ResolutionResult] = []
+    for a_id, b_id in find_unresolved_contradictions(store):
+        try:
+            out.append(resolve_contradiction(store, a_id, b_id, now=now))
+        except ValueError:
+            # Either endpoint missing — skip, do not abort batch.
+            continue
+    return out

--- a/src/aelfrice/slash_commands/resolve.md
+++ b/src/aelfrice/slash_commands/resolve.md
@@ -1,0 +1,19 @@
+---
+name: aelf:resolve
+description: Resolve unresolved CONTRADICTS edges via the v1.0.1 tie-breaker.
+allowed-tools:
+  - Bash
+---
+<objective>
+Sweep the belief graph for unresolved CONTRADICTS edges and run the
+v1.0.1 tie-breaker on each. The tie-breaker picks a winner per
+precedence (user_stated > user_corrected > document_recent; ties
+broken by recency, then by id) and creates a SUPERSEDES edge from
+winner to loser. Each resolution writes an audit row to
+feedback_history with source='contradiction_tiebreaker:&lt;rule&gt;'.
+</objective>
+
+<process>
+Run: `uv run aelf resolve`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -1,0 +1,377 @@
+"""Contradiction tie-breaker: precedence, resolution, audit, idempotence.
+
+Atomic short tests, one property each. Every test uses an in-memory
+store and finishes in milliseconds.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aelfrice.contradiction import (
+    CLASS_NAMES,
+    PRECEDENCE_DOCUMENT_RECENT,
+    PRECEDENCE_USER_CORRECTED,
+    PRECEDENCE_USER_STATED,
+    SOURCE_PREFIX,
+    auto_resolve_all_contradictions,
+    find_unresolved_contradictions,
+    precedence_class,
+    precedence_class_name,
+    resolve_contradiction,
+)
+from aelfrice.models import (
+    BELIEF_CORRECTION,
+    BELIEF_FACTUAL,
+    EDGE_CONTRADICTS,
+    EDGE_SUPERSEDES,
+    LOCK_NONE,
+    LOCK_USER,
+    Belief,
+    Edge,
+)
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    bid: str,
+    *,
+    btype: str = BELIEF_FACTUAL,
+    lock: str = LOCK_NONE,
+    locked_at: str | None = None,
+    created_at: str = "2026-04-26T00:00:00Z",
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=f"belief {bid}",
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=btype,
+        lock_level=lock,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at=created_at,
+        last_retrieved_at=None,
+    )
+
+
+def _seed(*beliefs: Belief) -> MemoryStore:
+    s = MemoryStore(":memory:")
+    for b in beliefs:
+        s.insert_belief(b)
+    return s
+
+
+# --- Precedence class assignment ----------------------------------------
+
+
+def test_user_locked_belief_is_user_stated() -> None:
+    b = _mk("X", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z")
+    assert precedence_class(b) == PRECEDENCE_USER_STATED
+    assert precedence_class_name(b) == "user_stated"
+
+
+def test_correction_belief_is_user_corrected() -> None:
+    b = _mk("X", btype=BELIEF_CORRECTION)
+    assert precedence_class(b) == PRECEDENCE_USER_CORRECTED
+    assert precedence_class_name(b) == "user_corrected"
+
+
+def test_factual_belief_is_document_recent() -> None:
+    b = _mk("X")
+    assert precedence_class(b) == PRECEDENCE_DOCUMENT_RECENT
+    assert precedence_class_name(b) == "document_recent"
+
+
+def test_locked_correction_is_user_stated_not_corrected() -> None:
+    """Lock takes priority over type — a locked correction is still
+    user-asserted ground truth."""
+    b = _mk("X", btype=BELIEF_CORRECTION, lock=LOCK_USER,
+            locked_at="2026-04-26T01:00:00Z")
+    assert precedence_class(b) == PRECEDENCE_USER_STATED
+
+
+# --- _pick_winner via resolve_contradiction -----------------------------
+
+
+def test_user_stated_beats_user_corrected() -> None:
+    a = _mk("A", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z")
+    b = _mk("B", btype=BELIEF_CORRECTION)
+    s = _seed(a, b)
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    result = resolve_contradiction(s, "A", "B")
+    assert result.winner_id == "A"
+    assert result.loser_id == "B"
+    assert result.rule_fired == "user_stated_beats_user_corrected"
+
+
+def test_user_stated_beats_document_recent() -> None:
+    a = _mk("A", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z")
+    b = _mk("B")  # factual, default class
+    s = _seed(a, b)
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    result = resolve_contradiction(s, "A", "B")
+    assert result.winner_id == "A"
+    assert result.rule_fired == "user_stated_beats_document_recent"
+
+
+def test_user_corrected_beats_document_recent() -> None:
+    a = _mk("A", btype=BELIEF_CORRECTION)
+    b = _mk("B")
+    s = _seed(a, b)
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    result = resolve_contradiction(s, "A", "B")
+    assert result.winner_id == "A"
+    assert result.rule_fired == "user_corrected_beats_document_recent"
+
+
+def test_argument_order_does_not_affect_outcome() -> None:
+    """Calling resolve(A, B) must produce the same winner as resolve(B, A)."""
+    a = _mk("A", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z")
+    b = _mk("B")
+    s = _seed(a, b)
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    forward = resolve_contradiction(s, "A", "B")
+    s2 = _seed(a, b)
+    s2.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    reverse = resolve_contradiction(s2, "B", "A")
+    assert forward.winner_id == reverse.winner_id
+    assert forward.rule_fired == reverse.rule_fired
+
+
+# --- Same-class tie-breaks ----------------------------------------------
+
+
+def test_same_class_more_recent_wins() -> None:
+    a = _mk("A", created_at="2026-04-26T00:00:00Z")
+    b = _mk("B", created_at="2026-04-27T00:00:00Z")  # newer
+    s = _seed(a, b)
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    result = resolve_contradiction(s, "A", "B")
+    assert result.winner_id == "B"
+    assert "by_recency" in result.rule_fired
+
+
+def test_same_class_same_timestamp_higher_id_wins() -> None:
+    """Final tiebreak: alphabetical id ordering (deterministic)."""
+    a = _mk("A", created_at="2026-04-26T00:00:00Z")
+    b = _mk("B", created_at="2026-04-26T00:00:00Z")
+    s = _seed(a, b)
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    result = resolve_contradiction(s, "A", "B")
+    assert result.winner_id == "B"
+    assert "by_id" in result.rule_fired
+
+
+def test_same_class_same_timestamp_id_winner_is_deterministic() -> None:
+    """Re-running the same resolution must produce identical results."""
+    a = _mk("A", created_at="2026-04-26T00:00:00Z")
+    b = _mk("B", created_at="2026-04-26T00:00:00Z")
+    s1 = _seed(a, b)
+    s1.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    r1 = resolve_contradiction(s1, "A", "B")
+    s2 = _seed(a, b)
+    s2.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    r2 = resolve_contradiction(s2, "A", "B")
+    assert r1.winner_id == r2.winner_id
+    assert r1.rule_fired == r2.rule_fired
+
+
+# --- SUPERSEDES edge written --------------------------------------------
+
+
+def test_resolve_inserts_supersedes_edge() -> None:
+    a = _mk("A", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z")
+    b = _mk("B")
+    s = _seed(a, b)
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    result = resolve_contradiction(s, "A", "B")
+    assert result.supersedes_created is True
+    edge = s.get_edge(result.winner_id, result.loser_id, EDGE_SUPERSEDES)
+    assert edge is not None
+
+
+def test_resolve_idempotent_no_duplicate_supersedes() -> None:
+    a = _mk("A", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z")
+    b = _mk("B")
+    s = _seed(a, b)
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    first = resolve_contradiction(s, "A", "B")
+    second = resolve_contradiction(s, "A", "B")
+    assert first.supersedes_created is True
+    assert second.supersedes_created is False
+    assert first.winner_id == second.winner_id
+
+
+# --- Audit row ----------------------------------------------------------
+
+
+def test_resolve_writes_audit_row_on_loser() -> None:
+    a = _mk("A", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z")
+    b = _mk("B")
+    s = _seed(a, b)
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    resolve_contradiction(s, "A", "B")
+    events = s.list_feedback_events()
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.belief_id == "B"
+    assert ev.valence == 0.0
+    assert ev.source.startswith(f"{SOURCE_PREFIX}:")
+    assert "user_stated_beats_document_recent" in ev.source
+
+
+def test_resolve_idempotent_writes_second_audit_row() -> None:
+    """Re-resolving the same pair leaves a fresh audit row each time —
+    so re-runs are visible in the log."""
+    a = _mk("A", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z")
+    b = _mk("B")
+    s = _seed(a, b)
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    resolve_contradiction(s, "A", "B")
+    resolve_contradiction(s, "A", "B")
+    assert s.count_feedback_events() == 2
+
+
+def test_resolve_audit_row_carries_now_kwarg() -> None:
+    a = _mk("A", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z")
+    b = _mk("B")
+    s = _seed(a, b)
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    resolve_contradiction(s, "A", "B", now="2026-04-30T12:00:00Z")
+    ev = s.list_feedback_events()[0]
+    assert ev.created_at == "2026-04-30T12:00:00Z"
+
+
+def test_resolve_audit_row_zero_valence_does_not_affect_replay() -> None:
+    """The audit row must have valence=0.0 so a future feedback-replay
+    pass doesn't treat the tie-breaker as a real Bayesian update."""
+    a = _mk("A", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z")
+    b = _mk("B")
+    s = _seed(a, b)
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    resolve_contradiction(s, "A", "B")
+    events = s.list_feedback_events()
+    assert all(ev.valence == 0.0 for ev in events
+                if ev.source.startswith(f"{SOURCE_PREFIX}:"))
+
+
+# --- Missing belief errors ----------------------------------------------
+
+
+def test_resolve_raises_on_missing_a() -> None:
+    s = _seed(_mk("B"))
+    with pytest.raises(ValueError, match="ghost"):
+        resolve_contradiction(s, "ghost", "B")
+
+
+def test_resolve_raises_on_missing_b() -> None:
+    s = _seed(_mk("A"))
+    with pytest.raises(ValueError, match="ghost"):
+        resolve_contradiction(s, "A", "ghost")
+
+
+# --- find_unresolved_contradictions -------------------------------------
+
+
+def test_find_no_contradicts_returns_empty() -> None:
+    s = _seed(_mk("A"), _mk("B"))
+    assert find_unresolved_contradictions(s) == []
+
+
+def test_find_one_contradicts_returns_pair() -> None:
+    s = _seed(_mk("A"), _mk("B"))
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    pairs = find_unresolved_contradictions(s)
+    assert pairs == [("A", "B")]
+
+
+def test_find_canonicalises_direction() -> None:
+    """B→A CONTRADICTS is the same logical pair as A→B."""
+    s = _seed(_mk("A"), _mk("B"))
+    s.insert_edge(Edge(src="B", dst="A", type=EDGE_CONTRADICTS, weight=1.0))
+    pairs = find_unresolved_contradictions(s)
+    assert pairs == [("A", "B")]  # canonical: lower id first
+
+
+def test_find_dedupes_both_directions() -> None:
+    """A→B and B→A together should still yield one pair."""
+    s = _seed(_mk("A"), _mk("B"))
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    s.insert_edge(Edge(src="B", dst="A", type=EDGE_CONTRADICTS, weight=1.0))
+    pairs = find_unresolved_contradictions(s)
+    assert len(pairs) == 1
+
+
+def test_find_skips_already_resolved_pair() -> None:
+    """A pair with an existing SUPERSEDES edge is not unresolved."""
+    s = _seed(_mk("A"), _mk("B"))
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_SUPERSEDES, weight=1.0))
+    pairs = find_unresolved_contradictions(s)
+    assert pairs == []
+
+
+# --- auto_resolve_all_contradictions ------------------------------------
+
+
+def test_auto_resolve_processes_all_pairs() -> None:
+    s = _seed(
+        _mk("A", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z"),
+        _mk("B"),
+        _mk("C", lock=LOCK_USER, locked_at="2026-04-26T02:00:00Z"),
+        _mk("D"),
+    )
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    s.insert_edge(Edge(src="C", dst="D", type=EDGE_CONTRADICTS, weight=1.0))
+    results = auto_resolve_all_contradictions(s)
+    assert len(results) == 2
+    winner_ids = {r.winner_id for r in results}
+    assert winner_ids == {"A", "C"}
+
+
+def test_auto_resolve_skips_already_resolved() -> None:
+    s = _seed(
+        _mk("A", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z"),
+        _mk("B"),
+    )
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_SUPERSEDES, weight=1.0))
+    results = auto_resolve_all_contradictions(s)
+    assert results == []
+
+
+def test_auto_resolve_skips_pair_with_missing_endpoint() -> None:
+    """If a CONTRADICTS edge points at a deleted belief, skip don't
+    crash."""
+    s = _seed(_mk("A"))
+    # Insert an edge pointing at a non-existent B.
+    s.insert_edge(Edge(src="A", dst="ghost", type=EDGE_CONTRADICTS, weight=1.0))
+    results = auto_resolve_all_contradictions(s)
+    assert results == []
+
+
+def test_auto_resolve_idempotent_second_run_no_op() -> None:
+    s = _seed(
+        _mk("A", lock=LOCK_USER, locked_at="2026-04-26T01:00:00Z"),
+        _mk("B"),
+    )
+    s.insert_edge(Edge(src="A", dst="B", type=EDGE_CONTRADICTS, weight=1.0))
+    first = auto_resolve_all_contradictions(s)
+    second = auto_resolve_all_contradictions(s)
+    assert len(first) == 1
+    assert second == []  # all resolved; nothing to do
+
+
+# --- Class-name constants -----------------------------------------------
+
+
+def test_class_names_cover_all_three_classes() -> None:
+    assert CLASS_NAMES[PRECEDENCE_USER_STATED] == "user_stated"
+    assert CLASS_NAMES[PRECEDENCE_USER_CORRECTED] == "user_corrected"
+    assert CLASS_NAMES[PRECEDENCE_DOCUMENT_RECENT] == "document_recent"
+
+
+def test_source_prefix_is_stable() -> None:
+    """Wire format. Renaming requires a migration."""
+    assert SOURCE_PREFIX == "contradiction_tiebreaker"

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -14,12 +14,14 @@ import pytest
 
 # The CLI's user-facing surface -- must match cli.py's subparsers exactly.
 # Lifecycle commands (upgrade/uninstall/statusline) added in v1.0.1.
+# `resolve` joins at v1.0.1 alongside the contradiction tie-breaker.
 EXPECTED_COMMANDS = (
     "onboard",
     "search",
     "lock",
     "locked",
     "demote",
+    "resolve",
     "feedback",
     "stats",
     "health",


### PR DESCRIPTION
## Summary

Closes the v1.0.1 contradiction tie-breaker line item from the ROADMAP.

When the graph holds a \`CONTRADICTS\` edge between two beliefs, the new tie-breaker picks a winner via deterministic precedence and creates a \`SUPERSEDES\` edge from winner → loser. Each resolution writes one \`feedback_history\` row tagged \`source='contradiction_tiebreaker:<rule>'\` so the rule that fired is inspectable without recomputing precedence.

### Precedence

1. **\`user_stated\`** — \`lock_level == LOCK_USER\`. The user explicitly asserted this belief.
2. **\`user_corrected\`** — \`type == BELIEF_CORRECTION\`. Correction-detector output.
3. **\`document_recent\`** — anything else. Within the class, more recent \`created_at\` wins.

Ties within a class break by recency; final tiebreak is alphabetical belief id (deterministic).

### Three classes, not four

The original LIMITATIONS bullet named four (\`user_stated > user_corrected > document_recent > agent_inferred\`). The fourth requires a \`Belief.origin\` field that the v1.0 schema lacks; in practice no v1.0 write path produces beliefs that map distinctly to \`agent_inferred\`. Adding the field is a schema migration out of scope for a patch release. v1.1.0 introduces \`origin\` alongside project-identity and the four-class split becomes faithful. Until then, \`document_recent\` absorbs any belief that isn't user-locked or type=correction.

This is documented in the module docstring and the resolved LIMITATIONS bullet.

### Integration

12th CLI subcommand: \`aelf resolve\`. Sweeps unresolved CONTRADICTS edges and runs the tie-breaker on each. Idempotent. Matching \`slash_commands/resolve.md\`. The 1:1 CLI ↔ slash invariant is preserved (test_slash_commands updated to expect 12 entries).

v1.0 has no write path that automatically creates CONTRADICTS edges, so there is no existing trigger to wire the tie-breaker into. Hooks into \`scan_repo\`, retrieval, and the relationship detector land in v1.x once those write paths exist. v1.0.1 ships the mechanism; v1.x ships the auto-firing.

## Files

- **\`src/aelfrice/contradiction.py\`** — new module. \`resolve_contradiction\`, \`find_unresolved_contradictions\`, \`auto_resolve_all_contradictions\`, plus precedence-class constants and \`ResolutionResult\` dataclass.
- **\`src/aelfrice/cli.py\`** — adds \`_cmd_resolve\` and registers the \`resolve\` subparser.
- **\`src/aelfrice/slash_commands/resolve.md\`** — matching slash command.
- **\`tests/test_contradiction.py\`** — 30 new tests.
- **\`tests/test_slash_commands.py\`** — invariant updated for the 12-command surface.
- **\`docs/ARCHITECTURE.md\`** — \`contradiction.py\` row in module map; \`cli.py\` row updated to \"12-subcommand\".
- **\`docs/COMMANDS.md\`** — \`resolve\` row in the reference table.
- **\`docs/LIMITATIONS.md\`** — Feedback-semantics bullet marked ✅ resolved.
- **\`CHANGELOG.md\`** — Added entries.

## Test plan

- [x] Full suite: 729 passed in 6.2s on Python 3.13. Was 693 before this branch; +30 contradiction unit + 6 incidental.
- [x] \`aelf resolve --help\` renders the epilog. Verified locally.
- [ ] Manual: on a real store, insert a CONTRADICTS edge, run \`aelf resolve\`, inspect the resulting SUPERSEDES edge and the audit row.

## Design calls baked in

- **Audit row valence is 0.0.** The tie-breaker is bookkeeping, not a Bayesian update. Replay logic should ignore zero-valence rows tagged with the \`contradiction_tiebreaker\` prefix. \`apply_feedback\` rejects zero valence; the tie-breaker bypasses \`apply_feedback\` and writes directly via \`store.insert_feedback_event\`.
- **Wire-format strings are stable.** \`SOURCE_PREFIX = "contradiction_tiebreaker"\` and the \`CLASS_NAMES\` strings (\`user_stated\`, \`user_corrected\`, \`document_recent\`) appear in audit rows; renaming them requires a migration.
- **Idempotent.** \`resolve_contradiction\` writes a fresh audit row even on re-runs (so re-resolves are visible in the log) but does not duplicate the SUPERSEDES edge. \`auto_resolve_all_contradictions\` skips already-resolved pairs entirely (no audit row).

## Notes for the v1.0.1 release

This is the second-to-last line item on the v1.0.1 ROADMAP. Next: \`feat/v1.0.1-onboard-perf\` (60s regression on a 50k-LOC fixture). Then the release PR.