### PR TITLE
release: v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-04-27
+
+Patch release: power-user ergonomics + retrieval-side feedback loop.
+Closes the v1.0.0 gap where hook retrievals never wrote audit rows,
+adds a no-config noise filter (with a TOML escape hatch), and ships
+`aelf --version` as a first-class CLI flag.
+
 ### Added
 
 - `aelfrice.hook_search` module: `search_for_prompt(store, prompt, ...)`
@@ -287,7 +294,8 @@ Foundation milestone — store, models, config.
 - Initial repo scaffold: pyproject, README, GitHub Actions workflows,
   scan configs (commit `67b4343`).
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/robotrocketscience/aelfrice/compare/v0.9.0rc0...v1.0.0
 [0.9.0rc0]: https://github.com/robotrocketscience/aelfrice/compare/v0.8.0...v0.9.0rc0
 [0.8.0]: https://github.com/robotrocketscience/aelfrice/compare/v0.7.0...v0.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "1.0.0"
+version = "1.0.1"
 description = "Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aelfrice/__init__.py
+++ b/src/aelfrice/__init__.py
@@ -1,2 +1,2 @@
 """aelfrice: Bayesian memory designed for feedback-driven learning."""
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Patch release bundling the three `v1.0.1` feats already merged to `main` since `v1.0.0`:

- `aelf --version` flag (#71)
- `hook_search` — retrieval-side feedback loop (#70)
- `noise_filter` + `.aelfrice.toml` power-user config (#72)

Plus the docs/exp commits that landed alongside (#62–#68).

## Sliding to next release

- #73 lifecycle commands + update notifier + statusline → v1.0.2
- #74 CONFIG.md → v1.0.2
- #75 contradiction tie-breaker + `aelf resolve` CLI → v1.0.2
- #69 LRU query cache → v1.1.0 (already tagged)

## Test plan

- [ ] staging-gate green (gitleaks, PII scan, commit-history audit, pytest matrix)
- [ ] After merge: tag `v1.0.1` on the merge commit, push to github
- [ ] Verify `publish.yml` fires on the tag and Trusted Publisher uploads to PyPI
- [ ] `pip install aelfrice==1.0.1` resolves and `aelf --version` prints `aelf 1.0.1`