### PR TITLE
fix: publish.yml installs archive+mcp extras; archive test importorskip

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - run: uv sync --frozen --extra dev
+      - run: uv sync --frozen --extra dev --extra archive --extra mcp
       - run: uv run pytest tests/ -q
       - run: uv build
       - uses: actions/attest-build-provenance@v1

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -251,6 +251,7 @@ def test_uninstall_purge_silent_when_db_absent(tmp_path: Path) -> None:
 
 
 def test_uninstall_archive_roundtrip(tmp_path: Path) -> None:
+    pytest.importorskip("cryptography")
     db = tmp_path / "memory.db"
     sqlite3.connect(str(db)).executescript(
         "CREATE TABLE x(y INT); INSERT INTO x VALUES(42);"


### PR DESCRIPTION
## Why

The first attempt to publish v1.0.1 (run [25018563210](https://github.com/robotrocketscience/aelfrice/actions/runs/25018563210)) failed at the pytest step:

\`\`\`
ModuleNotFoundError: No module named 'cryptography'
FAILED tests/test_lifecycle.py::test_uninstall_archive_roundtrip
\`\`\`

Root cause: \`publish.yml\` ran \`uv sync --frozen --extra dev\`, which excludes the \`archive\` extra. The lifecycle test added in #73 imports \`cryptography\` unconditionally. Staging-gate masked this because it installs all extras.

## Fix (defence in depth)

1. \`publish.yml\` now installs \`--extra dev --extra archive --extra mcp\` so the publish env matches the user-visible install surface.
2. \`test_uninstall_archive_roundtrip\` opens with \`pytest.importorskip("cryptography")\` to match the existing convention in \`test_uninstall_archive_wrong_password_rejected\`.

## Follow-up

After this merges, the v1.0.1 tag will be deleted from GitHub and re-pushed pointing at the merge commit, which will re-trigger \`publish.yml\` against the fixed env.

## Test plan

- [x] Local: \`uv run pytest tests/test_lifecycle.py -q\` → 45 passed
- [ ] staging-gate green
- [ ] After merge + retag: \`publish.yml\` succeeds and v1.0.1 lands on PyPI