### PR TITLE
fix: publish.yml drops --extra mcp (was masking mcp absence test)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - run: uv sync --frozen --extra dev --extra archive --extra mcp
+      - run: uv sync --frozen --extra dev --extra archive
       - run: uv run pytest tests/ -q
       - run: uv build
       - uses: actions/attest-build-provenance@v1


### PR DESCRIPTION
## Why

Run [25018743726](https://github.com/robotrocketscience/aelfrice/actions/runs/25018743726) (the retry after #78) failed at \`test_serve_raises_clear_error_when_fastmcp_missing\`:

\`\`\`
FAILED tests/test_mcp_server.py::test_serve_raises_clear_error_when_fastmcp_missing
io.UnsupportedOperation: not readable
\`\`\`

That test exists to verify the **user-facing error path when the \`mcp\` extra is NOT installed**. It expects \`serve()\` to raise \`RuntimeError\` matching \`aelfrice[mcp]\`. By adding \`--extra mcp\` in #78 we made fastmcp importable on the publish runner, the assertion silently flipped, and \`serve()\` actually started the FastMCP stdio server, which then crashed reading the inherited stdin.

## Fix

Drop \`--extra mcp\` from publish.yml. Keep \`--extra archive\` (the original fix — the lifecycle archive test needs it). Publish now installs \`--extra dev --extra archive\`, matching what the test suite legitimately requires.

## Test plan

- [x] Local: \`uv sync --frozen --extra dev --extra archive\` then \`pytest tests/test_mcp_server.py tests/test_lifecycle.py -q\` → 46 passed
- [ ] staging-gate green
- [ ] After merge: re-tag v1.0.1 (delete + retag) and publish.yml succeeds → v1.0.1 lands on PyPI