### PR TITLE
ci: release-docs-check gate + post-release docs sweep issue

### DIFF
--- a/.github/workflows/post-release-docs-issue.yml
+++ b/.github/workflows/post-release-docs-issue.yml
@@ -1,0 +1,60 @@
+name: Post-Release Docs Sweep
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  open-sweep-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Open docs sweep tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          title="docs sweep for ${TAG}"
+          body=$(cat <<EOF
+          Tracking docs that the **release-docs-check** staging-gate cannot verify automatically. Close once each item is either fixed in a follow-up PR or confirmed still accurate.
+
+          Release: ${RELEASE_URL}
+
+          ## Checklist
+
+          - [ ] \`README.md\` headline NOTE (\`> v1.0 ships the surface ...\`) reflects anything new in ${TAG} that changes the user-facing pitch
+          - [ ] \`README.md\` Install/60-seconds blocks mention any new install-time commands or extras shipped in ${TAG}
+          - [ ] \`README.md\` roadmap table — verify next-version row points at the right theme (status flip is gated by CI; theme drift is not)
+          - [ ] \`docs/ROADMAP.md\` — \`## v${version}\` section exists and lists what actually shipped (vs what was originally planned)
+          - [ ] \`docs/ROADMAP.md\` — next-version section reflects scope changes that happened in ${TAG} (deferred items, items pulled in)
+          - [ ] \`docs/RELEASING.md\` — pytest count comment ("~N passing at vX.Y.Z") still in the right ballpark
+          - [ ] \`docs/COMMANDS.md\` — every new CLI subcommand or flag is documented; total command count in the opening line matches
+          - [ ] \`docs/INSTALL.md\` — new optional extras and post-install verification commands present
+          - [ ] \`docs/BENCHMARKS.md\` — "Activation status" version label refreshed if any adapter changed status
+          - [ ] \`docs/LIMITATIONS.md\` — any items resolved by ${TAG} moved out of "known issues at v1.0" into resolved/historical
+          - [ ] \`docs/MCP.md\` / \`docs/SLASH_COMMANDS.md\` — surface counts and new entries reflect ${TAG}
+
+          ## What CI already verified (do not re-check)
+
+          - \`CHANGELOG.md\` has a \`## [${version}]\` section with a compare-link footnote
+          - \`README.md\` roadmap row for v${version} is no longer marked \`next\` or \`planned\`
+
+          Close this issue when the sweep is done, or convert remaining items into a tracked PR.
+          EOF
+          )
+          gh issue create \
+            --title "$title" \
+            --body "$body" \
+            --label "docs,release-followup" \
+            --repo "${{ github.repository }}" \
+            || gh issue create \
+              --title "$title" \
+              --body "$body" \
+              --repo "${{ github.repository }}"

--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -104,3 +104,44 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --frozen --extra dev --extra archive
       - run: uv run pytest tests/ -q
+
+  release-docs-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect release PR and verify docs
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          extract_version() {
+            grep -m1 -E '^version[[:space:]]*=' "$1" | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/'
+          }
+          head_ver="$(extract_version pyproject.toml)"
+          git fetch --no-tags origin "$BASE_REF" --depth=1
+          git show "origin/${BASE_REF}:pyproject.toml" > /tmp/base_pyproject.toml
+          base_ver="$(extract_version /tmp/base_pyproject.toml)"
+          if [ "$head_ver" = "$base_ver" ]; then
+            echo "Not a release PR (version unchanged: ${head_ver}). Skipping docs check."
+            exit 0
+          fi
+          echo "Release PR detected: ${base_ver} -> ${head_ver}"
+          fail=0
+          if ! grep -qE "^## \[${head_ver}\]" CHANGELOG.md; then
+            echo "::error file=CHANGELOG.md::Missing '## [${head_ver}]' section. Move [Unreleased] entries into a dated [${head_ver}] block."
+            fail=1
+          fi
+          if ! grep -qE "^\[${head_ver}\]:\s*https://github.com/" CHANGELOG.md; then
+            echo "::error file=CHANGELOG.md::Missing compare-link footnote '[${head_ver}]: https://github.com/...' near bottom of file."
+            fail=1
+          fi
+          if grep -qE "v?${head_ver}\s*\|\s*(next|planned)\b" README.md; then
+            echo "::error file=README.md::Roadmap row for v${head_ver} still says 'next' or 'planned'. Flip status to 'shipped' before cutting the release."
+            fail=1
+          fi
+          if [ -f docs/ROADMAP.md ] && ! grep -qE "v${head_ver}" docs/ROADMAP.md; then
+            echo "::warning file=docs/ROADMAP.md::No mention of v${head_ver}. Consider adding a section (non-blocking)."
+          fi
+          exit "$fail"


### PR DESCRIPTION
## Why

During the v1.0.1 cut, the README roadmap row still said \`v1.0.1 | next\` minutes after the wheel was on PyPI. Nothing in CI complained. These two new pieces close that gap with the lowest-friction enforcement that still catches the mistake.

## What

**1. \`staging-gate.yml\` → new \`release-docs-check\` job.** Compares \`pyproject.toml\` version between PR head and base. No-op on every non-release PR. On a release PR (version bumped), enforces:
- \`CHANGELOG.md\` has a \`## [X.Y.Z]\` section
- \`CHANGELOG.md\` has the \`[X.Y.Z]: https://github.com/...\` compare-link footnote
- \`README.md\` does NOT have a roadmap row matching \`vX.Y.Z | next|planned\`
- Non-blocking warning if \`docs/ROADMAP.md\` has no mention of \`vX.Y.Z\`

**2. \`post-release-docs-issue.yml\` → new workflow.** Triggers on \`release.published\`. Opens a tracking issue titled \`docs sweep for vX.Y.Z\` with a per-doc checklist for the second-order docs the gate can't verify (RELEASING.md test counts, ROADMAP.md narrative, COMMANDS.md surface count, BENCHMARKS.md / LIMITATIONS.md / MCP.md / SLASH_COMMANDS.md). Body lists what CI already verified so the sweep isn't duplicate work.

## Test plan

- [x] YAML syntactically valid (\`bash -n\`)
- [x] Local dry-run: same-version PR → \`Not a release PR. Skipping docs check.\`
- [x] Local dry-run: simulated v1.0.2 release PR against current main → fails on missing CHANGELOG section + footnote (correct — those don't exist yet for v1.0.2)
- [ ] CI: \`release-docs-check\` job appears in this PR's checks and passes (this PR is not a release, so it should report 'Not a release PR' and exit 0)
- [ ] First future release PR exercises the full check path
- [ ] First future GitHub Release fires \`post-release-docs-issue.yml\` and opens a tracking issue

## Notes

- The \`release-docs-check\` job intentionally lives in \`staging-gate.yml\` (PR-time) rather than as a separate workflow so it shares the existing required-status-check setup.
- The post-release issue workflow gracefully degrades if the \`docs\`/\`release-followup\` labels don't exist in the repo (creates the issue without labels rather than failing).