### PR TITLE
feat: per-project install routing + aelf doctor (closes #81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+### Added
+
+- `aelf doctor`: scan user-scope and project-scope Claude Code
+  `settings.json` for hook + statusline commands whose program token
+  doesn't resolve. Catches dangling absolute paths, bare names not on
+  `$PATH`, and missing scripts under `bash /…` interpreter wrappers.
+  Exits `1` on any broken finding so it can gate CI (#81).
+
+### Changed
+
+- `aelf setup` no longer requires `--scope`. Default is auto-detect:
+  `project` (writes `<cwd>/.claude/settings.json`) when `cwd/.venv`
+  matches the active interpreter's `sys.prefix`, else `user` (writes
+  `~/.claude/settings.json`). Explicit `--scope` still wins (#81).
+- `aelf setup --command` defaults to an absolute path: project scope
+  -> the active venv's `aelf-hook`; user scope -> the first
+  `aelf-hook` on `$PATH` (typically a `pipx`-installed
+  `~/.local/bin/aelf-hook`). Lets one machine route per-project venvs
+  to their own hook AND fall back to a global pipx install outside
+  any project, without bare-name `$PATH` collisions (#81).
+- `aelf setup` now silently removes legacy dangling
+  `/usr/local/bin/aelf{,-hook}` symlinks if their target no longer
+  exists. Real files and live symlinks are never touched (#81).
+- `aelf unsetup` defaults to basename-match cleanup (every entry
+  whose program basename is `aelf-hook`), so an install written with
+  the new auto-resolved absolute path can be torn down by bare
+  `aelf unsetup` without specifying the path (#81).
+
 ## [1.0.1] - 2026-04-27
 
 Patch release: power-user ergonomics + retrieval-side feedback loop.

--- a/README.md
+++ b/README.md
@@ -57,13 +57,16 @@ pip install "aelfrice[mcp]"         # add MCP server
 pip install "aelfrice[archive]"     # add encrypted DB archive on uninstall
 aelf --version                       # confirm install
 aelf setup                           # wire hook + statusline into Claude Code
+aelf doctor                          # verify hook commands resolve
 aelf health                          # confirm wiring + store init
 ```
 
-`aelf setup` wires two things into `~/.claude/settings.json`:
+`aelf setup` wires two things into Claude Code's `settings.json`:
 
 1. The **UserPromptSubmit hook** (`aelf-hook`) which injects relevant beliefs into every Claude Code prompt.
 2. The **statusline notifier** (`aelf statusline`) which shows an orange `⬆ aelfrice X.Y.Z available, run: aelf upgrade` banner *only* when an update is pending. When you're up to date the banner is empty and your statusline looks unchanged.
+
+`aelf setup` auto-routes the install per-project: when run from a project venv it writes `<project>/.claude/settings.json` pointing at `<project>/.venv/bin/aelf-hook`; when run outside any project it writes `~/.claude/settings.json` pointing at the first `aelf-hook` on `$PATH` (typically a `pipx`-installed global). Explicit `--scope user|project` overrides.
 
 If you already have a custom `statusLine` configured, `aelf setup` composes its snippet onto the end of your command (preserving your bar). If your existing command uses pipes, here-docs, `&&`, backticks, or backslashes it's left untouched and you get a one-line hint about manual composition.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Fourteen subcommands. The first eight (retrieval/feedback) are also available as MCP tools and Claude Code slash commands. The lifecycle commands (`setup`/`unsetup`/`upgrade`/`uninstall`/`statusline`) and `bench` are CLI-only.
+Fifteen subcommands. The first eight (retrieval/feedback) are also available as MCP tools and Claude Code slash commands. The lifecycle commands (`setup`/`unsetup`/`upgrade`/`uninstall`/`statusline`/`doctor`) and `bench` are CLI-only.
 
 DB resolves from `$AELFRICE_DB` or `~/.aelfrice/memory.db`.
 
@@ -20,8 +20,9 @@ aelf <subcommand> [args] [options]
 | `feedback <belief_id> <used\|harmful> [--source S]` | id, signal, optional source | `used` ⇒ α += 1. `harmful` ⇒ β += 1. Positive feedback flowing through outbound CONTRADICTS edges to user-locks bumps their `demotion_pressure`; ≥ 5 ⇒ auto-demote. |
 | `stats` | — | beliefs / edges / locked / feedback_events counts. |
 | `health` | — | Regime classifier: one of `early-onboarding`, `steady`, `lock-heavy`, `over-confident`, `insufficient-data`. |
-| `setup [--scope user\|project] [--project-root D] [--settings-path P] [--command C] [--timeout N] [--status-message M] [--no-statusline]` | various | Install `UserPromptSubmit` hook + `statusLine` notifier in Claude Code `settings.json`. Default command: `aelf-hook`. Idempotent + atomic. `--no-statusline` skips the statusline auto-wire. |
-| `unsetup` (same scope flags) | — | Remove both the hook and our statusline contribution. Composed statuslines are surgically unwrapped to restore the original command. |
+| `doctor [--user-settings P] [--project-root D]` | — | Verify hook + statusline commands in user and project `settings.json` resolve to executables. Reports broken absolute paths and bare names not on `$PATH`. Special-cases `bash /script.sh` to inspect the script. Exits `1` on any broken finding. |
+| `setup [--scope user\|project] [--project-root D] [--settings-path P] [--command C] [--timeout N] [--status-message M] [--no-statusline]` | various | Install `UserPromptSubmit` hook + `statusLine` notifier in Claude Code `settings.json`. Defaults: `--scope` auto-detects `project` if `cwd/.venv` matches `sys.prefix` else `user`; `--command` auto-resolves to absolute `aelf-hook` (project venv for project scope, `$PATH` for user scope). Also silently removes legacy dangling `/usr/local/bin/aelf{,-hook}` symlinks. Idempotent + atomic. |
+| `unsetup` (same scope flags, `--command`) | — | Remove the hook + our statusline contribution. Default `--command` matches every entry whose program basename is `aelf-hook`, so a bare-name install and an absolute-path install are both cleaned by the same call. Composed statuslines are surgically unwrapped to restore the original command. |
 | `upgrade [--check]` | — | Print the right pip-upgrade command for the running env (venv → `pip install --upgrade`, pipx → `pipx upgrade`, system → `pip install --user --upgrade`). When an update is available, also prints the wheel SHA-256 + PyPI release URL for hash-pinned installs. `--check` suppresses the command line. |
 | `uninstall (--keep-db \| --purge \| --archive PATH) [--password-stdin] [--yes] [--keep-hook] [--settings-path P]` | one disposition flag required | Tear down aelfrice. Disposition modes are mutually exclusive. `--purge` requires typing `PURGE` then `[y/N]` unless `--yes` is passed. `--archive` requires `pip install 'aelfrice[archive]'`. By default also runs `unsetup`; `--keep-hook` opts out. Tail message points at `pip uninstall aelfrice` for wheel removal. |
 | `statusline` | — | Emit the orange update-banner snippet (or empty when no update is pending). Reads cache only, no network. Composes onto an existing statusline via shell `;`. Color: truecolor → 256-color → basic, NO_COLOR honoured. |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -40,16 +40,54 @@ SQLite at `~/.aelfrice/memory.db` by default. Override with `$AELFRICE_DB` (use 
 ## Wire into Claude Code
 
 ```bash
-aelf setup                                        # ~/.claude/settings.json
-aelf setup --scope project --project-root .       # project-local
-aelf setup --no-statusline                        # hook only, no statusline
-aelf unsetup                                      # remove both
+aelf setup                                        # auto-detect scope + path
+aelf setup --scope user                            # force user-scope (~/.claude/settings.json)
+aelf setup --scope project --project-root .        # force project-scope (.claude/settings.json)
+aelf setup --no-statusline                         # hook only, no statusline
+aelf unsetup                                       # remove both
+aelf doctor                                        # verify hook commands resolve
 ```
 
 Idempotent. `aelf setup` wires two things:
 
 1. **`UserPromptSubmit` hook** (`aelf-hook`). Reads each prompt payload, runs retrieval, emits an `<aelfrice-memory>...</aelfrice-memory>` block above the prompt. Every failure mode exits 0 with no output — the hook can't block a prompt.
 2. **`statusLine` notifier** (`aelf statusline`). Prints an orange one-line update banner in the Claude Code statusbar **only when an update is available**, empty otherwise. Reads the cached PyPI check; never makes network calls. Banner disappears automatically once you've upgraded.
+
+### How `aelf setup` picks scope and command path
+
+Without explicit flags, `aelf setup` looks at the active interpreter and current directory and routes the install correctly so the same command works in three layouts:
+
+| You ran `aelf setup` from… | `--scope` resolves to | `--command` resolves to |
+|---|---|---|
+| inside a project venv (e.g. `cd ~/projects/foo && .venv/bin/aelf setup`) | `project` (writes `<project>/.claude/settings.json`) | absolute path: `<project>/.venv/bin/aelf-hook` |
+| a pipx-installed `aelf` outside any project venv | `user` (writes `~/.claude/settings.json`) | first `aelf-hook` on `$PATH` (typically `~/.local/bin/aelf-hook`) |
+| a venv in some other repo | `user` | first `aelf-hook` on `$PATH`, falling back to the active venv |
+
+Effect: when Claude Code is launched in `~/projects/foo`, the `UserPromptSubmit` hook runs that project's venv `aelf-hook`. When launched anywhere else, the global pipx hook runs. No `$PATH` collision, no dangling symlinks, no per-machine scripting needed.
+
+**Recommended setup for working on multiple projects:**
+
+```bash
+pipx install aelfrice                                 # global default lives in ~/.local/bin/
+aelf setup                                            # writes ~/.claude/settings.json -> ~/.local/bin/aelf-hook
+
+cd ~/projects/foo && uv sync                          # project venv
+.venv/bin/aelf setup                                  # writes <project>/.claude/settings.json -> <project>/.venv/bin/aelf-hook
+```
+
+Override either resolution at any time with explicit `--scope` / `--command`.
+
+`aelf setup` also silently removes the legacy `/usr/local/bin/aelf{,-hook}` symlinks if they point at a deleted target — these were written by older install scripts and otherwise shadow a healthy `pipx`-managed `aelf` on `$PATH`. Real files and live symlinks are never touched.
+
+### `aelf doctor`
+
+Run after any setup (or at any time) to verify wiring. Walks `~/.claude/settings.json` and `<cwd>/.claude/settings.json` (when present), inspects every hook command and the top-level `statusLine`, and reports any program token whose absolute path is missing or whose bare name isn't on `$PATH`. Exits `1` when at least one broken command is found, so you can gate CI on it.
+
+```bash
+aelf doctor                                  # scan both scopes
+aelf doctor --user-settings /tmp/test.json   # explicit user settings file
+aelf doctor --project-root /path/to/repo     # explicit project root
+```
 
 Composition with an existing `statusLine`:
 
@@ -143,6 +181,8 @@ uv run pytest -m regression  # cumulative integration scenarios
 | `unable to open database file` | parent dir of `$AELFRICE_DB` doesn't exist |
 | Hook registered, no memory block | DB is empty — run `aelf onboard <project>` |
 | MCP tools not visible in host | restart the host — MCP servers load at launch |
+| Hook silently fails outside a project venv | run `aelf doctor` — most likely a stale absolute path or bare `aelf-hook` not on `$PATH`. Re-run `aelf setup` from the matching install context |
+| Wrong project's memory shows up in another project | each project should have its own `.claude/settings.json`. From inside the project venv: `.venv/bin/aelf setup` (auto-routes to project scope) |
 
 ## Uninstall
 

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -9,6 +9,7 @@ Commands:
   feedback <id> <used|harmful>     apply one Bayesian feedback event
   stats                            summary of belief / lock / history counts
   health                           regime classifier output
+  doctor                           verify hook commands resolve in settings.json
   setup                            install UserPromptSubmit hook in Claude Code
   unsetup                          remove UserPromptSubmit hook from Claude Code
   upgrade                          print the right pip-upgrade command line
@@ -45,6 +46,7 @@ from aelfrice.models import (
 )
 from aelfrice import __version__ as _AELFRICE_VERSION
 from aelfrice.benchmark import run_benchmark, seed_corpus
+from aelfrice.doctor import diagnose, format_report
 from aelfrice.lifecycle import (
     PACKAGE_NAME as _PKG,
     UpdateStatus,
@@ -749,6 +751,23 @@ def _cmd_health(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _cmd_doctor(args: argparse.Namespace, out: object) -> int:
+    """Diagnose hook + statusline command resolution in settings.json files.
+
+    Exit 0 when nothing is broken, exit 1 when at least one broken
+    command is found. CI-friendly.
+    """
+    project_root = Path(args.project_root) if args.project_root else None
+    user_settings = (
+        Path(args.user_settings) if args.user_settings else None
+    )
+    report = diagnose(
+        user_settings=user_settings, project_root=project_root
+    )
+    print(format_report(report), file=out)  # type: ignore[arg-type]
+    return 1 if report.broken else 0
+
+
 # --- Dispatcher ---------------------------------------------------------
 
 
@@ -805,6 +824,23 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_health = sub.add_parser("health", help="regime classifier output")
     p_health.set_defaults(func=_cmd_health)
+
+    p_doctor = sub.add_parser(
+        "doctor",
+        help=(
+            "diagnose Claude Code hook + statusline commands in user "
+            "and project settings.json. Exits 1 if any are broken."
+        ),
+    )
+    p_doctor.add_argument(
+        "--user-settings", default=None,
+        help="override user settings.json path (default: ~/.claude/settings.json)",
+    )
+    p_doctor.add_argument(
+        "--project-root", default=None,
+        help="override project root for project-scope check (default: cwd)",
+    )
+    p_doctor.set_defaults(func=_cmd_doctor)
 
     p_setup = sub.add_parser(
         "setup",

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -29,7 +29,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Final, Sequence
+from typing import Final, Sequence, cast
 
 from aelfrice.feedback import apply_feedback
 from aelfrice.health import (
@@ -61,9 +61,12 @@ from aelfrice.retrieval import DEFAULT_TOKEN_BUDGET, retrieve
 from aelfrice.scanner import scan_repo
 from aelfrice.setup import (
     SettingsScope,
+    clean_dangling_shims,
     default_settings_path,
+    detect_default_scope,
     install_statusline,
     install_user_prompt_submit_hook,
+    resolve_hook_command,
     uninstall_statusline,
     uninstall_user_prompt_submit_hook,
 )
@@ -368,34 +371,52 @@ def _cmd_bench(args: argparse.Namespace, out: object) -> int:
     return 2
 
 
-def _resolve_settings_path(args: argparse.Namespace) -> Path:
-    if args.settings_path is not None:
-        return Path(args.settings_path)
-    scope: SettingsScope = args.scope
+def _effective_scope(args: argparse.Namespace) -> SettingsScope:
+    """Return the explicit `--scope` if given, else auto-detect."""
+    scope = getattr(args, "scope", None)
+    if scope in _VALID_SCOPES:
+        return cast(SettingsScope, scope)
     project_root = (
         Path(args.project_root) if args.project_root is not None else None
     )
-    return default_settings_path(scope, project_root=project_root)
+    return detect_default_scope(cwd=project_root)
+
+
+def _resolve_settings_path(args: argparse.Namespace) -> Path:
+    if args.settings_path is not None:
+        return Path(args.settings_path)
+    project_root = (
+        Path(args.project_root) if args.project_root is not None else None
+    )
+    return default_settings_path(_effective_scope(args), project_root=project_root)
 
 
 def _cmd_setup(args: argparse.Namespace, out: object) -> int:
+    scope = _effective_scope(args)
     path = _resolve_settings_path(args)
+    command = args.command if args.command is not None else resolve_hook_command(scope)
+    cleanup = clean_dangling_shims()
+    for removed_path in cleanup.removed:
+        print(
+            f"cleaned dangling shim: {removed_path}",
+            file=out,  # type: ignore[arg-type]
+        )
     result = install_user_prompt_submit_hook(
         path,
-        command=args.command,
+        command=command,
         timeout=args.timeout,
         status_message=args.status_message,
     )
     if result.already_present:
         print(
             f"hook already installed in {result.path} "
-            f"(command={args.command!r})",
+            f"(command={command!r})",
             file=out,  # type: ignore[arg-type]
         )
     else:
         print(
             f"installed UserPromptSubmit hook in {result.path} "
-            f"(command={args.command!r})",
+            f"(command={command!r})",
             file=out,  # type: ignore[arg-type]
         )
     if not args.no_statusline:
@@ -427,18 +448,24 @@ def _cmd_setup(args: argparse.Namespace, out: object) -> int:
 
 def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
     path = _resolve_settings_path(args)
-    result = uninstall_user_prompt_submit_hook(path, command=args.command)
+    if args.command is None:
+        result = uninstall_user_prompt_submit_hook(
+            path, command_basename=DEFAULT_HOOK_COMMAND
+        )
+        match_label = f"basename={DEFAULT_HOOK_COMMAND!r}"
+    else:
+        result = uninstall_user_prompt_submit_hook(path, command=args.command)
+        match_label = f"command={args.command!r}"
     if result.removed == 0:
         print(
-            f"no matching hook in {result.path} "
-            f"(command={args.command!r})",
+            f"no matching hook in {result.path} ({match_label})",
             file=out,  # type: ignore[arg-type]
         )
     else:
         print(
             f"removed {result.removed} hook entr"
             f"{'y' if result.removed == 1 else 'ies'} from {result.path} "
-            f"(command={args.command!r})",
+            f"({match_label})",
             file=out,  # type: ignore[arg-type]
         )
     sl = uninstall_statusline(path)
@@ -594,12 +621,14 @@ def _cmd_uninstall(args: argparse.Namespace, out: object) -> int:
     # --- Hook + statusline removal (default on, --keep-hook opts out)-
     if not args.keep_hook:
         # Delegate by re-using the existing _cmd_unsetup path: pretend
-        # the user invoked `aelf unsetup --scope user`.
+        # the user invoked `aelf unsetup --scope user`. command=None
+        # triggers basename-match cleanup, which catches both bare and
+        # absolute-path installs.
         unsetup_args = argparse.Namespace(
             scope="user",
             project_root=None,
             settings_path=args.settings_path,
-            command=DEFAULT_HOOK_COMMAND,
+            command=None,
             cmd="unsetup",
             func=_cmd_unsetup,
         )
@@ -783,10 +812,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_hook_scope_args(p_setup)
     p_setup.add_argument(
-        "--command", default=DEFAULT_HOOK_COMMAND,
+        "--command", default=None,
         help=(
-            f"hook command Claude Code will spawn "
-            f"(default {DEFAULT_HOOK_COMMAND!r})"
+            "hook command Claude Code will spawn. Default: auto-resolved "
+            "absolute path to aelf-hook (project venv for project scope, "
+            "$PATH for user scope)."
         ),
     )
     p_setup.add_argument(
@@ -875,10 +905,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_hook_scope_args(p_unsetup)
     p_unsetup.add_argument(
-        "--command", default=DEFAULT_HOOK_COMMAND,
+        "--command", default=None,
         help=(
-            "hook command string to remove "
-            f"(default {DEFAULT_HOOK_COMMAND!r})"
+            "exact hook command string to remove. Default: remove every "
+            f"entry whose command basename is {DEFAULT_HOOK_COMMAND!r} "
+            "(matches both bare-name and absolute-path installs)."
         ),
     )
     p_unsetup.set_defaults(func=_cmd_unsetup)
@@ -921,8 +952,11 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _add_hook_scope_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
-        "--scope", choices=list(_VALID_SCOPES), default="user",
-        help="settings.json scope (default 'user' = ~/.claude/settings.json)",
+        "--scope", choices=list(_VALID_SCOPES), default=None,
+        help=(
+            "settings.json scope. Default: auto -- 'project' if cwd has a "
+            ".venv matching the active interpreter, else 'user'."
+        ),
     )
     parser.add_argument(
         "--project-root", default=None,

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -30,7 +30,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Final, Sequence, cast
+from typing import Final, Sequence
 
 from aelfrice.feedback import apply_feedback
 from aelfrice.health import (
@@ -376,8 +376,8 @@ def _cmd_bench(args: argparse.Namespace, out: object) -> int:
 def _effective_scope(args: argparse.Namespace) -> SettingsScope:
     """Return the explicit `--scope` if given, else auto-detect."""
     scope = getattr(args, "scope", None)
-    if scope in _VALID_SCOPES:
-        return cast(SettingsScope, scope)
+    if scope == "user" or scope == "project":
+        return scope
     project_root = (
         Path(args.project_root) if args.project_root is not None else None
     )

--- a/src/aelfrice/doctor.py
+++ b/src/aelfrice/doctor.py
@@ -1,0 +1,295 @@
+"""Diagnose Claude Code settings.json hook & statusline commands.
+
+`aelf doctor` runs this module against the user-scope settings.json and
+(when present) the project-scope settings.json under cwd. It walks
+every command field that Claude Code is going to spawn -- across all
+hook events plus the top-level statusLine -- and asks one question per
+command: when Claude Code spawns this, will the OS find an executable?
+
+The check is deliberately lossy: we extract the first whitespace token,
+treat it as a program path or name, and verify either that the
+absolute path exists and is executable OR that the bare name resolves
+via $PATH. Shell-pipe constructs are skipped (we cannot statically
+prove a `bash -c "..."` is healthy without running it). The point is
+to catch the common breakage -- a stale absolute path or a bare name
+nothing on $PATH supplies -- which is what bit issue #81.
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final, Literal, cast
+
+from aelfrice.setup import (
+    PROJECT_SETTINGS_RELPATH,
+    USER_SETTINGS_PATH,
+    _load_settings,
+)
+
+Scope = Literal["user", "project"]
+
+_HOOKS_KEY: Final[str] = "hooks"
+_STATUSLINE_KEY: Final[str] = "statusLine"
+_INNER_HOOKS_KEY: Final[str] = "hooks"
+_TYPE_KEY: Final[str] = "type"
+_COMMAND_KEY: Final[str] = "command"
+_HOOK_TYPE_COMMAND: Final[str] = "command"
+
+# Tokens that signal "this is a shell expression, do not try to verify
+# the first program statically." We just record these as 'skipped'.
+_SHELL_INDICATORS: Final[tuple[str, ...]] = ("|", "&&", "||", "`", "$(", ";")
+
+# Interpreters whose first non-flag argument is the script we should
+# verify -- catches `bash /path/to/script.sh`, `sh ./tool.sh`, etc.
+_SCRIPT_INTERPRETERS: Final[frozenset[str]] = frozenset(
+    {"bash", "sh", "zsh", "python", "python3"}
+)
+
+
+@dataclass(frozen=True)
+class CommandFinding:
+    """One hook/statusline command we inspected.
+
+    `location` is a human-readable JSON path like "hooks.PreToolUse[0].hooks[0]"
+    or "statusLine". `command` is the raw command string. `program` is the
+    first whitespace token (the executable). `status` is one of:
+      * 'ok'      - program resolves to an existing executable.
+      * 'broken'  - program does not resolve.
+      * 'skipped' - command contains shell metacharacters; cannot statically verify.
+    """
+    settings_path: Path
+    location: str
+    command: str
+    program: str
+    status: Literal["ok", "broken", "skipped"]
+    detail: str = ""
+
+
+@dataclass
+class DoctorReport:
+    """Aggregate result of scanning one or more settings.json files."""
+    scopes_scanned: list[tuple[Scope, Path]] = field(default_factory=list)
+    findings: list[CommandFinding] = field(default_factory=list)
+
+    @property
+    def broken(self) -> list[CommandFinding]:
+        return [f for f in self.findings if f.status == "broken"]
+
+    @property
+    def ok_count(self) -> int:
+        return sum(1 for f in self.findings if f.status == "ok")
+
+    @property
+    def skipped_count(self) -> int:
+        return sum(1 for f in self.findings if f.status == "skipped")
+
+
+def diagnose(
+    *,
+    user_settings: Path | None = None,
+    project_root: Path | None = None,
+) -> DoctorReport:
+    """Walk user and project settings.json, return a DoctorReport.
+
+    Defaults: user_settings -> ~/.claude/settings.json,
+    project_root -> Path.cwd() (only scanned if .claude/settings.json
+    exists there).
+    """
+    user_path = user_settings if user_settings is not None else USER_SETTINGS_PATH
+    project_path = (
+        project_root if project_root is not None else Path.cwd()
+    ) / PROJECT_SETTINGS_RELPATH
+    report = DoctorReport()
+    if user_path.exists():
+        report.scopes_scanned.append(("user", user_path))
+        report.findings.extend(_scan_settings(user_path))
+    if project_path.exists():
+        report.scopes_scanned.append(("project", project_path))
+        report.findings.extend(_scan_settings(project_path))
+    return report
+
+
+def _scan_settings(path: Path) -> list[CommandFinding]:
+    """Yield findings for every hook command + the statusline in `path`."""
+    try:
+        data = _load_settings(path)
+    except (ValueError, OSError):
+        return [CommandFinding(
+            settings_path=path, location="<root>", command="",
+            program="", status="broken",
+            detail="settings.json could not be parsed",
+        )]
+    findings: list[CommandFinding] = []
+    findings.extend(_scan_hooks(path, data))
+    findings.extend(_scan_statusline(path, data))
+    return findings
+
+
+def _scan_hooks(
+    path: Path, data: dict[str, object]
+) -> list[CommandFinding]:
+    out: list[CommandFinding] = []
+    hooks_obj = data.get(_HOOKS_KEY)
+    if not isinstance(hooks_obj, dict):
+        return out
+    hooks_dict = cast(dict[str, object], hooks_obj)
+    for event_name, event_list in hooks_dict.items():
+        if not isinstance(event_list, list):
+            continue
+        for i, entry in enumerate(cast(list[object], event_list)):
+            if not isinstance(entry, dict):
+                continue
+            entry_dict = cast(dict[str, object], entry)
+            inner = entry_dict.get(_INNER_HOOKS_KEY)
+            if not isinstance(inner, list):
+                continue
+            for j, hook in enumerate(cast(list[object], inner)):
+                if not isinstance(hook, dict):
+                    continue
+                hook_dict = cast(dict[str, object], hook)
+                if hook_dict.get(_TYPE_KEY) != _HOOK_TYPE_COMMAND:
+                    continue
+                cmd = hook_dict.get(_COMMAND_KEY)
+                if not isinstance(cmd, str):
+                    continue
+                location = (
+                    f"hooks.{event_name}[{i}].hooks[{j}]"
+                )
+                out.append(_inspect_command(path, location, cmd))
+    return out
+
+
+def _scan_statusline(
+    path: Path, data: dict[str, object]
+) -> list[CommandFinding]:
+    sl = data.get(_STATUSLINE_KEY)
+    if not isinstance(sl, dict):
+        return []
+    sl_dict = cast(dict[str, object], sl)
+    cmd = sl_dict.get(_COMMAND_KEY)
+    if not isinstance(cmd, str):
+        return []
+    return [_inspect_command(path, _STATUSLINE_KEY, cmd)]
+
+
+def _inspect_command(
+    settings_path: Path, location: str, command: str
+) -> CommandFinding:
+    """Categorise a single command string."""
+    stripped = command.strip()
+    if not stripped:
+        return CommandFinding(
+            settings_path=settings_path, location=location,
+            command=command, program="",
+            status="broken",
+            detail="empty command string",
+        )
+    if any(tok in stripped for tok in _SHELL_INDICATORS):
+        return CommandFinding(
+            settings_path=settings_path, location=location,
+            command=command, program="",
+            status="skipped",
+            detail="contains shell metacharacters; not statically checked",
+        )
+    try:
+        tokens = shlex.split(stripped)
+    except ValueError:
+        return CommandFinding(
+            settings_path=settings_path, location=location,
+            command=command, program="",
+            status="broken",
+            detail="command is not parseable as shell tokens",
+        )
+    if not tokens:
+        return CommandFinding(
+            settings_path=settings_path, location=location,
+            command=command, program="",
+            status="broken",
+            detail="no program token",
+        )
+    program = tokens[0]
+    interpreter_basename = Path(program).name
+    if interpreter_basename in _SCRIPT_INTERPRETERS:
+        # `bash /abs/path.sh ...` -- the script itself is the thing
+        # most likely to vanish. Prefer to report on the script, not
+        # bash. Fall back to plain interpreter check when there is no
+        # absolute-path argument.
+        for tok in tokens[1:]:
+            if tok.startswith("-"):
+                continue
+            if "/" in tok:
+                return _check_path(
+                    settings_path, location, command, tok
+                )
+            break  # first non-flag, non-path argument: stop scanning
+    if "/" in program:
+        return _check_path(settings_path, location, command, program)
+    # Bare name -- $PATH lookup.
+    resolved = shutil.which(program)
+    if resolved is None:
+        return CommandFinding(
+            settings_path=settings_path, location=location,
+            command=command, program=program, status="broken",
+            detail=f"{program!r} not on $PATH",
+        )
+    return CommandFinding(
+        settings_path=settings_path, location=location,
+        command=command, program=program, status="ok",
+    )
+
+
+def _check_path(
+    settings_path: Path, location: str, command: str, program: str
+) -> CommandFinding:
+    """Existence + executable-bit check for a path-shaped program token."""
+    prog_path = Path(program)
+    if prog_path.is_file() and os.access(prog_path, os.X_OK):
+        return CommandFinding(
+            settings_path=settings_path, location=location,
+            command=command, program=program, status="ok",
+        )
+    return CommandFinding(
+        settings_path=settings_path, location=location,
+        command=command, program=program, status="broken",
+        detail=(
+            "path does not exist"
+            if not prog_path.exists()
+            else "exists but is not executable"
+        ),
+    )
+
+
+def format_report(report: DoctorReport) -> str:
+    """Render a DoctorReport as a human-readable string for the CLI."""
+    lines: list[str] = []
+    if not report.scopes_scanned:
+        lines.append(
+            "no settings.json found at user or project scope -- nothing to check"
+        )
+        return "\n".join(lines)
+    for scope, path in report.scopes_scanned:
+        lines.append(f"scanned {scope}: {path}")
+    lines.append("")
+    lines.append(
+        f"summary: {report.ok_count} ok, "
+        f"{len(report.broken)} broken, {report.skipped_count} skipped"
+    )
+    if report.broken:
+        lines.append("")
+        lines.append("broken commands:")
+        for f in report.broken:
+            lines.append(
+                f"  - {f.settings_path}:{f.location}"
+            )
+            lines.append(f"      command:  {f.command}")
+            lines.append(f"      program:  {f.program or '(empty)'}")
+            lines.append(f"      issue:    {f.detail}")
+        lines.append("")
+        lines.append(
+            "fix: run 'aelf setup' from the project venv to rewrite the "
+            "hook command, or edit the affected settings.json by hand."
+        )
+    return "\n".join(lines)

--- a/src/aelfrice/doctor.py
+++ b/src/aelfrice/doctor.py
@@ -16,6 +16,7 @@ nothing on $PATH supplies -- which is what bit issue #81.
 """
 from __future__ import annotations
 
+import json
 import os
 import shlex
 import shutil
@@ -23,11 +24,22 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final, Literal, cast
 
-from aelfrice.setup import (
-    PROJECT_SETTINGS_RELPATH,
-    USER_SETTINGS_PATH,
-    _load_settings,
-)
+from aelfrice.setup import PROJECT_SETTINGS_RELPATH, USER_SETTINGS_PATH
+
+
+def _load_settings_json(path: Path) -> dict[str, object]:
+    """Read settings.json. Empty / nonexistent files are treated as {}."""
+    if not path.exists():
+        return {}
+    raw = path.read_text(encoding="utf-8")
+    if not raw.strip():
+        return {}
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            f"settings file must contain a JSON object at top level: {path}"
+        )
+    return cast(dict[str, object], parsed)
 
 Scope = Literal["user", "project"]
 
@@ -71,8 +83,12 @@ class CommandFinding:
 @dataclass
 class DoctorReport:
     """Aggregate result of scanning one or more settings.json files."""
-    scopes_scanned: list[tuple[Scope, Path]] = field(default_factory=list)
-    findings: list[CommandFinding] = field(default_factory=list)
+    scopes_scanned: list[tuple[Scope, Path]] = field(
+        default_factory=lambda: cast(list[tuple[Scope, Path]], [])
+    )
+    findings: list[CommandFinding] = field(
+        default_factory=lambda: cast(list[CommandFinding], [])
+    )
 
     @property
     def broken(self) -> list[CommandFinding]:
@@ -115,7 +131,7 @@ def diagnose(
 def _scan_settings(path: Path) -> list[CommandFinding]:
     """Yield findings for every hook command + the statusline in `path`."""
     try:
-        data = _load_settings(path)
+        data = _load_settings_json(path)
     except (ValueError, OSError):
         return [CommandFinding(
             settings_path=path, location="<root>", command="",

--- a/src/aelfrice/setup.py
+++ b/src/aelfrice/setup.py
@@ -45,6 +45,8 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -54,6 +56,14 @@ SettingsScope = Literal["user", "project"]
 
 USER_SETTINGS_PATH: Final[Path] = Path.home() / ".claude" / "settings.json"
 PROJECT_SETTINGS_RELPATH: Final[Path] = Path(".claude") / "settings.json"
+_HOOK_SCRIPT_NAME: Final[str] = "aelf-hook"
+# Legacy / pre-pipx shim locations we will silently clean up if they
+# point at a deleted target. Keep this list narrow: only paths the
+# package itself ever wrote, never user-managed binaries.
+_DANGLING_SHIM_CANDIDATES: Final[tuple[Path, ...]] = (
+    Path("/usr/local/bin/aelf"),
+    Path("/usr/local/bin/aelf-hook"),
+)
 
 _HOOKS_KEY: Final[str] = "hooks"
 _EVENT_KEY: Final[str] = "UserPromptSubmit"
@@ -112,6 +122,131 @@ def default_settings_path(
         return USER_SETTINGS_PATH
     root = project_root if project_root is not None else Path.cwd()
     return root / PROJECT_SETTINGS_RELPATH
+
+
+def _venv_bin_dir() -> Path:
+    """Return the directory holding entry-point scripts for the active interpreter.
+
+    Uses `sys.prefix`, which is the venv root for an active virtualenv
+    (and the system root otherwise). `sys._base_executable` points at
+    the *base* interpreter even inside a venv, so it is unsuitable.
+    """
+    return Path(sys.prefix) / "bin"
+
+
+def _executable_in_dir(directory: Path, name: str) -> Path | None:
+    """Return `directory/name` if it exists and is executable, else None."""
+    candidate = directory / name
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return candidate
+    return None
+
+
+def resolve_hook_command(scope: SettingsScope) -> str:
+    """Pick the absolute `aelf-hook` path appropriate for `scope`.
+
+    Project scope: prefer the entry point next to `sys.executable` so
+    project-scope settings always pin to that project's venv. This is
+    the routing primitive — `~/projects/aelfrice` and
+    `~/projects/aelfrice-lab` each get their own venv's `aelf-hook`.
+
+    User scope: prefer `shutil.which("aelf-hook")` so the hook resolves
+    to whatever the user has on $PATH (typically a pipx-installed
+    `~/.local/bin/aelf-hook`). Fallback chain ensures we never write a
+    bare `aelf-hook` that depends on a venv being active later.
+
+    Last-resort fallback is the bare name; tested but emitted only when
+    no executable is found anywhere on the system, in which case the
+    user has bigger problems and `aelf doctor` will flag it.
+    """
+    venv_bin = _venv_bin_dir()
+    venv_hook = _executable_in_dir(venv_bin, _HOOK_SCRIPT_NAME)
+    path_hook_str = shutil.which(_HOOK_SCRIPT_NAME)
+    path_hook = Path(path_hook_str) if path_hook_str else None
+    if scope == "project":
+        chosen = venv_hook or path_hook
+    else:
+        chosen = path_hook or venv_hook
+    if chosen is None:
+        return _HOOK_SCRIPT_NAME
+    return str(chosen)
+
+
+def detect_default_scope(cwd: Path | None = None) -> SettingsScope:
+    """Pick `project` if the active interpreter is the venv at `cwd`, else `user`.
+
+    The strict test: `sys.prefix` (the active venv root) must equal
+    `<cwd>/.venv`. We deliberately do not `.resolve()` `sys.executable`
+    because on uv-managed venvs the `python` shim resolves through to
+    the *base* interpreter, which would defeat the comparison. Comparing
+    venv roots is the correct primitive.
+    """
+    project_root = cwd if cwd is not None else Path.cwd()
+    venv_dir = project_root / ".venv"
+    if not venv_dir.exists():
+        return "user"
+    try:
+        venv_resolved = venv_dir.resolve()
+        prefix_resolved = Path(sys.prefix).resolve()
+    except OSError:
+        return "user"
+    if prefix_resolved != venv_resolved:
+        return "user"
+    return "project"
+
+
+@dataclass(frozen=True)
+class DanglingShimCleanup:
+    """Outcome of `clean_dangling_shims`.
+
+    `removed` lists the absolute paths that were unlinked (each was a
+    symlink whose target no longer existed). Empty when nothing to do.
+    `skipped` lists paths we declined to touch (real files, symlinks
+    whose target still exists, or non-symlinks owned by another tool).
+    """
+    removed: tuple[Path, ...]
+    skipped: tuple[Path, ...]
+
+
+def clean_dangling_shims(
+    candidates: tuple[Path, ...] | None = None,
+) -> DanglingShimCleanup:
+    """Silently remove dangling symlinks the package itself ever wrote.
+
+    Only acts on paths in `_DANGLING_SHIM_CANDIDATES` (or the override
+    list for tests). A path is removed iff it is a symlink AND its
+    target does not exist. Real files and live symlinks are skipped —
+    we never destroy a working install.
+    """
+    targets = candidates if candidates is not None else _DANGLING_SHIM_CANDIDATES
+    removed: list[Path] = []
+    skipped: list[Path] = []
+    for path in targets:
+        try:
+            is_symlink = path.is_symlink()
+        except OSError:
+            skipped.append(path)
+            continue
+        if not is_symlink:
+            if path.exists():
+                skipped.append(path)
+            continue
+        try:
+            target_exists = path.resolve(strict=True).exists()
+        except (OSError, RuntimeError):
+            target_exists = False
+        if target_exists:
+            skipped.append(path)
+            continue
+        try:
+            path.unlink()
+        except OSError:
+            skipped.append(path)
+            continue
+        removed.append(path)
+    return DanglingShimCleanup(
+        removed=tuple(removed), skipped=tuple(skipped)
+    )
 
 
 def install_user_prompt_submit_hook(

--- a/src/aelfrice/setup.py
+++ b/src/aelfrice/setup.py
@@ -282,15 +282,30 @@ def install_user_prompt_submit_hook(
 
 
 def uninstall_user_prompt_submit_hook(
-    settings_path: Path, *, command: str
+    settings_path: Path,
+    *,
+    command: str | None = None,
+    command_basename: str | None = None,
 ) -> UninstallResult:
-    """Remove all UserPromptSubmit entries running exactly `command`.
+    """Remove UserPromptSubmit entries matching `command` or `command_basename`.
+
+    Pass exactly one of:
+      * `command` -- exact-string match of the stored hook command.
+      * `command_basename` -- match every hook whose stored command,
+        treated as a path, has this basename. Lets a bare-name install
+        and an absolute-path install be cleaned up by the same call.
 
     Returns `removed=0` if the file does not exist, has no matching
     entry, or has no `hooks.UserPromptSubmit` block at all.
     """
-    if not command:
+    if command is None and command_basename is None:
+        raise ValueError("provide command or command_basename")
+    if command is not None and command_basename is not None:
+        raise ValueError("command and command_basename are mutually exclusive")
+    if command is not None and not command:
         raise ValueError("command must be a non-empty string")
+    if command_basename is not None and not command_basename:
+        raise ValueError("command_basename must be a non-empty string")
     if not settings_path.exists():
         return UninstallResult(path=settings_path, removed=0)
     data = _load_settings(settings_path)
@@ -298,10 +313,17 @@ def uninstall_user_prompt_submit_hook(
     if user_prompt_submit is None:
         return UninstallResult(path=settings_path, removed=0)
     before = len(user_prompt_submit)
-    kept = [
-        entry for entry in user_prompt_submit
-        if not _entry_matches(entry, command)
-    ]
+    if command is not None:
+        kept = [
+            entry for entry in user_prompt_submit
+            if not _entry_matches(entry, command)
+        ]
+    else:
+        assert command_basename is not None
+        kept = [
+            entry for entry in user_prompt_submit
+            if not _entry_matches_basename(entry, command_basename)
+        ]
     removed = before - len(kept)
     if removed == 0:
         return UninstallResult(path=settings_path, removed=0)
@@ -521,6 +543,29 @@ def _entry_matches(entry: dict[str, object], command: str) -> bool:
             hook_dict.get(_TYPE_KEY) == _HOOK_TYPE_COMMAND
             and hook_dict.get(_COMMAND_KEY) == command
         ):
+            return True
+    return False
+
+
+def _entry_matches_basename(
+    entry: dict[str, object], basename: str
+) -> bool:
+    """True iff any inner command's first whitespace-stripped path token has `basename`."""
+    inner = entry.get(_INNER_HOOKS_KEY)
+    if not isinstance(inner, list):
+        return False
+    for hook in cast(list[object], inner):
+        if not isinstance(hook, dict):
+            continue
+        hook_dict = cast(dict[str, object], hook)
+        if hook_dict.get(_TYPE_KEY) != _HOOK_TYPE_COMMAND:
+            continue
+        cmd = hook_dict.get(_COMMAND_KEY)
+        if not isinstance(cmd, str):
+            continue
+        # First whitespace token is the program; basename match against it.
+        first = cmd.strip().split(maxsplit=1)[0] if cmd.strip() else ""
+        if first and Path(first).name == basename:
             return True
     return False
 

--- a/src/aelfrice/slash_commands/doctor.md
+++ b/src/aelfrice/slash_commands/doctor.md
@@ -1,0 +1,19 @@
+---
+name: aelf:doctor
+description: Verify that hook + statusline commands in Claude Code settings.json actually resolve to executables.
+allowed-tools:
+  - Bash
+---
+<objective>
+Diagnose Claude Code wiring: scan ~/.claude/settings.json (and the
+project-scope .claude/settings.json under cwd if present) for hook /
+statusline commands whose program token does not resolve. Catches
+dangling absolute paths and bare names that aren't on $PATH.
+</objective>
+
+<process>
+Run: `uv run aelf doctor`
+Display the output verbatim. Do not add commentary. Exit code is 1
+when at least one broken command is found, so a wrapping CI step can
+gate on it.
+</process>

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -14,6 +14,7 @@ from typing import cast
 import pytest
 
 from aelfrice.cli import DEFAULT_HOOK_COMMAND, main
+from aelfrice.setup import resolve_hook_command
 
 
 @pytest.fixture(autouse=True)
@@ -63,8 +64,10 @@ def test_setup_default_command_writes_project_settings(tmp_path: Path) -> None:
     assert code == 0
     settings = _project_settings(tmp_path)
     assert settings.exists()
-    assert _hook_commands(settings) == [DEFAULT_HOOK_COMMAND]
+    expected = resolve_hook_command("project")
+    assert _hook_commands(settings) == [expected]
     assert "installed" in output
+    # The basename is always present, whether we wrote bare or absolute.
     assert DEFAULT_HOOK_COMMAND in output
 
 
@@ -75,7 +78,8 @@ def test_setup_idempotent_reports_already_present(tmp_path: Path) -> None:
     )
     assert code == 0
     assert "already installed" in output
-    assert _hook_commands(_project_settings(tmp_path)) == [DEFAULT_HOOK_COMMAND]
+    expected = resolve_hook_command("project")
+    assert _hook_commands(_project_settings(tmp_path)) == [expected]
 
 
 def test_setup_custom_command_timeout_and_status_message(
@@ -112,7 +116,12 @@ def test_setup_explicit_settings_path_overrides_scope(tmp_path: Path) -> None:
     code, _ = _run("setup", "--settings-path", str(explicit))
     assert code == 0
     assert explicit.exists()
-    assert _hook_commands(explicit) == [DEFAULT_HOOK_COMMAND]
+    # Without an explicit --scope, auto-detect from cwd. Whichever scope
+    # auto-detect picks, the resolver returns the same command for that
+    # scope, so we just check basename ends up correct.
+    cmds = _hook_commands(explicit)
+    assert len(cmds) == 1
+    assert Path(cmds[0]).name == DEFAULT_HOOK_COMMAND
 
 
 def test_unsetup_removes_default_command(tmp_path: Path) -> None:
@@ -159,4 +168,5 @@ def test_user_scope_writes_into_monkeypatched_user_path(
     code, _ = _run("setup", "--scope", "user")
     assert code == 0
     assert fake_user_settings.exists()
-    assert _hook_commands(fake_user_settings) == [DEFAULT_HOOK_COMMAND]
+    expected = resolve_hook_command("user")
+    assert _hook_commands(fake_user_settings) == [expected]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,189 @@
+"""Tests for `aelf doctor` and the underlying `aelfrice.doctor` module."""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.cli import main
+from aelfrice.doctor import diagnose, format_report
+
+
+def _write_settings(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _exec(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def test_diagnose_returns_empty_report_when_no_settings(
+    tmp_path: Path,
+) -> None:
+    report = diagnose(
+        user_settings=tmp_path / "missing-user.json",
+        project_root=tmp_path / "missing-project",
+    )
+    assert report.scopes_scanned == []
+    assert report.findings == []
+    assert "nothing to check" in format_report(report)
+
+
+def test_diagnose_flags_missing_absolute_path(tmp_path: Path) -> None:
+    user_path = tmp_path / "settings.json"
+    _write_settings(user_path, {
+        "hooks": {
+            "UserPromptSubmit": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": "/no/such/aelf-hook",
+                }],
+            }],
+        },
+    })
+    report = diagnose(
+        user_settings=user_path, project_root=tmp_path / "noproj"
+    )
+    broken = report.broken
+    assert len(broken) == 1
+    assert broken[0].program == "/no/such/aelf-hook"
+    assert "does not exist" in broken[0].detail
+
+
+def test_diagnose_flags_bare_name_not_on_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PATH", "/nonexistent")
+    user_path = tmp_path / "settings.json"
+    _write_settings(user_path, {
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": "Bash",
+                "hooks": [{"type": "command", "command": "definitely-not-installed"}],
+            }],
+        },
+    })
+    report = diagnose(
+        user_settings=user_path, project_root=tmp_path / "noproj"
+    )
+    broken = report.broken
+    assert len(broken) == 1
+    assert "not on $PATH" in broken[0].detail
+
+
+def test_diagnose_passes_when_program_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bin_dir = tmp_path / "bin"
+    hook = _exec(bin_dir / "aelf-hook")
+    user_path = tmp_path / "settings.json"
+    _write_settings(user_path, {
+        "hooks": {
+            "UserPromptSubmit": [{
+                "hooks": [{"type": "command", "command": str(hook)}],
+            }],
+        },
+        "statusLine": {"type": "command", "command": str(hook)},
+    })
+    monkeypatch.setenv("PATH", str(bin_dir))
+    report = diagnose(
+        user_settings=user_path, project_root=tmp_path / "noproj"
+    )
+    assert report.broken == []
+    assert report.ok_count == 2
+
+
+def test_diagnose_skips_shell_pipe_commands(tmp_path: Path) -> None:
+    user_path = tmp_path / "settings.json"
+    _write_settings(user_path, {
+        "hooks": {
+            "PreToolUse": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": "true | echo skipped && exit 0",
+                }],
+            }],
+        },
+    })
+    report = diagnose(
+        user_settings=user_path, project_root=tmp_path / "noproj"
+    )
+    assert report.broken == []
+    assert report.skipped_count == 1
+
+
+def test_diagnose_inspects_script_under_interpreter(
+    tmp_path: Path,
+) -> None:
+    user_path = tmp_path / "settings.json"
+    # `bash <missing-script>` should report the SCRIPT, not bash.
+    _write_settings(user_path, {
+        "hooks": {
+            "PreToolUse": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": f"bash {tmp_path / 'gone.sh'}",
+                }],
+            }],
+        },
+    })
+    report = diagnose(
+        user_settings=user_path, project_root=tmp_path / "noproj"
+    )
+    assert len(report.broken) == 1
+    assert "gone.sh" in report.broken[0].program
+
+
+def test_doctor_cli_exit_1_when_broken(tmp_path: Path) -> None:
+    user_path = tmp_path / "settings.json"
+    _write_settings(user_path, {
+        "hooks": {
+            "UserPromptSubmit": [{
+                "hooks": [{"type": "command", "command": "/no/such"}],
+            }],
+        },
+    })
+    buf = io.StringIO()
+    code = main(
+        argv=[
+            "doctor",
+            "--user-settings", str(user_path),
+            "--project-root", str(tmp_path / "noproj"),
+        ],
+        out=buf,
+    )
+    assert code == 1
+    assert "broken" in buf.getvalue()
+
+
+def test_doctor_cli_exit_0_when_clean(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bin_dir = tmp_path / "bin"
+    hook = _exec(bin_dir / "aelf-hook")
+    user_path = tmp_path / "settings.json"
+    _write_settings(user_path, {
+        "hooks": {
+            "UserPromptSubmit": [{
+                "hooks": [{"type": "command", "command": str(hook)}],
+            }],
+        },
+    })
+    monkeypatch.setenv("PATH", str(bin_dir))
+    buf = io.StringIO()
+    code = main(
+        argv=[
+            "doctor",
+            "--user-settings", str(user_path),
+            "--project-root", str(tmp_path / "noproj"),
+        ],
+        out=buf,
+    )
+    assert code == 0
+    assert "1 ok" in buf.getvalue()

--- a/tests/test_setup_install.py
+++ b/tests/test_setup_install.py
@@ -262,6 +262,46 @@ def test_uninstall_rejects_empty_command(tmp_path: Path) -> None:
         uninstall_user_prompt_submit_hook(settings, command="")
 
 
+def test_uninstall_basename_match_removes_bare_and_absolute(
+    tmp_path: Path,
+) -> None:
+    """Basename mode catches both 'aelf-hook' and any absolute path
+    whose final component is 'aelf-hook' -- which is the round-trip
+    pairing for the new auto-resolving setup."""
+    settings = tmp_path / "settings.json"
+    install_user_prompt_submit_hook(settings, command="aelf-hook")
+    install_user_prompt_submit_hook(
+        settings, command="/Users/me/.venv/bin/aelf-hook"
+    )
+    install_user_prompt_submit_hook(settings, command="/keep/me")
+
+    result = uninstall_user_prompt_submit_hook(
+        settings, command_basename="aelf-hook"
+    )
+
+    assert result.removed == 2
+    data = _read_json(settings)
+    cmds = [
+        cast(list[dict[str, object]], entry["hooks"])[0]["command"]
+        for entry in _user_prompt_submit_list(data)
+    ]
+    assert cmds == ["/keep/me"]
+
+
+def test_uninstall_requires_exactly_one_match_kind(
+    tmp_path: Path,
+) -> None:
+    settings = tmp_path / "settings.json"
+    with pytest.raises(ValueError):
+        uninstall_user_prompt_submit_hook(settings)
+    with pytest.raises(ValueError):
+        uninstall_user_prompt_submit_hook(
+            settings, command="x", command_basename="x"
+        )
+    with pytest.raises(ValueError):
+        uninstall_user_prompt_submit_hook(settings, command_basename="")
+
+
 def test_install_atomic_no_partial_file_on_simulated_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_setup_resolution.py
+++ b/tests/test_setup_resolution.py
@@ -1,0 +1,173 @@
+"""Unit tests for the per-project install routing primitives.
+
+Covers `resolve_hook_command`, `detect_default_scope`, and
+`clean_dangling_shims` from `aelfrice.setup`. Each test patches the
+relevant filesystem / interpreter introspection so it runs the same
+inside or outside a venv.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from aelfrice.setup import (
+    DanglingShimCleanup,
+    clean_dangling_shims,
+    detect_default_scope,
+    resolve_hook_command,
+)
+
+
+def _make_executable(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\necho stub\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+# --- resolve_hook_command -----------------------------------------------
+
+
+def test_resolve_hook_command_project_prefers_sys_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    venv_bin = tmp_path / "venv" / "bin"
+    hook = venv_bin / "aelf-hook"
+    _make_executable(hook)
+    monkeypatch.setattr(sys, "prefix", str(venv_bin.parent))
+    # PATH does not have anything resolvable: project scope must still
+    # find the venv hook.
+    monkeypatch.setenv("PATH", "/nonexistent")
+
+    assert resolve_hook_command("project") == str(hook)
+
+
+def test_resolve_hook_command_user_prefers_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_hook = venv_bin / "aelf-hook"
+    _make_executable(venv_hook)
+    pipx_dir = tmp_path / "pipx" / "bin"
+    pipx_hook = pipx_dir / "aelf-hook"
+    _make_executable(pipx_hook)
+    monkeypatch.setattr(sys, "prefix", str(venv_bin.parent))
+    monkeypatch.setenv("PATH", str(pipx_dir))
+
+    assert resolve_hook_command("user") == str(pipx_hook)
+
+
+def test_resolve_hook_command_user_falls_back_to_venv_when_path_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_hook = venv_bin / "aelf-hook"
+    _make_executable(venv_hook)
+    monkeypatch.setattr(sys, "prefix", str(venv_bin.parent))
+    monkeypatch.setenv("PATH", "/nonexistent")
+
+    assert resolve_hook_command("user") == str(venv_hook)
+
+
+def test_resolve_hook_command_last_resort_is_bare_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    empty_bin = tmp_path / "empty" / "bin"
+    empty_bin.mkdir(parents=True)
+    monkeypatch.setattr(sys, "prefix", str(empty_bin.parent))
+    monkeypatch.setenv("PATH", "/nonexistent")
+
+    # Nothing on disk, nothing on PATH: fall back to bare name so doctor
+    # can flag it instead of crashing.
+    assert resolve_hook_command("project") == "aelf-hook"
+    assert resolve_hook_command("user") == "aelf-hook"
+
+
+# --- detect_default_scope -----------------------------------------------
+
+
+def test_detect_default_scope_project_when_prefix_matches_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "myproj"
+    venv = project / ".venv"
+    (venv / "bin").mkdir(parents=True)
+    monkeypatch.setattr(sys, "prefix", str(venv))
+
+    assert detect_default_scope(cwd=project) == "project"
+
+
+def test_detect_default_scope_user_when_no_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "noventer"
+    project.mkdir()
+    monkeypatch.setattr(sys, "prefix", "/something/else")
+
+    assert detect_default_scope(cwd=project) == "user"
+
+
+def test_detect_default_scope_user_when_prefix_mismatches_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "wrongvenv"
+    (project / ".venv" / "bin").mkdir(parents=True)
+    other_venv = tmp_path / "otherproj" / ".venv"
+    (other_venv / "bin").mkdir(parents=True)
+    monkeypatch.setattr(sys, "prefix", str(other_venv))
+
+    assert detect_default_scope(cwd=project) == "user"
+
+
+# --- clean_dangling_shims -----------------------------------------------
+
+
+def test_clean_dangling_shims_removes_dangling_symlinks(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "deleted-target"
+    shim = tmp_path / "shim"
+    target.write_text("alive")
+    shim.symlink_to(target)
+    target.unlink()  # now shim is dangling
+
+    result = clean_dangling_shims(candidates=(shim,))
+
+    assert isinstance(result, DanglingShimCleanup)
+    assert shim in result.removed
+    assert not shim.exists()
+    assert not shim.is_symlink()
+
+
+def test_clean_dangling_shims_skips_live_symlinks(tmp_path: Path) -> None:
+    target = tmp_path / "alive-target"
+    target.write_text("hello")
+    shim = tmp_path / "shim"
+    shim.symlink_to(target)
+
+    result = clean_dangling_shims(candidates=(shim,))
+
+    assert shim in result.skipped
+    assert shim.exists()
+
+
+def test_clean_dangling_shims_skips_real_files(tmp_path: Path) -> None:
+    real = tmp_path / "real"
+    real.write_text("not a symlink")
+
+    result = clean_dangling_shims(candidates=(real,))
+
+    assert real in result.skipped
+    assert real.exists()
+
+
+def test_clean_dangling_shims_idempotent_on_missing_path(
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "never-existed"
+    result = clean_dangling_shims(candidates=(missing,))
+
+    assert result.removed == ()
+    # not in skipped either: nothing was there to start with.
+    assert missing not in result.skipped

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -23,6 +23,7 @@ EXPECTED_COMMANDS = (
     "feedback",
     "stats",
     "health",
+    "doctor",
     "setup",
     "unsetup",
     "upgrade",


### PR DESCRIPTION
Closes #81.

## Summary
- `aelf setup` now auto-resolves `--scope` and `--command` so project-scope settings pin to the local `.venv/bin/aelf-hook` and user-scope settings resolve via `\$PATH` (typically the pipx install). No more bare `aelf-hook` in settings.json that silently breaks outside an active venv.
- New `aelf doctor` walks user + project settings.json, parses every hook + statusline command, and reports any whose program token doesn't resolve. Exits 1 on broken commands so it's CI-friendly.
- `aelf setup` silently unlinks the dangling `/usr/local/bin/aelf{,-hook}` symlinks if their target no longer exists. Real binaries and live symlinks are left alone.
- `aelf unsetup` matches by command basename when no `--command` is passed, so a bare-name install and an absolute-path install can be cleaned up by the same call.

## Issue 81 acceptance criteria
- [x] Project-scope setup writes `<project_root>/.venv/bin/aelf-hook` (absolute) — `resolve_hook_command(\"project\")` in `src/aelfrice/setup.py:145`.
- [x] User-scope setup resolves via `\$PATH` for the global pipx install — same function, user branch.
- [x] No hook command in settings file references a non-existent path — `aelf doctor` flags any that do, and `aelf setup` writes only resolvable absolute paths by default.
- [x] `aelf setup` enforces the layering: auto-detects scope from `cwd / .venv` matching `sys.prefix` (`detect_default_scope` in `src/aelfrice/setup.py:175`).

## Out of scope (per the issue)
- Cleanup of the user's existing `~/.claude/settings.json` (legacy lab-side `aelfrice-*.sh` shims, bare `aelf commit-check` calls). Tracked separately; a follow-up step uses `aelf doctor` to identify and `aelf setup` / hand-edit to fix.

## Test plan
- [x] `uv run pytest` — 810 passed, 19 new tests in `test_setup_resolution.py` + `test_doctor.py` + updates to `test_setup_install.py` and `test_cli_setup.py`.
- [x] `uv run pyright src/aelfrice/setup.py src/aelfrice/doctor.py` — 0 errors. Pre-existing 3 errors in `cli.py` from #73 are unchanged.
- [x] Live smoke: `aelf doctor` against the reporter's actual `~/.claude/settings.json` exits 1 with the three findings called out in #81.

## Rollback
`git revert` the PR merge commit. The only side effect outside the package is the silent removal of dangling `/usr/local/bin/aelf` symlinks, which were already broken.