### PR TITLE
release: v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-04-27
+
+Patch release: per-project install routing, `aelf doctor` settings
+linter, and CI guardrails for release docs. Closes the v1.0.1 gap
+where one machine couldn't cleanly route per-project venv hooks
+alongside a global `pipx` install, and the README roadmap drifted out
+of sync minutes after the wheel was on PyPI.
+
 ### Added
 
 - `aelf doctor`: scan user-scope and project-scope Claude Code
@@ -17,6 +25,15 @@ installable release; see the roadmap in [README.md](README.md).
   doesn't resolve. Catches dangling absolute paths, bare names not on
   `$PATH`, and missing scripts under `bash /…` interpreter wrappers.
   Exits `1` on any broken finding so it can gate CI (#81).
+- `staging-gate.yml` `release-docs-check` job: when a PR bumps
+  `pyproject.toml` `version`, enforce `CHANGELOG.md` has a matching
+  `## [X.Y.Z]` section + compare-link footnote, and that `README.md`
+  has no roadmap row marking the released version as `next` /
+  `planned`. No-op on non-release PRs (#80).
+- `post-release-docs-issue.yml`: on `release.published`, opens a
+  tracking issue `docs sweep for vX.Y.Z` with a per-doc checklist
+  for the second-order docs the gate can't verify automatically
+  (RELEASING.md test counts, ROADMAP.md narrative, etc.) (#80).
 
 ### Changed
 
@@ -357,7 +374,8 @@ Foundation milestone — store, models, config.
 - Initial repo scaffold: pyproject, README, GitHub Actions workflows,
   scan configs (commit `67b4343`).
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/robotrocketscience/aelfrice/compare/v0.9.0rc0...v1.0.0
 [0.9.0rc0]: https://github.com/robotrocketscience/aelfrice/compare/v0.8.0...v0.9.0rc0

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Same operations are available as MCP tools and Claude Code slash commands. Full 
 | | Status | |
 |---|---|---|
 | v0.1 – v1.0 | **shipped** | core memory, CLI, MCP, hook wiring, synthetic benchmark, PyPI publish |
-| v1.0.1 | next | launch fix-up — hook→retrieval wiring, onboard noise, `aelf --version` |
+| v1.0.1 | **shipped** | launch fix-up — hook→retrieval wiring, onboard noise, `aelf --version` |
+| v1.0.2 | **shipped** | per-project install routing, `aelf doctor`, release-docs CI gate |
 | v1.1.0 | planned | project identity (`.git/aelfrice/`, `.aelfrice.toml`), edges→threads, status/health split |
 | v1.2.0 | planned | commit-ingest hook, seed files, triple-extraction port |
 | v1.3 | planned | retrieval wave — entity index + BFS multi-hop + LLM classification |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,7 +17,8 @@ This is a rebuild, not a port. Structural issues that survived agentmemory are b
 | Version | Status | Theme |
 |---|---|---|
 | v0.1 – v1.0 | shipped | core memory, CLI, MCP, hook wiring, synthetic benchmark, PyPI publish |
-| **v1.0.1** | next | launch fix-up — hook→retrieval wiring, onboard noise, `aelf --version` |
+| **v1.0.1** | shipped | launch fix-up — hook→retrieval wiring, onboard noise, `aelf --version` |
+| **v1.0.2** | shipped | per-project install routing, `aelf doctor`, release-docs CI gate |
 | **v1.1.0** | planned | project identity, edges→threads, status/health split |
 | **v1.2.0** | planned | commit-ingest hook, seed files, triple-extraction port |
 | **v1.3.0** | planned | retrieval wave — entity index + BFS multi-hop + LLM classification |
@@ -37,6 +38,13 @@ The first patch closes the highest-visibility gaps from launch. Each item is tra
 - **Contradiction tie-breaker.** Default precedence `user_stated > user_corrected > document_recent > agent_inferred`, with ISO timestamp as the deciding fallback. The loser is auto-superseded; the audit row records which rule fired.
 - **`aelf --version`.** Reads from `aelfrice.__version__`. Trivial, but currently raises an argparse error.
 - **Query result cache.** A bounded LRU cache wrapping `aelfrice.retrieval.retrieve()`, keyed on a canonicalized form of `(query, token_budget, l1_limit)` and invalidated on every store mutation. Skips a full L0+L1 pass when an agent loop re-issues the same query. Spec: [`lru_query_cache.md`](lru_query_cache.md).
+
+## v1.0.2 — install routing + release guardrails
+
+Second patch. Two threads:
+
+- **Per-project install routing + `aelf doctor`.** `aelf setup` auto-detects scope (`project` if `cwd/.venv` matches the active interpreter, else `user`) and writes an absolute `aelf-hook` path so one machine can route per-project venvs to their own hook alongside a global `pipx`-installed fallback without bare-name `$PATH` collisions. `aelf doctor` is a settings linter that scans user- and project-scope `settings.json` for hook + statusline commands whose program token doesn't resolve, exits `1` on findings so it can gate CI. Closes [#81](https://github.com/robotrocketscience/aelfrice/issues/81).
+- **Release-docs CI gate + post-release docs sweep.** The v1.0.1 cut shipped to PyPI with the README roadmap row still saying `v1.0.1 | next`. New `staging-gate.yml` `release-docs-check` job enforces, on any version-bump PR, that `CHANGELOG.md` has the matching `[X.Y.Z]` section + compare-link footnote and that `README.md` has no roadmap row marking the released version as `next` / `planned`. New `post-release-docs-issue.yml` opens a tracking issue on `release.published` for second-order docs the gate can't verify (RELEASING.md test counts, ROADMAP.md narrative).
 
 ## v1.1.0 — project identity and cosmetic surface
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "1.0.1"
+version = "1.0.2"
 description = "Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aelfrice/__init__.py
+++ b/src/aelfrice/__init__.py
@@ -1,2 +1,2 @@
 """aelfrice: Bayesian memory designed for feedback-driven learning."""
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Patch release. Two threads:

- **Per-project install routing + `aelf doctor`** (#83, closes #81). `aelf setup` auto-detects scope, defaults `--command` to an absolute `aelf-hook` path so per-project venvs and a global `pipx` install can co-exist without `$PATH` collisions, and silently cleans up dangling `/usr/local/bin/aelf{,-hook}` symlinks. New `aelf doctor` command lints user- and project-scope `settings.json` for broken hook + statusline programs and exits 1 on findings (CI-gateable).
- **Release-docs CI gate + post-release docs sweep** (#80). New `staging-gate.yml` `release-docs-check` job enforces, on any version-bump PR, that `CHANGELOG.md` has the matching `[X.Y.Z]` section + compare-link footnote and that `README.md` has no roadmap row marking the released version as `next` / `planned`. New `post-release-docs-issue.yml` opens a tracking issue on `release.published` for second-order docs.

## Local verification

- `uv lock` → updated 1.0.1 -> 1.0.2.
- `uv run pytest tests/ -x -q` → 808 passed, 2 skipped.
- `uv build` → wheel and sdist built clean.
- `uv run aelf --version` → `aelf 1.0.2`.
- `uv run pyright src/` → 61 errors / 0 warnings (pre-existing on main, not gated by CI).

## CHANGELOG

Moved `[Unreleased]` -> `[1.0.2] - 2026-04-27` and added the #80 CI-gate entries that weren't logged. Updated link footer.

## Roadmap rows

- README.md: v1.0.1 flipped to **shipped**, added v1.0.2 row as **shipped** (not `next` / `planned`, satisfies release-docs-check).
- docs/ROADMAP.md: same flip + new `## v1.0.2 — install routing + release guardrails` narrative section.

## Tag and publish

After merge, on `main`:

```
git tag -s v1.0.2 -m "release: v1.0.2"
git push github v1.0.2
```

`publish.yml` triggers on the tag and uploads to PyPI via Trusted Publishing.