### PR TITLE
docs: v1.4.0 context rebuilder + v1.2.0 transcript-ingest

### DIFF
--- a/benchmarks/context-rebuilder/.gitignore
+++ b/benchmarks/context-rebuilder/.gitignore
@@ -1,0 +1,9 @@
+# Eval corpus is real captured transcripts. PII-scrub before adding.
+# Files churn frequently; gitignore them and track only meta.
+eval_corpus/*.jsonl
+eval_corpus/*.meta.json
+
+# Sweep outputs are run-specific; track only calibration_*.json
+# files referenced from the spec.
+results/*
+!results/calibration_*.json

--- a/benchmarks/context-rebuilder/README.md
+++ b/benchmarks/context-rebuilder/README.md
@@ -1,0 +1,61 @@
+# context-rebuilder eval harness
+
+Skeleton for the eval that backs [`docs/context_rebuilder.md`](../../docs/context_rebuilder.md).
+
+## What this measures
+
+**Continuation fidelity at fixed token budget.** Given a real working
+session captured as a `turns.jsonl` (per the v1.2.0 transcript-ingest
+spec), fork at midpoint turn `T`, force a clear, run the rebuilder,
+replay turns `T+1..end`, and ask: does the agent continue as it did
+originally, on a smaller context budget?
+
+Three numbers per run:
+
+1. **fidelity** — fraction of post-clear turns where the agent's
+   answer matches the original session's answer. Judge: deterministic
+   string-match for explicit recall questions; LLM-judge for
+   open-ended turns.
+2. **token_cost_ratio** — rebuild block size / pre-clear context size.
+3. **rebuild_latency_ms** — wall-time of the PreCompact hook.
+
+## Layout
+
+- `eval_harness.py` — entry point.
+- `eval_corpus/` — gitignored. Holds scrubbed `turns.jsonl` files
+  for replay. Populate from real working sessions; PII-scrub each
+  before adding to the corpus.
+- `judges/` — fidelity scorers (string-match + LLM-judge). To be
+  added in v1.3.0.
+- `results/` — per-run JSON output. Gitignored except for
+  `calibration_*.json` files referenced from the spec.
+
+## Run modes
+
+- `--mode threshold-sweep` — sweep PreCompact trigger thresholds
+  (50/60/70/80/90%) per task type, output the fidelity-vs-trigger
+  curve. Default for calibration.
+- `--mode dynamic` — evaluate the dynamic-threshold heuristic
+  against fixed thresholds. Gate for shipping dynamic mode.
+- `--mode budget-sweep` — sweep token budgets (500/1000/2000/4000)
+  at a fixed trigger. Drives the default budget choice.
+- `--mode regression` — fixed config, pass/fail against the v1.0.0
+  baseline numbers. Run on every release.
+
+## Open questions answered by the eval, not the spec
+
+1. The default trigger threshold for v1.4.0.
+2. The default token budget for v1.4.0.
+3. Whether dynamic-mode improves over a fixed threshold.
+4. Whether augment-mode loses fidelity vs. suppress-mode (matters
+   for v2.x suppress-mode promotion decision).
+
+## Status
+
+This is a skeleton. The four core integration points
+(`replay_to_fork`, `run_rebuilder`, `replay_post_fork`,
+`measure_token_cost`) raise `NotImplementedError` and depend on the
+v1.2.0 transcript-ingest module and the v1.4.0 rebuilder
+implementation. The skeleton ships now to lock the metric names,
+JSON output format, and run-mode list against the spec's
+acceptance criteria.

--- a/benchmarks/context-rebuilder/eval_harness.py
+++ b/benchmarks/context-rebuilder/eval_harness.py
@@ -1,0 +1,301 @@
+"""Context-rebuilder eval harness — skeleton.
+
+Backs docs/context_rebuilder.md. NOT runnable as-is — the TODOs
+mark integration points that fill in as the rebuilder
+implementation lands across v1.2.0–v1.4.0. The shape of this file
+is the contract: the spec's acceptance criteria reference these
+run modes and metric names.
+
+Run:
+    uv run python benchmarks/context-rebuilder/eval_harness.py \\
+        --mode threshold-sweep \\
+        --corpus benchmarks/context-rebuilder/eval_corpus/ \\
+        --out benchmarks/context-rebuilder/results/sweep_$(date +%Y%m%d).json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Literal
+
+
+Mode = Literal["threshold-sweep", "budget-sweep", "dynamic", "regression"]
+
+
+@dataclass(frozen=True)
+class TranscriptCase:
+    """One replayable transcript fixture."""
+    path: Path
+    task_type: str  # "debug" | "plan" | "review" | "explore"
+    fork_turn: int  # midpoint turn at which to force the clear
+    eval_turns: tuple[int, ...]  # turns whose answers we score
+
+
+@dataclass
+class RunResult:
+    """One eval run on one transcript at one config."""
+    case_path: str
+    task_type: str
+    config: dict
+    fidelity: float  # 0.0 to 1.0
+    token_cost_ratio: float
+    rebuild_latency_ms: float
+    fork_turn: int
+    n_eval_turns: int
+    failures: list[dict] = field(default_factory=list)
+
+
+@dataclass
+class SweepResult:
+    """Aggregated result of a sweep across configs."""
+    mode: Mode
+    runs: list[RunResult]
+    summary: dict = field(default_factory=dict)
+
+
+def load_corpus(corpus_dir: Path) -> list[TranscriptCase]:
+    """Load `eval_corpus/*.jsonl` and the matching `*.meta.json`.
+
+    Each fixture has two files:
+      - turns.jsonl — the captured transcript
+      - turns.meta.json — task_type, fork_turn, eval_turns
+    """
+    cases: list[TranscriptCase] = []
+    for jsonl in sorted(corpus_dir.glob("*.jsonl")):
+        meta_path = jsonl.with_suffix(".meta.json")
+        if not meta_path.exists():
+            continue
+        meta = json.loads(meta_path.read_text())
+        cases.append(
+            TranscriptCase(
+                path=jsonl,
+                task_type=meta["task_type"],
+                fork_turn=meta["fork_turn"],
+                eval_turns=tuple(meta["eval_turns"]),
+            )
+        )
+    return cases
+
+
+def replay_to_fork(case: TranscriptCase) -> "object":
+    """Populate a fresh aelfrice store with turns 0..fork_turn-1.
+
+    Returns the store handle. TODO: wire to MemoryStore + ingest_jsonl
+    once docs/transcript_ingest.md ships.
+    """
+    raise NotImplementedError("Wire to ingest_jsonl from transcript_ingest spec")
+
+
+def run_rebuilder(
+    store: object,
+    case: TranscriptCase,
+    *,
+    trigger_threshold: float,
+    token_budget: int,
+) -> tuple[str, float]:
+    """Run the rebuilder against the store at the fork point.
+
+    Returns (rebuilt_context_block, latency_ms). TODO: wire to
+    aelfrice.context_rebuilder.rebuild() once context_rebuilder spec
+    ships an implementation.
+    """
+    raise NotImplementedError("Wire to context_rebuilder.rebuild()")
+
+
+def replay_post_fork(
+    rebuilt_context: str,
+    case: TranscriptCase,
+) -> list[dict]:
+    """Replay turns fork_turn..end with rebuilt_context as session start.
+
+    Returns one dict per eval_turn with keys:
+      {"turn_idx": int, "expected": str, "actual": str, "matched": bool}.
+
+    TODO: wire to a Claude API client once we decide on the eval
+    invocation surface. Initially can be agent-API-driven; later may
+    move to a Claude-Code-harness-equivalent for higher fidelity.
+    """
+    raise NotImplementedError("Wire to model invocation client")
+
+
+def score_fidelity(replay_results: list[dict]) -> float:
+    """Fraction of eval_turns where actual matches expected.
+
+    For string-match turns, exact substring or normalized-token
+    match. For open-ended turns, defer to an LLM judge (see
+    judges/llm_judge.py — TODO).
+    """
+    if not replay_results:
+        return 0.0
+    matched = sum(1 for r in replay_results if r["matched"])
+    return matched / len(replay_results)
+
+
+def measure_token_cost(
+    rebuilt_context: str,
+    case: TranscriptCase,
+) -> float:
+    """Rebuild block size / pre-clear context size.
+
+    TODO: needs a tokenizer (tiktoken or model-specific) and the
+    pre-clear context size from the captured transcript.
+    """
+    raise NotImplementedError("Wire to tokenizer + transcript size")
+
+
+def run_one(
+    case: TranscriptCase,
+    *,
+    trigger_threshold: float,
+    token_budget: int,
+) -> RunResult:
+    """End-to-end one run on one case at one config."""
+    store = replay_to_fork(case)
+    t0 = time.monotonic()
+    rebuilt, latency_ms = run_rebuilder(
+        store,
+        case,
+        trigger_threshold=trigger_threshold,
+        token_budget=token_budget,
+    )
+    replay = replay_post_fork(rebuilt, case)
+    fidelity = score_fidelity(replay)
+    cost_ratio = measure_token_cost(rebuilt, case)
+    return RunResult(
+        case_path=str(case.path),
+        task_type=case.task_type,
+        config={
+            "trigger_threshold": trigger_threshold,
+            "token_budget": token_budget,
+        },
+        fidelity=fidelity,
+        token_cost_ratio=cost_ratio,
+        rebuild_latency_ms=latency_ms,
+        fork_turn=case.fork_turn,
+        n_eval_turns=len(replay),
+        failures=[r for r in replay if not r["matched"]],
+    )
+
+
+def sweep_thresholds(
+    cases: list[TranscriptCase],
+    *,
+    thresholds: tuple[float, ...] = (0.5, 0.6, 0.7, 0.8, 0.9),
+    token_budget: int = 2000,
+) -> SweepResult:
+    runs = [
+        run_one(case, trigger_threshold=t, token_budget=token_budget)
+        for case in cases
+        for t in thresholds
+    ]
+    summary = _summarize_by_threshold(runs)
+    return SweepResult(mode="threshold-sweep", runs=runs, summary=summary)
+
+
+def sweep_budgets(
+    cases: list[TranscriptCase],
+    *,
+    budgets: tuple[int, ...] = (500, 1000, 2000, 4000),
+    trigger_threshold: float = 0.7,
+) -> SweepResult:
+    runs = [
+        run_one(case, trigger_threshold=trigger_threshold, token_budget=b)
+        for case in cases
+        for b in budgets
+    ]
+    summary = _summarize_by_budget(runs)
+    return SweepResult(mode="budget-sweep", runs=runs, summary=summary)
+
+
+def _summarize_by_threshold(runs: list[RunResult]) -> dict:
+    """Group runs by threshold and report median fidelity per task type."""
+    out: dict = {}
+    by_task = _group(runs, key=lambda r: r.task_type)
+    for task, task_runs in by_task.items():
+        by_t = _group(task_runs, key=lambda r: r.config["trigger_threshold"])
+        out[task] = {
+            f"threshold={t}": {
+                "median_fidelity": statistics.median(r.fidelity for r in rs),
+                "median_token_cost_ratio": statistics.median(
+                    r.token_cost_ratio for r in rs
+                ),
+                "p99_latency_ms": _p99([r.rebuild_latency_ms for r in rs]),
+                "n_runs": len(rs),
+            }
+            for t, rs in by_t.items()
+        }
+    return out
+
+
+def _summarize_by_budget(runs: list[RunResult]) -> dict:
+    out: dict = {}
+    by_task = _group(runs, key=lambda r: r.task_type)
+    for task, task_runs in by_task.items():
+        by_b = _group(task_runs, key=lambda r: r.config["token_budget"])
+        out[task] = {
+            f"budget={b}": {
+                "median_fidelity": statistics.median(r.fidelity for r in rs),
+                "p99_latency_ms": _p99([r.rebuild_latency_ms for r in rs]),
+                "n_runs": len(rs),
+            }
+            for b, rs in by_b.items()
+        }
+    return out
+
+
+def _group(items, *, key):
+    out: dict = {}
+    for it in items:
+        out.setdefault(key(it), []).append(it)
+    return out
+
+
+def _p99(xs: list[float]) -> float:
+    if not xs:
+        return 0.0
+    s = sorted(xs)
+    idx = max(0, int(round(0.99 * (len(s) - 1))))
+    return s[idx]
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--mode", choices=("threshold-sweep", "budget-sweep", "dynamic", "regression"), required=True)
+    p.add_argument("--corpus", type=Path, required=True)
+    p.add_argument("--out", type=Path, required=True)
+    args = p.parse_args()
+
+    cases = load_corpus(args.corpus)
+    if not cases:
+        print(f"no cases found in {args.corpus}")
+        return 1
+
+    if args.mode == "threshold-sweep":
+        result = sweep_thresholds(cases)
+    elif args.mode == "budget-sweep":
+        result = sweep_budgets(cases)
+    elif args.mode == "dynamic":
+        raise NotImplementedError("dynamic mode lands once the heuristic exists")
+    elif args.mode == "regression":
+        raise NotImplementedError("regression mode lands once a v1.0.0 baseline is recorded")
+    else:
+        raise AssertionError(args.mode)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps({
+        "mode": result.mode,
+        "n_cases": len(cases),
+        "summary": result.summary,
+        "runs": [asdict(r) for r in result.runs],
+    }, indent=2))
+    print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,6 +22,7 @@ This is a rebuild, not a port. Structural issues that survived agentmemory are b
 | **v1.1.0** | planned | project identity, edges→threads, status/health split |
 | **v1.2.0** | planned | commit-ingest hook, seed files, triple-extraction port |
 | **v1.3.0** | planned | retrieval wave — entity index + BFS multi-hop + LLM classification |
+| **v1.4.0** | planned | context rebuilder — automatic PreCompact-driven retrieval-curated context |
 | **v2.0.0** | planned | feature parity with the earlier research line + full benchmark reproducibility |
 
 ## v1.0.0 — shipped
@@ -59,6 +60,7 @@ Second patch. Two threads:
 ## v1.2.0 — auto-capture and triple extraction
 
 - **Commit-ingest `PostToolUse` hook.** The graph grows during normal sessions without explicit `onboard` / `remember` / `feedback` calls.
+- **Transcript-ingest hooks.** A pair of `UserPromptSubmit` + `Stop` hooks append every conversation turn to a per-project `<root>/.git/aelfrice/transcripts/turns.jsonl` log; a `PreCompact` hook rotates the log and triggers `ingest_jsonl()` to pull turns into the brain graph as beliefs and edges. Closes the harness-conflict write-path gap (the MCP no longer depends on the harness's auto-memory directive to receive new beliefs from normal session activity) and densifies production data with `session_id` and `DERIVED_FROM` edges from real conversations. Required prerequisite for the v1.4.0 context rebuilder.
 - **`.aelfrice/seed.md`.** A git-tracked seed file auto-ingested on first `onboard`. Lets a project author bootstrap collaborator memory directly from the repository.
 - **Triple-extraction port.** The triple-extraction ingest module from the earlier research line ports forward. Migration is forward-compatible against v1.0 stores — existing rows continue to read.
 - **First academic benchmark activations.** `mab_triple_adapter` activates in `benchmarks/`.
@@ -72,6 +74,19 @@ This is the release where retrieval moves beyond BM25-only.
 - **LLM-classification onboard path.** A Haiku-backed classifier becomes an opt-in alternative to the regex classifier. Cost is documented per-session in the published claims.
 - **Bayesian-weighted ranking — partial.** Retrieval scoring begins to incorporate posterior confidence on top of BM25. The full feedback-into-ranking eval lands in v2.0.0.
 - **Benchmark activations.** `mab_entity_index_adapter` and `mab_llm_entity_adapter` activate in `benchmarks/`.
+
+## v1.4.0 — context rebuilder
+
+The release that makes long-running sessions cheaper without a visible seam to the user.
+
+- **`PreCompact`-driven context rebuild.** When the harness signals an approaching context limit, an aelfrice hook intercepts and queries the brain graph for the highest-value beliefs against the tail of the session transcript. The rebuild emits as `additionalContext`: locked beliefs first, then session-scoped beliefs from the same `session_id`, then BM25 / posterior-weighted hits, packed to a configurable token budget. The user's next prompt is answered against a leaner, retrieval-curated working set instead of the harness's generic compaction summary.
+- **Augment mode at v1.4.0.** The hook augments the harness's default compaction; both summaries land in the new context. Suppress mode (replacing the harness's compaction entirely) is parked as a v2.x candidate gated on continuation-fidelity evidence.
+- **Trigger modes.** Manual (`/aelf-rebuild` slash command) ships first as the explicit testing surface. Threshold mode (auto-fire at a configurable fraction of the model's window) ships with calibration data — the default threshold is derived from the eval harness, not hardcoded. Dynamic mode (heuristic-driven trigger) is gated on showing it tracks fidelity better than a fixed threshold.
+- **Continuation-fidelity eval harness.** A new harness in `benchmarks/context-rebuilder/` replays captured transcripts, forces a midpoint clear, runs the rebuilder, and measures: (a) fraction of post-clear turns where the agent's answer matches the original session's answer, (b) rebuild block size as a fraction of the full-replay baseline, (c) PreCompact hook latency. Headline regression band: ≥80% continuation fidelity at ≤30% token cost on the v1.0.0 baseline. Higher targets land at v1.5.x and v2.0.0.
+- **Hard prerequisites.** v1.2.0 transcript-ingest (the rebuilder reads `<root>/.git/aelfrice/transcripts/turns.jsonl`) and the v1.2.0 `session_id` schema addition.
+- **Soft prerequisites.** v1.3.0 partial Bayesian-weighted ranking improves rebuild quality; without it the rebuilder ships against BM25-only retrieval.
+
+The central claim of v1.4.0: long-running sessions use less context per steady-state turn without measurable continuation regression. The eval harness is what makes that claim falsifiable.
 
 ## v2.0.0 — feature parity and reproducibility
 
@@ -94,6 +109,8 @@ The earlier research line implemented these modules. They are not in v1.0.0; eac
 |---|---|
 | Triple extraction (`triple_extraction`) | v1.2.0 |
 | Commit-ingest `PostToolUse` integration (`commit_tracker`) | v1.2.0 |
+| Transcript-ingest hooks + `ingest_jsonl()` (`transcript_ingest`) | v1.2.0 |
+| Context rebuilder + continuation-fidelity eval (`context_rebuilder`) | v1.4.0 |
 | Graph metrics + status/health split (`graph_metrics`) | v1.1.0 |
 | Entity-index retrieval (regex + entity patterns) | v1.3.0 |
 | BFS multi-hop graph traversal | v1.3.0 |

--- a/docs/context_rebuilder.md
+++ b/docs/context_rebuilder.md
@@ -1,0 +1,356 @@
+# Context rebuilder
+
+**Status:** spec.
+**Target milestone:** v1.4.0 (new milestone — slot is post-v1.3.0
+retrieval wave so the partial Bayesian-weighted ranker is real
+when the rebuilder ships).
+**Dependencies (hard):**
+- [transcript_ingest.md](transcript_ingest.md) (v1.2.0) — without a
+  transcript log to query, this feature has nothing to read.
+- v1.2.0 ingest enrichment — `session_id` must be a real field for
+  session-scoped retrieval to work.
+**Dependencies (soft, quality-gating):**
+- v1.3.0 partial Bayesian-weighted ranking — without
+  posterior-weighted ranking, the rebuilder is BM25-only and the
+  "right" beliefs may not float to the top.
+- v1.2.0 triple-extraction port — better edge structure on the
+  transcript ingest path produces better recall on the rebuild
+  query.
+**Risk:** high. Three sources of risk:
+1. Quality. "Seamless from the user's perspective" is a strong
+   claim. Needs an eval harness (see "Validation") to be
+   measurable, not just intuited.
+2. Latency. PreCompact is on the user-facing latency budget; the
+   rebuild must complete fast enough that the user doesn't notice
+   the swap.
+3. Coordination with the harness. Claude Code's auto-compaction
+   runs whether or not we hook PreCompact; we either suppress and
+   replace it, or augment it. Both have failure modes.
+
+## Summary
+
+A `PreCompact` hook that, instead of letting Claude Code compact
+the context window with its default summarization, queries
+aelfrice for the highest-value beliefs from the current session
+and emits them as the new session-start context block. The user
+sees no `/clear`, no compaction summary, no resume prompt — the
+agent simply continues with a leaner, retrieval-curated working
+set.
+
+```
+context approaches threshold (configured: 50% / 80% / dynamic)
+        ↓
+PreCompact hook fires
+        ↓
+context_rebuilder.rebuild():
+  1. Read last N turns of <project>/.git/aelfrice/transcripts/turns.jsonl
+  2. Extract entities + intents from those turns (triple extractor)
+  3. Query aelfrice with those entities:
+       L0 locked beliefs (always in)
+       L1 BM25 hits (today) → posterior-weighted (v1.3+)
+       L2 session-scoped beliefs from same session_id
+  4. Pack to budget B (default ~2000 tokens, tunable)
+  5. Emit additionalContext block + a "continue" continuation cue
+        ↓
+Harness clears prior context; new session inherits the rebuild block
+        ↓
+User submits next prompt; agent continues without visible seam
+```
+
+## Motivation
+
+Three failure modes the rebuilder is designed to fix:
+
+1. **Recursive context cost.** A long-running session re-pays the
+   full prior-context token cost on every turn until compaction
+   fires. The rebuilder can fire earlier (at 50% rather than 80%+
+   thresholds) when the eval shows continuation quality holds, which
+   reduces the per-turn token cost across the steady-state work.
+
+2. **Default compaction loses task state.** Claude Code's built-in
+   compaction is a generic summarizer. It does not know which facts
+   in the session are load-bearing for the user's current task. An
+   aelfrice-driven rebuild can preferentially keep the user's
+   active task's beliefs and decisions — closing a gap the earlier
+   research line identified as the missing piece between cold-start
+   and post-compaction state (the cold-start path injected too much
+   general context; nothing closed the gap with a working-state
+   delta).
+
+3. **Manual `/clear` is a productivity tax.** Today the user is
+   tracking when to clear, what to re-paste, and how to resume.
+   The rebuilder makes that bookkeeping the system's job.
+
+## Non-goals
+
+- **A new ranker.** The rebuilder consumes whatever ranker
+  aelfrice ships. v1.4.0 ships against v1.3.0's partial Bayesian
+  ranker; v2.0.0 inherits the full one for free.
+- **A summarizer.** The rebuild is *retrieval*, not summarization.
+  No LLM is called inside the hook. Beliefs come back as their
+  literal stored content.
+- **A perfect zero-loss feature.** Set a regression band; do not
+  promise lossless. See "Validation."
+- **Codex parity at v1.4.0.** Codex has no equivalent of
+  PreCompact. A Codex slice is future work — likely a manual
+  `/aelf-resume` slash command + tool.
+
+## Design
+
+### Trigger policy
+
+Three trigger modes, configured via `.aelfrice.toml` (the project
+config file introduced in v1.1.0; the rebuilder adds new keys):
+
+- **`threshold`** (default): fire when the harness's pre-compaction
+  signal indicates context is at or above a configured fraction of
+  the model's window. Default fraction is set from eval-harness
+  calibration data, not hardcoded; an initial guess of 70% is used
+  during early calibration runs.
+- **`dynamic`**: fire based on a derived metric (e.g.,
+  rolling-window entropy of new beliefs per turn — when the agent
+  stops introducing new entities, working state is small enough to
+  rebuild safely). Implementation gated on eval-harness evidence
+  that the dynamic metric tracks continuation quality. May not
+  ship in v1.4.0.
+- **`manual`**: fire only on explicit `/aelf-rebuild` slash command
+  invocation. Useful for users who don't trust auto-trigger and
+  for the rebuilder's own QA.
+
+Whatever the trigger, the hook contract is the same: exit 0 in
+under 50ms even if ingest is in progress in the background.
+
+### What the hook reads
+
+The hook needs the most recent N turns of the conversation to
+seed the rebuild query. Source: the project's
+`<root>/.git/aelfrice/transcripts/turns.jsonl` (per
+[transcript_ingest.md](transcript_ingest.md)). The hook reads the
+tail of this file directly — fast, no network, no DB roundtrip
+required for the seed.
+
+`N` is a config key. Initial value: 10 (5 user, 5 assistant).
+Eval-tunable.
+
+### Rebuild algorithm
+
+```python
+def rebuild(
+    transcript_path: Path,
+    store: MemoryStore,
+    *,
+    n_recent_turns: int,
+    token_budget: int,
+    session_id: str | None,
+) -> str:
+    """Build a context block to inject as the new session start.
+
+    Returns a string that goes into Claude Code's hook
+    additionalContext. Must be deterministic given the same inputs
+    so eval-harness runs are reproducible.
+    """
+    recent = read_tail(transcript_path, n=n_recent_turns)
+
+    # Stage 1: seed the query. Triple-extract entities + intents
+    # from the recent turns; build a query string from them.
+    triples = extract_triples_batch(recent)
+    query = triples_to_query(triples)
+
+    # Stage 2: retrieve.
+    hits = store.retrieve(
+        query=query,
+        token_budget=token_budget,
+        # Session-scoped beliefs always pull. Cross-session
+        # beliefs ranked by L1 BM25 / posterior.
+        session_filter=session_id,
+        include_locked=True,  # L0 always in
+    )
+
+    # Stage 3: pack. Locked first, then session-scoped, then
+    # the open BM25 / posterior tail. Truncate at budget.
+    return format_context_block(hits, recent_turns=recent)
+```
+
+### Output format
+
+The hook emits a single XML-tag-delimited block, matching the v1.0
+hook's existing `<aelfrice-memory>` envelope so the model's prompt
+processing has one consistent signal:
+
+```xml
+<aelfrice-rebuild session_id="20260427T154010Z-3f8a">
+  <recent-turns>
+    <turn role="user">...</turn>
+    <turn role="assistant">...</turn>
+    ...
+  </recent-turns>
+  <retrieved-beliefs budget_used="1842/2000">
+    <belief id="..." score="..." locked="true">...</belief>
+    <belief id="..." score="...">...</belief>
+    ...
+  </retrieved-beliefs>
+  <continue/>
+</aelfrice-rebuild>
+```
+
+The `<continue/>` element is a marker prompt — a stable signal the
+agent learns to interpret as "resume the prior task using the
+above context, do not greet, do not summarize."
+
+### Coordination with the harness
+
+PreCompact hook fires *before* the harness compacts. Two modes:
+
+1. **Augment.** Hook emits additionalContext; the harness still runs
+   its own compaction afterwards. Result: both the harness summary
+   and our rebuild are in the new context. Bigger token cost, lower
+   risk.
+
+2. **Suppress + replace.** Hook emits additionalContext; the harness
+   skips compaction (Claude Code's `decision: "block"` semantics for
+   PreCompact, if available). Result: only our rebuild is in the
+   new context. Tighter token cost, higher risk if our rebuild is
+   incomplete.
+
+v1.4.0 ships **augment-mode only**. Suppress mode requires high
+confidence in the eval harness scores. Suppress mode is a v2.x
+candidate.
+
+### What does NOT change
+
+- The harness's transcript log under `~/.claude/projects/...` is
+  untouched. We don't read it, don't write it, don't depend on it.
+- The v1.0 `UserPromptSubmit` hook continues to inject memory
+  retrieval into every prompt. The rebuilder is orthogonal — it
+  fires only on PreCompact.
+- The v1.0.1 hook→retrieval feedback loop continues to log every
+  retrieval. The rebuilder's retrieval call goes through the same
+  `retrieve()` codepath and writes the same `feedback_history`
+  rows.
+
+## Validation
+
+This is the load-bearing section. Without a falsifiable eval, the
+"seamless" claim is not a claim, it's a vibe.
+
+### Eval harness
+
+A new harness at `benchmarks/context-rebuilder/eval_harness.py`
+(skeleton shipped alongside this spec) does:
+
+1. Read a corpus of replayable transcripts from
+   `benchmarks/context-rebuilder/eval_corpus/`. Each transcript
+   is a captured `turns.jsonl` from a real working session, with
+   PII scrubbed. Multiple transcripts; multiple task types
+   (debugging, planning, code-review, exploratory).
+2. For each transcript, fork at a midpoint turn `T`. Replay turns
+   `0..T` to populate a fresh aelfrice store.
+3. Force a clear at `T`. Run the rebuilder. Inject its output as
+   the new context.
+4. Replay turns `T+1..end` and let the agent continue. Compare:
+   - **Continuation fidelity**: does the agent answer the same
+     subsequent questions correctly? Scored binary by the agent's
+     responses against the ground-truth original session.
+   - **Token cost**: how many tokens did the rebuild emit vs. the
+     full-replay baseline?
+   - **Latency**: PreCompact hook wall-time from fire to
+     additionalContext emit.
+
+### Headline metric
+
+**Continuation fidelity at fixed token budget.** A regression band:
+v1.4.0 must hit ≥80% continuation fidelity at a token budget of
+≤30% of the full-replay baseline. v1.5.x targets 90%; v2.0.0
+targets 95%.
+
+These numbers are placeholders until the eval harness produces
+the v1.0.0 baseline. The actual targets get set after the first
+calibration run, not from this spec.
+
+### Per-trigger-mode tuning
+
+The threshold (50% / 70% / 80%) is not a guess. The eval harness
+sweeps trigger thresholds and produces a fidelity-vs-trigger curve
+per task type. The default ships at the threshold where fidelity
+is within the regression band on all task types.
+
+The dynamic-mode metric (entropy-based or other) is gated on
+showing it tracks fidelity better than a fixed threshold across
+task types. If the eval doesn't show that, dynamic mode does not
+ship.
+
+### Failure modes the eval must catch
+
+- **Working-state loss.** The agent had a partially-formed plan
+  pre-clear; post-rebuild, the plan is gone and the agent
+  re-derives from scratch (or worse, re-derives differently). The
+  eval should mark these as fidelity failures even if the
+  *eventual* answer is correct.
+- **Hallucinated continuation.** The rebuild was incomplete; the
+  agent confabulates plausible-sounding context. The eval scores
+  these as failures and the eval corpus should specifically
+  include questions the rebuild *cannot* recover (so the agent
+  has the option to say "I don't have that context" rather than
+  invent it).
+- **Trigger storms.** Threshold misconfigured; rebuilder fires
+  every 2 turns. Eval should detect via the per-session
+  rebuild-event count and gate trigger configs accordingly.
+
+## Acceptance criteria
+
+1. `aelf setup --rebuilder` (or equivalent flag on existing
+   `aelf setup`) installs the PreCompact hook idempotently.
+2. The hook contract is honored: exit 0 in <50ms regardless of
+   internal state.
+3. The eval harness ships and produces a calibration JSON file
+   showing fidelity-vs-trigger curves on at least 3 task types.
+4. Default trigger threshold is set from the calibration, not
+   hardcoded. The chosen threshold is documented in
+   `benchmarks/context-rebuilder/calibration_v1.4.0.json` and
+   referenced from the spec when v1.4.0 cuts.
+5. Manual mode (`/aelf-rebuild`) works as an explicit testing
+   surface and ships before threshold mode auto-triggers.
+6. Round-trip test: a real 50-turn session, force a midpoint
+   clear, observe the agent continues to answer correctly on
+   ≥80% of subsequent questions about prior turns.
+
+## Test plan
+
+- `tests/test_rebuilder_unit.py` — unit tests on rebuild()
+  determinism, token-budget packing, output format.
+- `tests/test_rebuilder_hook.py` — PreCompact hook script,
+  non-blocking contract, 50ms budget.
+- `benchmarks/context-rebuilder/eval_harness.py` — the eval
+  harness (skeleton shipped alongside this spec; corpus and
+  scoring fill out through v1.2.0–v1.4.0).
+- `tests/integration/test_rebuilder_roundtrip.py` — end-to-end
+  round-trip with a fixture transcript.
+
+Per project test policy: every test deterministic and short.
+Eval-harness runs are explicitly slow and live in `benchmarks/`,
+not `tests/` — they aren't run on every CI invocation.
+
+## Roadmap
+
+Listed in [ROADMAP.md](ROADMAP.md) as the v1.4.0 milestone. The
+"Context rebuilder" entry there is the user-facing summary; this
+document is the implementation contract.
+
+## Open questions
+
+These don't gate the spec but need answers before implementation:
+
+1. **PreCompact `decision: "block"` semantics.** Does Claude Code
+   currently honor it? If not, augment-mode is the only available
+   path until it does.
+2. **Trigger from where.** The harness's pre-compaction signal —
+   is it exposed to hooks, or do we have to compute "approaching
+   threshold" ourselves from token counts? If self-computed, that's
+   another small spec.
+3. **Slash command surface.** `/aelf-rebuild` for manual mode —
+   does it live in the v1.0 slash-commands surface or as a CLI
+   command piped through Bash?
+4. **Per-project vs. user-global config.** Trigger threshold
+   probably wants project-local override; the rebuilder behavior
+   probably wants user-global default. Reuse `.aelfrice.toml`
+   (v1.1.0) for the project layer.

--- a/docs/transcript_ingest.md
+++ b/docs/transcript_ingest.md
@@ -1,0 +1,306 @@
+# Transcript ingest
+
+**Status:** spec.
+**Target milestone:** v1.2.0 (rides alongside the commit-ingest hook
+and triple-extraction port; same machinery, different producer).
+**Dependencies:** the v1.2.0 ingest enrichment work — needs
+`Belief.session_id`, `Edge.anchor_text`, and the `DERIVED_FROM`
+edge type added before this is useful. Otherwise stdlib only.
+**Risk:** medium. Hook integration into the Claude Code transcript
+runtime; per-turn budget must stay sub-100ms or the hook degrades the
+user-facing latency of every prompt and every assistant turn.
+**Prior art:** the earlier research line shipped a working version
+of this in production, with a per-turn JSONL writer, a `PreCompact`
+rotation step, and a batch `ingest_jsonl()` reader. This spec ports
+that design forward to the v1.0+ aelfrice schema rather than
+copying — the implementation is being re-validated, not lifted.
+
+## Summary
+
+Two ingest paths that turn live conversation transcripts into beliefs
+and edges:
+
+1. **Live per-turn path.** A `UserPromptSubmit` hook + a `Stop` hook
+   that each append one JSONL line per turn to a project-scoped
+   `turns.jsonl`. Each line carries the turn text, role
+   (`user`|`assistant`), session id, and timestamp. Append-only,
+   sub-10ms, never blocks the model.
+
+2. **Batch ingest path.** A new `aelfrice.ingest.ingest_jsonl()`
+   function reads a `turns.jsonl` file, runs the existing
+   `ingest_turn` per line, and produces beliefs and edges with
+   `session_id` populated and `source='transcript'`. Invoked by:
+   (a) the `PreCompact` hook on rotation (see "Compaction
+   coupling"); (b) a CLI command `aelf ingest-transcript PATH` for
+   manual runs and CI tests; (c) any caller that wants to ingest a
+   captured session.
+
+These two paths together give every later v1.x retrieval feature a
+real production data source — the actual conversations the user is
+having with the agent, captured as they happen, ingested at
+compaction boundaries.
+
+```
+turn fires (user prompt or assistant stop)
+        ↓
+  hook script appends one JSONL line to turns.jsonl  (~5ms)
+        ↓
+  [eventually] PreCompact hook fires
+        ↓
+  rotate turns.jsonl → archive/turns-<ts>.jsonl
+  trigger ingest_jsonl(archive/turns-<ts>.jsonl)
+        ↓
+  one ingest_turn per line:
+     start_ingest_session(session_id=<derived>)
+     classify + emit beliefs
+     emit edges (DERIVED_FROM linking turns within a session,
+                 anchor_text = the literal turn text)
+     complete_ingest_session
+```
+
+## Motivation
+
+Three independent v1.x asks all bottleneck on this:
+
+1. **Closing the harness-conflict gap** documented at
+   [LIMITATIONS.md § harness conflict](LIMITATIONS.md). Today the
+   MCP receives no new beliefs from normal session activity; the
+   harness's auto-memory directive routes "save a memory" intents
+   elsewhere. Transcript ingest is a parallel write path that does
+   not depend on the harness directive at all — it captures
+   regardless.
+
+2. **Densifying production data for v1.3+ retrieval techniques.**
+   Production stores observed in development today have `session_id`
+   populated on a small fraction of beliefs and zero `DERIVED_FROM`
+   edges. Most v1.3+ retrieval techniques (entity-index, BFS
+   multi-hop, posterior-weighted ranking) read from edge structure
+   that v1.0 ingest paths do not produce densely. Transcript ingest
+   is a producer of both `session_id` and `DERIVED_FROM`, on the
+   densest data source aelfrice has access to (every conversation
+   turn).
+
+3. **Enabling the v1.4.0 context rebuilder**
+   ([context_rebuilder.md](context_rebuilder.md)). The rebuilder's
+   premise is that the full conversation log is recoverable from
+   aelfrice on demand. That premise requires this spec to ship
+   first.
+
+## Where transcripts come from
+
+Claude Code already writes per-session transcripts to
+`~/.claude/projects/<cwd-hash>/conversation_*.jsonl`. We do **not**
+read those directly because:
+
+- The path is undocumented and subject to change between Claude Code
+  releases.
+- The format is internal-harness JSON, not aelfrice's ingest schema.
+- Per-project `cwd-hash` collides with the same `cwd-hash` orphan
+  problem v1.1.0 solves for the memory DB.
+
+Instead, this spec writes its own canonical log via hook
+instrumentation. The Claude-Code-internal log stays untouched and
+remains the harness's ground truth for replay / audit.
+
+## Design
+
+### Per-turn hook script
+
+A new entry point `aelfrice.transcript_logger:main` registered as
+two hook events:
+
+- `UserPromptSubmit` — appends `{"role": "user", ...}`.
+- `Stop` — appends `{"role": "assistant", ...}`.
+
+Both hooks read the Claude Code hook JSON payload from stdin, extract
+the relevant text field (`prompt` for `UserPromptSubmit`, the most
+recent assistant turn for `Stop`), and append a single line to the
+project-scoped `turns.jsonl`. Both follow the v1.0 hook
+non-blocking contract: any exception writes to stderr and returns
+exit 0; the conversation must never stall on logger failure.
+
+Storage location: `<project-root>/.git/aelfrice/transcripts/turns.jsonl`
+(matches v1.1.0's in-repo DB location at
+`<root>/.git/aelfrice/memory.db`). Living under `.git/` means the
+file is structurally uncommittable — git does not track its own
+internals, so users do not need a gitignore entry per project. One
+file per project; rotated by PreCompact into a sibling
+`<root>/.git/aelfrice/transcripts/archive/` directory.
+
+This also matches the data-flow story: `turns.jsonl` feeds the
+brain-graph DB (which is itself under `.git/`), the brain graph
+serves retrieval at hook time, and nothing on this path is ever
+committed. The original conversation prose lives on disk locally and
+on the brain graph in extracted form locally, and that's it.
+
+### JSONL line schema
+
+```json
+{
+  "schema_version": 1,
+  "ts": "2026-04-27T15:42:11.337Z",
+  "role": "user",
+  "text": "What database does this project use?",
+  "session_id": "20260427T154010Z-3f8a",
+  "turn_id": "20260427T154211Z-7c2e",
+  "context": {
+    "cwd": "/abs/path/to/project",
+    "git_branch": "main",
+    "git_head": "abc1234"
+  }
+}
+```
+
+Notes:
+
+- `session_id` is derived once per Claude-Code session start and
+  stays stable for the duration. Source: a session-start hook that
+  writes a `session_id` env var the per-turn hooks read.
+- `turn_id` is unique per line; used by the rebuilder to thread
+  user→assistant pairs.
+- `context.git_*` is populated cheaply from `git rev-parse` and
+  `git symbolic-ref --short HEAD`. Failures (non-git directories)
+  set the fields to `null`; never block the hook.
+- `schema_version` lets future readers detect format drift without
+  breaking existing logs.
+
+### Batch ingest
+
+```python
+def ingest_jsonl(
+    store: MemoryStore,
+    jsonl_path: Path,
+    *,
+    source_label: str = "transcript",
+) -> IngestResult:
+    """Read a turns.jsonl file and ingest one belief per turn.
+
+    Each line: {"role": str, "text": str, "session_id": str, ...}.
+    Calls ingest_turn(text=..., source=source_label,
+    session_id=...) for each. Aggregates the IngestResults.
+
+    Backward-compat with v1.0 stores: if session_id is None or the
+    store doesn't carry it (legacy schema), still ingests the
+    belief; the session field is silently dropped.
+
+    Edges:
+      - Within a session, consecutive turns get a DERIVED_FROM edge
+        linking turn N+1's belief to turn N's belief, with
+        anchor_text = the prior turn's literal text.
+      - The triple extractor (separate v1.2.0 work) optionally adds
+        typed edges (CITES, SUPPORTS, CONTRADICTS) discovered in the
+        prose.
+
+    Idempotent: re-ingesting the same JSONL line is a no-op (deduped
+    on (session_id, turn_id)).
+    """
+```
+
+The implementation lifts the earlier research line's batch JSONL
+ingest design with these v1.x deltas:
+
+- v1.x carries `session_id` end-to-end (the predecessor implementation
+  accepted it as an arg-parity placeholder but did not persist it).
+- v1.x emits `DERIVED_FROM` edges explicitly; the predecessor left
+  edge emission to a separate relationship-detection pass.
+- v1.x sets `anchor_text` on every edge; predecessor edges carried
+  no anchor text.
+
+### Compaction coupling
+
+`PreCompact` hook fires when Claude Code is about to compact. The
+hook script:
+
+1. Writes a `{"event": "compaction_start", "ts": ...}` marker to
+   `turns.jsonl`.
+2. Renames `turns.jsonl` → `archive/turns-<iso8601-ts>.jsonl`.
+3. Spawns `aelf ingest-transcript archive/turns-<iso8601-ts>.jsonl`
+   in the background. (Background-spawn is critical: the PreCompact
+   path is on the user-facing latency budget.)
+4. Returns exit 0 immediately. New turns start writing to a fresh
+   `turns.jsonl`.
+
+`PostCompact` hook fires after compaction completes. Writes a
+`{"event": "compaction_complete", "ts": ...}` marker to the new
+`turns.jsonl` so the next archived segment carries an unambiguous
+boundary.
+
+These two markers let the rebuilder (separate spec) reason about
+session boundaries without needing the harness's internal compaction
+state.
+
+### `aelf setup` integration
+
+`aelf setup --transcript-ingest` adds the four hook entries
+(`UserPromptSubmit`, `Stop`, `PreCompact`, `PostCompact`) to
+`~/.claude/settings.json` or the project-scoped `.claude/settings.json`.
+Idempotent per the same contract as the existing v1.0 setup flow.
+
+`aelf unsetup --transcript-ingest` removes them.
+
+The flag is opt-in at v1.2.0. v1.3.0 may flip it on by default once
+the disk-footprint and latency telemetry on opt-in users is
+acceptable.
+
+## Acceptance criteria
+
+1. `aelf setup --transcript-ingest` writes four hook entries
+   idempotently to the appropriate `settings.json`.
+2. A round-trip test (manual): in a fresh project, run
+   `aelf setup --transcript-ingest`, hold a 5-turn conversation,
+   trigger a manual compact, verify `turns.jsonl` rotated to
+   `archive/`, verify the archived file ingested into the DB,
+   verify `aelf search` against a query about the conversation
+   surfaces the ingested beliefs.
+3. The per-turn hook stays sub-10ms p99 on a 50-turn conversation.
+4. The PreCompact hook returns exit 0 within 50ms regardless of
+   ingest progress (background-spawn requirement).
+5. `ingest_jsonl` is idempotent: re-running it on the same file
+   produces 0 new beliefs and 0 new edges.
+6. The schema migration is forward-compatible per the v1.x
+   convention: v1.0 stores ingest transcripts (silently dropping
+   `session_id`), v1.x stores ingest legacy logs (silently
+   dropping unknown fields).
+
+## Test plan
+
+- `tests/test_transcript_logger.py` — unit tests on the per-turn
+  JSONL write path, including non-blocking exception handling.
+- `tests/test_ingest_jsonl.py` — `ingest_jsonl` correctness, edge
+  emission, idempotency, schema-version handling.
+- `tests/test_compaction_rotation.py` — PreCompact rotation, marker
+  emission, background-spawn budget.
+- `tests/integration/test_round_trip.py` — full round-trip with a
+  fixture transcript.
+- `tests/test_setup_transcript_ingest.py` — `aelf setup
+  --transcript-ingest` idempotency, conflict detection with existing
+  hook entries.
+
+Per the project test policy, every test is deterministic and
+short-running.
+
+## Out of scope
+
+- The rebuilder itself. That's a separate spec
+  ([context_rebuilder.md](context_rebuilder.md)).
+- Codex transcript ingest. Codex doesn't have hooks the way Claude
+  Code does. A v1.x slice for Codex would need a different mechanism
+  — likely an `aelf log-turn` MCP tool the Codex side calls
+  explicitly. Out of scope for this spec.
+- Real-time ingest (per turn into the brain graph, rather than
+  per compaction). The earlier research line tested this and found
+  it added latency on the user-facing prompt path. Defer until the
+  rebuilder eval shows real-time is needed.
+- PII scrubbing on ingest. `turns.jsonl` lives under
+  `<root>/.git/aelfrice/transcripts/` and is structurally
+  uncommittable. Same for the brain-graph DB it feeds. Both stay
+  local. No scrub on the live ingest path. If a user ever
+  exports a transcript out-of-tree (eval corpus contribution,
+  bug report attachment), scrub at the export boundary — that's
+  a separate concern from this spec.
+
+## Roadmap
+
+Listed under v1.2.0 in [ROADMAP.md](ROADMAP.md) as the
+"Transcript-ingest hooks" bullet. v1.4.0 declares this spec as a
+hard prerequisite.


### PR DESCRIPTION
## Summary

- **ROADMAP.md** gains a v1.2.0 transcript-ingest bullet and a new v1.4.0 milestone for the context rebuilder.
- **`docs/transcript_ingest.md`** (new): per-turn `UserPromptSubmit` + `Stop` hooks write to `<root>/.git/aelfrice/transcripts/turns.jsonl`, `PreCompact` rotates and triggers a batch `ingest_jsonl()` path. Closes the harness-conflict write-path gap and produces `session_id` + `DERIVED_FROM` edges from real conversations.
- **`docs/context_rebuilder.md`** (new): `PreCompact` hook intercepts and replaces (augment-mode at v1.4.0; suppress is v2.x) the harness's default compaction with retrieval-curated beliefs against the session transcript. Three trigger modes; default threshold is calibrated from eval data, not hardcoded.
- **`benchmarks/context-rebuilder/`** (new): eval harness skeleton — locked metric names (`fidelity`, `token_cost_ratio`, `rebuild_latency_ms`) and run modes (`threshold-sweep`, `budget-sweep`, `dynamic`, `regression`) per the spec's acceptance criteria. Integration points raise `NotImplementedError` pending v1.2.0 transcript-ingest module.

## Why now

Both specs are docs-only and lock contracts well before any implementation work begins, so v1.2.0 / v1.4.0 planning isn't bottlenecked on coordinated multi-spec drafting later.

## Test plan

- [ ] CI passes (gitleaks + PII scan + commit-history audit + pytest)
- [ ] No code-path changes to existing modules; eval harness syntax-checks via `uv run python -c "import ast; ast.parse(open('benchmarks/context-rebuilder/eval_harness.py').read())"` (verified locally)
- [ ] Cross-references between the two specs and ROADMAP.md resolve (manual review)
- [ ] No new hard-coded thresholds — `docs/context_rebuilder.md` explicitly defers default trigger threshold and token budget to eval-harness calibration

## Open questions tracked in the rebuilder spec

1. PreCompact `decision: "block"` semantics in current Claude Code release.
2. Whether the harness's pre-compaction signal is exposed to hooks or self-computed.
3. Slash-command vs CLI surface for manual `/aelf-rebuild`.
4. Per-project vs user-global config layering.

These don't gate the spec but need answers before v1.4.0 implementation.