### PR TITLE
feat(v1.1.0): per-project DB resolution at .git/aelfrice/memory.db (#88)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -18,15 +18,19 @@ Commands:
   bench                            run the v0.9.0-rc benchmark harness
 
 DB path resolves from AELFRICE_DB environment variable when set,
-otherwise from ~/.aelfrice/memory.db. Callers can run `main(argv=...)`
-in-process for tests; the `aelf` entry point in pyproject.toml maps to
-`main()`.
+otherwise from <git-common-dir>/aelfrice/memory.db when cwd is inside
+a git work-tree, otherwise from ~/.aelfrice/memory.db. The git-common-dir
+branch makes worktrees of one repo share a single DB; .git/ is not
+git-tracked, so the brain graph never crosses the git boundary. Callers
+can run `main(argv=...)` in-process for tests; the `aelf` entry point in
+pyproject.toml maps to `main()`.
 """
 from __future__ import annotations
 
 import argparse
 import hashlib
 import os
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -82,11 +86,50 @@ _LOCK_ID_LEN: Final[int] = 16
 _VALID_SCOPES: Final[tuple[SettingsScope, ...]] = ("user", "project")
 
 
+def _git_common_dir() -> Path | None:
+    """Absolute path of cwd's git-common-dir, or None when not in a repo.
+
+    Two worktrees of one repo share a --git-common-dir, so resolving
+    against this gives them a single shared DB. Returns None when cwd
+    is outside any git work-tree, when the `git` binary is missing, or
+    when the rev-parse call fails for any reason — callers fall back to
+    the home-dir path.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    raw = result.stdout.strip()
+    if not raw:
+        return None
+    return Path(raw).resolve()
+
+
 def db_path() -> Path:
-    """Resolve the DB path from $AELFRICE_DB or the default."""
+    """Resolve the DB path.
+
+    Resolution order:
+    1. $AELFRICE_DB (explicit override; honoured even inside a git repo).
+    2. <git-common-dir>/aelfrice/memory.db when cwd is in a git work-tree.
+    3. ~/.aelfrice/memory.db (legacy global fallback for non-git dirs).
+
+    The DB stays under .git/, which git does not track — the brain
+    graph never crosses the git boundary.
+    """
     override = os.environ.get("AELFRICE_DB")
     if override:
         return Path(override)
+    git_dir = _git_common_dir()
+    if git_dir is not None:
+        return git_dir / "aelfrice" / DEFAULT_DB_FILENAME
     return DEFAULT_DB_DIR / DEFAULT_DB_FILENAME
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,11 +9,12 @@ property each, per the deterministic-atomic-short policy.
 from __future__ import annotations
 
 import io
+import subprocess
 from pathlib import Path
 
 import pytest
 
-from aelfrice.cli import db_path, main
+from aelfrice.cli import DEFAULT_DB_DIR, DEFAULT_DB_FILENAME, db_path, main
 from aelfrice.models import LOCK_USER
 from aelfrice.store import MemoryStore
 
@@ -42,11 +43,71 @@ def test_db_path_honors_env_override(tmp_path: Path,
     assert db_path() == target
 
 
-def test_db_path_falls_back_to_default_when_no_env(
-    monkeypatch: pytest.MonkeyPatch,
+def test_db_path_resolves_to_git_common_dir_when_in_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Inside a git work-tree, the DB lives at <git-common-dir>/aelfrice/memory.db."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
     monkeypatch.delenv("AELFRICE_DB", raising=False)
-    assert db_path().name == "memory.db"
+    monkeypatch.chdir(repo)
+    resolved = db_path()
+    assert resolved == (repo / ".git" / "aelfrice" / DEFAULT_DB_FILENAME).resolve()
+
+
+def test_db_path_worktrees_share_one_db(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two worktrees of one repo resolve to the same DB path."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    # need at least one commit before adding a worktree
+    (repo / "README").write_text("seed", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+         "-c", "commit.gpgsign=false",
+         "commit", "-q", "-m", "seed"],
+        cwd=repo, check=True,
+    )
+    wt = tmp_path / "worktree-feature"
+    subprocess.run(
+        ["git", "worktree", "add", "-q", "-b", "feature", str(wt)],
+        cwd=repo, check=True,
+    )
+    monkeypatch.delenv("AELFRICE_DB", raising=False)
+
+    monkeypatch.chdir(repo)
+    main_db = db_path()
+    monkeypatch.chdir(wt)
+    wt_db = db_path()
+    assert main_db == wt_db
+
+
+def test_db_path_falls_back_to_home_outside_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-git directory falls back to ~/.aelfrice/memory.db."""
+    monkeypatch.delenv("AELFRICE_DB", raising=False)
+    non_git = tmp_path / "no-repo"
+    non_git.mkdir()
+    monkeypatch.chdir(non_git)
+    assert db_path() == DEFAULT_DB_DIR / DEFAULT_DB_FILENAME
+
+
+def test_db_path_env_override_wins_inside_git_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """$AELFRICE_DB beats git-common-dir resolution."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    target = tmp_path / "explicit.db"
+    monkeypatch.setenv("AELFRICE_DB", str(target))
+    monkeypatch.chdir(repo)
+    assert db_path() == target
 
 
 # --- onboard ------------------------------------------------------------


### PR DESCRIPTION
## Why

v1.0 ships a single global DB at \`~/.aelfrice/memory.db\` shared across every project on the machine. Onboarding repo A and repo B writes both projects' beliefs into one file. Worktrees of one repo also collide. Workaround today: pin per-project with \`AELFRICE_DB=/abs/path/.aelfrice.db\` (e.g. via direnv).

Closes #88. Supersedes #91 (was phase 3 — folded into this PR because the public repo never had the SHA256(cwd) intermediate step the lab plan assumed).

## What

New \`cli.db_path()\` resolution chain (in priority order):

1. **\`\$AELFRICE_DB\`** — explicit override, honoured even inside a git repo.
2. **\`<git-common-dir>/aelfrice/memory.db\`** — when \`cwd\` is in a git work-tree.  Resolved via \`git rev-parse --path-format=absolute --git-common-dir\` (Git 2.31+, March 2021). Two worktrees of one repo share a \`--git-common-dir\` and therefore share one DB.
3. **\`~/.aelfrice/memory.db\`** — legacy global fallback for non-git directories.

The git-common-dir keying means worktrees of one repo share a single DB. \`.git/\` is not git-tracked, so the brain graph never crosses the git boundary. \`mcp_server.py\` and \`hook.py\` both delegate to \`cli.db_path()\` unchanged — they get the new chain for free.

New \`_git_common_dir()\` helper shells out to \`git rev-parse\` and returns \`None\` gracefully when \`git\` is unavailable or rev-parse fails. **No new runtime dependencies.**

## Tests

Added 5 unit tests in \`tests/test_cli.py\`:

- \`test_db_path_honors_env_override\` (existing — still passes)
- \`test_db_path_resolves_to_git_common_dir_when_in_repo\` (new)
- \`test_db_path_worktrees_share_one_db\` (new — uses \`git worktree add\`)
- \`test_db_path_falls_back_to_home_outside_git\` (new — replaces the old \"falls_back_to_default\" test which wasn't actually verifying the home-dir branch since the test process sits in a git repo)
- \`test_db_path_env_override_wins_inside_git_repo\` (new)

## Verification

- \`uv run pytest tests/ -q\` → **861 passed in 8.93s** (no regressions).
- \`uv run python -c \"from aelfrice.cli import db_path; print(db_path())\"\` from \`/tmp\` → \`/Users/thelorax/.aelfrice/memory.db\` (home-dir fallback).
- Same command from this repo → \`/Users/thelorax/projects/aelfrice/.git/aelfrice/memory.db\` (git-common-dir resolution).

## Out of scope (follow-ups on this branch or separate)

- **LIMITATIONS § Project identity** — depends on PR #87 (\`docs/local-only-contract\`) merging first to avoid conflicts. Will flip the entry from gap to shipped after PR #87 lands.
- **Documentation sweep** for ARCHITECTURE.md / COMMANDS.md / INSTALL.md / PRIVACY.md / README.md tagline references to \`~/.aelfrice/memory.db\` as the canonical default — separate doc-only commit on this branch (or follow-up PR).
- **\`aelf migrate\`** — copies beliefs from legacy global DB into per-project store. Tracked in #93.
- **Worktree concurrency tests** — tracked in #89.

## Local-only contract

\`.git/aelfrice/\` is not git-tracked. Brain graph never crosses the git boundary. No git-tracked files added by this PR.