### PR TITLE
release: v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-04-27
+
+Patch release: contradiction tie-breaker, `aelf resolve` CLI, onboard
+performance regression test, and a power-user CONFIG.md for the
+`.aelfrice.toml` schema. Three feature PRs and a docs PR landed
+between v1.0.2 and v1.0.3 — this release surfaces them to PyPI.
+
+### Added
+
+- `aelfrice.contradiction` module: `resolve_contradiction`,
+  `find_unresolved_contradictions`, `auto_resolve_all_contradictions`.
+  When the graph holds a CONTRADICTS edge, the tie-breaker picks a
+  winner via precedence (`user_stated > user_corrected >
+  document_recent`; ties broken by recency, then by id), creates a
+  SUPERSEDES edge from winner to loser, and writes a
+  `feedback_history` audit row tagged
+  `source='contradiction_tiebreaker:<rule>'`. v1.0.x collapses to
+  three precedence classes (the fourth `agent_inferred` class needs
+  a `Belief.origin` field landing in v1.1.0) (#75).
+- `aelf resolve` CLI subcommand (12th) — sweeps unresolved
+  CONTRADICTS edges in the store and runs the tie-breaker on each.
+  Matching `slash_commands/resolve.md`. The 1:1 CLI ↔ slash
+  invariant is preserved at 12/12 (#75).
+- `tests/regression/test_onboard_perf_50k_loc.py`: regression benchmark
+  asserting `scan_repo` finishes in under 60s on a synthetic ~55k-LOC
+  project (250 .py + 60 doc files). Marked `regression`. Held against
+  the `:memory:` store. Current measured time ~0.8s on Apple Silicon;
+  the 60s budget is a regression alarm, not a target (#76).
+- `docs/CONFIG.md`: power-user reference for `.aelfrice.toml` —
+  full schema, worked examples, and what each setting affects. Linked
+  from the noise-filter LIMITATIONS entry, the onboard CLI help, and
+  ARCHITECTURE.md (#74).
+
 ## [1.0.2] - 2026-04-27
 
 Patch release: per-project install routing, `aelf doctor` settings
@@ -61,31 +94,6 @@ Patch release: power-user ergonomics + retrieval-side feedback loop.
 Closes the v1.0.0 gap where hook retrievals never wrote audit rows,
 adds a no-config noise filter (with a TOML escape hatch), and ships
 `aelf --version` as a first-class CLI flag.
-
-### Added
-
-- `tests/regression/test_onboard_perf_50k_loc.py`: regression benchmark
-  asserting `scan_repo` finishes in under 60s on a synthetic ~55k-LOC
-  project (250 .py + 60 doc files). Marked `regression`. Held against
-  the `:memory:` store. Current measured time ~0.8s on Apple Silicon;
-  the 60s budget is a regression alarm, not a target (#NN).
-
-### Added
-
-- `aelfrice.contradiction` module: `resolve_contradiction`,
-  `find_unresolved_contradictions`, `auto_resolve_all_contradictions`.
-  When the graph holds a CONTRADICTS edge, the tie-breaker picks a
-  winner via precedence (`user_stated > user_corrected >
-  document_recent`; ties broken by recency, then by id), creates a
-  SUPERSEDES edge from winner to loser, and writes a
-  `feedback_history` audit row tagged
-  `source='contradiction_tiebreaker:<rule>'`. v1.0.1 collapses to
-  three precedence classes (the fourth `agent_inferred` class needs
-  a `Belief.origin` field landing in v1.1.0) (#NN).
-- `aelf resolve` CLI subcommand (12th) — sweeps unresolved
-  CONTRADICTS edges in the store and runs the tie-breaker on each.
-  Matching `slash_commands/resolve.md`. The 1:1 CLI ↔ slash
-  invariant is preserved at 12/12 (#NN).
 
 ### Added
 
@@ -399,7 +407,8 @@ Foundation milestone — store, models, config.
 - Initial repo scaffold: pyproject, README, GitHub Actions workflows,
   scan configs (commit `67b4343`).
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/robotrocketscience/aelfrice/compare/v0.9.0rc0...v1.0.0

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Same operations are available as MCP tools and Claude Code slash commands. Full 
 | v0.1 – v1.0 | **shipped** | core memory, CLI, MCP, hook wiring, synthetic benchmark, PyPI publish |
 | v1.0.1 | **shipped** | launch fix-up — hook→retrieval wiring, onboard noise, `aelf --version` |
 | v1.0.2 | **shipped** | per-project install routing, `aelf doctor`, release-docs CI gate |
+| v1.0.3 | **shipped** | contradiction tie-breaker + `aelf resolve`, onboard perf regression, CONFIG.md |
 | v1.1.0 | planned | project identity (`.git/aelfrice/`), edges→threads, status/health split |
 | v1.2.0 | planned | commit-ingest hook, triple-extraction port, harness-integration doc |
 | v1.3 | planned | retrieval wave — entity index + BFS multi-hop + LLM classification |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "1.0.2"
+version = "1.0.3"
 description = "Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Patch release surfacing four post-v1.0.2 PRs to PyPI:

- **#75** contradiction tie-breaker + `aelf resolve` CLI
- **#76** onboard-perf 50k-LOC regression test
- **#74** `docs/CONFIG.md` power-user reference for `.aelfrice.toml`
- **(this commit)** version bump + CHANGELOG reorganization

## CHANGELOG fix

PRs #75 and #76 had merged with their entries filed under `[1.0.1]` (which had already shipped). This release relocates those entries into a new `[1.0.3]` section. PR #74 (docs-only) had no CHANGELOG entry — added under `[1.0.3]` here.

The `[1.0.1]` section is now the authoritative record of what shipped at v1.0.1.

## Verification (local)

- ✅ `uv run pytest tests/` — 856 passed, 2 skipped (~9s)
- ✅ `uv build` — wheel + sdist clean
- ✅ `uv lock` — single-line bump (aelfrice 1.0.2 → 1.0.3)

## Pyright drift (flagged, not blocking this release)

`uv run pyright src/` reports 65 errors at this HEAD vs 42 at v1.0.2. These are inherited from v1.0.x feature PRs (#74, #75, #76, #69, #87) that merged through the staging-gate, which currently does not enforce pyright. This release commit touches only docs + version files; it does not introduce new typing errors. Worth a v1.0.4 cleanup pass.

## Test plan

- [x] CI green (gitleaks + PII + history audit + release-docs-check + pytest matrix)
- [x] CHANGELOG `[1.0.3]` section + compare-link footnote present
- [x] README roadmap row for v1.0.3 marked **shipped**

## Post-merge

1. `git switch main && git pull github main`
2. `git tag -s v1.0.3 -m "release: v1.0.3"`
3. `git push github v1.0.3` — triggers `publish.yml` for PyPI Trusted Publishing