### PR TITLE
docs: v1.2.0 spec triplet — ingest enrichment + triple extractor + commit-ingest hook

### DIFF
--- a/docs/commit_ingest_hook.md
+++ b/docs/commit_ingest_hook.md
@@ -1,0 +1,256 @@
+# Commit-ingest hook
+
+**Status:** spec.
+**Target milestone:** v1.2.0 (named on the public roadmap as
+"commit-ingest `PostToolUse` hook").
+**Dependencies:** stdlib only. Consumes the
+[triple extractor](triple_extractor.md) and the
+[ingest enrichment](ingest_enrichment.md) schema.
+**Risk:** medium. Hook integration into the Claude Code transcript
+runtime; runtime budget must stay tight or the hook degrades the
+user-facing latency of every commit.
+
+## Summary
+
+A Claude Code `PostToolUse` hook that fires after a successful
+`git commit` Bash invocation, parses the commit message, runs the
+triple extractor on the prose, and inserts the resulting beliefs
+and edges under a session derived from the git context. Closes the
+v1.0 limitation that the belief graph only grows on explicit
+`aelf onboard` / `aelf remember` calls.
+
+```
+git commit -m "extends triple-extractor to handle DERIVED_FROM"
+        ↓
+  PostToolUse hook fires (cmd matched ^git commit\b)
+        ↓
+  read commit message + git show --stat HEAD
+        ↓
+  start_ingest_session(model="commit-ingest", project_context=<repo>)
+  triples = extract_triples(commit_message)
+  ingest_triples(store, triples, session_id=...)
+  complete_ingest_session(session_id)
+```
+
+## Motivation
+
+Every reasonable v1.x retrieval technique reads from edge structure
+(typed edges, anchor text, session groupings). Today's ingest paths
+do not produce that structure during normal session activity — the
+graph grows only when a user explicitly runs `aelf remember` or
+`aelf onboard`. The user shouldn't have to remember to hand-write
+relationships; commit messages already encode them in prose. This
+hook turns every commit into an ingest event.
+
+This is also the v1.x mechanism through which production data
+finally starts populating `Edge.anchor_text`, `Belief.session_id`,
+and `DERIVED_FROM` edges — the schema fields the
+[ingest enrichment](ingest_enrichment.md) spec adds. Without this
+hook (or an equivalent), those fields would stay scarce in
+production even after the schema migrations land.
+
+## Design
+
+### Hook registration
+
+A new entry point `aelfrice.hook_commit_ingest:main` registered as
+a Claude Code `PostToolUse` hook. The hook configuration matches
+on `Bash` tool calls whose command starts with `git commit` and
+exited successfully (non-zero exit codes mean no commit happened).
+
+Configuration lives under the user's `~/.claude/settings.json` (the
+existing hook-config surface). `aelf setup` writes the entry on
+install if the user opts in.
+
+### Hook body
+
+```python
+def main() -> None:
+    """PostToolUse handler for git commit."""
+    transcript = read_transcript_input()
+    if not _is_successful_git_commit(transcript):
+        return
+    commit_message = _extract_commit_message_from_diff(transcript)
+    if not commit_message.strip():
+        return
+
+    store = _open_default_store()
+    session_id = _derive_session_id_from_git_context()
+    try:
+        store.start_ingest_session(
+            session_id=session_id,
+            model="commit-ingest",
+            project_context=_repo_relative_cwd(),
+        )
+        triples = extract_triples(commit_message)
+        result = ingest_triples(store, triples, session_id=session_id)
+        _audit_log(store, session_id, result)
+    finally:
+        store.complete_ingest_session(session_id)
+```
+
+### Session id derivation
+
+The hook derives `session_id` from git context rather than asking
+the user or generating a random uuid:
+
+```
+session_id = sha256(branch_name + ":" + commit_hash)[:16]
+```
+
+Stable across hook invocations on the same commit (idempotent if
+the hook fires twice). Distinct per commit. Surface-stable across
+machines (the same commit on two clones produces the same id),
+which makes future cross-machine session deduplication easier.
+
+The hook is self-contained: start session, extract, insert, complete
+session, all in one fire.
+
+### Latency budget
+
+The hook runs synchronously after every commit. User-facing latency
+matters — the hook must not add perceptible delay to a `git commit`
+followed by a `git status`. Budget: **median ≤ 30 ms, p95 ≤ 100 ms**
+on a 200-character commit message.
+
+Tactics:
+
+1. **Lazy import** of `aelfrice.triple_extractor` and
+   `aelfrice.store`. Cold-start a Python interpreter is the
+   dominant cost on most systems.
+2. **Skip work on empty messages.** Merge commits, automated
+   commits with empty bodies, etc. exit immediately.
+3. **Cap message size.** Truncate commit messages above 4 KB
+   before extraction. Long commit messages are rare; the cap
+   bounds the worst case.
+4. **Skip the diff.** v1.2.0 ships extracting from the commit
+   message only. Diff-aware extraction is a v1.3+ candidate once
+   we know whether commit-message-only catches enough relations
+   in practice.
+5. **Read-write to the SQLite store with WAL.** Concurrent reads
+   from other aelfrice consumers are not blocked.
+
+A regression test verifies the budget on a representative fixture.
+
+### What gets ingested
+
+- **Beliefs.** Each unique noun phrase resolved by the triple
+  extractor's content-hash lookup.
+- **Edges.** One per extracted triple, typed by the relation
+  template, `anchor_text` populated from the citing commit-message
+  substring.
+- **Session.** One row per commit; `session_id` derived as above.
+
+What does NOT get ingested:
+
+- The diff itself. Out of scope at v1.2.0.
+- File metadata (paths touched, file count, etc.). The v1.0
+  filesystem-walk scanner covers that surface.
+- Author / timestamp metadata. The store records `created_at` per
+  belief; nothing more is needed.
+
+### Failure modes
+
+- **Hook crashes mid-extraction.** The session is left open. The
+  store's `complete_ingest_session` is idempotent on re-entry, and
+  a follow-up sweep can close orphans (out of scope for v1.2.0).
+- **Store is locked by another process.** Hook returns silently;
+  no commit is degraded by an aelfrice problem. Logs a single line
+  to a per-project log file for post-hoc debugging.
+- **Triple extractor produces zero triples.** Normal case for
+  one-word commit messages; hook completes the session with no
+  inserts and exits.
+- **Disk full / permission error.** Same as locked: silent skip,
+  one-line log.
+
+The principle: the hook may NEVER cause a `git commit` to feel
+broken. Worst case is "memory didn't grow this commit," which is
+the same as v1.0 behavior. Brain-graph writes are local-only — the
+hook never crosses the git boundary or any network boundary.
+
+### Opt-in surface
+
+`aelf setup --commit-ingest` writes the hook configuration. Default
+on fresh install: opt-in (the v1.0.1 hook→retrieval wiring is
+opt-in too; consistency).
+
+`aelf setup --no-commit-ingest` removes it. Same shape as the
+existing `UserPromptSubmit` hook surface.
+
+## Acceptance criteria
+
+1. The hook fires on a successful `git commit` Bash invocation and
+   does NOT fire on a failed one (exit code != 0).
+2. Empty / whitespace-only commit messages are no-ops; the hook
+   exits without opening the store.
+3. A commit message containing one extractable triple produces:
+   one new session row, two new beliefs (if both noun phrases are
+   new), one new edge with non-empty `anchor_text`, all stamped
+   with the derived `session_id`.
+4. Re-running the same hook on the same commit (idempotency) does
+   not produce new beliefs or duplicate edges.
+5. The same commit on two different clones produces the same
+   `session_id` (cross-machine session stability).
+6. Median latency on a 200-char commit message ≤ 30 ms; p95 ≤ 100 ms
+   on commodity hardware. Verified by a regression test in
+   `tests/regression/`.
+7. Store-locked / disk-full / permission-error conditions cause
+   the hook to exit silently with one log line; the `git commit`
+   itself is not affected.
+8. `aelf setup --commit-ingest` writes the hook config and
+   `aelf setup --no-commit-ingest` removes it. Idempotent in both
+   directions.
+
+## Test plan
+
+- `tests/test_commit_ingest_hook.py` covering criteria 1–5 + 7–8.
+- `tests/regression/test_commit_ingest_latency.py` for criterion 6.
+  Uses `time.perf_counter`, runs N=20, asserts median + p95.
+- All deterministic. Subprocess git tests use a fresh `:memory:`
+  store and a temporary git repo per test.
+- Wall-clock budget: < 2 s per test (the regression test is the
+  longest at ~1 s for N=20 commits).
+
+## Out of scope
+
+- Diff-based extraction. Commit message only at v1.2.0.
+- LLM-augmented extraction. Mechanical only.
+- Cross-repo session linking. Each repo's hook produces its own
+  session ids.
+- Pre-commit ingest. Only PostToolUse on successful commit; pre-
+  commit ingest could double-write on amended commits.
+- Push-time ingest. Out of scope; commits, not pushes, are the
+  natural ingest unit for "what did this work establish."
+- Squash / rebase handling. The hook fires once per resulting
+  commit. Old session ids are garbage; cleanup is a follow-up.
+
+## What unblocks when this lands
+
+This is the first ingest path that:
+
+- Populates `Edge.anchor_text` densely on real corpora — the
+  prereq for the v1.3.0 augmented-BM25F retrieval work.
+- Populates `Belief.session_id` densely — the prereq for
+  session-coherent supersession work in v1.3.0+.
+- Emits `DERIVED_FROM` edges on commits that mention "derived from
+  / based on / extends" — the second prereq for that work.
+
+Combined with the v1.0.1 hook→retrieval wiring (which produces
+feedback events on every retrieval) and the v1.2.0 transcript-ingest
+hooks, v1.2.0 is the milestone where production data finally starts
+looking like the data the v1.3+ techniques expect.
+
+## Open questions
+
+- Should `aelf setup --commit-ingest` be the default on install at
+  v1.2.0, or stay opt-in like the v1.0.1 hook? Recommendation:
+  opt-in at v1.2.0; flip to default-on at v1.3.0 once a
+  representative corpus shows the latency budget holds in the wild.
+- Diff-based extraction is the natural v1.3.0 extension. Worth
+  reserving a `--diff` flag on the hook config now so adding it
+  later doesn't require a config rewrite. Recommendation: yes,
+  reserve the flag with default `False`.
+- Squash / rebase produces stale session ids whose commits no
+  longer exist. A garbage-collection pass to remove orphan
+  sessions is a v1.x housekeeping item — flagged here, not
+  addressed.

--- a/docs/ingest_enrichment.md
+++ b/docs/ingest_enrichment.md
@@ -1,0 +1,271 @@
+# Ingest enrichment
+
+**Status:** spec.
+**Target milestone:** v1.2.0 (alongside the commit-ingest hook,
+transcript-ingest, and triple-extraction port already on the public
+roadmap).
+**Dependencies:** stdlib only.
+**Risk:** medium. Three small schema additions plus a contract for
+what new ingest paths must populate. Backward-compatible — existing
+v1.0 stores read forward without alteration.
+
+## Summary
+
+Three coupled schema additions to the ingest path that, together,
+unblock several downstream retrieval techniques whose synthetic
+results cannot fire on real production data because the upstream
+ingest does not currently write the fields they read:
+
+1. **Sessions on beliefs.** A new ingest call carries a `session_id`;
+   the store records it on every belief inserted in that call.
+2. **Anchor text on edges.** A new `anchor_text` column on `edges`,
+   populated by ingest paths that have access to the citing belief's
+   own phrasing of the relationship.
+3. **`DERIVED_FROM` re-added** to the edge-type vocabulary, with an
+   ingest path positioned to emit it.
+
+These changes are bundled in one spec because they share an
+implementation surface (the ingest module + the store mutators), have
+the same migration shape (nullable column / opt-in edge type), and
+the same correctness story (fields populated only on the new write
+path; existing rows unchanged).
+
+## Motivation
+
+A retrieval technique that reads a field the ingest pipeline never
+writes lands as dead code. Several downstream v1.3+ retrieval
+techniques on the roadmap depend on data the v1.0 ingest paths do not
+produce:
+
+- Posterior-weighted ranking reads `(α, β)` updated by
+  `apply_feedback`. Without dense feedback events, the signal stays
+  flat against the prior — the technique would not move ranking on
+  real corpora.
+- Augmented BM25F reads `Edge.anchor_text`. v1.0 edges have no
+  anchor text — the technique would index empty strings.
+- Session-coherent supersession reads `Belief.session_id` plus
+  `RELATES_TO` / `DERIVED_FROM` edges. v1.0 stores have neither
+  populated densely.
+
+This spec lands the schema. The producers that populate it densely
+are the v1.2.0 transcript-ingest hooks, commit-ingest hook, and
+triple-extraction port (each documented separately).
+
+## Design
+
+### 1. Sessions on beliefs
+
+Add a nullable `session_id` column to `beliefs`:
+
+```sql
+ALTER TABLE beliefs ADD COLUMN session_id TEXT;
+```
+
+A new ingest entry point `start_ingest_session(model: str | None,
+project_context: str | None) -> str` returns a fresh session id and
+records the open session. Subsequent ingest calls take an optional
+`session_id` parameter; when present, the store writes it on every
+belief inserted in the call. Caller is responsible for calling
+`complete_ingest_session(session_id)` at the end of a logical group.
+
+Bare ingest (no session) is still allowed for backward compatibility
+— `session_id` stays NULL on those beliefs, and any downstream
+technique that requires session-coherent grouping simply does not
+fire on legacy rows. Conservative-failure behavior, no false
+positives on legacy data.
+
+The existing `MemoryStore.create_session` / `complete_session`
+methods (which today are no-ops) become the natural entry points.
+
+### 2. Anchor text on edges
+
+Add a nullable `anchor_text` column to `edges`:
+
+```sql
+ALTER TABLE edges ADD COLUMN anchor_text TEXT;
+```
+
+`anchor_text` is a short free-text label the citing belief's author
+wrote describing the relationship. Example: belief A `CITES` belief
+B with `anchor_text = "the WAL discussion"`.
+
+The `Edge` dataclass gains a corresponding optional field:
+
+```python
+@dataclass
+class Edge:
+    src: str
+    dst: str
+    type: str
+    weight: float
+    anchor_text: str | None = None
+```
+
+Ingest contract: any path that has access to the citing prose at
+edge-creation time MUST populate `anchor_text`. This includes the
+v1.2.0 triple-extraction port (which reads sentences and identifies
+relationships, so the surrounding prose is in scope) and the
+v1.2.0 commit-ingest hook (which reads commit messages, where
+"because of X" / "supersedes Y" framing is common).
+
+Ingest paths that lack the source prose (programmatic edge creation
+from internal logic; tests; bulk imports) leave `anchor_text` NULL.
+Downstream augmented-BM25F retrieval ignores NULL anchors, so legacy
+edges are neutral — neither helping nor hurting retrieval.
+
+### 3. `DERIVED_FROM` edge type
+
+Re-add `DERIVED_FROM` to `EDGE_TYPES` and `EDGE_VALENCE`:
+
+```python
+EDGE_DERIVED_FROM: Final[str] = "DERIVED_FROM"
+
+EDGE_VALENCE[EDGE_DERIVED_FROM] = 0.5   # mirrors CITES
+```
+
+The valence weight matches `CITES` because the relationships are
+structurally similar: B `CITES` A and B `DERIVED_FROM` A both
+indicate B's content depends on A's existence. Distinct types because
+`DERIVED_FROM` carries a stronger contextual coupling (the sibling
+becomes stale if A is superseded; a citer does not).
+
+The producer is the v1.2.0 triple-extraction port. Triples of the
+form `(B, derived-from, A)` map directly. Programmatic
+`store.insert_edge` calls can also emit `DERIVED_FROM` when the
+caller knows the relationship is derivational rather than citational.
+
+### Interlock with `apply_feedback`
+
+This spec does NOT add a new feedback path. The v1.0.1 hook→retrieval
+wiring already commits to writing one `feedback_history` row per
+hook-time retrieval; that fix is the natural producer of feedback
+events on the read side. Once v1.0.1 is exercised in agent loops,
+feedback density should climb to a value sufficient to drive
+posterior-weighted ranking.
+
+If a re-survey on representative production data shows density still
+lagging, this spec needs a follow-up patch with explicit feedback-
+emission rules (e.g., one feedback row per `aelf onboard` call; one
+per `aelf remember`). For now, leave that to v1.0.1's loop and
+re-measure.
+
+### Backward compatibility
+
+All three changes are forward-compatible:
+
+- `ALTER TABLE` adds nullable columns; existing rows remain readable.
+- `EDGE_TYPES` is a frozenset; adding to it does not break enumeration
+  callers.
+- The `Edge` dataclass field has a default of `None`; existing
+  callers that construct without `anchor_text` keep working.
+- The new `start_ingest_session` entry point is additive; existing
+  ingest paths that don't use it produce beliefs with `session_id =
+  NULL`, which is the same as today.
+
+A v1.x store opened by a v1.0 reader sees the new columns ignored
+(SQLite is permissive about unknown columns on SELECT *). A v1.0
+store opened by a v1.x reader sees the new columns NULL. No
+schema-version table needed for this round.
+
+## Acceptance criteria
+
+### Sessions
+
+1. `start_ingest_session(model="x")` returns a fresh non-empty id and
+   records it in the `sessions` table (or equivalent).
+2. Ingest calls passing `session_id=X` write `X` to `beliefs.session_id`
+   on every inserted belief.
+3. `complete_ingest_session(X)` is idempotent and does not fail when
+   the session is already completed.
+4. Ingest calls without `session_id` produce beliefs with
+   `session_id = NULL`. Existing v1.0 ingest tests continue to pass.
+
+### Anchor text
+
+5. `Edge` constructed without `anchor_text` has the field set to None.
+6. `MemoryStore.insert_edge(e)` persists `e.anchor_text` exactly,
+   including None.
+7. The store's `Edge` round-trip preserves `anchor_text` through
+   `insert_edge` → `get_edge`.
+
+### `DERIVED_FROM`
+
+8. `EDGE_TYPES` contains `DERIVED_FROM` and `EDGE_VALENCE` returns
+   `0.5` for it.
+9. `MemoryStore.insert_edge` accepts and persists `DERIVED_FROM`-typed
+   edges.
+10. `propagate_valence` walks `DERIVED_FROM` edges with the same
+    semantics as `CITES` (positive propagation, attenuated by broker
+    confidence).
+
+### Migration
+
+11. A v1.0 SQLite fixture file opens cleanly with the v1.x store and
+    all CRUD round-trips succeed on existing rows.
+12. The `ALTER TABLE` migrations are idempotent (running twice does
+    not error).
+
+## Test plan
+
+- `tests/test_ingest_session.py` — sessions sub-feature (criteria 1–4).
+- `tests/test_edge_anchor_text.py` — anchor sub-feature (criteria 5–7).
+- `tests/test_edge_type_derived_from.py` — `DERIVED_FROM`
+  sub-feature (criteria 8–10).
+- `tests/test_v1_to_v1x_migration.py` — backward compat (criteria
+  11–12). Requires a small fixture v1.0 SQLite file under
+  `tests/fixtures/`.
+- All deterministic, in-memory `:memory:` store, < 200 ms per test
+  except the migration test (< 1 s).
+
+## Out of scope
+
+- Implementing the downstream techniques that consume these fields
+  (augmented BM25F, posterior-weighted ranking, session-coherent
+  supersession). Each lands in v1.3.0+ with its own spec.
+- Backfilling `anchor_text` or `session_id` on existing beliefs.
+  Legacy rows stay NULL; downstream techniques degrade gracefully on
+  NULL inputs.
+- LLM-generated anchor text. The spec is purely mechanical — anchor
+  text comes from the ingest path's source prose, not from a model.
+- Cross-session belief sharing. A belief belongs to exactly one
+  session (or none). Multi-session membership is a future v2.x
+  consideration if a use case emerges.
+- Session expiration / garbage collection. Sessions live until
+  explicitly completed; orphan-session cleanup is a follow-up.
+
+## Open questions
+
+- Should `start_ingest_session` write a `sessions` row immediately,
+  or only on first belief insert? Immediate is simpler;
+  lazy avoids empty-session rows. Recommendation: immediate
+  (simpler; orphan cleanup handles the rare empty-session case).
+- Should `anchor_text` have a max length cap? Real anchor text is
+  short prose (~20–200 chars). A max of 1000 protects against
+  pathological writes without constraining real use. Recommendation:
+  cap at 1000 chars at the dataclass level; truncate with a warning
+  rather than reject.
+- Should `DERIVED_FROM` participate in the supersession cascade
+  predicate? Yes — that's the entire point of re-adding it.
+  Confirmed by the future v1.3+/v2.0 supersession-cascade work that
+  reads it.
+
+## Producers (the actual ingest paths that populate the new fields)
+
+The schema this spec adds is necessary but not sufficient — fields
+must be populated by some ingest path. The v1.2.0 milestone names
+three producers, each documented separately:
+
+- [`triple_extractor.md`](triple_extractor.md) — pure function
+  reading prose and emitting `(subject, relation, object)` triples
+  with `anchor_text`. Reusable by every ingest caller.
+- [`commit_ingest_hook.md`](commit_ingest_hook.md) — Claude Code
+  PostToolUse hook that fires on `git commit`, runs the triple
+  extractor on the commit message, and inserts under a session
+  derived from git context.
+- [`transcript_ingest.md`](transcript_ingest.md) — per-turn
+  conversation logger plus `PreCompact` rotation that ingests entire
+  conversations under a per-session id.
+
+Together these three producers populate `session_id`, `anchor_text`,
+and `DERIVED_FROM` densely on real corpora during normal Claude Code
+sessions.

--- a/docs/triple_extractor.md
+++ b/docs/triple_extractor.md
@@ -1,0 +1,214 @@
+# Triple extractor
+
+**Status:** spec.
+**Target milestone:** v1.2.0 (named on the public roadmap as
+"triple-extraction port").
+**Dependencies:** stdlib only (regex). No LLM. Consumes the
+[ingest enrichment](ingest_enrichment.md) schema.
+**Risk:** medium. New module surface; correctness depends on the
+extraction patterns generalizing beyond the test fixtures.
+
+## Summary
+
+A pure function that reads prose and emits zero or more
+`(subject, relation, object)` triples. Each triple becomes an `Edge`
+between two beliefs (creating either or both as needed) with the
+relation mapped to an `EDGE_TYPES` member and `anchor_text`
+populated from the citing prose. Reusable by every v1.x ingest
+caller that has prose to extract from — the commit-ingest hook,
+transcript-ingest, manual `aelf remember` calls, the v1.3.0
+entity-index path.
+
+```python
+def extract_triples(text: str) -> list[Triple]:
+    """Pure extraction. No store side-effects."""
+
+def ingest_triples(
+    store: MemoryStore,
+    triples: list[Triple],
+    session_id: str | None = None,
+) -> IngestResult:
+    """Apply extracted triples to the store."""
+```
+
+The split keeps extraction testable in isolation and lets callers
+inspect / filter triples before they hit the store.
+
+## Motivation
+
+The v1.0 ingest paths (filesystem walk, git log scanner, Python AST)
+produce beliefs with content but no relational edges between them.
+The retrieval-side techniques planned for v1.3+ (BFS multi-hop,
+entity index, augmented BM25F, supersession cascade, posterior-
+weighted ranking) all benefit from — or require — typed edges with
+non-empty `anchor_text`. The triple extractor is the first ingest
+surface that produces those edges from real prose.
+
+The v1.2.0 commit-ingest hook and transcript-ingest are the named
+consumers at this milestone, but the extractor is positioned to serve
+every prose-ingesting caller that lands later. Building it as a
+reusable library rather than embedding it in any one hook is what
+keeps that promise.
+
+## Design
+
+### Module: `src/aelfrice/triple_extractor.py`
+
+Two pieces, each independently testable.
+
+#### `extract_triples(text: str) -> list[Triple]`
+
+Pure function. Input is a free-text string (commit message, prose
+paragraph, sentence). Output is a list of `Triple` dataclass
+instances. No store reference; no side effects.
+
+```python
+@dataclass(frozen=True)
+class Triple:
+    subject: str        # short noun phrase
+    relation: str       # one of EDGE_TYPES
+    object: str         # short noun phrase
+    anchor_text: str    # the substring of `text` the triple was extracted from
+```
+
+The extractor matches a fixed set of relational templates and emits
+one `Triple` per match. Initial template set:
+
+| pattern | edge type | example |
+| --- | --- | --- |
+| `X supports Y` / `Y is supported by X` | `SUPPORTS` | "the new index supports faster queries" |
+| `X cites Y` / `X mentions Y` | `CITES` | "the proposal cites RFC 8259" |
+| `X contradicts Y` / `X disagrees with Y` | `CONTRADICTS` | "the new finding contradicts the earlier paper" |
+| `X supersedes Y` / `X replaces Y` | `SUPERSEDES` | "this commit replaces the legacy parser" |
+| `X relates to Y` / `X is related to Y` | `RELATES_TO` | "the cache layer relates to retrieval" |
+| `X is derived from Y` / `X is based on Y` / `X extends Y` | `DERIVED_FROM` | "the spec is derived from the prior memo" |
+
+Patterns are mechanical (regex + light noun-phrase heuristics).
+Implementation can use a small grammar of capitalized words /
+dashes / underscores for noun phrases; punctuation and conjunctions
+delimit candidate boundaries. No POS tagger, no embedding, no LLM.
+
+`anchor_text` is the literal matched substring (with surrounding
+context up to ~80 chars), preserving the citing prose's own
+phrasing.
+
+#### `ingest_triples(store, triples, session_id=None) -> IngestResult`
+
+Side-effecting. For each `Triple`:
+
+1. Resolve / create the subject belief (look up by `content_hash`;
+   create a new belief if absent).
+2. Resolve / create the object belief.
+3. Insert an `Edge(src=subject_id, dst=object_id, type=relation,
+   weight=1.0, anchor_text=triple.anchor_text)`.
+
+`session_id` (if provided) is written to every newly-created belief
+per the [ingest enrichment](ingest_enrichment.md) spec.
+
+```python
+@dataclass(frozen=True)
+class IngestResult:
+    new_beliefs: list[str]      # ids
+    new_edges: list[tuple[str, str, str]]
+    skipped_duplicate_edges: int
+    skipped_no_subject_or_object: int
+```
+
+### Resolution policy
+
+- **Subject / object resolution:** content-hash lookup. Same noun
+  phrase → same belief id. If the lookup misses, create a new
+  belief with `type=BELIEF_FACTUAL`, `lock_level=LOCK_NONE`, and
+  the noun phrase as content. Future v1.x callers can override
+  the type via a kwarg if context demands it.
+- **Edge dedup:** if the `(src, dst, type)` tuple already exists,
+  do not insert a second edge. Update `anchor_text` to the new
+  value if provided (last-write-wins, simple).
+- **Self-edges:** subject == object after resolution → skip.
+
+### Confidence stance
+
+Newly-created beliefs from extraction get the project default
+prior, NOT a boosted prior. The triple extractor is mechanical,
+non-authoritative, and may extract noise. Downstream `apply_feedback`
+calls (or user `aelf lock`) are how a triple-derived belief earns
+posterior confidence.
+
+### What this spec does NOT do
+
+- It does NOT decide *when* to extract — that is the caller's
+  responsibility (the commit-ingest hook fires on commits;
+  transcript-ingest fires per turn; seed-file ingest fires on
+  `aelf onboard`).
+- It does NOT do co-reference resolution. "the parser" in one
+  triple and "the parser" in another both resolve to the same
+  belief by content hash; "the parser" and "our parser" do not.
+  Coref is a v2.x consideration if production data shows the gap.
+- It does NOT extract from structured input (JSON, AST). Those
+  callers should produce edges directly via `store.insert_edge()`
+  with the relevant `anchor_text`.
+
+## Acceptance criteria
+
+1. `extract_triples("the new index supports faster queries")`
+   returns at least one triple with relation `SUPPORTS`.
+2. `extract_triples("")` and `extract_triples("no relational
+   structure here")` return empty lists.
+3. `extract_triples` produces a `Triple` whose `anchor_text` is a
+   substring of the input.
+4. Each triple's `relation` field is in `EDGE_TYPES` (no extractor
+   ever emits an unknown edge type).
+5. `ingest_triples` is idempotent: calling twice with the same
+   triples produces zero new edges on the second call.
+6. `ingest_triples` writes `session_id` on every new belief when
+   the kwarg is provided; leaves NULL when omitted.
+7. A triple whose subject and object resolve to the same belief id
+   is dropped; the count appears in
+   `IngestResult.skipped_no_subject_or_object`.
+8. `extract_triples("X is derived from Y")` produces a triple with
+   relation `DERIVED_FROM`. (Validates that ingest-enrichment's
+   `DERIVED_FROM` re-add has a real producer.)
+
+## Test plan
+
+- `tests/test_triple_extractor_patterns.py` — one test per relation
+  template (criteria 1, 4, 8). Each fixture is a single sentence
+  that triggers exactly one pattern.
+- `tests/test_triple_extractor_negatives.py` — empty / non-relational
+  / ambiguous inputs (criterion 2, plus "extracts nothing rather
+  than something wrong" cases).
+- `tests/test_triple_extractor_anchor_text.py` — anchor text is a
+  substring of the input (criterion 3).
+- `tests/test_ingest_triples_idempotency.py` — idempotency +
+  session_id propagation + self-edge handling (criteria 5, 6, 7).
+- All deterministic, in-memory `:memory:` store, < 200 ms per test.
+
+## Out of scope
+
+- LLM-based extraction. The v1.3.0 LLM-classification onboard path
+  is a separate track; v1.2.0 is mechanical-only.
+- Coreference resolution.
+- Multi-sentence relations ("X. It supersedes Y.")
+- Structured-input extraction (handled by callers via direct
+  `insert_edge`).
+- Confidence-weighted extraction (every triple is uniformly weighted
+  for now; a downstream v1.x patch could weight by pattern
+  reliability).
+- Cross-language extraction. English only at v1.2.0.
+
+## Open questions
+
+- The pattern set above is a starting point. Real commit messages
+  and prose have far more varied phrasings. Should the extractor
+  ship with the minimal set and grow via observed false negatives,
+  or should the v1.2.0 release include a wider pattern bank?
+  Recommendation: minimal set + an `aelf health` check that
+  surfaces "X commit messages parsed; Y triples produced" so users
+  can see when their corpus needs more patterns.
+- Anchor text length cap. The ingest-enrichment spec proposes 1000
+  chars; this spec produces ~80 chars per triple. Consistent with
+  that cap.
+- Should `ingest_triples` create a new session if `session_id` is
+  None, or leave it NULL? Recommendation: leave NULL. Session
+  creation is the caller's responsibility (the commit-ingest hook
+  spec handles that explicitly).


### PR DESCRIPTION
## Summary

Three new specs that complete the v1.2.0 milestone's spec coverage. Together with the already-merged [transcript_ingest.md](https://github.com/robotrocketscience/aelfrice/blob/main/docs/transcript_ingest.md), v1.2.0 now has full spec docs for every roadmap bullet.

| Spec | What it adds | Producer for |
|---|---|---|
| **`docs/ingest_enrichment.md`** | `Belief.session_id`, `Edge.anchor_text`, `DERIVED_FROM` edge type — all nullable / additive | the schema fields the next two specs populate |
| **`docs/triple_extractor.md`** | `extract_triples()` (pure regex, no LLM) + `ingest_triples()` (content-hash-keyed, idempotent) | `Edge.anchor_text` + `DERIVED_FROM` edges |
| **`docs/commit_ingest_hook.md`** | `PostToolUse` hook on `git commit` runs the triple extractor and inserts under git-derived `session_id` | `Belief.session_id` + the schema fields, on real corpora during normal session activity |

## Why this matters

`docs/ROADMAP.md` v1.2.0 names commit-ingest hook, transcript-ingest, triple-extraction port, and harness-integration doc. Until this PR, only transcript-ingest had a spec doc backing it. The other three were named bullets without contracts — implementation could not start without each implementer first re-deriving the design.

These are the four specs together that turn v1.2.0 from "auto-capture milestone" into "milestone where v1.3+ retrieval techniques can fire on real data." The schema (ingest enrichment) without producers (triple extractor + commit-ingest hook) is dead code. Producers without schema have nowhere to write. Documenting the contract for all three at once locks the integration shape before any one of them lands.

## Order of implementation

1. **`ingest_enrichment.md`** — schema migrations land first; v1.0 stores read forward without alteration.
2. **`triple_extractor.md`** — pure function, no hook plumbing; can land second independently.
3. **`commit_ingest_hook.md`** — depends on 1 + 2.

The transcript-ingest hooks (separate spec, already merged) consume the same schema. Both hooks can land in parallel after the schema and extractor land.

## Test plan

- [ ] CI green (gitleaks + PII scan + commit-history audit + pytest matrix)
- [ ] No code paths touched — three new docs only
- [ ] Cross-references between the three new docs and `transcript_ingest.md` resolve
- [ ] Leak-scan: no `R*`/`G*`/`S*` round/research labels, no lab-internal paths, no codename references — verified locally before commit

## Out of scope

- Implementation of any of the three specs. Each is a contract; code lands in subsequent PRs.
- The `harness-integration` doc the v1.2.0 roadmap also names — that's a separate documentation task not in this PR.
- Updates to ROADMAP.md cross-referencing the new spec files. Not strictly necessary; the roadmap already names the work, and the spec files are findable via standard repo discovery.