### PR TITLE
docs: align project-identity narrative with #96-shipped reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Opt out of the update notifier at any time with `export AELF_NO_UPDATE_CHECK=1`.
 aelfrice has an explicit teardown command. You **must** pick exactly one disposition for the brain-graph DB:
 
 ```bash
-aelf uninstall --keep-db       # leave ~/.aelfrice/memory.db alone (safe)
+aelf uninstall --keep-db       # leave the resolved DB alone (safe)
 aelf uninstall --archive ~/aelf-backup.aenc   # encrypt then delete
 aelf uninstall --purge         # permanently delete (redundant gates fire)
 pip uninstall aelfrice         # finally, remove the wheel

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,7 +39,7 @@ One-directional imports — lower in the table imports from higher.
 | `scanner.py` | `scan_repo` — filesystem + git log + Python AST extractors, noise filter, classification, persistence. Idempotent against `content_hash`. |
 | `health.py` | Regime classifier (`insufficient_data` / `early-onboarding` / `steady` / `lock-heavy` / `over-confident`) over confidence, mass, lock density, edge density. |
 | `benchmark.py` | `seed_corpus(store)` + `run_benchmark(store, *, aelfrice_version, top_k=5)` — deterministic 16-belief × 16-query synthetic harness. Frozen `BenchmarkReport` with `hit_at_1` / `hit_at_3` / `hit_at_5` / `mrr` + `p50_latency_ms` / `p99_latency_ms`. |
-| `cli.py` | argparse 12-subcommand CLI (added `aelf resolve` at v1.0.1 alongside the contradiction tie-breaker). DB resolves from `$AELFRICE_DB` or `~/.aelfrice/memory.db`. Entry: `aelf`. |
+| `cli.py` | argparse 12-subcommand CLI (added `aelf resolve` at v1.0.1 alongside the contradiction tie-breaker). DB resolves from `$AELFRICE_DB` (override), then `<git-common-dir>/aelfrice/memory.db` when `cwd` is in a git work-tree, then `~/.aelfrice/memory.db` as the non-git fallback (v1.1.0). `.git/` is not git-tracked, so the brain graph never crosses the git boundary. Entry: `aelf`. |
 | `mcp_server.py` | FastMCP server, 8 tools. `[mcp]` optional extra. |
 | `setup.py` | Idempotent install/uninstall of the Claude Code `UserPromptSubmit` hook. Atomic write via tempfile + `os.replace`. |
 | `hook.py` | `aelfrice.hook:main` — process Claude Code spawns when the hook fires. Reads JSON from stdin, calls `retrieve()`, emits `<aelfrice-memory>...</aelfrice-memory>` on stdout. Non-blocking by contract. Entry: `aelf-hook`. |
@@ -108,7 +108,7 @@ Classification via `TYPE_PRIORS` + regex fallback. Idempotent: `content_hash` de
                                   ↓ JSON payload on stdin
                           aelf-hook subprocess (aelfrice.hook:main)
                                   ↓ retrieve(store, prompt)
-                          ~/.aelfrice/memory.db
+                          .git/aelfrice/memory.db (or ~/.aelfrice/memory.db)
                                   ↓ <aelfrice-memory> on stdout
                           Claude Code injects above prompt
 ```

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -2,7 +2,7 @@
 
 Fifteen subcommands. The first eight (retrieval/feedback) are also available as MCP tools and Claude Code slash commands. The lifecycle commands (`setup`/`unsetup`/`upgrade`/`uninstall`/`statusline`/`doctor`) and `bench` are CLI-only.
 
-DB resolves from `$AELFRICE_DB` or `~/.aelfrice/memory.db`.
+DB resolves from `$AELFRICE_DB` (override), then `<git-common-dir>/aelfrice/memory.db` when `cwd` is in a git work-tree, then `~/.aelfrice/memory.db` as the non-git fallback. `.git/` is not git-tracked — the brain graph never crosses the git boundary.
 
 ```
 aelf <subcommand> [args] [options]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -123,7 +123,7 @@ Edits to `.aelfrice.toml` apply on the next `aelf onboard` run. They do **not** 
 If you want to remove existing noise from a store, the cleanest path is:
 
 ```bash
-rm ~/.aelfrice/memory.db        # or AELFRICE_DB path
+rm "$(python -c 'from aelfrice.cli import db_path; print(db_path())')"  # resolves to .git/aelfrice/memory.db inside a repo, ~/.aelfrice/memory.db otherwise, or AELFRICE_DB if set
 aelf onboard /path/to/project   # re-onboard with new config
 ```
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -35,7 +35,13 @@ uv sync --extra dev      # add pytest, pyright
 
 ## Database
 
-SQLite at `~/.aelfrice/memory.db` by default. Override with `$AELFRICE_DB` (use `:memory:` for tests).
+SQLite. Resolution order:
+
+1. `$AELFRICE_DB` if set (override; use `:memory:` for tests).
+2. `<git-common-dir>/aelfrice/memory.db` when `cwd` is inside a git work-tree (v1.1.0). Two worktrees of one repo share a `--git-common-dir` and therefore one DB. `.git/` is not git-tracked, so the brain graph never crosses the git boundary.
+3. `~/.aelfrice/memory.db` as the fallback for non-git directories.
+
+Pin per-project (overriding the chain) with `export AELFRICE_DB=/abs/path/.aelfrice.db` — handy via direnv.
 
 ## Wire into Claude Code
 
@@ -186,7 +192,7 @@ uv run pytest -m regression  # cumulative integration scenarios
 
 ## Uninstall
 
-aelfrice ships an explicit teardown command. You **must** pick exactly one of `--keep-db`, `--purge`, or `--archive PATH` so the brain-graph SQLite DB at `~/.aelfrice/memory.db` doesn't get accidentally lost or accidentally retained.
+aelfrice ships an explicit teardown command. You **must** pick exactly one of `--keep-db`, `--purge`, or `--archive PATH` so the brain-graph SQLite DB doesn't get accidentally lost or accidentally retained. The command operates on the resolved DB path for the current `cwd` (see [§ Database](#database) for the resolution chain).
 
 ```bash
 aelf uninstall --keep-db                           # safe default for review
@@ -199,12 +205,14 @@ Verification:
 
 ```bash
 aelf --version 2>&1 | grep -q aelfrice || echo "wheel removed"
-test -f ~/.aelfrice/memory.db && echo "db still there" || echo "db gone"
+# Resolve DB path for current cwd, then test it:
+DB=$(uv run python -c "from aelfrice.cli import db_path; print(db_path())")
+test -f "$DB" && echo "db still there at $DB" || echo "db gone"
 ```
 
 ### `--keep-db`
 
-DB preserved at `~/.aelfrice/memory.db`. The default also runs `unsetup` so the Claude Code hook + statusline are removed from `~/.claude/settings.json`. Pass `--keep-hook` if you want to keep those wired (e.g. you plan to reinstall and skip onboarding).
+DB preserved at the resolved path. The default also runs `unsetup` so the Claude Code hook + statusline are removed from `~/.claude/settings.json`. Pass `--keep-hook` if you want to keep those wired (e.g. you plan to reinstall and skip onboarding).
 
 ### `--archive PATH`
 
@@ -240,7 +248,7 @@ Wrong password raises `cryptography.fernet.InvalidToken`. Requires `pip install 
 
 ### `--purge`
 
-Permanently deletes `~/.aelfrice/memory.db`. Three gates fire before deletion:
+Permanently deletes the resolved DB. Three gates fire before deletion:
 
 1. The `--purge` flag must be passed explicitly. Default behavior is an error pointing at `--help`.
 2. Print the target path + size, then require the user to type `PURGE` verbatim (case-sensitive).

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -37,7 +37,7 @@ Tracked openly. Each item is mapped to its target version below.
 
 ### Project identity — v1.1.0
 
-- **The default DB is keyed by `SHA256(cwd)`.** Worktree and directory rename each produce a different orphan DB. Workaround today: pin with `AELFRICE_DB=/abs/path/.aelfrice.db`. v1.1.0 lands `.git/aelfrice/memory.db` (in-repo storage; `.git/` is not git-tracked, so the brain graph never crosses the git boundary), plus orphan-DB cleanup tooling and worktree concurrency tests. Note that fresh clones intentionally start with an empty store — the brain graph stays on the machine it was written on (see [§ Sharing or sync of brain-graph content](#sharing-or-sync-of-brain-graph-content)). Bootstrap a clone with `aelf onboard .`.
+- ✅ **Per-project DB resolution (v1.1.0, [#88](https://github.com/robotrocketscience/aelfrice/issues/88)).** v1.0.x shipped a single global DB at `~/.aelfrice/memory.db` shared across every project on the machine — onboarding repo A and repo B writes both projects' beliefs into one file. v1.1.0 introduces a resolution chain in `cli.db_path()`: `$AELFRICE_DB` (override, honoured even inside a git repo) → `<git-common-dir>/aelfrice/memory.db` (when `cwd` is inside a git work-tree; resolved via `git rev-parse --path-format=absolute --git-common-dir`, so worktrees of one repo share one DB) → `~/.aelfrice/memory.db` (legacy global fallback for non-git dirs). `.git/` is not git-tracked, so the brain graph never crosses the git boundary. `aelf migrate` ([#93](https://github.com/robotrocketscience/aelfrice/issues/93)) ports beliefs from the legacy global store into per-project stores. Fresh clones intentionally start with an empty store — the brain graph stays on the machine it was written on (see [§ Sharing or sync of brain-graph content](#sharing-or-sync-of-brain-graph-content)); bootstrap a clone with `aelf onboard .`.
 
 ### Cosmetic — v1.1.0
 
@@ -118,7 +118,7 @@ This applies to the v2.0.0 release also: there is no "cross-project shared store
 - **Classifier is regex-based on the CLI path.** Only the polymorphic MCP onboard uses host-LLM classification.
 - **No bulk operations.** No batch lock, no `delete <pattern>`, no merge.
 - **No edit.** Wrong belief → insert corrected one with `SUPERSEDES` edge; original stays.
-- **No graph viz.** Inspect with `sqlite3 ~/.aelfrice/memory.db`.
+- **No graph viz.** Inspect with `sqlite3 "$(python -c 'from aelfrice.cli import db_path; print(db_path())')"`.
 
 ## Performance caveats
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -18,13 +18,17 @@ There is no usage tracking. No analytics. No phone-home. Not opt-out — **the c
 
 ## No accounts
 
-No sign-in, no API key, no sync server. Everything is the file at `~/.aelfrice/memory.db` (or `$AELFRICE_DB`). To back up: copy the file. To share across machines: sync the file. It's plain SQLite.
+No sign-in, no API key, no sync server. Everything is one local SQLite file. To back up: copy the file. aelfrice ships no mechanism for sharing memory contents between users, machines, or projects — see [LIMITATIONS § Sharing or sync of brain-graph content](LIMITATIONS.md#sharing-or-sync-of-brain-graph-content).
 
 ## Data location
 
-Default `~/.aelfrice/memory.db` — single SQLite file with WAL journaling. Six tables: `beliefs`, `beliefs_fts`, `edges`, `feedback_history`, `onboard_sessions`, `schema_meta`.
+A single SQLite file with WAL journaling. Six tables: `beliefs`, `beliefs_fts`, `edges`, `feedback_history`, `onboard_sessions`, `schema_meta`.
 
-Override with `AELFRICE_DB`. Use `:memory:` for ephemeral.
+Resolution order (v1.1.0):
+
+1. `$AELFRICE_DB` if set (override; use `:memory:` for ephemeral).
+2. `<git-common-dir>/aelfrice/memory.db` when `cwd` is inside a git work-tree. `.git/` is not git-tracked — the brain graph never crosses the git boundary.
+3. `~/.aelfrice/memory.db` for non-git directories.
 
 ## What aelfrice doesn't control
 
@@ -37,7 +41,7 @@ If a fact must never leave your machine, don't store it.
 
 ## Reproducible from source
 
-All beliefs come from files you already have: code, docs, git history. After `rm ~/.aelfrice/memory.db`, re-running onboard is deterministic up to the classifier. The state of the world is your codebase, not the memory.
+All beliefs come from files you already have: code, docs, git history. After `rm <resolved-db-path>`, re-running `aelf onboard .` is deterministic up to the classifier. The state of the world is your codebase, not the memory.
 
 ## Reporting
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,12 +49,13 @@ Second patch. Two threads:
 
 ## v1.1.0 — project identity and cosmetic surface
 
-- **In-repo store.** `.git/aelfrice/memory.db` becomes the default location. The current `SHA256(cwd)`-keyed path produces orphan databases on directory rename or worktree creation; the new layout is portable and survives both. The DB stays under `.git/`, which git does not track — the brain graph never crosses the git boundary.
-- **Orphan-DB cleanup tooling.** A migration command finds and merges abandoned per-`cwd` databases into the in-repo store.
-- **Worktree concurrency tests.** Multiple worktrees of the same repo share one `.git/aelfrice/memory.db` without corruption.
-- **`aelf health` vs `aelf status` split.** `status` becomes a counts snapshot; `health` becomes a real graph auditor — orphan edges, isolated clusters, FTS5 sync, locked-belief contradictions, decay anomalies.
+- **Per-project DB resolution.** v1.0.x shipped a single global DB at `~/.aelfrice/memory.db` shared across every project on the machine. v1.1.0 lands a resolution chain: `$AELFRICE_DB` (override) → `<git-common-dir>/aelfrice/memory.db` (when `cwd` is inside a git work-tree) → `~/.aelfrice/memory.db` (non-git fallback). Worktrees of one repo share one DB via the git-common-dir. `.git/` is not git-tracked — the brain graph never crosses the git boundary. Shipped at [#88](https://github.com/robotrocketscience/aelfrice/issues/88).
+- **`aelf migrate` from legacy global store.** One-shot copy from `~/.aelfrice/memory.db` (the v1.0 single global DB) into the active project's `.git/aelfrice/memory.db`. Dry-run by default; `--apply` writes. Idempotent.
+- **Worktree concurrency tests.** Multiple worktrees of the same repo share one `.git/aelfrice/memory.db` without corruption under WAL mode.
+- **`aelf health` rewritten as diagnostic auditor.** Replaces the v1.0 regime classifier output (preserved as `aelf regime`). Reports credal gap, orphan beliefs, edge type counts, feedback coverage, FTS5 sync, locked-belief contradictions. Exits 1 on structural failures (orphan edges, FTS5 mismatch, locked-belief contradictions); informational metrics stay exit 0. `aelf status` aliases `aelf health` per lab COMMAND_DESIGN convention.
 - **`edges` → `threads`.** User-facing rename in CLI output and MCP tool descriptions. Internal schema is unchanged.
-- **Onboard improvements.** Git-recency weighting for source files; explicit `agent_inferred` → `user_validated` promotion path so onboard-derived beliefs can graduate without being re-locked.
+- **Onboard git-recency weighting.** Scanner records source file's most-recent git commit date as `belief.created_at`, so the existing decay mechanism penalises pre-migration content from old branches.
+- **`agent_inferred` → `user_validated` promotion path.** Designed in v1.1.0 ([docs/promotion_path.md](promotion_path.md), [#95](https://github.com/robotrocketscience/aelfrice/issues/95)); implemented in v1.2.0.
 - **Query result cache.** A bounded LRU cache wrapping `aelfrice.retrieval.retrieve()`, keyed on a canonicalized form of `(query, token_budget, l1_limit)` and invalidated on every store mutation. Skips a full L0+L1 pass when an agent loop re-issues the same query. Spec: [`lru_query_cache.md`](lru_query_cache.md).
 
 ## v1.2.0 — auto-capture and triple extraction
@@ -131,7 +132,7 @@ The earlier research line implemented these modules. They are not in v1.0.0; eac
 
 The rewrite is fixing the following structural issues at the foundation rather than patching them forward.
 
-- **Per-project DB identity** keyed off arbitrary `cwd` hashes silently produced orphan stores on directory rename and worktree creation. Fixed in v1.1.0 by storing the DB inside `.git/` (which git does not track), keyed off the git-common-dir.
+- **No per-project DB identity.** v1.0 shipped a single global DB at `~/.aelfrice/memory.db` shared across every project on the machine; onboarding repo A and repo B mixed their beliefs in one file. Fixed in v1.1.0 ([#88](https://github.com/robotrocketscience/aelfrice/issues/88)) by introducing per-project resolution: the DB defaults to `.git/aelfrice/memory.db` for git repos (keyed off the git-common-dir so worktrees share one DB) and falls back to `~/.aelfrice/memory.db` for non-git directories. `.git/` is not git-tracked, so the brain graph never crosses the git boundary. A one-shot `aelf migrate` copies beliefs from the legacy global store into the active project's in-repo store.
 - **Hook → retrieval coupling** missed the feedback-history audit row, so retrievals did not exercise posteriors and were not auditable. Fixed in v1.0.1 by routing the hook through the same `retrieval.retrieve()` codepath as the CLI / MCP, with one `feedback_history` row per retrieval.
 - **Contradictions** were detected but never resolved — both beliefs remained equally retrievable, with a warning logged. Fixed in v1.0.1 by a default tie-breaker that auto-supersedes the loser and records the rule that fired.
 - **Onboard noise** (Markdown headings, license boilerplate, three-word fragments) entered as first-class beliefs and depressed signal-to-noise on every subsequent retrieval. Fixed in v1.0.1 by the `noise_filter` module wired into the synchronous onboard path.


### PR DESCRIPTION
## Why

Two-fold motivation:

**(1) Lost framing fix.** PR #87 squash-merged at the older SHA, so the second commit on that branch (\`314f21b\`, \"correct stale SHA256(cwd) claim — v1.0 ships one global DB\") never reached main. The corrected text — that v1.0 ships a single global DB at \`~/.aelfrice/memory.db\` rather than a per-cwd-hash keyed store — needs to land. The lab plan and original LIMITATIONS text described an assumed/aspirational state, not the shipped one. \`git log -S 'SHA256' -- src/aelfrice/cli.py\` confirms SHA256(cwd) was never in the public repo.

**(2) Post-#96 doc sweep.** PR #96 shipped per-project DB resolution. Multiple docs still describe the old global-only state.

## What

**LIMITATIONS § Project identity** flips to ✅ shipped, references the real resolution chain (\`\$AELFRICE_DB\` → git-common-dir → home-dir).

**ROADMAP § v1.1.0** reframed:
- Drop wrong \"in-repo store fixes orphan databases\" framing (no orphans existed; v1.0 had one global DB).
- Drop \"aelf health vs aelf status split\" (lab COMMAND_DESIGN.md says \`status\` aliases \`health\`; the ROADMAP framing was wrong — see issue #90 for the actual rework).
- Each entry now has issue refs: #88 (shipped), #89, #90, #92, #93, #94, #95.

**ROADMAP § Built fresh, not copied**: per-project DB identity entry rewritten to describe what actually shipped, not the lab plan's assumption.

**ARCHITECTURE.md** \`cli.py\` row + hook diagram, **COMMANDS.md** preamble, **INSTALL.md § Database**, **PRIVACY.md § Data location**: all describe the new resolution chain.

**INSTALL.md uninstall section**: replace literal \`~/.aelfrice/memory.db\` references with \"resolved DB path\" language; verification command uses \`cli.db_path()\` to discover the path.

**PRIVACY.md § No accounts**: removed \"to share across machines: sync the file\" line — conflicts with the local-only contract from #87. Cross-link added to LIMITATIONS § Sharing or sync of brain-graph content.

**CONFIG.md** cleanup recipe + **LIMITATIONS** no-graph-viz line: use \`db_path()\` resolver in shell example.

**README.md** uninstall snippet: comment reworded to \"resolved DB\" instead of literal home-dir path.

## Open question for reviewer

**README.md tagline at line 22-24** (\`SQLite at ~/.aelfrice/memory.db. That's the whole runtime.\`) — left alone. Three options:

1. Leave as-is. Home-dir path is still a valid resolution (the non-git fallback). Tagline reads as the spirit, not a literal spec.
2. Change to \`SQLite at .git/aelfrice/memory.db. That's the whole runtime.\` — accurate for the new default in git repos but feels less iconic.
3. Change to \`Local SQLite. That's the whole runtime.\` — neutral, loses some specificity.

Recommend (1). The README is marketing copy; the docs spell out the chain precisely. Confirm and I'll leave it; respond otherwise and I'll edit.

## Verification

- \`grep -rE 'SHA256.*cwd|cwd.*hash'\` over docs/ + README.md + CHANGELOG.md → 0 matches.
- \`grep -n '~/.aelfrice/memory'\` over docs/ + README.md → all remaining matches are either the legacy fallback (correct in context), the resolution chain description, or the non-fixed CHANGELOG (out of scope — historical commits).
- Existing docs/lab tests not affected; this PR is markdown-only.