### PR TITLE
feat(v1.1.0): aelf health rewritten as structural auditor + aelf regime + aelf status alias

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,13 +37,14 @@ One-directional imports — lower in the table imports from higher.
 | `classification.py` | `TYPE_PRIORS` + regex fallback. Polymorphic onboard state machine. |
 | `noise_filter.py` | `is_noise(text, config)` — drops markdown heading blocks, checklist blocks, three-word fragments, and license boilerplate before classification. `NoiseConfig` dataclass + `.aelfrice.toml` discovery via `discover()` walk-up. Power-user surface documented in [CONFIG.md](CONFIG.md). |
 | `scanner.py` | `scan_repo` — filesystem + git log + Python AST extractors, noise filter, classification, persistence. Idempotent against `content_hash`. |
-| `health.py` | Regime classifier (`insufficient_data` / `early-onboarding` / `steady` / `lock-heavy` / `over-confident`) over confidence, mass, lock density, edge density. |
+| `health.py` | v1.0 regime classifier (`supersede` / `ignore` / `mixed` / `insufficient_data`) over confidence, mass, lock density, edge density. Exposed via `aelf regime` since v1.1.0. |
+| `auditor.py` | v1.1.0 structural auditor: three mechanical checks (orphan edges, FTS5 sync drift, locked-belief CONTRADICTS pairs) plus informational metrics (counts, avg confidence, credal gap, edge type breakdown). Backs `aelf health` (exit 1 on any failed check). Pure read-only. |
 | `benchmark.py` | `seed_corpus(store)` + `run_benchmark(store, *, aelfrice_version, top_k=5)` — deterministic 16-belief × 16-query synthetic harness. Frozen `BenchmarkReport` with `hit_at_1` / `hit_at_3` / `hit_at_5` / `mrr` + `p50_latency_ms` / `p99_latency_ms`. |
-| `cli.py` | argparse 12-subcommand CLI (added `aelf resolve` at v1.0.1 alongside the contradiction tie-breaker). DB resolves from `$AELFRICE_DB` (override), then `<git-common-dir>/aelfrice/memory.db` when `cwd` is in a git work-tree, then `~/.aelfrice/memory.db` as the non-git fallback (v1.1.0). `.git/` is not git-tracked, so the brain graph never crosses the git boundary. Entry: `aelf`. |
+| `cli.py` | argparse 14-subcommand CLI (`aelf health` rewritten + `aelf status` alias + `aelf regime` added at v1.1.0). DB resolves from `$AELFRICE_DB` (override), then `<git-common-dir>/aelfrice/memory.db` when `cwd` is in a git work-tree, then `~/.aelfrice/memory.db` as the non-git fallback (v1.1.0). `.git/` is not git-tracked, so the brain graph never crosses the git boundary. Entry: `aelf`. |
 | `mcp_server.py` | FastMCP server, 8 tools. `[mcp]` optional extra. |
 | `setup.py` | Idempotent install/uninstall of the Claude Code `UserPromptSubmit` hook. Atomic write via tempfile + `os.replace`. |
 | `hook.py` | `aelfrice.hook:main` — process Claude Code spawns when the hook fires. Reads JSON from stdin, calls `retrieve()`, emits `<aelfrice-memory>...</aelfrice-memory>` on stdout. Non-blocking by contract. Entry: `aelf-hook`. |
-| `slash_commands/` | 11 markdown files, 1:1 with CLI subcommands. |
+| `slash_commands/` | One markdown file per CLI subcommand surfaced as a slash command. |
 
 ## Data model
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Fifteen subcommands. The first eight (retrieval/feedback) are also available as MCP tools and Claude Code slash commands. The lifecycle commands (`setup`/`unsetup`/`upgrade`/`uninstall`/`statusline`/`doctor`) and `bench` are CLI-only.
+Eighteen subcommands. The first eight (retrieval/feedback) are also available as MCP tools and Claude Code slash commands. The lifecycle commands (`setup`/`unsetup`/`upgrade`/`uninstall`/`statusline`/`doctor`) and `bench` are CLI-only.
 
 DB resolves from `$AELFRICE_DB` (override), then `<git-common-dir>/aelfrice/memory.db` when `cwd` is in a git work-tree, then `~/.aelfrice/memory.db` as the non-git fallback. `.git/` is not git-tracked — the brain graph never crosses the git boundary.
 
@@ -20,7 +20,9 @@ aelf <subcommand> [args] [options]
 | `resolve` | — | Sweep unresolved CONTRADICTS edges. For each pair, pick a winner per precedence (`user_stated > user_corrected > document_recent`; ties broken by recency, then by id) and create a SUPERSEDES edge from winner to loser. Writes one `feedback_history` row per resolution with `source='contradiction_tiebreaker:<rule>'`. Idempotent. |
 | `feedback <belief_id> <used\|harmful> [--source S]` | id, signal, optional source | `used` ⇒ α += 1. `harmful` ⇒ β += 1. Positive feedback flowing through outbound CONTRADICTS edges to user-locks bumps their `demotion_pressure`; ≥ 5 ⇒ auto-demote. |
 | `stats` | — | beliefs / edges / locked / feedback_events counts. |
-| `health` | — | Regime classifier: one of `early-onboarding`, `steady`, `lock-heavy`, `over-confident`, `insufficient-data`. |
+| `health` | — | Structural auditor (v1.1.0): three checks fire — orphan edges, FTS5 sync drift, locked-belief CONTRADICTS pairs. Each finding prints `[ok  ]` or `[FAIL]`. Exit 1 if any failure, 0 otherwise. Informational metrics (counts, average confidence, credal gap, edge counts by type) print alongside but don't affect exit. |
+| `status` | — | Alias for `health`. Same output, same exit codes. |
+| `regime` | — | v1.0 regime classifier preserved as a separate command. One of `supersede`, `ignore`, `mixed`, `insufficient_data`. Informational only; always exits 0. |
 | `doctor [--user-settings P] [--project-root D]` | — | Verify hook + statusline commands in user and project `settings.json` resolve to executables. Reports broken absolute paths and bare names not on `$PATH`. Special-cases `bash /script.sh` to inspect the script. Exits `1` on any broken finding. |
 | `setup [--scope user\|project] [--project-root D] [--settings-path P] [--command C] [--timeout N] [--status-message M] [--no-statusline]` | various | Install `UserPromptSubmit` hook + `statusLine` notifier in Claude Code `settings.json`. Defaults: `--scope` auto-detects `project` if `cwd/.venv` matches `sys.prefix` else `user`; `--command` auto-resolves to absolute `aelf-hook` (project venv for project scope, `$PATH` for user scope). Also silently removes legacy dangling `/usr/local/bin/aelf{,-hook}` symlinks. Idempotent + atomic. |
 | `unsetup` (same scope flags, `--command`) | — | Remove the hook + our statusline contribution. Default `--command` matches every entry whose program basename is `aelf-hook`, so a bare-name install and an absolute-path install are both cleaned by the same call. Composed statuslines are surgically unwrapped to restore the original command. |

--- a/src/aelfrice/auditor.py
+++ b/src/aelfrice/auditor.py
@@ -1,0 +1,156 @@
+"""Structural auditor for `aelf health`.
+
+Three mechanical checks in v1.1.0. Each fires `severity='fail'` when the
+invariant is violated; `aelf health` exits 1 if any failure is present
+so CI can gate on it. Informational metrics (credal gap, edge counts,
+feedback coverage, average confidence) are reported alongside but do
+not affect exit status.
+
+Checks:
+  - orphan_edges     edges whose src or dst no longer exists in beliefs
+  - fts_sync         beliefs_fts row count matches beliefs row count
+  - locked_contradicts pairs of locked beliefs joined by a CONTRADICTS edge
+
+Threshold-tuned checks (isolated clusters, decay anomalies) are deferred
+to v1.2.0+ — they require calibration data the v1.1.0 store doesn't yet
+make available.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Final
+
+from aelfrice.store import MemoryStore
+
+SEVERITY_FAIL: Final[str] = "fail"
+SEVERITY_INFO: Final[str] = "info"
+
+CHECK_ORPHAN_EDGES: Final[str] = "orphan_edges"
+CHECK_FTS_SYNC: Final[str] = "fts_sync"
+CHECK_LOCKED_CONTRADICTS: Final[str] = "locked_contradicts"
+
+
+@dataclass(frozen=True)
+class AuditFinding:
+    """One row of the audit report."""
+
+    check: str
+    severity: str
+    count: int
+    detail: str
+
+
+@dataclass(frozen=True)
+class AuditReport:
+    """Result of `audit(store)`."""
+
+    findings: list[AuditFinding]
+    metrics: dict[str, float | int] = field(default_factory=dict)
+
+    @property
+    def failed(self) -> bool:
+        """True iff any finding has severity `fail`."""
+        return any(f.severity == SEVERITY_FAIL for f in self.findings)
+
+
+def _check_orphan_edges(store: MemoryStore) -> AuditFinding:
+    n = store.count_orphan_edges()
+    if n == 0:
+        return AuditFinding(
+            check=CHECK_ORPHAN_EDGES,
+            severity=SEVERITY_INFO,
+            count=0,
+            detail="all edges resolve to existing beliefs",
+        )
+    return AuditFinding(
+        check=CHECK_ORPHAN_EDGES,
+        severity=SEVERITY_FAIL,
+        count=n,
+        detail=f"{n} edge(s) reference deleted or missing beliefs",
+    )
+
+
+def _check_fts_sync(store: MemoryStore) -> AuditFinding:
+    beliefs = store.count_beliefs()
+    fts = store.count_fts_rows()
+    if beliefs == fts:
+        return AuditFinding(
+            check=CHECK_FTS_SYNC,
+            severity=SEVERITY_INFO,
+            count=0,
+            detail=f"FTS5 mirror in sync ({beliefs} rows)",
+        )
+    drift = abs(beliefs - fts)
+    return AuditFinding(
+        check=CHECK_FTS_SYNC,
+        severity=SEVERITY_FAIL,
+        count=drift,
+        detail=f"beliefs={beliefs} vs beliefs_fts={fts} (drift {drift})",
+    )
+
+
+def _check_locked_contradicts(store: MemoryStore) -> AuditFinding:
+    pairs = store.list_locked_contradicts_pairs()
+    if not pairs:
+        return AuditFinding(
+            check=CHECK_LOCKED_CONTRADICTS,
+            severity=SEVERITY_INFO,
+            count=0,
+            detail="no unresolved contradictions between locked beliefs",
+        )
+    sample = ", ".join(f"({a},{b})" for a, b in pairs[:3])
+    if len(pairs) > 3:
+        sample += f", … ({len(pairs) - 3} more)"
+    return AuditFinding(
+        check=CHECK_LOCKED_CONTRADICTS,
+        severity=SEVERITY_FAIL,
+        count=len(pairs),
+        detail=f"{len(pairs)} locked CONTRADICTS pair(s): {sample} — run `aelf resolve`",
+    )
+
+
+def _gather_metrics(store: MemoryStore) -> dict[str, float | int]:
+    """Informational metrics displayed alongside the audit. Read-only."""
+    n_beliefs = store.count_beliefs()
+    n_edges = store.count_edges()
+    n_locked = store.count_locked()
+    n_feedback = store.count_feedback_events()
+    edges_by_type = store.count_edges_by_type()
+    pairs = store.alpha_beta_pairs()
+    if pairs:
+        avg_confidence = sum(a / (a + b) for a, b in pairs if a + b > 0) / len(pairs)
+        # credal gap: beliefs whose alpha+beta is at the type prior — i.e.
+        # never received feedback. v1.0 type priors all sum to mass <= 4.0
+        # (factual 4.0, requirement 9.5, preference 5.0, correction 9.0);
+        # we approximate "untested" as (alpha+beta) <= the smallest prior
+        # mass observed (3.5, the factual prior alpha=3.0, beta=0.5 ≈ 3.5).
+        # Beliefs at higher mass have received feedback events.
+        credal_gap = sum(1 for a, b in pairs if a + b <= 3.5)
+    else:
+        avg_confidence = 0.0
+        credal_gap = 0
+    metrics: dict[str, float | int] = {
+        "beliefs": n_beliefs,
+        "edges": n_edges,
+        "locked": n_locked,
+        "feedback_events": n_feedback,
+        "avg_confidence": round(avg_confidence, 3),
+        "credal_gap": credal_gap,
+    }
+    for edge_type, count in sorted(edges_by_type.items()):
+        metrics[f"edges_{edge_type.lower()}"] = count
+    return metrics
+
+
+def audit(store: MemoryStore) -> AuditReport:
+    """Run the v1.1.0 mechanical-auditor checks against `store`.
+
+    Pure read-only operation. Returns a structured report; the caller
+    decides how to render it and what exit code to emit.
+    """
+    findings = [
+        _check_orphan_edges(store),
+        _check_fts_sync(store),
+        _check_locked_contradicts(store),
+    ]
+    return AuditReport(findings=findings, metrics=_gather_metrics(store))

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -8,7 +8,9 @@ Commands:
   demote <id>                      manually demote a lock to none
   feedback <id> <used|harmful>     apply one Bayesian feedback event
   stats                            summary of belief / lock / history counts
-  health                           regime classifier output
+  health                           structural auditor (orphan edges, FTS5 sync, locked contradictions)
+  status                           alias for health
+  regime                           v1.0 regime classifier (supersede / ignore / mixed)
   doctor                           verify hook commands resolve in settings.json
   setup                            install UserPromptSubmit hook in Claude Code
   unsetup                          remove UserPromptSubmit hook from Claude Code
@@ -36,6 +38,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Final, Sequence
 
+from aelfrice.auditor import (
+    SEVERITY_FAIL as AUDIT_SEVERITY_FAIL,
+    audit,
+)
 from aelfrice.feedback import apply_feedback
 from aelfrice.health import (
     REGIME_INSUFFICIENT_DATA,
@@ -801,6 +807,46 @@ def _cmd_upgrade(args: argparse.Namespace, out: object) -> int:
 
 
 def _cmd_health(args: argparse.Namespace, out: object) -> int:
+    """Run the v1.1.0 structural auditor and print findings + metrics.
+
+    Exits 1 if any audit check fails (orphan edges, FTS5 sync, locked
+    contradictions). Informational metrics never affect exit status.
+    The v1.0 regime classifier moved to `aelf regime`.
+    """
+    _ = args
+    store = _open_store()
+    try:
+        report = audit(store)
+    finally:
+        store.close()
+    print("audit:", file=out)  # type: ignore[arg-type]
+    for f in report.findings:
+        marker = "FAIL" if f.severity == AUDIT_SEVERITY_FAIL else "ok"
+        print(
+            f"  [{marker:4s}] {f.check:24s} {f.detail}",
+            file=out,  # type: ignore[arg-type]
+        )
+    print("", file=out)  # type: ignore[arg-type]
+    print("metrics:", file=out)  # type: ignore[arg-type]
+    for key, value in report.metrics.items():
+        if isinstance(value, float):
+            display = f"{value:.3f}"
+        else:
+            display = str(value)
+        print(f"  {key:24s} {display}", file=out)  # type: ignore[arg-type]
+    print("", file=out)  # type: ignore[arg-type]
+    print("run `aelf regime` for the v1.0 regime classifier.",
+          file=out)  # type: ignore[arg-type]
+    return 1 if report.failed else 0
+
+
+def _cmd_regime(args: argparse.Namespace, out: object) -> int:
+    """Print the v1.0 regime classifier output (supersede / ignore / mixed).
+
+    Preserved as a separate command in v1.1.0 after `aelf health` was
+    rewritten as the structural auditor. The classifier is informational
+    — it never affects exit status.
+    """
     _ = args
     store = _open_store()
     try:
@@ -921,8 +967,23 @@ def build_parser() -> argparse.ArgumentParser:
     p_stats = sub.add_parser("stats", help="summary of belief / lock / history counts")
     p_stats.set_defaults(func=_cmd_stats)
 
-    p_health = sub.add_parser("health", help="regime classifier output")
+    p_health = sub.add_parser(
+        "health",
+        help="structural auditor (orphan edges, FTS5 sync, locked contradictions)",
+    )
     p_health.set_defaults(func=_cmd_health)
+
+    p_status = sub.add_parser(
+        "status",
+        help="alias for `aelf health` (structural auditor)",
+    )
+    p_status.set_defaults(func=_cmd_health)
+
+    p_regime = sub.add_parser(
+        "regime",
+        help="v1.0 regime classifier (supersede / ignore / mixed)",
+    )
+    p_regime.set_defaults(func=_cmd_regime)
 
     p_doctor = sub.add_parser(
         "doctor",

--- a/src/aelfrice/slash_commands/health.md
+++ b/src/aelfrice/slash_commands/health.md
@@ -1,12 +1,16 @@
 ---
 name: aelf:health
-description: Run the regime classifier and report the brain's current operating mode.
+description: Run the structural auditor and report orphan edges, FTS5 sync, and locked-belief contradictions plus informational metrics.
 allowed-tools:
   - Bash
 ---
 <objective>
-Diagnose the brain's regime — supersede vs. ignore vs. balanced — based
-on aggregate confidence, lock density, and edge density.
+Run the v1.1.0 structural auditor against the local memory store. Each
+of three checks (orphan edges, FTS5 sync drift, locked-belief
+CONTRADICTS pairs) reports ok or FAIL; the command exits 1 if any
+check fails. Informational metrics (counts, average confidence, credal
+gap) are printed alongside but do not affect exit status. For the v1.0
+regime classifier output, use `aelf regime`.
 </objective>
 
 <process>

--- a/src/aelfrice/slash_commands/regime.md
+++ b/src/aelfrice/slash_commands/regime.md
@@ -1,0 +1,19 @@
+---
+name: aelf:regime
+description: Print the v1.0 regime classifier output (supersede / ignore / mixed / insufficient_data).
+allowed-tools:
+  - Bash
+---
+<objective>
+Print the brain's current regime label as computed by the v1.0
+classifier. Five features (confidence mean / median, mass mean, lock
+density, edge density) are scored against published anchors and
+aggregated into one of four labels. Informational only; never affects
+exit status. For structural auditing (orphan edges, FTS5 sync, locked
+contradictions), use `aelf health`.
+</objective>
+
+<process>
+Run: `uv run aelf regime`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/slash_commands/status.md
+++ b/src/aelfrice/slash_commands/status.md
@@ -1,0 +1,15 @@
+---
+name: aelf:status
+description: Alias for `aelf:health` — runs the structural auditor.
+allowed-tools:
+  - Bash
+---
+<objective>
+`aelf status` is an alias for `aelf health`. Same output, same exit
+codes. Use whichever name fits your muscle memory.
+</objective>
+
+<process>
+Run: `uv run aelf status`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -400,6 +400,73 @@ class MemoryStore:
         )
         return [_row_to_belief(r) for r in cur.fetchall()]
 
+    # --- Auditor queries (used by aelf health) ---------------------------
+
+    def count_orphan_edges(self) -> int:
+        """Edges whose `src` or `dst` no longer exists in `beliefs`.
+
+        Should always be zero in a healthy store: `delete_belief` cascades
+        to incident edges. A nonzero result indicates a foreign-key invariant
+        violation (or a partial write the v1.0 schema's lack of FK enforcement
+        let through).
+        """
+        cur = self._conn.execute(
+            """
+            SELECT COUNT(*) AS n FROM edges e
+            WHERE NOT EXISTS (SELECT 1 FROM beliefs WHERE id = e.src)
+               OR NOT EXISTS (SELECT 1 FROM beliefs WHERE id = e.dst)
+            """
+        )
+        row = cur.fetchone()
+        return int(row["n"]) if row else 0
+
+    def count_fts_rows(self) -> int:
+        """Row count of the `beliefs_fts` virtual table.
+
+        Should equal `count_beliefs()` in a healthy store. Drift indicates
+        an FTS5 / `beliefs` write was not properly mirrored — usually a
+        crash mid-`update_belief` or a manual schema edit.
+        """
+        cur = self._conn.execute("SELECT COUNT(*) AS n FROM beliefs_fts")
+        row = cur.fetchone()
+        return int(row["n"]) if row else 0
+
+    def list_locked_contradicts_pairs(self) -> list[tuple[str, str]]:
+        """All `(a_id, b_id)` pairs where both beliefs are locked AND a
+        `CONTRADICTS` edge exists between them in either direction.
+
+        Pairs are deduplicated and ordered by `(min(a,b), max(a,b))` so the
+        result is deterministic. The contradiction tie-breaker (v1.0.1)
+        should resolve these via SUPERSEDES; remaining pairs indicate
+        unresolved contradictions a reviewer or `aelf resolve` should act on.
+        """
+        cur = self._conn.execute(
+            """
+            SELECT DISTINCT
+                MIN(e.src, e.dst) AS a,
+                MAX(e.src, e.dst) AS b
+            FROM edges e
+            JOIN beliefs ba ON ba.id = e.src
+            JOIN beliefs bb ON bb.id = e.dst
+            WHERE e.type = 'CONTRADICTS'
+              AND ba.lock_level != 'none'
+              AND bb.lock_level != 'none'
+            ORDER BY a, b
+            """
+        )
+        return [(str(r["a"]), str(r["b"])) for r in cur.fetchall()]
+
+    def count_edges_by_type(self) -> dict[str, int]:
+        """`{edge_type: count}` for every edge type in the store.
+
+        Used by `aelf health` informational output and the v1.1.0 auditor
+        feedback-coverage metric.
+        """
+        cur = self._conn.execute(
+            "SELECT type, COUNT(*) AS n FROM edges GROUP BY type"
+        )
+        return {str(r["type"]): int(r["n"]) for r in cur.fetchall()}
+
     # --- Edge CRUD --------------------------------------------------------
 
     def insert_edge(self, e: Edge) -> None:

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -1,0 +1,201 @@
+"""Tests for `aelfrice.auditor` — the v1.1.0 structural auditor.
+
+Three checks: orphan_edges, fts_sync, locked_contradicts. Each test
+seeds a state that triggers exactly one check, asserting the report's
+`failed` flag and the specific finding's severity / count.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aelfrice.auditor import (
+    CHECK_FTS_SYNC,
+    CHECK_LOCKED_CONTRADICTS,
+    CHECK_ORPHAN_EDGES,
+    SEVERITY_FAIL,
+    SEVERITY_INFO,
+    audit,
+)
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CONTRADICTS,
+    EDGE_SUPPORTS,
+    LOCK_NONE,
+    LOCK_USER,
+    Belief,
+    Edge,
+)
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path):
+    s = MemoryStore(str(tmp_path / "audit.db"))
+    yield s
+    s.close()
+
+
+def _belief(bid: str, *, content: str = None, locked: bool = False) -> Belief:
+    return Belief(
+        id=bid,
+        content=content or f"belief content for {bid}",
+        content_hash=f"hash-{bid}",
+        alpha=9.0 if locked else 1.0,
+        beta=0.5,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_USER if locked else LOCK_NONE,
+        locked_at="2026-04-27T00:00:00Z" if locked else None,
+        demotion_pressure=0,
+        created_at="2026-04-27T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _find(report, check: str):
+    for f in report.findings:
+        if f.check == check:
+            return f
+    raise AssertionError(f"finding for {check!r} not in report")
+
+
+# --- Empty store -----------------------------------------------------
+
+
+def test_audit_empty_store_passes_all_checks(store: MemoryStore) -> None:
+    report = audit(store)
+    assert not report.failed
+    for f in report.findings:
+        assert f.severity == SEVERITY_INFO
+
+
+def test_audit_empty_store_metrics_are_zeros(store: MemoryStore) -> None:
+    report = audit(store)
+    assert report.metrics["beliefs"] == 0
+    assert report.metrics["edges"] == 0
+    assert report.metrics["locked"] == 0
+
+
+# --- orphan_edges ----------------------------------------------------
+
+
+def test_audit_flags_orphan_edge(store: MemoryStore) -> None:
+    """An edge whose dst doesn't exist must fail the orphan_edges check."""
+    a = _belief("aaaa")
+    store.insert_belief(a)
+    # Insert an edge to a missing dst by going under the API:
+    store._conn.execute(  # type: ignore[attr-defined]
+        "INSERT INTO edges (src, dst, type, weight) VALUES (?, ?, ?, ?)",
+        (a.id, "ghost", EDGE_SUPPORTS, 1.0),
+    )
+    store._conn.commit()  # type: ignore[attr-defined]
+    report = audit(store)
+    assert report.failed
+    f = _find(report, CHECK_ORPHAN_EDGES)
+    assert f.severity == SEVERITY_FAIL
+    assert f.count == 1
+
+
+def test_audit_clean_edges_pass_orphan_check(store: MemoryStore) -> None:
+    a, b = _belief("aaaa"), _belief("bbbb")
+    store.insert_belief(a)
+    store.insert_belief(b)
+    store.insert_edge(Edge(src=a.id, dst=b.id, type=EDGE_SUPPORTS, weight=1.0))
+    report = audit(store)
+    f = _find(report, CHECK_ORPHAN_EDGES)
+    assert f.severity == SEVERITY_INFO
+    assert f.count == 0
+
+
+# --- fts_sync --------------------------------------------------------
+
+
+def test_audit_flags_fts_drift(store: MemoryStore) -> None:
+    """A belief without its FTS mirror row must fail fts_sync."""
+    a = _belief("aaaa")
+    store.insert_belief(a)
+    # Manually delete the FTS row so beliefs and beliefs_fts disagree:
+    store._conn.execute(  # type: ignore[attr-defined]
+        "DELETE FROM beliefs_fts WHERE id = ?", (a.id,),
+    )
+    store._conn.commit()  # type: ignore[attr-defined]
+    report = audit(store)
+    assert report.failed
+    f = _find(report, CHECK_FTS_SYNC)
+    assert f.severity == SEVERITY_FAIL
+    assert f.count == 1
+
+
+def test_audit_passes_fts_sync_after_normal_inserts(store: MemoryStore) -> None:
+    for bid in ("aa", "bb", "cc"):
+        store.insert_belief(_belief(bid))
+    report = audit(store)
+    f = _find(report, CHECK_FTS_SYNC)
+    assert f.severity == SEVERITY_INFO
+
+
+# --- locked_contradicts ---------------------------------------------
+
+
+def test_audit_flags_locked_contradicts_pair(store: MemoryStore) -> None:
+    """Two locked beliefs joined by CONTRADICTS must fail."""
+    a = _belief("aaaa", content="rule one is true", locked=True)
+    b = _belief("bbbb", content="rule one is false", locked=True)
+    store.insert_belief(a)
+    store.insert_belief(b)
+    store.insert_edge(Edge(src=a.id, dst=b.id, type=EDGE_CONTRADICTS, weight=1.0))
+    report = audit(store)
+    assert report.failed
+    f = _find(report, CHECK_LOCKED_CONTRADICTS)
+    assert f.severity == SEVERITY_FAIL
+    assert f.count == 1
+
+
+def test_audit_ignores_unlocked_contradicts(store: MemoryStore) -> None:
+    """A CONTRADICTS edge between unlocked beliefs is informational."""
+    a = _belief("aaaa", content="rule one is true")
+    b = _belief("bbbb", content="rule one is false")
+    store.insert_belief(a)
+    store.insert_belief(b)
+    store.insert_edge(Edge(src=a.id, dst=b.id, type=EDGE_CONTRADICTS, weight=1.0))
+    report = audit(store)
+    f = _find(report, CHECK_LOCKED_CONTRADICTS)
+    assert f.severity == SEVERITY_INFO
+    assert not report.failed
+
+
+def test_audit_locked_contradicts_pair_is_undirected(store: MemoryStore) -> None:
+    """CONTRADICTS dst→src is the same finding as src→dst — pair-level."""
+    a = _belief("aaaa", content="rule one is true", locked=True)
+    b = _belief("bbbb", content="rule one is false", locked=True)
+    store.insert_belief(a)
+    store.insert_belief(b)
+    # Two contradicts edges — one each direction. Should still be ONE pair.
+    store.insert_edge(Edge(src=a.id, dst=b.id, type=EDGE_CONTRADICTS, weight=1.0))
+    store.insert_edge(Edge(src=b.id, dst=a.id, type=EDGE_CONTRADICTS, weight=1.0))
+    report = audit(store)
+    f = _find(report, CHECK_LOCKED_CONTRADICTS)
+    assert f.count == 1
+
+
+# --- failed flag aggregation ----------------------------------------
+
+
+def test_audit_failed_when_any_check_fails(store: MemoryStore) -> None:
+    a = _belief("aaaa")
+    store.insert_belief(a)
+    store._conn.execute(  # type: ignore[attr-defined]
+        "DELETE FROM beliefs_fts WHERE id = ?", (a.id,),
+    )
+    store._conn.commit()  # type: ignore[attr-defined]
+    report = audit(store)
+    assert report.failed
+
+
+def test_audit_metrics_include_avg_confidence(store: MemoryStore) -> None:
+    a = _belief("aaaa")
+    store.insert_belief(a)
+    report = audit(store)
+    # alpha=1.0, beta=0.5 → posterior mean 0.667
+    assert 0.6 <= report.metrics["avg_confidence"] <= 0.7

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -303,17 +303,63 @@ def test_stats_after_lock_shows_one_belief_one_locked(isolated_db: Path) -> None
     assert lines.get("locked") == "1"
 
 
-# --- health -------------------------------------------------------------
+# --- health (v1.1.0 auditor) -------------------------------------------
 
 
-def test_health_on_empty_db_reports_insufficient_data(isolated_db: Path) -> None:
+def test_health_on_empty_db_passes_audit(isolated_db: Path) -> None:
+    """Empty store: no findings can fire. Exit 0."""
     code, out = _run("health")
+    assert code == 0
+    assert "audit:" in out
+    assert "[ok  ]" in out  # at least one ok line
+
+
+def test_health_emits_metrics_section(isolated_db: Path) -> None:
+    code, out = _run("health")
+    assert code == 0
+    assert "metrics:" in out
+    assert "beliefs" in out
+
+
+def test_health_points_at_aelf_regime_for_classifier(isolated_db: Path) -> None:
+    code, out = _run("health")
+    assert code == 0
+    assert "aelf regime" in out
+
+
+def test_status_aliases_health(isolated_db: Path) -> None:
+    """`aelf status` produces the same output as `aelf health`."""
+    code_h, out_h = _run("health")
+    code_s, out_s = _run("status")
+    assert code_h == code_s == 0
+    assert out_h == out_s
+
+
+def test_health_exits_nonzero_when_audit_fails(isolated_db: Path) -> None:
+    """Forcing an FTS5 drift makes `aelf health` exit 1."""
+    _run("lock", "rule for the failing case")
+    s = MemoryStore(str(isolated_db))
+    try:
+        s._conn.execute("DELETE FROM beliefs_fts")  # type: ignore[attr-defined]
+        s._conn.commit()  # type: ignore[attr-defined]
+    finally:
+        s.close()
+    code, out = _run("health")
+    assert code == 1
+    assert "FAIL" in out
+
+
+# --- regime (v1.0 classifier preserved) --------------------------------
+
+
+def test_regime_on_empty_db_reports_insufficient_data(isolated_db: Path) -> None:
+    code, out = _run("regime")
     assert code == 0
     assert "insufficient_data" in out
 
 
-def test_health_output_contains_brain_mode_label(isolated_db: Path) -> None:
-    code, out = _run("health")
+def test_regime_output_contains_brain_mode_label(isolated_db: Path) -> None:
+    code, out = _run("regime")
     assert code == 0
     assert "brain mode" in out
 

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -1,4 +1,4 @@
-"""Verify the 11 slash-command markdown files match the CLI surface.
+"""Verify the slash-command markdown files match the CLI surface.
 
 These files ship inside the aelfrice package so `setup.py` (v0.7.0) can
 copy them into `~/.claude/commands/aelf/`. The tests check structural
@@ -15,6 +15,8 @@ import pytest
 # The CLI's user-facing surface -- must match cli.py's subparsers exactly.
 # Lifecycle commands (upgrade/uninstall/statusline) added in v1.0.1.
 # `resolve` joins at v1.0.1 alongside the contradiction tie-breaker.
+# `status` (alias for health) and `regime` (preserved v1.0 classifier)
+# join at v1.1.0 alongside the structural auditor.
 EXPECTED_COMMANDS = (
     "onboard",
     "search",
@@ -25,6 +27,8 @@ EXPECTED_COMMANDS = (
     "feedback",
     "stats",
     "health",
+    "status",
+    "regime",
     "doctor",
     "setup",
     "unsetup",


### PR DESCRIPTION
## Why

Closes #90.

v1.0 ships \`aelf health\` as a regime classifier (supersede / ignore / mixed) — informational, never affects exit. Lab \`COMMAND_DESIGN.md\` § \"Decisions made\" is explicit: **\"\`/aelf:stats\` = numbers. \`/aelf:health\` = diagnostics. Stats is analytics, health is 'is anything broken?'\"** and **\"\`aelfrice status\` is an alias for \`aelfrice health\`\"**.

This patch:
- Rewrites \`aelf health\` to that contract (auditor, exits 1 on findings).
- Preserves the v1.0 regime classifier under a new \`aelf regime\` command (no R&D loss).
- Adds \`aelf status\` as alias for \`aelf health\` per lab convention.

## What

**New \`aelfrice.auditor\` module.** Three mechanical checks against the local store. \`AuditFinding\` dataclass with \`severity ∈ {fail, info}\`. \`audit(store) -> AuditReport\` packages findings + a metrics dict.

| Check | Fails when |
|---|---|
| \`orphan_edges\` | edge.src or edge.dst not in beliefs |
| \`fts_sync\` | \`count_beliefs() != count_fts_rows()\` |
| \`locked_contradicts\` | any pair of locked beliefs joined by CONTRADICTS edge |

Threshold-tuned checks (\`isolated_clusters\`, \`decay_anomalies\`) **deferred to v1.2.0+**. They need calibration data the v1.1.0 store doesn't yet make available; shipping them with arbitrary thresholds would generate noise.

**Store API additions** (read-only): \`count_orphan_edges()\`, \`count_fts_rows()\`, \`list_locked_contradicts_pairs()\`, \`count_edges_by_type()\`.

**CLI surface** (3 changes):
- \`aelf health\` — runs the auditor. Prints findings + metrics. Exit 1 on any FAIL, 0 otherwise.
- \`aelf status\` — alias for \`health\`. Same handler, same output.
- \`aelf regime\` — preserves v1.0 regime classifier output. Always exit 0.

**Slash commands**: \`status.md\` and \`regime.md\` added; \`health.md\` rewritten.

## Verification

- \`uv run pytest tests/\` → **889 passed** (up from 877; +11 auditor + 8 cli + 3 slash-parametrized).
- \`uv run aelf health\` from \`/tmp\` (empty DB) → all 3 checks ok, exit 0.
- \`uv run aelf health\` after seeding a CONTRADICTS-locked-pair fixture → \`[FAIL] locked_contradicts\`, exit 1.
- \`uv run aelf status\` produces byte-identical output to \`aelf health\`.
- \`uv run aelf regime\` produces v1.0 regime output unchanged.

## Sample output

```
audit:
  [ok  ] orphan_edges             all edges resolve to existing beliefs
  [ok  ] fts_sync                 FTS5 mirror in sync (1 rows)
  [ok  ] locked_contradicts       no unresolved contradictions between locked beliefs

metrics:
  beliefs                  1
  edges                    0
  locked                   1
  feedback_events          0
  avg_confidence           0.947
  credal_gap               0

run \`aelf regime\` for the v1.0 regime classifier.
```

## Docs

- \`COMMANDS.md\` — table updated for \`health\` / \`status\` / \`regime\`; preamble bumped to \"eighteen subcommands\".
- \`ARCHITECTURE.md\` — \`auditor.py\` module row added; \`cli.py\` row updated.

## Local-only contract

Pure read-only against the local store. No network, no git boundary crossing.