### PR TITLE
feat(v1.1.0): onboard git-recency weighting (Tier 2) (#94)

### DIFF
--- a/src/aelfrice/scanner.py
+++ b/src/aelfrice/scanner.py
@@ -73,10 +73,18 @@ class SentenceCandidate:
     - source: stable identifier for the origin (e.g. `doc:README.md`,
       `git:commit:abcdef`, `ast:src/foo.py:bar`); read by the
       classifier and stored on the Belief for provenance
+    - commit_date: ISO-8601 author date of the most recent commit that
+      touched the source file (or, for `git:commit:*` candidates, the
+      commit's own date). `None` for files outside any git work-tree
+      and for files with no commit history (newly added, untracked).
+      v1.1.0 git-recency feature: when set, scan_repo uses this as
+      `belief.created_at` so the existing decay mechanism penalises
+      pre-migration content from old branches.
     """
 
     text: str
     source: str
+    commit_date: str | None = None
 
 
 def scan_repo(
@@ -121,10 +129,19 @@ def scan_repo(
         else NoiseConfig.discover(root)
     )
 
+    # v1.1.0 git-recency: one git invocation produces a map of
+    # {relative-path: most-recent-author-date}. Extractors enrich each
+    # SentenceCandidate with the matching commit_date so the eventual
+    # belief gets `created_at = commit_date` instead of wall-clock now.
+    # Files outside git, untracked files, and the entire fallback when
+    # git is unavailable all yield commit_date=None and the wall-clock
+    # path applies as before.
+    recency = _build_file_recency_map(root)
+
     candidates: list[SentenceCandidate] = []
-    candidates.extend(extract_filesystem(root))
+    candidates.extend(extract_filesystem(root, recency=recency))
     candidates.extend(extract_git_log(root))
-    candidates.extend(extract_ast(root))
+    candidates.extend(extract_ast(root, recency=recency))
 
     inserted = 0
     skipped_existing = 0
@@ -143,6 +160,7 @@ def scan_repo(
         if store.get_belief(belief_id) is not None:
             skipped_existing += 1
             continue
+        created_at = candidate.commit_date or timestamp
         store.insert_belief(Belief(
             id=belief_id,
             content=candidate.text,
@@ -153,7 +171,7 @@ def scan_repo(
             lock_level=LOCK_NONE,
             locked_at=None,
             demotion_pressure=0,
-            created_at=timestamp,
+            created_at=created_at,
             last_retrieved_at=None,
         ))
         inserted += 1
@@ -260,6 +278,67 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _build_file_recency_map(root: Path) -> dict[str, str]:
+    """Return `{relative-path: most-recent-author-date-iso}` for every
+    file in the git work-tree.
+
+    Walks `git log --name-only --pretty=format:%aI` once. Output is
+    pairs of `<iso-date>` lines followed by a blank line followed by
+    one or more `<file>` lines, separated by blank lines between
+    commits. Newer commits come first; we record the first date seen
+    for each file (which is the most recent).
+
+    Returns an empty dict when:
+    - `root` is not a directory
+    - `root` is not a git work-tree
+    - `git` binary is missing or rev-parse fails or times out
+
+    Pure stdlib subprocess. One fork per `scan_repo` call regardless of
+    file count.
+    """
+    if not root.exists() or not root.is_dir():
+        return {}
+    if not (root / ".git").exists():
+        return {}
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "log",
+                "--name-only",
+                "--pretty=format:%aI",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_LOG_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return {}
+    if result.returncode != 0:
+        return {}
+
+    out: dict[str, str] = {}
+    current_date: str | None = None
+    for raw in result.stdout.splitlines():
+        line = raw.rstrip()
+        if not line:
+            continue
+        # ISO-8601 author date starts with a 4-digit year; file paths
+        # never do. Cheap classifier without re-parsing the format.
+        if len(line) >= 10 and line[0:4].isdigit() and line[4] == "-":
+            current_date = line
+            continue
+        if current_date is None:
+            continue
+        # First-seen wins (newer commits come first). Don't overwrite.
+        if line not in out:
+            out[line] = current_date
+    return out
+
+
 def extract_git_log(
     root: Path,
     limit: int = _GIT_LOG_DEFAULT_LIMIT,
@@ -290,7 +369,7 @@ def extract_git_log(
                 "-C",
                 str(root),
                 "log",
-                "--format=%H%x09%s",
+                "--format=%H%x09%aI%x09%s",
                 "-n",
                 str(limit),
             ],
@@ -307,9 +386,10 @@ def extract_git_log(
 
     candidates: list[SentenceCandidate] = []
     for line in result.stdout.splitlines():
-        if "\t" not in line:
+        parts = line.split("\t", 2)
+        if len(parts) != 3:
             continue
-        sha, _, subject = line.partition("\t")
+        sha, iso_date, subject = parts
         subject = subject.strip()
         if not subject:
             continue
@@ -317,6 +397,7 @@ def extract_git_log(
             SentenceCandidate(
                 text=subject,
                 source=f"git:commit:{sha[:7]}",
+                commit_date=iso_date or None,
             )
         )
     return candidates
@@ -403,7 +484,11 @@ def _extract_from_module(
     return out
 
 
-def extract_ast(root: Path) -> list[SentenceCandidate]:
+def extract_ast(
+    root: Path,
+    *,
+    recency: dict[str, str] | None = None,
+) -> list[SentenceCandidate]:
     """Walk .py files under root and extract docstrings as candidates.
 
     Three sources only — module docstrings, top-level function
@@ -419,7 +504,13 @@ def extract_ast(root: Path) -> list[SentenceCandidate]:
       `ast:<rel-path>:module`
       `ast:<rel-path>:func:<name>`
       `ast:<rel-path>:class:<name>`
+
+    `recency` maps relative-path -> ISO-8601 author date of the most
+    recent commit that touched the file. When provided and the file
+    has an entry, every candidate from that file is tagged with the
+    matching `commit_date` so scan_repo writes it as `belief.created_at`.
     """
+    rec = recency or {}
     candidates: list[SentenceCandidate] = []
     for path in _iter_py_files(root):
         try:
@@ -431,17 +522,31 @@ def extract_ast(root: Path) -> list[SentenceCandidate]:
         except SyntaxError:
             continue
         rel = path.relative_to(root).as_posix()
-        candidates.extend(_extract_from_module(tree, rel))
+        commit_date = rec.get(rel)
+        for c in _extract_from_module(tree, rel):
+            if commit_date is not None:
+                c.commit_date = commit_date
+            candidates.append(c)
     return candidates
 
 
-def extract_filesystem(root: Path) -> list[SentenceCandidate]:
+def extract_filesystem(
+    root: Path,
+    *,
+    recency: dict[str, str] | None = None,
+) -> list[SentenceCandidate]:
     """Walk `root` and emit one candidate per doc paragraph.
 
     Pure-stdlib, deterministic for any stable input tree. Handles
     missing/non-directory roots gracefully (returns empty list).
     Source string format: `doc:<relative_path>:p<paragraph-index>`.
+
+    `recency` maps relative-path -> ISO-8601 author date of the most
+    recent commit that touched the file. When provided and the file
+    has an entry, every candidate from that file is tagged with the
+    matching `commit_date` so scan_repo writes it as `belief.created_at`.
     """
+    rec = recency or {}
     candidates: list[SentenceCandidate] = []
     if not root.exists() or not root.is_dir():
         return candidates
@@ -452,11 +557,13 @@ def extract_filesystem(root: Path) -> list[SentenceCandidate]:
         except (PermissionError, OSError):
             continue
         rel = path.relative_to(root).as_posix()
+        commit_date = rec.get(rel)
         for idx, para in enumerate(_split_paragraphs(text)):
             candidates.append(
                 SentenceCandidate(
                     text=para,
                     source=f"doc:{rel}:p{idx}",
+                    commit_date=commit_date,
                 )
             )
     return candidates

--- a/tests/test_scanner_git_recency.py
+++ b/tests/test_scanner_git_recency.py
@@ -1,0 +1,225 @@
+"""Tests for the v1.1.0 git-recency weighting (#94, Tier 2 of CORE_RANKING).
+
+The scanner records the most-recent author date of the commit that
+touched each source file. `scan_repo` uses that as `belief.created_at`
+so the existing decay mechanism penalises pre-migration content from
+old branches.
+
+Files outside any git work-tree, untracked files, and the entire
+fallback when `git` is unavailable continue to use the wall-clock
+`now` parameter — preserving the v1.0 behaviour.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aelfrice.scanner import (
+    SentenceCandidate,
+    _build_file_recency_map,
+    extract_ast,
+    extract_filesystem,
+    extract_git_log,
+    scan_repo,
+)
+from aelfrice.store import MemoryStore
+
+
+def _git_init(repo: Path, env_extra: dict[str, str] | None = None) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+
+
+def _git_commit(
+    repo: Path,
+    *files: str,
+    message: str,
+    author_date: str = "2024-01-01T00:00:00+00:00",
+) -> None:
+    subprocess.run(["git", "add", *files], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c", "user.email=t@t",
+            "-c", "user.name=t",
+            "-c", "commit.gpgsign=false",
+            "commit", "-q", "-m", message,
+            "--date", author_date,
+        ],
+        cwd=repo,
+        check=True,
+        env={
+            **__import__("os").environ,
+            "GIT_AUTHOR_DATE": author_date,
+            "GIT_COMMITTER_DATE": author_date,
+        },
+    )
+
+
+# --- _build_file_recency_map ---------------------------------------
+
+
+def test_recency_map_empty_outside_git(tmp_path: Path) -> None:
+    """A non-git directory yields no recency entries."""
+    assert _build_file_recency_map(tmp_path) == {}
+
+
+def test_recency_map_records_one_commit(tmp_path: Path) -> None:
+    repo = tmp_path / "r"
+    repo.mkdir()
+    _git_init(repo)
+    (repo / "README.md").write_text("hello", encoding="utf-8")
+    _git_commit(repo, "README.md", message="add readme",
+                author_date="2024-06-15T12:00:00+00:00")
+    rec = _build_file_recency_map(repo)
+    assert "README.md" in rec
+    assert rec["README.md"].startswith("2024-06-15")
+
+
+def test_recency_map_keeps_most_recent_when_file_touched_twice(
+    tmp_path: Path,
+) -> None:
+    """A file modified across two commits is recorded with the newer date."""
+    repo = tmp_path / "r"
+    repo.mkdir()
+    _git_init(repo)
+    (repo / "f.md").write_text("v1", encoding="utf-8")
+    _git_commit(repo, "f.md", message="v1",
+                author_date="2023-01-01T00:00:00+00:00")
+    (repo / "f.md").write_text("v2", encoding="utf-8")
+    _git_commit(repo, "f.md", message="v2",
+                author_date="2025-06-01T00:00:00+00:00")
+    rec = _build_file_recency_map(repo)
+    # newer commit comes first in `git log`, so first-seen wins
+    assert rec["f.md"].startswith("2025-06-01")
+
+
+# --- extract_filesystem ---------------------------------------------
+
+
+def test_extract_filesystem_passes_commit_date_through(
+    tmp_path: Path,
+) -> None:
+    """Doc candidates carry the recency map's date in commit_date."""
+    repo = tmp_path / "r"
+    repo.mkdir()
+    (repo / "DOC.md").write_text(
+        "this is a paragraph long enough to pass the minimum char filter",
+        encoding="utf-8",
+    )
+    recency = {"DOC.md": "2024-09-01T00:00:00+00:00"}
+    cands = extract_filesystem(repo, recency=recency)
+    assert cands
+    for c in cands:
+        assert c.commit_date == "2024-09-01T00:00:00+00:00"
+
+
+def test_extract_filesystem_no_recency_means_no_commit_date(
+    tmp_path: Path,
+) -> None:
+    """No recency arg -> commit_date stays None (back-compat path)."""
+    repo = tmp_path / "r"
+    repo.mkdir()
+    (repo / "DOC.md").write_text(
+        "this is a paragraph long enough to pass the minimum char filter",
+        encoding="utf-8",
+    )
+    cands = extract_filesystem(repo)
+    assert cands
+    for c in cands:
+        assert c.commit_date is None
+
+
+# --- extract_ast ----------------------------------------------------
+
+
+def test_extract_ast_passes_commit_date_through(tmp_path: Path) -> None:
+    repo = tmp_path / "r"
+    repo.mkdir()
+    (repo / "m.py").write_text(
+        '"""module-level docstring describing what this module does."""\n',
+        encoding="utf-8",
+    )
+    recency = {"m.py": "2024-04-01T00:00:00+00:00"}
+    cands = extract_ast(repo, recency=recency)
+    assert cands
+    for c in cands:
+        assert c.commit_date == "2024-04-01T00:00:00+00:00"
+
+
+# --- extract_git_log ------------------------------------------------
+
+
+def test_git_log_candidate_carries_commit_date(tmp_path: Path) -> None:
+    """Each git:commit:* candidate carries the commit's own author date."""
+    repo = tmp_path / "r"
+    repo.mkdir()
+    _git_init(repo)
+    (repo / "f").write_text("x", encoding="utf-8")
+    _git_commit(repo, "f", message="atomic descriptive subject for the test",
+                author_date="2024-12-25T08:00:00+00:00")
+    cands = extract_git_log(repo)
+    assert cands
+    assert cands[0].commit_date is not None
+    assert cands[0].commit_date.startswith("2024-12-25")
+
+
+# --- scan_repo end-to-end ------------------------------------------
+
+
+def test_scan_repo_uses_commit_date_for_committed_doc(tmp_path: Path) -> None:
+    """A doc file with a git commit lands in the store with
+    `belief.created_at == commit author date` rather than the wall-clock
+    `now` argument."""
+    repo = tmp_path / "r"
+    repo.mkdir()
+    _git_init(repo)
+    (repo / "RULES.md").write_text(
+        "lock fast and ship small commits with conventional prefixes",
+        encoding="utf-8",
+    )
+    _git_commit(repo, "RULES.md", message="add rules",
+                author_date="2024-08-01T00:00:00+00:00")
+
+    db = tmp_path / "db.sqlite"
+    store = MemoryStore(str(db))
+    try:
+        scan_repo(store, repo, now="2099-01-01T00:00:00Z")
+        # Find the doc-derived belief and check its created_at
+        cur = store._conn.execute(  # type: ignore[attr-defined]
+            "SELECT created_at FROM beliefs WHERE id IN ("
+            "  SELECT id FROM beliefs WHERE content LIKE '%lock fast%'"
+            ") LIMIT 1"
+        )
+        row = cur.fetchone()
+        assert row is not None
+        # Must be the commit date, not the 2099 wall-clock
+        assert row["created_at"].startswith("2024-08-01")
+    finally:
+        store.close()
+
+
+def test_scan_repo_falls_back_to_wallclock_outside_git(
+    tmp_path: Path,
+) -> None:
+    """Non-git directory: every belief gets `created_at = now`."""
+    project = tmp_path / "p"
+    project.mkdir()
+    (project / "DOC.md").write_text(
+        "the project ships only the regex fallback at version zero point five",
+        encoding="utf-8",
+    )
+    db = tmp_path / "db.sqlite"
+    store = MemoryStore(str(db))
+    try:
+        scan_repo(store, project, now="2030-05-05T00:00:00Z")
+        cur = store._conn.execute(  # type: ignore[attr-defined]
+            "SELECT created_at FROM beliefs"
+        )
+        rows = cur.fetchall()
+        assert rows
+        for row in rows:
+            assert row["created_at"] == "2030-05-05T00:00:00Z"
+    finally:
+        store.close()


### PR DESCRIPTION
## Why

Closes #94.

Pre-migration content from old branches surfaced as first-class beliefs with \`created_at = scan-time wall clock\`. The existing decay mechanism (\`src/aelfrice/scoring.py\`) is parameterised on \`created_at\`, so beliefs derived from a 3-year-old README decayed at the same rate as a brand-new lock. Lab \`docs/CORE_RANKING.md\` § Tier 2 specifies the fix: pass git's most-recent commit date through to \`belief.created_at\` and let the existing decay code do the rest. **No new ranking math.**

## What

**\`SentenceCandidate\`** gains an optional \`commit_date: str | None = None\` field. Default preserves every existing call site.

**\`_build_file_recency_map(root)\`** — new helper. **One** \`git log --name-only --pretty=format:%aI\` invocation per \`scan_repo\` call. Walks output newest-to-oldest; first-seen wins per relative path. Returns \`{}\` when:

- \`root\` is not a directory
- \`root\` is not a git work-tree
- \`git\` binary is missing
- subprocess errors or times out (shared 5s budget)

O(commits + files), one fork regardless of file count.

**Extractors enriched**:

| Extractor | How it picks up \`commit_date\` |
|---|---|
| \`extract_filesystem(root, *, recency=...)\` | Looks up \`recency.get(relative-path)\` once per file, stamps every paragraph candidate from that file. |
| \`extract_ast(root, *, recency=...)\` | Same — every docstring candidate from a file gets the file's date. |
| \`extract_git_log(root)\` | Native: \`--format\` extended from \`%H%x09%s\` to \`%H%x09%aI%x09%s\`; each \`git:commit:*\` candidate carries its own commit's author date. |

**\`scan_repo\`**: builds the map once, passes it to \`extract_filesystem\` and \`extract_ast\`, then writes \`created_at = candidate.commit_date or timestamp\`. The wall-clock fallback is unchanged for non-git directories and untracked files.

## Verification

- \`uv run pytest tests/test_scanner_git_recency.py\` → **9 passed**.
- 80 existing scanner tests still pass.
- Full suite: **898 passed** (up from 889).
- One-fork-per-scan keeps onboard performance well under the 60s regression budget — the perf test passes.

## Tests added

\`tests/test_scanner_git_recency.py\` — 9 cases:

| Test | What it verifies |
|---|---|
| \`test_recency_map_empty_outside_git\` | Non-git directory yields \`{}\` |
| \`test_recency_map_records_one_commit\` | Single commit lands the date |
| \`test_recency_map_keeps_most_recent_when_file_touched_twice\` | Newer commit wins on conflict |
| \`test_extract_filesystem_passes_commit_date_through\` | Doc candidates carry the date |
| \`test_extract_filesystem_no_recency_means_no_commit_date\` | Backcompat: no recency arg → \`commit_date=None\` |
| \`test_extract_ast_passes_commit_date_through\` | Docstring candidates carry the date |
| \`test_git_log_candidate_carries_commit_date\` | \`git:commit:*\` candidates self-date |
| \`test_scan_repo_uses_commit_date_for_committed_doc\` | End-to-end: commit-dated belief lands with \`created_at\` = commit author date even when \`now\` is set to 2099 |
| \`test_scan_repo_falls_back_to_wallclock_outside_git\` | Non-git project still uses wall-clock \`now\` |

## Out of scope

- **Promotion path** (\`agent_inferred → user_validated\`): designed in #95 (PR #101 is the memo); implemented in v1.2.0.
- **Bayesian-weighted retrieval ranking**: v1.3.0.

## Local-only contract

Reads from the local git repo. No data movement.