### PR TITLE
release: v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,44 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-27
+
+Minor release: project identity, structural auditor, onboarding
+git-recency, legacy-DB migration tool, design memo for the v1.2.0
+promotion path, worktree concurrency tests, and the `edges → threads`
+user-facing rename. Eight PRs landed between v1.0.3 and v1.1.0.
+
+### Added
+
+- **Per-project DB resolution** ([#88](https://github.com/robotrocketscience/aelfrice/issues/88), PR [#96](https://github.com/robotrocketscience/aelfrice/pull/96)). v1.0.x stored everything in a single global `~/.aelfrice/memory.db`. v1.1.0 introduces a resolution chain in `cli.db_path()`: `$AELFRICE_DB` (override) → `<git-common-dir>/aelfrice/memory.db` (when `cwd` is in a git work-tree; resolved via `git rev-parse --path-format=absolute --git-common-dir`, so worktrees of one repo share one DB) → `~/.aelfrice/memory.db` (legacy fallback for non-git dirs). `.git/` is not git-tracked — the brain graph never crosses the git boundary. New `_git_common_dir()` helper shells out to `git rev-parse` and returns `None` gracefully when git is unavailable. No new runtime dependencies.
+- **`aelfrice.auditor` module + rewritten `aelf health`** ([#90](https://github.com/robotrocketscience/aelfrice/issues/90), PR [#100](https://github.com/robotrocketscience/aelfrice/pull/100)). `audit(store) -> AuditReport` runs three mechanical structural checks: `orphan_threads` (edges whose src/dst no longer exists), `fts_sync` (`beliefs_fts` row count vs `beliefs`), `locked_contradicts` (pairs of locked beliefs joined by CONTRADICTS). `aelf health` exits 1 if any check fails. Informational metrics (counts, average confidence, credal gap, thread counts by type) print alongside but don't affect exit. The v1.0 regime classifier is preserved as a separate `aelf regime` command (always exit 0).
+- **`aelf status`** ([#90](https://github.com/robotrocketscience/aelfrice/issues/90)). Alias for `aelf health` per lab `COMMAND_DESIGN.md`. Same handler, same exit codes.
+- **`aelf regime`** ([#90](https://github.com/robotrocketscience/aelfrice/issues/90)). New command preserving the v1.0 regime classifier output (`supersede` / `ignore` / `mixed` / `insufficient_data`).
+- **Store API additions** for the auditor: `count_orphan_edges()`, `count_fts_rows()`, `list_locked_contradicts_pairs()`, `count_edges_by_type()`. Read-only.
+- **`aelf migrate`** ([#93](https://github.com/robotrocketscience/aelfrice/issues/93), PR [#104](https://github.com/robotrocketscience/aelfrice/pull/104)). One-shot copy from the legacy global `~/.aelfrice/memory.db` into the active project's resolved DB. Reads source via SQLite `mode=ro` URI (rejects writes at the SQLite layer). Default project-mention filter (belief content references the absolute project root); `--all` overrides. Edges follow only when both endpoints land. Dry-run by default; `--apply` writes. `--from PATH` overrides the source. Idempotent. Never deletes from the source. New module `aelfrice.migrate` with `default_legacy_db_path()` and `migrate(...) -> MigrateReport`.
+- **`PRAGMA busy_timeout=5000`** in `MemoryStore.__init__` ([#89](https://github.com/robotrocketscience/aelfrice/issues/89), PR [#102](https://github.com/robotrocketscience/aelfrice/pull/102)). Required for safe multi-worktree access where two processes share one `.git/aelfrice/memory.db`. Without it, the second writer hits `database is locked` immediately instead of waiting.
+- **Worktree concurrency test suite** at `tests/test_worktree_concurrency.py` ([#89](https://github.com/robotrocketscience/aelfrice/issues/89)). Five tests: WAL-on regression, busy_timeout regression, two-worktree DB-path identity, concurrent multi-process write correctness (40 beliefs across 2 spawn processes), and a three-round repeat to catch flakes.
+- **Onboard git-recency weighting (Tier 2)** ([#94](https://github.com/robotrocketscience/aelfrice/issues/94), PR [#103](https://github.com/robotrocketscience/aelfrice/pull/103)). Scanner records the most-recent author date of the commit that touched each source file, then `scan_repo` writes that as `belief.created_at` so the existing decay mechanism (already in `scoring.py` at v1.0) penalises stale prose. New `_build_file_recency_map(root)` makes ONE `git log --name-only --pretty=format:%aI` call per scan and returns `{relative-path: most-recent-iso-date}`. `SentenceCandidate` gains an optional `commit_date: str | None = None` field. `extract_filesystem` and `extract_ast` accept the recency map and stamp candidates from recency-known files; `extract_git_log` carries each commit's own author date. Files outside git, untracked files, and the entire fallback when git is unavailable continue to use wall-clock `now`. No new ranking math.
+- **`docs/promotion_path.md`** ([#95](https://github.com/robotrocketscience/aelfrice/issues/95), PR [#101](https://github.com/robotrocketscience/aelfrice/pull/101)). Design memo for the v1.2.0 `agent_inferred → user_validated` promotion path. Recommends adding `origin TEXT NOT NULL DEFAULT 'unknown'` to `beliefs` (v1.1.0 schema bump deferred to v1.2.0 implementation alongside the command), conservative backfill, flag-only flip mechanism (preserve `α/β` and `lock_level`), `aelf validate <belief_id>` CLI surface mirroring `aelf demote`, tie-breaker slot between `user_corrected` and `document_recent`, zero-valence audit row tagged `source='promotion:user_validated'`. 10 open TBDs explicitly enumerated.
+- **`aelf` CLI grew from 12 to 19 subcommands.** Added: `health` (rewritten), `status` (alias), `regime`, `migrate`. Slash commands: `health.md` rewritten, new `status.md`, `regime.md`, `migrate.md`.
+- **MCP `aelf:stats` returns `threads` key.** Same integer value as `edges`. `edges` retained for one minor.
+- **MCP `aelf:health.features.thread_per_belief` field.** Same value as `edge_per_belief`. `edge_per_belief` retained for one minor.
+
 ### Changed
 
-- **`edges` → `threads` user-facing rename ([#92](https://github.com/robotrocketscience/aelfrice/issues/92)).** All user-facing surfaces (CLI output labels in `aelf stats` / `aelf health`; slash command descriptions; COMMANDS.md / MCP.md prose) now use "threads". The internal SQLite schema, the `Edge` Python dataclass, and the `EDGE_*` type constants are unchanged. The auditor's `metrics` dict keys (`threads`, `threads_supports`, `threads_contradicts`, …) follow the rename.
+- **`edges` → `threads` user-facing rename** ([#92](https://github.com/robotrocketscience/aelfrice/issues/92), PR [#105](https://github.com/robotrocketscience/aelfrice/pull/105)). All user-facing surfaces — CLI output labels (`aelf stats`, `aelf health`, `aelf migrate`), slash command descriptions, COMMANDS.md / MCP.md prose, auditor finding strings — now use "threads". The internal SQLite `edges` table, the `Edge` Python dataclass, and the `EDGE_*` type constants are unchanged. The auditor's `metrics` dict keys (`threads`, `threads_supports`, `threads_contradicts`, …) follow the rename. Schema docs (ARCHITECTURE.md, design memos) keep `edge` / `Edge` because they describe internals.
+- **Project-identity narrative reconciled** ([#99](https://github.com/robotrocketscience/aelfrice/pull/99)). Re-applies the framing fix dropped from #87's squash and sweeps post-#96 docs: ARCHITECTURE.md / COMMANDS.md / INSTALL.md § Database / PRIVACY.md / LIMITATIONS § Project identity all describe the new resolution chain. PRIVACY.md drops "to share across machines: sync the file" and links to LIMITATIONS § Sharing or sync of brain-graph content. INSTALL.md uninstall section uses "resolved DB path" language and a `cli.db_path()`-discovering verification command.
 
 ### Deprecated
 
 - **MCP `aelf:stats` JSON: `edges` key.** v1.1.0 emits both `edges` and `threads` with the same integer value. **`edges` is removed in v1.2.0.** Clients should migrate to `threads` now.
 - **MCP `aelf:health.features.edge_per_belief` key.** v1.1.0 emits both `edge_per_belief` and `thread_per_belief` with the same value. `edge_per_belief` is removed in v1.2.0.
 - **`aelfrice.auditor.CHECK_ORPHAN_EDGES` constant.** Kept as a deprecated alias of `CHECK_ORPHAN_THREADS` for v1.0 importer compatibility. Removed in v1.2.0.
+
+### Documentation
+
+- **Local-only contract locked** ([#87](https://github.com/robotrocketscience/aelfrice/pull/87)). LIMITATIONS.md gains "Sharing or sync of brain-graph content" under "Out of scope by design" with privacy/determinism/audit rationale. ROADMAP.md "Non-goals" adds "Brain-graph sharing, sync, or export between users / machines / projects." `.aelfrice/seed.md`, `.aelfrice.toml` cross-machine identity, and v2.0 cross-project shared store are removed from the roadmap. Bootstrap recipe for new clones is `aelf onboard .`.
+- **`docs/promotion_path.md`** linked from ROADMAP § v1.2.0 and LIMITATIONS § Onboarding.
 
 ## [1.0.3] - 2026-04-27
 
@@ -417,7 +446,8 @@ Foundation milestone — store, models, config.
 - Initial repo scaffold: pyproject, README, GitHub Actions workflows,
   scan configs (commit `67b4343`).
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.3...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.0...v1.0.1

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Same operations are available as MCP tools and Claude Code slash commands. Full 
 | v1.0.1 | **shipped** | launch fix-up — hook→retrieval wiring, onboard noise, `aelf --version` |
 | v1.0.2 | **shipped** | per-project install routing, `aelf doctor`, release-docs CI gate |
 | v1.0.3 | **shipped** | contradiction tie-breaker + `aelf resolve`, onboard perf regression, CONFIG.md |
-| v1.1.0 | planned | project identity (`.git/aelfrice/`), edges→threads, status/health split |
+| v1.1.0 | **shipped** | project identity (`.git/aelfrice/`), edges→threads, status/health split, `aelf migrate`, git-recency onboard |
 | v1.2.0 | planned | commit-ingest hook, triple-extraction port, harness-integration doc |
 | v1.3 | planned | retrieval wave — entity index + BFS multi-hop + LLM classification |
 | v2.0 | planned | feature parity with the earlier research line + full benchmark reproducibility |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,7 +19,7 @@ This is a rebuild, not a port. Structural issues that survived agentmemory are b
 | v0.1 – v1.0 | shipped | core memory, CLI, MCP, hook wiring, synthetic benchmark, PyPI publish |
 | **v1.0.1** | shipped | launch fix-up — hook→retrieval wiring, onboard noise, `aelf --version` |
 | **v1.0.2** | shipped | per-project install routing, `aelf doctor`, release-docs CI gate |
-| **v1.1.0** | planned | project identity, edges→threads, status/health split |
+| **v1.1.0** | shipped | project identity, edges→threads, status/health split, `aelf migrate`, git-recency onboard |
 | **v1.2.0** | planned | commit-ingest hook, triple-extraction port, harness-integration doc |
 | **v1.3.0** | planned | retrieval wave — entity index + BFS multi-hop + LLM classification |
 | **v1.4.0** | planned | context rebuilder — automatic PreCompact-driven retrieval-curated context |
@@ -49,14 +49,16 @@ Second patch. Two threads:
 
 ## v1.1.0 — project identity and cosmetic surface
 
-- **Per-project DB resolution.** v1.0.x shipped a single global DB at `~/.aelfrice/memory.db` shared across every project on the machine. v1.1.0 lands a resolution chain: `$AELFRICE_DB` (override) → `<git-common-dir>/aelfrice/memory.db` (when `cwd` is inside a git work-tree) → `~/.aelfrice/memory.db` (non-git fallback). Worktrees of one repo share one DB via the git-common-dir. `.git/` is not git-tracked — the brain graph never crosses the git boundary. Shipped at [#88](https://github.com/robotrocketscience/aelfrice/issues/88).
-- **`aelf migrate` from legacy global store.** One-shot copy from `~/.aelfrice/memory.db` (the v1.0 single global DB) into the active project's `.git/aelfrice/memory.db`. Dry-run by default; `--apply` writes. Idempotent.
-- **Worktree concurrency tests.** Multiple worktrees of the same repo share one `.git/aelfrice/memory.db` without corruption under WAL mode.
-- **`aelf health` rewritten as diagnostic auditor.** Replaces the v1.0 regime classifier output (preserved as `aelf regime`). Reports credal gap, orphan beliefs, edge type counts, feedback coverage, FTS5 sync, locked-belief contradictions. Exits 1 on structural failures (orphan edges, FTS5 mismatch, locked-belief contradictions); informational metrics stay exit 0. `aelf status` aliases `aelf health` per lab COMMAND_DESIGN convention.
-- **`edges` → `threads`.** User-facing rename in CLI output and MCP tool descriptions. Internal schema is unchanged.
-- **Onboard git-recency weighting.** Scanner records source file's most-recent git commit date as `belief.created_at`, so the existing decay mechanism penalises pre-migration content from old branches.
-- **`agent_inferred` → `user_validated` promotion path.** Designed in v1.1.0 ([docs/promotion_path.md](promotion_path.md), [#95](https://github.com/robotrocketscience/aelfrice/issues/95)); implemented in v1.2.0.
-- **Query result cache.** A bounded LRU cache wrapping `aelfrice.retrieval.retrieve()`, keyed on a canonicalized form of `(query, token_budget, l1_limit)` and invalidated on every store mutation. Skips a full L0+L1 pass when an agent loop re-issues the same query. Spec: [`lru_query_cache.md`](lru_query_cache.md).
+Minor release. Eight PRs landed between v1.0.3 and v1.1.0. See [CHANGELOG § v1.1.0](../CHANGELOG.md) for the full surface.
+
+- ✅ **Per-project DB resolution.** v1.0.x shipped a single global DB at `~/.aelfrice/memory.db` shared across every project on the machine. v1.1.0 lands a resolution chain: `$AELFRICE_DB` (override) → `<git-common-dir>/aelfrice/memory.db` (when `cwd` is inside a git work-tree) → `~/.aelfrice/memory.db` (non-git fallback). Worktrees of one repo share one DB via the git-common-dir. `.git/` is not git-tracked — the brain graph never crosses the git boundary. Shipped at [#88](https://github.com/robotrocketscience/aelfrice/issues/88) / PR [#96](https://github.com/robotrocketscience/aelfrice/pull/96).
+- ✅ **`aelf migrate` from legacy global store.** One-shot copy from `~/.aelfrice/memory.db` (the v1.0 single global DB) into the active project's `.git/aelfrice/memory.db`. Dry-run by default; `--apply` writes. `--all` skips the project-mention filter. Idempotent. PR [#104](https://github.com/robotrocketscience/aelfrice/pull/104).
+- ✅ **Worktree concurrency tests + `busy_timeout=5000`.** Multiple worktrees share one `.git/aelfrice/memory.db` without corruption under WAL mode + the new busy_timeout. PR [#102](https://github.com/robotrocketscience/aelfrice/pull/102).
+- ✅ **`aelf health` rewritten as diagnostic auditor.** Replaces the v1.0 regime classifier output (preserved as `aelf regime`). Reports credal gap, orphan threads, thread type counts, feedback coverage, FTS5 sync, locked-belief contradictions. Exits 1 on structural failures (orphan threads, FTS5 mismatch, locked-belief contradictions); informational metrics stay exit 0. `aelf status` aliases `aelf health`. PR [#100](https://github.com/robotrocketscience/aelfrice/pull/100).
+- ✅ **`edges` → `threads` user-facing rename.** All user-facing surfaces use "threads"; internal schema, `Edge` dataclass, and `EDGE_*` type constants unchanged. MCP `aelf:stats` emits both `edges` and `threads` keys for one minor; `edges` removed in v1.2.0. PR [#105](https://github.com/robotrocketscience/aelfrice/pull/105).
+- ✅ **Onboard git-recency weighting.** Scanner records source file's most-recent git commit date as `belief.created_at`, so the existing decay mechanism penalises pre-migration content from old branches. One `git log --name-only --pretty=format:%aI` call per scan. PR [#103](https://github.com/robotrocketscience/aelfrice/pull/103).
+- ✅ **`agent_inferred` → `user_validated` promotion path designed.** [docs/promotion_path.md](promotion_path.md) — schema bump, conservative backfill, flag-only flip mechanism, `aelf validate` surface, tie-breaker slot. Implementation lands in v1.2.0. PR [#101](https://github.com/robotrocketscience/aelfrice/pull/101).
+- **Query result cache.** A bounded LRU cache wrapping `aelfrice.retrieval.retrieve()`, keyed on a canonicalized form of `(query, token_budget, l1_limit)` and invalidated on every store mutation. Skips a full L0+L1 pass when an agent loop re-issues the same query. Spec: [`lru_query_cache.md`](lru_query_cache.md). Shipped pre-v1.1.0 in [#69](https://github.com/robotrocketscience/aelfrice/pull/69).
 
 ## v1.2.0 — auto-capture and triple extraction
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "1.0.3"
+version = "1.1.0"
 description = "Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aelfrice/__init__.py
+++ b/src/aelfrice/__init__.py
@@ -1,2 +1,2 @@
 """aelfrice: Bayesian memory designed for feedback-driven learning."""
-__version__ = "1.0.2"
+__version__ = "1.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "1.0.3"
+version = "1.1.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Minor release consolidating the v1.1.0 milestone. **Eight PRs landed between v1.0.3 and v1.1.0** — this PR surfaces them to PyPI.

## What shipped

| PR | Theme |
|---|---|
| [#96](https://github.com/robotrocketscience/aelfrice/pull/96) | Per-project DB resolution at \`.git/aelfrice/memory.db\` |
| [#99](https://github.com/robotrocketscience/aelfrice/pull/99) | Doc-sweep aligning project-identity narrative with #96-shipped reality |
| [#100](https://github.com/robotrocketscience/aelfrice/pull/100) | \`aelf health\` rewritten as structural auditor + \`aelf status\` alias + \`aelf regime\` |
| [#101](https://github.com/robotrocketscience/aelfrice/pull/101) | Design memo for \`agent_inferred → user_validated\` promotion (v1.2.0 gate) |
| [#102](https://github.com/robotrocketscience/aelfrice/pull/102) | Worktree concurrency tests + \`PRAGMA busy_timeout=5000\` |
| [#103](https://github.com/robotrocketscience/aelfrice/pull/103) | Onboard git-recency weighting (Tier 2) |
| [#104](https://github.com/robotrocketscience/aelfrice/pull/104) | \`aelf migrate\` from legacy global DB |
| [#105](https://github.com/robotrocketscience/aelfrice/pull/105) | \`edges → threads\` user-facing rename with v1.2.0 deprecation window |

## Local verification

- \`uv run pytest tests/\` → **921 passed**.
- \`uv run python -c \"from aelfrice import __version__; print(__version__)\"\` → \`1.1.0\`.
- \`uv lock\` → updated \`aelfrice v1.0.3 -> v1.1.0\`.
- \`grep -c '^## \\[1\\.1\\.0\\]' CHANGELOG.md\` → \`1\`.
- \`grep -c '^\\[1\\.1\\.0\\]:' CHANGELOG.md\` → \`1\` (compare-link footnote).
- \`grep -c 'v1\\.1\\.0 | next\\|v1\\.1\\.0 | planned' README.md\` → \`0\`.

## CHANGELOG

\`[Unreleased]\` emptied; new \`## [1.1.0] - 2026-04-27\` section structured as Added / Changed / Deprecated / Documentation, with per-PR cross-links on each bullet. Compare-link footnote added (\`[1.1.0]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.3...v1.1.0\`).

## Roadmap rows

- **README.md**: v1.1.0 flipped from \`planned\` to \`**shipped**\` (satisfies \`release-docs-check\`).
- **docs/ROADMAP.md**: v1.1.0 row flipped to \`shipped\`; v1.1.0 narrative section rewritten with ✅ checkmarks per delivered item and PR cross-links per bullet. Backwards-compat note about the LRU query cache (#69, pre-v1.1.0) preserved.

## Version bumps

- \`pyproject.toml\`: \`1.0.3 → 1.1.0\`.
- \`src/aelfrice/__init__.py\`: \`1.0.2 → 1.1.0\` (catches up the prior version drift between \`pyproject.toml\` and \`__version__\`).
- \`uv.lock\`: refreshed.

## Tag and publish flow

After this PR merges to main:

1. \`git tag v1.1.0 && git push github v1.1.0\`
2. \`.github/workflows/publish.yml\` triggers on the \`v*\` tag and publishes to PyPI via Trusted Publishing (Ubuntu 3.12/3.13 matrix).
3. \`.github/workflows/post-release-docs-issue.yml\` opens a tracking issue \`docs sweep for v1.1.0\` for second-order docs the gate can't verify (RELEASING.md test counts, narrative cross-references).

## Pre-merge checklist

- [x] \`pyproject.toml\` and \`__init__.py\` agree on 1.1.0
- [x] \`uv.lock\` reflects the bump
- [x] CHANGELOG \`[1.1.0]\` section + compare-link footnote present
- [x] README roadmap shows v1.1.0 as **shipped**
- [x] ROADMAP.md narrative reflects what actually shipped
- [x] Full test suite passes (921 / 0 failures)

## Local-only contract

This release continues the v1.0 commitment: no network in default install, no telemetry, no brain-graph sharing/sync mechanism. Every v1.1.0 phase preserves the contract — auditor is read-only, migrate reads source via \`mode=ro\` URI and writes only to local target, git-recency reads from the local git repo.