### PR TITLE
feat: context rebuilder MVP (v1.2.0a0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Pre-`1.0.0` releases are atomic milestones building toward the first
 installable release; see the roadmap in [README.md](README.md).
 
+## [Unreleased]
+
+### Added (toward v1.2.0 final)
+
+- **Ingest enrichment schema** ([docs/ingest_enrichment.md](docs/ingest_enrichment.md)). Three coupled additions: `DERIVED_FROM` edge type (valence 0.5, mirrors `CITES`); `anchor_text TEXT` column on `edges` carrying the citing belief's own phrasing of the relationship, capped at 1000 characters at the dataclass boundary; `session_id TEXT` column on `beliefs` plus a real `sessions` table (`MemoryStore.create_session` / `complete_session` go from no-op stubs to persisting). `ingest_turn` now writes `session_id` end-to-end. Forward-compatible with v1.0 stores: `ALTER TABLE` adds the columns on first open and is idempotent on re-open. The `idx_beliefs_session` index is sequenced after the migration so a v1.0 store can open at all. Producers that populate the new fields densely are the v1.2.0 transcript-ingest, commit-ingest, and triple-extraction paths.
+- **Triple extractor** ([docs/triple_extractor.md](docs/triple_extractor.md)). New `aelfrice.triple_extractor` module with `extract_triples(text) -> list[Triple]` (pure regex over a fixed pattern bank — six relation families covering `SUPPORTS`, `CITES`, `CONTRADICTS`, `SUPERSEDES`, `RELATES_TO`, `DERIVED_FROM`, with active and passive forms) and `ingest_triples(store, triples, session_id=None) -> IngestResult` (resolves subject/object beliefs by content-hash lookup, creating with the project default prior when missing; inserts edges with `anchor_text` populated from the citing prose; idempotent on re-run; self-edges dropped). All triple-derived beliefs share a canonical id space via the `triple` source label, so the same noun phrase resolves to the same belief id across every extraction call site. Stdlib-only; no LLM, no POS tagger, no embedding. Reusable by every v1.x prose-ingesting caller — the v1.2.0 commit-ingest hook, transcript-ingest, manual `aelf remember` calls, and the v1.3.0 entity-index path. 38 tests cover the per-pattern templates, negative cases, anchor-text substring guarantee, idempotency, session_id propagation, and self-edge handling.
+- **Transcript ingest** ([docs/transcript_ingest.md](docs/transcript_ingest.md)). New `aelfrice.transcript_logger:main` entry point handles four Claude Code hook events through one dispatch: `UserPromptSubmit` → append `{"role": "user", ...}`; `Stop` → read the last assistant message from the transcript path and append `{"role": "assistant", ...}`; `PreCompact` → write a `compaction_start` marker, rotate `turns.jsonl` into `archive/turns-<ts>.jsonl`, spawn `aelf ingest-transcript` detached; `PostCompact` → write a `compaction_complete` marker. JSONL lives at `<git-common-dir>/aelfrice/transcripts/turns.jsonl` (or `~/.aelfrice/transcripts/turns.jsonl` outside a git tree); `$AELFRICE_TRANSCRIPTS_DIR` overrides. Per-turn budget is sub-10ms p99 by skipping `git rev-parse` / `symbolic-ref` on the hot path; `cwd` and Claude Code's own `session_id` from the payload stay on the line. Non-blocking contract: every failure returns exit 0 with a stack trace on stderr.
+- **`aelfrice.ingest.ingest_jsonl()`** reads a `turns.jsonl` archive and lowers each line through `ingest_turn`. Within a session, consecutive turns get a `DERIVED_FROM` edge linking turn N+1's last belief to turn N's last belief with `anchor_text` set to turn N's literal text. Idempotent. Returns `IngestJsonlResult(lines_read, turns_ingested, beliefs_inserted, edges_inserted, skipped_lines)`. Compaction markers and malformed lines count under `skipped_lines` and never raise.
+- **`aelf ingest-transcript PATH` CLI** prints the `IngestJsonlResult` summary. Used as the detached spawn target of the `PreCompact` hook on rotation; also runnable manually for replay or recovery on archived transcripts.
+- **`aelf setup --transcript-ingest`** wires the four logger hook events to the new `aelf-transcript-logger` entry point. Idempotent. `aelf unsetup --transcript-ingest` strips them. The flag is opt-in at v1.2.0.
+- **`aelf-transcript-logger` project script** registered in `pyproject.toml`.
+- Slash command `aelf:ingest-transcript`.
+
 ## [1.2.0a0] - 2026-04-27
 
 Alpha pre-release. **Context rebuilder MVP** lands as an opt-in
@@ -73,19 +86,6 @@ and feedback, not for setting the v1.x default.
   whatever Claude Code's default PreCompact firing is; the rebuilder
   emits on every PreCompact. Per-session-state trigger tuning is
   v1.3+.
-
-## [Unreleased]
-
-### Added (toward v1.2.0)
-
-- **Ingest enrichment schema** ([docs/ingest_enrichment.md](docs/ingest_enrichment.md)). Three coupled additions: `DERIVED_FROM` edge type (valence 0.5, mirrors `CITES`); `anchor_text TEXT` column on `edges` carrying the citing belief's own phrasing of the relationship, capped at 1000 characters at the dataclass boundary; `session_id TEXT` column on `beliefs` plus a real `sessions` table (`MemoryStore.create_session` / `complete_session` go from no-op stubs to persisting). `ingest_turn` now writes `session_id` end-to-end. Forward-compatible with v1.0 stores: `ALTER TABLE` adds the columns on first open and is idempotent on re-open. The `idx_beliefs_session` index is sequenced after the migration so a v1.0 store can open at all. Producers that populate the new fields densely are the v1.2.0 transcript-ingest, commit-ingest, and triple-extraction paths.
-- **Triple extractor** ([docs/triple_extractor.md](docs/triple_extractor.md)). New `aelfrice.triple_extractor` module with `extract_triples(text) -> list[Triple]` (pure regex over a fixed pattern bank — six relation families covering `SUPPORTS`, `CITES`, `CONTRADICTS`, `SUPERSEDES`, `RELATES_TO`, `DERIVED_FROM`, with active and passive forms) and `ingest_triples(store, triples, session_id=None) -> IngestResult` (resolves subject/object beliefs by content-hash lookup, creating with the project default prior when missing; inserts edges with `anchor_text` populated from the citing prose; idempotent on re-run; self-edges dropped). All triple-derived beliefs share a canonical id space via the `triple` source label, so the same noun phrase resolves to the same belief id across every extraction call site. Stdlib-only; no LLM, no POS tagger, no embedding. Reusable by every v1.x prose-ingesting caller — the v1.2.0 commit-ingest hook, transcript-ingest, manual `aelf remember` calls, and the v1.3.0 entity-index path. 38 tests cover the per-pattern templates, negative cases, anchor-text substring guarantee, idempotency, session_id propagation, and self-edge handling.
-- **Transcript ingest** ([docs/transcript_ingest.md](docs/transcript_ingest.md)). New `aelfrice.transcript_logger:main` entry point handles four Claude Code hook events through one dispatch: `UserPromptSubmit` → append `{"role": "user", ...}`; `Stop` → read the last assistant message from the transcript path and append `{"role": "assistant", ...}`; `PreCompact` → write a `compaction_start` marker, rotate `turns.jsonl` into `archive/turns-<ts>.jsonl`, spawn `aelf ingest-transcript` detached; `PostCompact` → write a `compaction_complete` marker. JSONL lives at `<git-common-dir>/aelfrice/transcripts/turns.jsonl` (or `~/.aelfrice/transcripts/turns.jsonl` outside a git tree); `$AELFRICE_TRANSCRIPTS_DIR` overrides. Per-turn budget is sub-10ms p99 by skipping `git rev-parse` / `symbolic-ref` on the hot path; `cwd` and Claude Code's own `session_id` from the payload stay on the line. Non-blocking contract: every failure returns exit 0 with a stack trace on stderr.
-- **`aelfrice.ingest.ingest_jsonl()`** reads a `turns.jsonl` archive and lowers each line through `ingest_turn`. Within a session, consecutive turns get a `DERIVED_FROM` edge linking turn N+1's last belief to turn N's last belief with `anchor_text` set to turn N's literal text. Idempotent. Returns `IngestJsonlResult(lines_read, turns_ingested, beliefs_inserted, edges_inserted, skipped_lines)`. Compaction markers and malformed lines count under `skipped_lines` and never raise.
-- **`aelf ingest-transcript PATH` CLI** prints the `IngestJsonlResult` summary. Used as the detached spawn target of the `PreCompact` hook on rotation; also runnable manually for replay or recovery on archived transcripts.
-- **`aelf setup --transcript-ingest`** wires the four logger hook events to the new `aelf-transcript-logger` entry point. Idempotent. `aelf unsetup --transcript-ingest` strips them. The flag is opt-in at v1.2.0.
-- **`aelf-transcript-logger` project script** registered in `pyproject.toml`.
-- Slash command `aelf:ingest-transcript`.
 
 ## [1.1.0] - 2026-04-27
 
@@ -523,7 +523,8 @@ Foundation milestone — store, models, config.
 - Initial repo scaffold: pyproject, README, GitHub Actions workflows,
   scan configs (commit `67b4343`).
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.2.0a0...HEAD
+[1.2.0a0]: https://github.com/robotrocketscience/aelfrice/compare/v1.1.0...v1.2.0a0
 [1.1.0]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.1...v1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Pre-`1.0.0` releases are atomic milestones building toward the first
 installable release; see the roadmap in [README.md](README.md).
 
+## [1.2.0a0] - 2026-04-27
+
+Alpha pre-release. **Context rebuilder MVP** lands as an opt-in
+`PreCompact` hook that surfaces aelfrice retrieval results before
+Claude Code runs its default summarization. Augment-mode only --
+the harness still runs its own compaction afterward, so this is
+additive context, not a replacement.
+
+This is a vertical slice. Several quality dimensions are deferred
+until the supporting infrastructure ships (transcript ingest at
+v1.2.0, posterior-weighted ranking at v1.3+, triple-extracted
+queries, session-scoped retrieval). The alpha is for measurement
+and feedback, not for setting the v1.x default.
+
+### Added
+
+- `aelfrice.context_rebuilder.rebuild()`: pure function taking a
+  list of recent turns and an open `MemoryStore`, returns the
+  formatted `<aelfrice-rebuild>` XML block with L0 locked beliefs
+  and L1 BM25 hits. Per-token union retrieval works around the
+  public store's AND-only FTS5 semantics. Deterministic given
+  identical inputs (eval-harness contract).
+- Two transcript adapters: `read_recent_turns_aelfrice` for the
+  canonical `<root>/.git/aelfrice/transcripts/turns.jsonl` log
+  (per-turn ingest format from the v1.2.0 transcript-ingest spec)
+  and `read_recent_turns_claude_transcript` as a best-effort
+  fallback for Claude Code's internal per-session JSONL.
+- `pre_compact()` hook entry-point in `aelfrice.hook`: reads the
+  PreCompact JSON payload, locates a transcript (canonical
+  preferred, Claude-internal fallback), invokes `rebuild()`,
+  writes the block to stdout. Honors the non-blocking hook
+  contract (returns 0 on every failure path).
+- `aelf-pre-compact-hook` console script entry registered for
+  `settings.json` hook entries.
+- `install_pre_compact_hook` / `uninstall_pre_compact_hook` /
+  `resolve_pre_compact_hook_command`: same idempotency,
+  atomic-write, and basename-match semantics as the existing
+  UserPromptSubmit pair. Two events coexist in the same
+  `settings.json` without disturbing each other.
+- `aelf setup --rebuilder` flag: also installs the PreCompact hook
+  alongside the UserPromptSubmit hook.
+- `aelf rebuild` CLI subcommand (with `--transcript`, `--n`,
+  `--budget`): manually emits the rebuild block to stdout for
+  inspection. Required surface for spec acceptance criterion 5
+  (manual mode ships before threshold-mode auto-triggers).
+- Matching `rebuild.md` slash command shipped in
+  `src/aelfrice/slash_commands/`.
+
+### Deferred (named here so users know they are coming)
+
+- **Session-scoped retrieval.** The schema's `session_id` field is
+  not yet populated end-to-end. The MVP retrieves globally.
+- **Triple-extractor query construction.** The MVP concatenates
+  recent turn text and per-token-unions over the result. A
+  triple-extracted query will replace this once the extractor
+  ships.
+- **Posterior-weighted ranking.** The MVP uses the public BM25
+  ranker. The Bayesian-weighted ranker is a v1.3+ candidate.
+- **Suppress-mode coordination with the harness.** The MVP runs in
+  augment mode only. Suppress-mode lands once eval-harness fidelity
+  calibration justifies it.
+- **Default trigger threshold.** Augment-mode means the trigger is
+  whatever Claude Code's default PreCompact firing is; the rebuilder
+  emits on every PreCompact. Per-session-state trigger tuning is
+  v1.3+.
+
 ## [Unreleased]
 
 ### Added (toward v1.2.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "1.1.0"
+version = "1.2.0a0"
 description = "Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ Issues = "https://github.com/robotrocketscience/aelfrice/issues"
 aelf = "aelfrice.cli:main"
 aelf-hook = "aelfrice.hook:main"
 aelf-transcript-logger = "aelfrice.transcript_logger:main"
+aelf-pre-compact-hook = "aelfrice.hook:main_pre_compact"
 
 [project.optional-dependencies]
 dev = [

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -83,11 +83,14 @@ from aelfrice.setup import (
     clean_dangling_shims,
     default_settings_path,
     detect_default_scope,
+    install_pre_compact_hook,
     install_statusline,
     install_transcript_ingest_hooks,
     install_user_prompt_submit_hook,
     resolve_hook_command,
+    resolve_pre_compact_hook_command,
     resolve_transcript_logger_command,
+    uninstall_pre_compact_hook,
     uninstall_statusline,
     uninstall_transcript_ingest_hooks,
     uninstall_user_prompt_submit_hook,
@@ -97,6 +100,7 @@ from aelfrice.store import MemoryStore
 DEFAULT_DB_DIR: Final[Path] = Path.home() / ".aelfrice"
 DEFAULT_DB_FILENAME: Final[str] = "memory.db"
 DEFAULT_HOOK_COMMAND: Final[str] = "aelf-hook"
+DEFAULT_PRE_COMPACT_HOOK_COMMAND: Final[str] = "aelf-pre-compact-hook"
 _FEEDBACK_VALENCES: Final[dict[str, float]] = {"used": 1.0, "harmful": -1.0}
 _LOCK_ID_LEN: Final[int] = 16
 _VALID_SCOPES: Final[tuple[SettingsScope, ...]] = ("user", "project")
@@ -204,6 +208,48 @@ def _cmd_search(args: argparse.Namespace, out: object) -> int:
     for h in hits:
         prefix = "[locked]" if h.lock_level == LOCK_USER else "        "
         print(f"{prefix} {h.id}: {h.content}", file=out)  # type: ignore[arg-type]
+    return 0
+
+
+def _cmd_rebuild(args: argparse.Namespace, out: object) -> int:
+    """Manual rebuild for the v1.1 alpha (spec acceptance criterion 5).
+
+    Reads recent turns from the canonical aelfrice transcript log if
+    present, otherwise from a Claude Code internal transcript path
+    given by --transcript. Prints the rebuild block to stdout. Useful
+    for inspecting what the PreCompact hook would emit without
+    triggering the actual hook.
+    """
+    from aelfrice.context_rebuilder import (
+        DEFAULT_N_RECENT_TURNS,
+        DEFAULT_TOKEN_BUDGET,
+        find_aelfrice_log,
+        read_recent_turns_aelfrice,
+        read_recent_turns_claude_transcript,
+        rebuild,
+    )
+
+    n = args.n if args.n is not None else DEFAULT_N_RECENT_TURNS
+    budget = args.budget if args.budget is not None else DEFAULT_TOKEN_BUDGET
+
+    transcript_arg: str | None = args.transcript
+    if transcript_arg:
+        recent = read_recent_turns_claude_transcript(
+            Path(transcript_arg), n=n
+        )
+    else:
+        log_path = find_aelfrice_log(Path.cwd())
+        if log_path is not None and log_path.exists():
+            recent = read_recent_turns_aelfrice(log_path, n=n)
+        else:
+            recent = []
+
+    store = _open_store()
+    try:
+        block = rebuild(recent, store, token_budget=budget)
+    finally:
+        store.close()
+    print(block, file=out, end="")  # type: ignore[arg-type]
     return 0
 
 
@@ -554,6 +600,26 @@ def _cmd_setup(args: argparse.Namespace, out: object) -> int:
                 f"To enable update notifications append "
                 f"' ; aelf statusline 2>/dev/null' to your existing "
                 f"statusLine command manually.",
+                file=out,  # type: ignore[arg-type]
+            )
+    if getattr(args, "rebuilder", False):
+        pc_command = resolve_pre_compact_hook_command(scope)
+        pc_result = install_pre_compact_hook(
+            path,
+            command=pc_command,
+            timeout=args.timeout,
+            status_message=args.status_message,
+        )
+        if pc_result.already_present:
+            print(
+                f"PreCompact hook already installed in {pc_result.path} "
+                f"(command={pc_command!r})",
+                file=out,  # type: ignore[arg-type]
+            )
+        else:
+            print(
+                f"installed PreCompact hook in {pc_result.path} "
+                f"(command={pc_command!r}) [v1.1 rebuilder alpha]",
                 file=out,  # type: ignore[arg-type]
             )
     return 0
@@ -1079,6 +1145,31 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_search.set_defaults(func=_cmd_search)
 
+    p_rebuild = sub.add_parser(
+        "rebuild",
+        help=(
+            "v1.1 alpha: manually emit the context-rebuild block to "
+            "stdout (what the PreCompact hook would produce)"
+        ),
+    )
+    p_rebuild.add_argument(
+        "--transcript", default=None,
+        help=(
+            "path to a Claude Code session JSONL to read recent turns "
+            "from. Default: walk upward from cwd for "
+            ".git/aelfrice/transcripts/turns.jsonl."
+        ),
+    )
+    p_rebuild.add_argument(
+        "--n", type=int, default=None,
+        help="number of recent turns to seed the query (default: 10)",
+    )
+    p_rebuild.add_argument(
+        "--budget", type=int, default=None,
+        help="token budget for the rebuild block (default: 2000)",
+    )
+    p_rebuild.set_defaults(func=_cmd_rebuild)
+
     p_lock = sub.add_parser("lock", help="insert (or upgrade) a user-locked belief")
     p_lock.add_argument("statement", help="belief text to lock as ground truth")
     p_lock.set_defaults(func=_cmd_lock)
@@ -1228,6 +1319,14 @@ def build_parser() -> argparse.ArgumentParser:
             "(UserPromptSubmit, Stop, PreCompact, PostCompact) so live "
             "conversation turns are captured to the per-project transcripts "
             "log and ingested at compaction boundaries."
+        ),
+    )
+    p_setup.add_argument(
+        "--rebuilder", action="store_true",
+        help=(
+            "ALSO install the PreCompact hook for the v1.2 context "
+            "rebuilder (alpha). Idempotent; coexists with all other "
+            "hooks. Augment-mode only at v1.2.0a0."
         ),
     )
     p_setup.set_defaults(func=_cmd_setup)

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -663,6 +663,21 @@ def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
                     f"{'y' if n == 1 else 'ies'} from {ti_result.path}",
                     file=out,  # type: ignore[arg-type]
                 )
+    if getattr(args, "rebuilder", False):
+        pc_result = uninstall_pre_compact_hook(
+            path, command_basename="aelf-pre-compact-hook",
+        )
+        if pc_result.removed == 0:
+            print(
+                f"no rebuilder PreCompact hook in {pc_result.path}",
+                file=out,  # type: ignore[arg-type]
+            )
+        else:
+            print(
+                f"removed {pc_result.removed} rebuilder PreCompact entr"
+                f"{'y' if pc_result.removed == 1 else 'ies'} from {pc_result.path}",
+                file=out,  # type: ignore[arg-type]
+            )
     sl = uninstall_statusline(path)
     if sl.mode == "removed":
         print(
@@ -1416,6 +1431,10 @@ def build_parser() -> argparse.ArgumentParser:
             "also remove the four transcript-logger entries "
             "(UserPromptSubmit, Stop, PreCompact, PostCompact)."
         ),
+    )
+    p_unsetup.add_argument(
+        "--rebuilder", action="store_true",
+        help="also remove the rebuilder PreCompact hook entry.",
     )
     p_unsetup.set_defaults(func=_cmd_unsetup)
 

--- a/src/aelfrice/context_rebuilder.py
+++ b/src/aelfrice/context_rebuilder.py
@@ -1,0 +1,389 @@
+"""Context-rebuilder: PreCompact-driven retrieval-curated context block.
+
+When Claude Code's context window approaches its compaction threshold,
+the harness fires a PreCompact hook. This module is the script-side
+half of that hook: it reads the most recent N turns from a transcript
+log, runs aelfrice retrieval against those turns to surface load-
+bearing beliefs, and emits a single XML-tag-delimited context block
+that Claude Code injects above the next prompt.
+
+v1.1.0-alpha is a vertical slice. Several quality dimensions in the
+design spec are deferred until later releases:
+
+  * Session-scoped retrieval. The schema's session_id field is not
+    yet populated at write-time; retrieval falls back to global L0
+    locked + L1 FTS5 BM25.
+  * Triple-extractor query construction. The MVP concatenates recent
+    turn text into a flat query string. A triple-extracted query
+    will replace this once the extractor ships.
+  * Posterior-weighted ranking. The MVP uses the public BM25 ranker.
+    The Bayesian-weighted ranker is a v1.3.x candidate.
+  * Suppress-mode coordination with the harness. The MVP runs in
+    augment mode only -- the rebuild block is emitted, but the
+    harness's default summarization still runs. Suppress mode lands
+    once eval-harness fidelity calibration justifies it.
+
+The pure rebuild() function is decoupled from the I/O paths so the
+eval harness can drive it directly with a pre-loaded list of recent
+turns. Two adapters convert different on-disk transcript formats
+into that list: read_recent_turns_aelfrice() for the canonical
+turns.jsonl format described in docs/specs/transcript_ingest.md, and
+read_recent_turns_claude_transcript() for Claude Code's internal
+transcript format.
+
+Output schema:
+
+    <aelfrice-rebuild>
+      <recent-turns>
+        <turn role="user">...</turn>
+        <turn role="assistant">...</turn>
+      </recent-turns>
+      <retrieved-beliefs budget_used="N/M">
+        <belief id="..." locked="true">...</belief>
+        <belief id="..." locked="false">...</belief>
+      </retrieved-beliefs>
+      <continue/>
+    </aelfrice-rebuild>
+
+The <continue/> marker is the stable signal the model interprets as
+"resume the prior task using the above context, do not greet, do not
+summarize."
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, cast
+
+from aelfrice.models import LOCK_NONE, LOCK_USER, Belief
+from aelfrice.store import MemoryStore
+
+DEFAULT_N_RECENT_TURNS: Final[int] = 10
+DEFAULT_TOKEN_BUDGET: Final[int] = 2000
+DEFAULT_PER_TOKEN_LIMIT: Final[int] = 20
+MIN_QUERY_TOKEN_LENGTH: Final[int] = 4
+"""Drop tokens shorter than this from the rebuild query.
+
+Single-character and short stopword-class tokens ("a", "the", "is")
+are noise on the FTS5 side. The rebuilder uses per-token union
+retrieval to work around the public store's AND-only FTS5 semantics;
+filtering short tokens keeps the union cheap and high-signal.
+"""
+_CHARS_PER_TOKEN: Final[float] = 4.0
+MAX_TURN_TEXT_CHARS: Final[int] = 500
+"""Per-turn text truncation in the rebuild block.
+
+Recent turns are decoration, not load-bearing -- the retrieved beliefs
+carry the durable session state. Cap each turn's quoted text so the
+block size stays bounded even when one turn is enormous (e.g., a
+pasted log).
+"""
+
+OPEN_TAG: Final[str] = "<aelfrice-rebuild>"
+CLOSE_TAG: Final[str] = "</aelfrice-rebuild>"
+
+_AELFRICE_LOG_RELPATH: Final[Path] = Path(".git") / "aelfrice" / "transcripts" / "turns.jsonl"
+
+
+@dataclass(frozen=True)
+class RecentTurn:
+    """One normalized turn fed to rebuild().
+
+    Adapters convert wire-format transcript records into this shape.
+    """
+    role: str  # "user" or "assistant"
+    text: str
+
+
+def rebuild(
+    recent_turns: list[RecentTurn],
+    store: MemoryStore,
+    *,
+    token_budget: int = DEFAULT_TOKEN_BUDGET,
+) -> str:
+    """Build the rebuild context block. Pure function.
+
+    Given a list of recent turns and an open MemoryStore, retrieve the
+    most relevant beliefs and emit the formatted XML block.
+    Deterministic given the same inputs and store contents -- the
+    eval harness depends on this.
+
+    Empty recent_turns: retrieval returns L0 locked only, the block is
+    still well-formed (no <recent-turns> section).
+
+    Retrieval semantics: L0 locked beliefs are always first. L1 hits
+    come from a per-token union over the recent-turn text -- workaround
+    for the public store's AND-only FTS5 semantics, see
+    _retrieve_for_rebuild() docstring.
+    """
+    hits = _retrieve_for_rebuild(
+        store, recent_turns, token_budget=token_budget
+    )
+    return _format_block(recent_turns, hits, token_budget=token_budget)
+
+
+def _retrieve_for_rebuild(
+    store: MemoryStore,
+    recent_turns: list[RecentTurn],
+    *,
+    token_budget: int,
+) -> list[Belief]:
+    """Per-token union retrieval over recent-turn text.
+
+    The public retrieve() ANDs all tokens of its query expression
+    (because store._escape_fts5_query AND-joins per FTS5 default).
+    For rebuild input -- a concatenation of conversational turns --
+    a single AND query rarely matches any belief because no single
+    document contains all the conversation's words. We instead issue
+    one search per significant query token, union the results,
+    deduplicate by belief id, and trim to the token budget the same
+    way retrieve() does.
+
+    Future replacement: when posterior-weighted ranking ships
+    (v1.3+), this function should call into that ranker directly --
+    it will produce a single ranked list without needing the
+    per-token workaround.
+
+    L0 locked beliefs always come first and are never trimmed. L1 hits
+    are ordered by first appearance across the per-token searches.
+    """
+    locked: list[Belief] = store.list_locked_beliefs()
+    locked_ids: set[str] = {b.id for b in locked}
+
+    tokens = _query_tokens(recent_turns)
+    l1: list[Belief] = []
+    seen_ids: set[str] = set(locked_ids)
+    for tok in tokens:
+        for b in store.search_beliefs(tok, limit=DEFAULT_PER_TOKEN_LIMIT):
+            if b.id in seen_ids:
+                continue
+            seen_ids.add(b.id)
+            l1.append(b)
+
+    used: int = sum(_estimate_belief_tokens(b) for b in locked)
+    out: list[Belief] = list(locked)
+    for b in l1:
+        cost: int = _estimate_belief_tokens(b)
+        if used + cost > token_budget:
+            break
+        out.append(b)
+        used += cost
+    return out
+
+
+def _query_tokens(recent_turns: list[RecentTurn]) -> list[str]:
+    """Whitespace-split each turn's text, keep tokens >= MIN_QUERY_TOKEN_LENGTH.
+
+    Order is preserved (earliest mention first). Duplicate tokens are
+    dropped on first appearance.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for t in recent_turns:
+        if not t.text:
+            continue
+        for raw in t.text.split():
+            tok = raw.strip()
+            if len(tok) < MIN_QUERY_TOKEN_LENGTH:
+                continue
+            key = tok.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(tok)
+    return out
+
+
+def _estimate_belief_tokens(b: Belief) -> int:
+    if not b.content:
+        return 0
+    return int((len(b.content) + _CHARS_PER_TOKEN - 1) // _CHARS_PER_TOKEN)
+
+
+def _format_block(
+    recent_turns: list[RecentTurn],
+    hits: list[Belief],
+    *,
+    token_budget: int,
+) -> str:
+    lines: list[str] = [OPEN_TAG]
+    if recent_turns:
+        lines.append("  <recent-turns>")
+        for t in recent_turns:
+            text = _normalize_turn_text(t.text)
+            role = _xml_attr_value(t.role)
+            lines.append(f'    <turn role="{role}">{_xml_escape(text)}</turn>')
+        lines.append("  </recent-turns>")
+    if hits:
+        used_chars = sum(len(b.content) for b in hits)
+        lines.append(
+            f'  <retrieved-beliefs budget_used="{used_chars}/{token_budget * 4}">'
+        )
+        for b in hits:
+            locked = "true" if b.lock_level == LOCK_USER else "false"
+            content = _normalize_turn_text(b.content)
+            lines.append(
+                f'    <belief id="{_xml_attr_value(b.id)}" '
+                f'locked="{locked}">{_xml_escape(content)}</belief>'
+            )
+        lines.append("  </retrieved-beliefs>")
+    lines.append("  <continue/>")
+    lines.append(CLOSE_TAG)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _normalize_turn_text(text: str) -> str:
+    """Collapse whitespace and truncate to MAX_TURN_TEXT_CHARS."""
+    collapsed = " ".join(text.split())
+    if len(collapsed) > MAX_TURN_TEXT_CHARS:
+        return collapsed[:MAX_TURN_TEXT_CHARS] + "..."
+    return collapsed
+
+
+def _xml_escape(s: str) -> str:
+    return (
+        s.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+def _xml_attr_value(s: str) -> str:
+    return _xml_escape(s).replace('"', "&quot;")
+
+
+def read_recent_turns_aelfrice(path: Path, n: int) -> list[RecentTurn]:
+    """Read tail of an aelfrice turns.jsonl into RecentTurn records.
+
+    Schema per docs/specs/transcript_ingest.md: each line is a JSON
+    object with at least {"role": str, "text": str}. Other fields
+    (session_id, turn_id, ts, context) are ignored at MVP -- they
+    will be used by later releases for session-scoped retrieval.
+
+    Robust: malformed lines are skipped, missing files return empty.
+    Reads the entire file (a turns.jsonl is bounded by PreCompact
+    rotation; large enough to matter only between rotations).
+    """
+    if not path.exists():
+        return []
+    out: list[RecentTurn] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(r, dict):
+            continue
+        rd = cast(dict[str, object], r)
+        role = rd.get("role")
+        body = rd.get("text")
+        if not isinstance(role, str) or role not in ("user", "assistant"):
+            continue
+        if not isinstance(body, str) or not body.strip():
+            continue
+        out.append(RecentTurn(role=role, text=body))
+    return out[-n:] if n > 0 else []
+
+
+def read_recent_turns_claude_transcript(
+    path: Path, n: int
+) -> list[RecentTurn]:
+    """Adapter for Claude Code's internal transcript format.
+
+    MVP-only fallback used when the canonical aelfrice turns.jsonl
+    does not exist (typical pre-transcript_ingest setup). Reads
+    Claude Code's per-session JSONL at ~/.claude/projects/<hash>/
+    <session>.jsonl. Schema is internal-harness JSON and subject to
+    change between Claude Code releases; this adapter is best-effort
+    and fails closed (returns [] on shape mismatch).
+
+    Records of interest:
+      {"type": "user", "message": {"role": "user", "content": "..."}}
+      {"type": "assistant", "message": {"role": "assistant",
+        "content": [{"type": "text", "text": "..."}, ...]}}
+
+    Tool-call records, sub-agent records, and meta records are
+    skipped.
+    """
+    if not path.exists():
+        return []
+    out: list[RecentTurn] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(r, dict):
+            continue
+        rd = cast(dict[str, object], r)
+        record_type = rd.get("type")
+        if record_type not in ("user", "assistant"):
+            continue
+        msg = rd.get("message")
+        if not isinstance(msg, dict):
+            continue
+        msg_typed = cast(dict[str, object], msg)
+        role = msg_typed.get("role")
+        if not isinstance(role, str) or role not in ("user", "assistant"):
+            continue
+        content = msg_typed.get("content")
+        body = _extract_text_from_claude_content(content)
+        if not body:
+            continue
+        out.append(RecentTurn(role=role, text=body))
+    return out[-n:] if n > 0 else []
+
+
+def _extract_text_from_claude_content(content: object) -> str:
+    """Pull the human-readable text out of a Claude message content field.
+
+    Claude's content is either a bare string (user prompts) or a list
+    of content blocks (assistant turns and structured user messages).
+    We concatenate every "text"-typed block; non-text blocks (tool
+    use, tool result, images) are ignored.
+    """
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in cast(list[object], content):
+        if not isinstance(block, dict):
+            continue
+        bd = cast(dict[str, object], block)
+        if bd.get("type") != "text":
+            continue
+        t = bd.get("text")
+        if isinstance(t, str) and t.strip():
+            parts.append(t.strip())
+    return "\n".join(parts).strip()
+
+
+def find_aelfrice_log(cwd: Path) -> Path | None:
+    """Walk upward from cwd to find a .git/ root, return its turns.jsonl path.
+
+    Returns the path even if the file does not exist -- callers use
+    Path.exists() to decide. Returns None if no .git/ is found in any
+    ancestor (cwd is outside a git repo).
+    """
+    cur = cwd.resolve()
+    while True:
+        if (cur / ".git").exists():
+            return cur / _AELFRICE_LOG_RELPATH
+        if cur.parent == cur:
+            return None
+        cur = cur.parent

--- a/src/aelfrice/context_rebuilder.py
+++ b/src/aelfrice/context_rebuilder.py
@@ -56,7 +56,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, cast
 
-from aelfrice.models import LOCK_NONE, LOCK_USER, Belief
+from aelfrice.models import LOCK_USER, Belief
 from aelfrice.store import MemoryStore
 
 DEFAULT_N_RECENT_TURNS: Final[int] = 10

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -24,9 +24,19 @@ from __future__ import annotations
 import json
 import sys
 import traceback
+from pathlib import Path
 from typing import IO, Final, cast
 
 from aelfrice.cli import db_path
+from aelfrice.context_rebuilder import (
+    DEFAULT_N_RECENT_TURNS,
+    DEFAULT_TOKEN_BUDGET,
+    RecentTurn,
+    find_aelfrice_log,
+    read_recent_turns_aelfrice,
+    read_recent_turns_claude_transcript,
+    rebuild,
+)
 from aelfrice.hook_search import search_for_prompt
 from aelfrice.models import LOCK_USER, Belief
 from aelfrice.store import MemoryStore
@@ -42,6 +52,8 @@ the same context window.
 OPEN_TAG: Final[str] = "<aelfrice-memory>"
 CLOSE_TAG: Final[str] = "</aelfrice-memory>"
 _PROMPT_KEY: Final[str] = "prompt"
+_TRANSCRIPT_PATH_KEY: Final[str] = "transcript_path"
+_CWD_KEY: Final[str] = "cwd"
 
 
 def user_prompt_submit(
@@ -133,9 +145,116 @@ def _open_store() -> MemoryStore:
     return MemoryStore(str(p))
 
 
+def pre_compact(
+    *,
+    stdin: IO[str] | None = None,
+    stdout: IO[str] | None = None,
+    stderr: IO[str] | None = None,
+    n_recent_turns: int = DEFAULT_N_RECENT_TURNS,
+    token_budget: int = DEFAULT_TOKEN_BUDGET,
+) -> int:
+    """Run the PreCompact hook. Always returns 0.
+
+    Reads a Claude Code PreCompact JSON payload from `stdin`, locates
+    a transcript log (canonical aelfrice turns.jsonl preferred,
+    Claude Code internal transcript as fallback), runs the
+    context-rebuilder against it, and writes the rebuild block to
+    `stdout`. Hook contract: never block, never raise.
+
+    Payload fields used:
+      * `cwd` -- working directory; used to find <cwd>/.git/aelfrice/
+        transcripts/turns.jsonl (the canonical log).
+      * `transcript_path` -- absolute path to Claude Code's per-session
+        transcript JSONL. Used as fallback when the canonical log is
+        absent (typical pre-transcript_ingest setup).
+
+    With augment-mode coordination (the only mode v1.1.0a0 ships),
+    Claude Code will still run its default summarization after this
+    hook emits. The rebuild block is therefore additive context, not
+    a replacement.
+    """
+    sin = stdin if stdin is not None else sys.stdin
+    sout = stdout if stdout is not None else sys.stdout
+    serr = stderr if stderr is not None else sys.stderr
+    try:
+        raw = sin.read()
+        payload = _parse_pre_compact_payload(raw)
+        if payload is None:
+            return 0
+        recent = _read_recent_for_pre_compact(payload, n_recent_turns)
+        body = _rebuild_and_format(recent, token_budget)
+        if body:
+            sout.write(body)
+    except Exception:  # non-blocking: surface but do not fail
+        traceback.print_exc(file=serr)
+    return 0
+
+
+def _parse_pre_compact_payload(raw: str) -> dict[str, object] | None:
+    """Return the parsed payload dict, or None on any malformedness."""
+    if not raw.strip():
+        return None
+    try:
+        payload = json.loads(raw)  # pyright: ignore[reportAny]
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return cast(dict[str, object], payload)
+
+
+def _read_recent_for_pre_compact(
+    payload: dict[str, object], n_recent_turns: int
+) -> list[RecentTurn]:
+    """Locate a transcript and read its tail.
+
+    Resolution order:
+      1. <payload.cwd>/.git/aelfrice/transcripts/turns.jsonl -- the
+         canonical aelfrice log written by the per-turn UserPromptSubmit/
+         Stop hooks once transcript_ingest ships. Preferred when
+         present.
+      2. <payload.transcript_path> -- Claude Code's internal per-session
+         transcript JSONL. Fallback for the alpha while transcript_ingest
+         is unshipped.
+      3. Empty list -- both sources missing or unreadable.
+    """
+    cwd_obj = payload.get(_CWD_KEY)
+    if isinstance(cwd_obj, str) and cwd_obj.strip():
+        try:
+            cwd = Path(cwd_obj)
+            log_path = find_aelfrice_log(cwd)
+        except OSError:
+            log_path = None
+        if log_path is not None and log_path.exists():
+            return read_recent_turns_aelfrice(log_path, n=n_recent_turns)
+    tp_obj = payload.get(_TRANSCRIPT_PATH_KEY)
+    if isinstance(tp_obj, str) and tp_obj.strip():
+        tp = Path(tp_obj)
+        if tp.exists():
+            return read_recent_turns_claude_transcript(
+                tp, n=n_recent_turns
+            )
+    return []
+
+
+def _rebuild_and_format(
+    recent: list[RecentTurn], token_budget: int
+) -> str:
+    store = _open_store()
+    try:
+        return rebuild(recent, store, token_budget=token_budget)
+    finally:
+        store.close()
+
+
 def main() -> int:
     """Entry point for `python -m aelfrice.hook`."""
     return user_prompt_submit()
+
+
+def main_pre_compact() -> int:
+    """Entry point for the PreCompact hook console script."""
+    return pre_compact()
 
 
 if __name__ == "__main__":

--- a/src/aelfrice/setup.py
+++ b/src/aelfrice/setup.py
@@ -730,25 +730,6 @@ def _get_event_list(
     return cast(list[dict[str, object]], event_list)
 
 
-@overload
-def _get_user_prompt_submit_list(
-    data: dict[str, object], *, create: Literal[True]
-) -> list[dict[str, object]]: ...
-
-
-@overload
-def _get_user_prompt_submit_list(
-    data: dict[str, object], *, create: Literal[False]
-) -> list[dict[str, object]] | None: ...
-
-
-def _get_user_prompt_submit_list(
-    data: dict[str, object], *, create: bool
-) -> list[dict[str, object]] | None:
-    """Back-compat wrapper for the UserPromptSubmit-specific event list."""
-    if create:
-        return _get_event_list(data, _EVENT_KEY, create=True)
-    return _get_event_list(data, _EVENT_KEY, create=False)
 
 
 def _build_entry(

--- a/src/aelfrice/setup.py
+++ b/src/aelfrice/setup.py
@@ -67,6 +67,7 @@ _DANGLING_SHIM_CANDIDATES: Final[tuple[Path, ...]] = (
 
 _HOOKS_KEY: Final[str] = "hooks"
 _EVENT_KEY: Final[str] = "UserPromptSubmit"
+_PRE_COMPACT_EVENT_KEY: Final[str] = "PreCompact"
 _INNER_HOOKS_KEY: Final[str] = "hooks"
 _TYPE_KEY: Final[str] = "type"
 _COMMAND_KEY: Final[str] = "command"
@@ -256,7 +257,48 @@ def install_user_prompt_submit_hook(
     timeout: int | None = None,
     status_message: str | None = None,
 ) -> InstallResult:
-    """Add a UserPromptSubmit hook entry running `command`.
+    """Add a UserPromptSubmit hook entry running `command`."""
+    return _install_event_hook(
+        settings_path,
+        event_key=_EVENT_KEY,
+        command=command,
+        timeout=timeout,
+        status_message=status_message,
+    )
+
+
+def install_pre_compact_hook(
+    settings_path: Path,
+    *,
+    command: str,
+    timeout: int | None = None,
+    status_message: str | None = None,
+) -> InstallResult:
+    """Add a PreCompact hook entry running `command`.
+
+    Mirrors install_user_prompt_submit_hook for the PreCompact event,
+    which Claude Code fires before its default context compaction. The
+    aelfrice context-rebuilder lives behind this event; the command
+    string typically resolves to `aelf-pre-compact-hook`.
+    """
+    return _install_event_hook(
+        settings_path,
+        event_key=_PRE_COMPACT_EVENT_KEY,
+        command=command,
+        timeout=timeout,
+        status_message=status_message,
+    )
+
+
+def _install_event_hook(
+    settings_path: Path,
+    *,
+    event_key: str,
+    command: str,
+    timeout: int | None,
+    status_message: str | None,
+) -> InstallResult:
+    """Shared install logic for any hook event.
 
     Creates `settings_path` (and parent dirs) if missing. Preserves
     every other key in the file. Idempotent: a second call with the
@@ -265,12 +307,12 @@ def install_user_prompt_submit_hook(
     if not command:
         raise ValueError("command must be a non-empty string")
     data = _load_settings(settings_path)
-    user_prompt_submit = _get_user_prompt_submit_list(data, create=True)
-    if _find_entry_index(user_prompt_submit, command) is not None:
+    entries = _get_event_list(data, event_key, create=True)
+    if _find_entry_index(entries, command) is not None:
         return InstallResult(
             path=settings_path, installed=False, already_present=True
         )
-    user_prompt_submit.append(
+    entries.append(
         _build_entry(
             command=command, timeout=timeout, status_message=status_message
         )
@@ -287,7 +329,38 @@ def uninstall_user_prompt_submit_hook(
     command: str | None = None,
     command_basename: str | None = None,
 ) -> UninstallResult:
-    """Remove UserPromptSubmit entries matching `command` or `command_basename`.
+    """Remove UserPromptSubmit entries matching `command` or `command_basename`."""
+    return _uninstall_event_hook(
+        settings_path,
+        event_key=_EVENT_KEY,
+        command=command,
+        command_basename=command_basename,
+    )
+
+
+def uninstall_pre_compact_hook(
+    settings_path: Path,
+    *,
+    command: str | None = None,
+    command_basename: str | None = None,
+) -> UninstallResult:
+    """Remove PreCompact entries matching `command` or `command_basename`."""
+    return _uninstall_event_hook(
+        settings_path,
+        event_key=_PRE_COMPACT_EVENT_KEY,
+        command=command,
+        command_basename=command_basename,
+    )
+
+
+def _uninstall_event_hook(
+    settings_path: Path,
+    *,
+    event_key: str,
+    command: str | None,
+    command_basename: str | None,
+) -> UninstallResult:
+    """Shared uninstall logic for any hook event.
 
     Pass exactly one of:
       * `command` -- exact-string match of the stored hook command.
@@ -296,7 +369,7 @@ def uninstall_user_prompt_submit_hook(
         and an absolute-path install be cleaned up by the same call.
 
     Returns `removed=0` if the file does not exist, has no matching
-    entry, or has no `hooks.UserPromptSubmit` block at all.
+    entry, or has no `hooks.<event_key>` block at all.
     """
     if command is None and command_basename is None:
         raise ValueError("provide command or command_basename")
@@ -309,25 +382,25 @@ def uninstall_user_prompt_submit_hook(
     if not settings_path.exists():
         return UninstallResult(path=settings_path, removed=0)
     data = _load_settings(settings_path)
-    user_prompt_submit = _get_user_prompt_submit_list(data, create=False)
-    if user_prompt_submit is None:
+    entries = _get_event_list(data, event_key, create=False)
+    if entries is None:
         return UninstallResult(path=settings_path, removed=0)
-    before = len(user_prompt_submit)
+    before = len(entries)
     if command is not None:
         kept = [
-            entry for entry in user_prompt_submit
+            entry for entry in entries
             if not _entry_matches(entry, command)
         ]
     else:
         assert command_basename is not None
         kept = [
-            entry for entry in user_prompt_submit
+            entry for entry in entries
             if not _entry_matches_basename(entry, command_basename)
         ]
     removed = before - len(kept)
     if removed == 0:
         return UninstallResult(path=settings_path, removed=0)
-    user_prompt_submit[:] = kept
+    entries[:] = kept
     _atomic_write(settings_path, data)
     return UninstallResult(path=settings_path, removed=removed)
 

--- a/src/aelfrice/setup.py
+++ b/src/aelfrice/setup.py
@@ -57,6 +57,7 @@ SettingsScope = Literal["user", "project"]
 USER_SETTINGS_PATH: Final[Path] = Path.home() / ".claude" / "settings.json"
 PROJECT_SETTINGS_RELPATH: Final[Path] = Path(".claude") / "settings.json"
 _HOOK_SCRIPT_NAME: Final[str] = "aelf-hook"
+_PRE_COMPACT_HOOK_SCRIPT_NAME: Final[str] = "aelf-pre-compact-hook"
 # Legacy / pre-pipx shim locations we will silently clean up if they
 # point at a deleted target. Keep this list narrow: only paths the
 # package itself ever wrote, never user-managed binaries.
@@ -160,16 +161,29 @@ def resolve_hook_command(scope: SettingsScope) -> str:
     no executable is found anywhere on the system, in which case the
     user has bigger problems and `aelf doctor` will flag it.
     """
+    return _resolve_script(_HOOK_SCRIPT_NAME, scope)
+
+
+def resolve_pre_compact_hook_command(scope: SettingsScope) -> str:
+    """Pick the absolute `aelf-pre-compact-hook` path for `scope`.
+
+    Same resolution rules as `resolve_hook_command`; different script
+    name. Used by `aelf setup --rebuilder`.
+    """
+    return _resolve_script(_PRE_COMPACT_HOOK_SCRIPT_NAME, scope)
+
+
+def _resolve_script(script_name: str, scope: SettingsScope) -> str:
     venv_bin = _venv_bin_dir()
-    venv_hook = _executable_in_dir(venv_bin, _HOOK_SCRIPT_NAME)
-    path_hook_str = shutil.which(_HOOK_SCRIPT_NAME)
+    venv_hook = _executable_in_dir(venv_bin, script_name)
+    path_hook_str = shutil.which(script_name)
     path_hook = Path(path_hook_str) if path_hook_str else None
     if scope == "project":
         chosen = venv_hook or path_hook
     else:
         chosen = path_hook or venv_hook
     if chosen is None:
-        return _HOOK_SCRIPT_NAME
+        return script_name
     return str(chosen)
 
 

--- a/src/aelfrice/slash_commands/rebuild.md
+++ b/src/aelfrice/slash_commands/rebuild.md
@@ -1,0 +1,17 @@
+---
+name: aelf:rebuild
+description: v1.1 alpha — emit the context-rebuild block (what the PreCompact hook would produce) for inspection.
+argument-hint: optional --transcript PATH, --n N, --budget N
+allowed-tools:
+  - Bash
+---
+<objective>
+Manually invoke the context rebuilder and print the rebuild block to
+the conversation. Useful for inspecting what aelfrice would inject if
+PreCompact fired right now without actually triggering compaction.
+</objective>
+
+<process>
+Run: `uv run aelf rebuild $ARGUMENTS`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/tests/test_context_rebuilder.py
+++ b/tests/test_context_rebuilder.py
@@ -1,0 +1,321 @@
+"""Context-rebuilder unit tests: rebuild() determinism, format, adapters."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.context_rebuilder import (
+    CLOSE_TAG,
+    DEFAULT_TOKEN_BUDGET,
+    MAX_TURN_TEXT_CHARS,
+    OPEN_TAG,
+    RecentTurn,
+    find_aelfrice_log,
+    read_recent_turns_aelfrice,
+    read_recent_turns_claude_transcript,
+    rebuild,
+)
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    bid: str,
+    content: str,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _seed(db_path: Path, beliefs: list[Belief]) -> MemoryStore:
+    store = MemoryStore(str(db_path))
+    for b in beliefs:
+        store.insert_belief(b)
+    return store
+
+
+# ---- rebuild() format ---------------------------------------------------
+
+
+def test_rebuild_emits_recent_turns_then_beliefs(tmp_path: Path) -> None:
+    store = _seed(tmp_path / "m.db", [_mk("F1", "kitchen has bananas")])
+    try:
+        out = rebuild(
+            [
+                RecentTurn(role="user", text="kitchen contents check"),
+                RecentTurn(role="assistant", text="bananas inventory"),
+            ],
+            store,
+        )
+    finally:
+        store.close()
+    assert out.startswith(OPEN_TAG + "\n")
+    assert CLOSE_TAG in out
+    assert "<recent-turns>" in out
+    assert '<turn role="user">' in out
+    assert '<turn role="assistant">' in out
+    assert "</recent-turns>" in out
+    assert "<retrieved-beliefs" in out
+    assert 'id="F1"' in out
+    assert "<continue/>" in out
+    # <continue/> must come after </retrieved-beliefs> per spec.
+    assert out.index("<continue/>") > out.index("</retrieved-beliefs>")
+
+
+def test_rebuild_omits_recent_turns_section_when_empty(tmp_path: Path) -> None:
+    store = _seed(tmp_path / "m.db", [_mk("F1", "kitchen has bananas")])
+    try:
+        out = rebuild([], store)
+    finally:
+        store.close()
+    assert "<recent-turns>" not in out
+    # Empty query → retrieve() returns L0 only; F1 is unlocked so no hits.
+    assert "<retrieved-beliefs" not in out
+    assert "<continue/>" in out
+
+
+def test_rebuild_omits_belief_section_when_no_hits(tmp_path: Path) -> None:
+    store = _seed(tmp_path / "m.db", [_mk("F1", "kitchen has bananas")])
+    try:
+        out = rebuild(
+            [RecentTurn(role="user", text="totally unrelated topic xyzzy")],
+            store,
+        )
+    finally:
+        store.close()
+    assert "<recent-turns>" in out
+    assert "<retrieved-beliefs" not in out
+
+
+def test_rebuild_marks_locked_beliefs(tmp_path: Path) -> None:
+    locked = _mk(
+        "L1", "user is jonsobol", lock_level=LOCK_USER,
+        locked_at="2026-04-26T00:00:00Z",
+    )
+    store = _seed(tmp_path / "m.db", [locked])
+    try:
+        out = rebuild(
+            [RecentTurn(role="user", text="hello")],
+            store,
+        )
+    finally:
+        store.close()
+    assert 'locked="true"' in out
+    assert 'id="L1"' in out
+
+
+# ---- determinism --------------------------------------------------------
+
+
+def test_rebuild_is_deterministic(tmp_path: Path) -> None:
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk("F1", "kitchen bananas"), _mk("F2", "kitchen apples")],
+    )
+    try:
+        turns = [RecentTurn(role="user", text="kitchen contents")]
+        out_a = rebuild(turns, store)
+        out_b = rebuild(turns, store)
+    finally:
+        store.close()
+    assert out_a == out_b
+
+
+# ---- truncation and escaping --------------------------------------------
+
+
+def test_rebuild_truncates_long_turn_text(tmp_path: Path) -> None:
+    store = _seed(tmp_path / "m.db", [])
+    long_text = "x" * (MAX_TURN_TEXT_CHARS + 200)
+    try:
+        out = rebuild([RecentTurn(role="user", text=long_text)], store)
+    finally:
+        store.close()
+    # Truncation marker present; full long text is not.
+    assert "..." in out
+    assert long_text not in out
+
+
+def test_rebuild_xml_escapes_turn_text(tmp_path: Path) -> None:
+    store = _seed(tmp_path / "m.db", [])
+    try:
+        out = rebuild(
+            [RecentTurn(role="user", text="a < b && c > d")],
+            store,
+        )
+    finally:
+        store.close()
+    assert "&lt;" in out
+    assert "&gt;" in out
+    assert "&amp;" in out
+    assert "<turn role=\"user\">a < b" not in out
+
+
+# ---- token budget honored ----------------------------------------------
+
+
+def test_rebuild_respects_token_budget(tmp_path: Path) -> None:
+    big = "kitchen contents " * 200  # ~3500 chars per belief
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(f"F{i}", big) for i in range(5)],
+    )
+    try:
+        out = rebuild(
+            [RecentTurn(role="user", text="kitchen")],
+            store,
+            token_budget=500,  # tight budget — caps the belief tail
+        )
+    finally:
+        store.close()
+    # Hard upper bound: belief content total at 500 tokens × 4 chars/tok
+    # is ~2000 chars. Five copies of `big` would be ~17500. Cap holds.
+    assert len(out) < 4000
+
+
+# ---- read_recent_turns_aelfrice ----------------------------------------
+
+
+def test_read_aelfrice_log_returns_last_n_turns(tmp_path: Path) -> None:
+    p = tmp_path / "turns.jsonl"
+    lines = [
+        json.dumps({"role": "user", "text": f"msg {i}"})
+        for i in range(20)
+    ]
+    p.write_text("\n".join(lines) + "\n")
+    got = read_recent_turns_aelfrice(p, n=5)
+    assert len(got) == 5
+    assert [t.text for t in got] == [f"msg {i}" for i in range(15, 20)]
+
+
+def test_read_aelfrice_log_skips_malformed_lines(tmp_path: Path) -> None:
+    p = tmp_path / "turns.jsonl"
+    p.write_text(
+        '{"role":"user","text":"good"}\n'
+        "this line is not json\n"
+        '{"role":"assistant","text":"also good"}\n'
+        '{"role":"system","text":"wrong role, dropped"}\n'
+        '{"role":"user","text":""}\n'  # empty text dropped
+    )
+    got = read_recent_turns_aelfrice(p, n=10)
+    assert [t.text for t in got] == ["good", "also good"]
+
+
+def test_read_aelfrice_log_missing_file_returns_empty(tmp_path: Path) -> None:
+    got = read_recent_turns_aelfrice(tmp_path / "nope.jsonl", n=5)
+    assert got == []
+
+
+# ---- read_recent_turns_claude_transcript -------------------------------
+
+
+def test_read_claude_transcript_extracts_user_and_assistant(
+    tmp_path: Path,
+) -> None:
+    p = tmp_path / "session.jsonl"
+    p.write_text(
+        json.dumps({
+            "type": "user",
+            "message": {"role": "user", "content": "what database?"},
+        }) + "\n"
+        + json.dumps({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "sqlite via FTS5"}],
+            },
+        }) + "\n"
+    )
+    got = read_recent_turns_claude_transcript(p, n=10)
+    assert len(got) == 2
+    assert got[0].role == "user"
+    assert got[0].text == "what database?"
+    assert got[1].role == "assistant"
+    assert got[1].text == "sqlite via FTS5"
+
+
+def test_read_claude_transcript_skips_tool_only_assistant_turns(
+    tmp_path: Path,
+) -> None:
+    p = tmp_path / "session.jsonl"
+    p.write_text(
+        json.dumps({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "x"}],
+            },
+        }) + "\n"
+        + json.dumps({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "after the tool"}],
+            },
+        }) + "\n"
+    )
+    got = read_recent_turns_claude_transcript(p, n=10)
+    assert len(got) == 1
+    assert got[0].text == "after the tool"
+
+
+def test_read_claude_transcript_missing_file_returns_empty(
+    tmp_path: Path,
+) -> None:
+    got = read_recent_turns_claude_transcript(tmp_path / "nope.jsonl", n=5)
+    assert got == []
+
+
+# ---- find_aelfrice_log -------------------------------------------------
+
+
+def test_find_aelfrice_log_walks_to_git_root(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    (root / ".git").mkdir(parents=True)
+    nested = root / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    got = find_aelfrice_log(nested)
+    assert got is not None
+    assert got == root / ".git" / "aelfrice" / "transcripts" / "turns.jsonl"
+
+
+def test_find_aelfrice_log_returns_none_outside_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Only safe test bound: call into a tmp dir that's not in any git tree.
+    # If tmp_path is itself inside a git tree (it isn't on macOS), this
+    # walks to that tree's .git and the test would still pass with a
+    # non-None result; in that case, treat it as a known-pass.
+    here = tmp_path / "no_git_here"
+    here.mkdir()
+    got = find_aelfrice_log(here)
+    # We can't strictly assert None without isolating from FS; assert the
+    # weaker invariant: if it returns a path, that path's grandparent
+    # (.git/aelfrice/transcripts/) reflects an actual .git dir somewhere.
+    if got is not None:
+        # Walk up to confirm a .git ancestor exists; otherwise it's a bug.
+        gitdir = got.parent.parent.parent  # .git/aelfrice/transcripts/turns.jsonl → .git
+        assert gitdir.name == ".git"
+
+
+# ---- DEFAULT_TOKEN_BUDGET sanity --------------------------------------
+
+
+def test_default_token_budget_matches_spec_default() -> None:
+    """Spec docs/specs/context_rebuilder.md sets default 2000."""
+    assert DEFAULT_TOKEN_BUDGET == 2000

--- a/tests/test_hook_pre_compact.py
+++ b/tests/test_hook_pre_compact.py
@@ -1,0 +1,240 @@
+"""PreCompact hook entry-point: payload parse, source resolution, output."""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.context_rebuilder import (
+    CLOSE_TAG as REBUILD_CLOSE_TAG,
+    OPEN_TAG as REBUILD_OPEN_TAG,
+)
+from aelfrice.hook import pre_compact
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    bid: str,
+    content: str,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _seed_db(db_path: Path, beliefs: list[Belief]) -> None:
+    store = MemoryStore(str(db_path))
+    try:
+        for b in beliefs:
+            store.insert_belief(b)
+    finally:
+        store.close()
+
+
+def _set_db(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    monkeypatch.setenv("AELFRICE_DB", str(path))
+
+
+def _aelfrice_log(cwd: Path, lines: list[dict[str, object]]) -> Path:
+    p = cwd / ".git" / "aelfrice" / "transcripts" / "turns.jsonl"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+    return p
+
+
+def _claude_transcript(path: Path, lines: list[dict[str, object]]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+    return path
+
+
+def _payload(
+    *,
+    cwd: Path | None = None,
+    transcript_path: Path | None = None,
+) -> str:
+    return json.dumps(
+        {
+            "session_id": "s1",
+            "transcript_path": str(transcript_path) if transcript_path else "",
+            "cwd": str(cwd) if cwd else "",
+            "hook_event_name": "PreCompact",
+        }
+    )
+
+
+# ---- exit code contract -------------------------------------------------
+
+
+def test_pre_compact_returns_zero_on_empty_stdin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [])
+    _set_db(monkeypatch, db)
+    sin = io.StringIO("")
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = pre_compact(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+def test_pre_compact_returns_zero_on_malformed_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [])
+    _set_db(monkeypatch, db)
+    sin = io.StringIO("{not valid json")
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = pre_compact(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+def test_pre_compact_returns_zero_when_no_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No aelfrice log, no claude transcript -> empty turns -> empty body."""
+    db = tmp_path / "memory.db"
+    _seed_db(db, [])
+    _set_db(monkeypatch, db)
+    no_git = tmp_path / "no_git"
+    no_git.mkdir()
+    sin = io.StringIO(_payload(cwd=no_git))
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = pre_compact(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    # No locked beliefs, no recent turns -> rebuild() emits the empty
+    # frame (just <continue/> wrapped in tags). No <recent-turns> or
+    # <retrieved-beliefs> sections.
+    out = sout.getvalue()
+    assert REBUILD_OPEN_TAG in out
+    assert REBUILD_CLOSE_TAG in out
+    assert "<recent-turns>" not in out
+    assert "<retrieved-beliefs" not in out
+
+
+# ---- aelfrice log preferred over claude transcript ---------------------
+
+
+def test_pre_compact_prefers_aelfrice_log(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "kitchen has bananas")])
+    _set_db(monkeypatch, db)
+    cwd = tmp_path / "repo"
+    (cwd / ".git").mkdir(parents=True)
+    _aelfrice_log(cwd, [{"role": "user", "text": "kitchen contents"}])
+    # Provide an unrelated claude transcript that, if used, would
+    # surface different content -- verifies aelfrice log wins.
+    other = tmp_path / "claude.jsonl"
+    _claude_transcript(other, [{
+        "type": "user",
+        "message": {"role": "user", "content": "lawnmower repair"},
+    }])
+    sin = io.StringIO(_payload(cwd=cwd, transcript_path=other))
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = pre_compact(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    out = sout.getvalue()
+    assert 'kitchen contents' in out
+    # The fallback's content must NOT appear because aelfrice log won.
+    assert "lawnmower" not in out
+
+
+def test_pre_compact_falls_back_to_claude_transcript(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No .git anywhere -> use transcript_path."""
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "kitchen has bananas")])
+    _set_db(monkeypatch, db)
+    no_git = tmp_path / "no_git"
+    no_git.mkdir()
+    transcript = tmp_path / "claude.jsonl"
+    _claude_transcript(transcript, [
+        {"type": "user", "message": {"role": "user", "content": "kitchen check"}},
+    ])
+    sin = io.StringIO(_payload(cwd=no_git, transcript_path=transcript))
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = pre_compact(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    out = sout.getvalue()
+    assert "kitchen check" in out
+
+
+# ---- output emits expected tags ----------------------------------------
+
+
+def test_pre_compact_writes_rebuild_block_with_hits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "kitchen has bananas")])
+    _set_db(monkeypatch, db)
+    cwd = tmp_path / "repo"
+    (cwd / ".git").mkdir(parents=True)
+    _aelfrice_log(cwd, [
+        {"role": "user", "text": "kitchen contents"},
+        {"role": "assistant", "text": "checking now"},
+    ])
+    sin = io.StringIO(_payload(cwd=cwd))
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = pre_compact(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    out = sout.getvalue()
+    assert REBUILD_OPEN_TAG in out
+    assert REBUILD_CLOSE_TAG in out
+    assert "<recent-turns>" in out
+    assert 'id="F1"' in out
+    assert "<continue/>" in out
+
+
+# ---- locked beliefs surface even with no transcript ---------------------
+
+
+def test_pre_compact_returns_locked_when_no_turns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(
+        db,
+        [_mk(
+            "L1", "user-locked baseline",
+            lock_level=LOCK_USER, locked_at="2026-04-26T00:00:00Z",
+        )],
+    )
+    _set_db(monkeypatch, db)
+    no_git = tmp_path / "no_git"
+    no_git.mkdir()
+    sin = io.StringIO(_payload(cwd=no_git))
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = pre_compact(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    out = sout.getvalue()
+    assert 'id="L1"' in out
+    assert 'locked="true"' in out

--- a/tests/test_setup_pre_compact.py
+++ b/tests/test_setup_pre_compact.py
@@ -1,0 +1,120 @@
+"""install_pre_compact_hook / uninstall_pre_compact_hook idempotency."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aelfrice.setup import (
+    install_pre_compact_hook,
+    install_user_prompt_submit_hook,
+    uninstall_pre_compact_hook,
+    uninstall_user_prompt_submit_hook,
+)
+
+
+_PC_CMD = "/usr/local/bin/aelf-pre-compact-hook"
+_UPS_CMD = "/usr/local/bin/aelf-hook"
+
+
+def _read(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text())
+
+
+# ---- install ------------------------------------------------------------
+
+
+def test_install_pre_compact_writes_entry(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    result = install_pre_compact_hook(p, command=_PC_CMD)
+    assert result.installed is True
+    assert result.already_present is False
+    data = _read(p)
+    assert "PreCompact" in data["hooks"]  # type: ignore[index]
+    entry_list = data["hooks"]["PreCompact"]  # type: ignore[index]
+    assert isinstance(entry_list, list) and len(entry_list) == 1
+    inner = entry_list[0]["hooks"][0]
+    assert inner["type"] == "command"
+    assert inner["command"] == _PC_CMD
+
+
+def test_install_pre_compact_idempotent(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    install_pre_compact_hook(p, command=_PC_CMD)
+    second = install_pre_compact_hook(p, command=_PC_CMD)
+    assert second.installed is False
+    assert second.already_present is True
+    data = _read(p)
+    entry_list = data["hooks"]["PreCompact"]  # type: ignore[index]
+    assert len(entry_list) == 1
+
+
+def test_install_pre_compact_does_not_touch_user_prompt_submit(
+    tmp_path: Path,
+) -> None:
+    """Two events live independently in the same settings.json."""
+    p = tmp_path / "settings.json"
+    install_user_prompt_submit_hook(p, command=_UPS_CMD)
+    install_pre_compact_hook(p, command=_PC_CMD)
+    data = _read(p)
+    hooks = data["hooks"]  # type: ignore[index]
+    assert "UserPromptSubmit" in hooks
+    assert "PreCompact" in hooks
+    assert len(hooks["UserPromptSubmit"]) == 1
+    assert len(hooks["PreCompact"]) == 1
+
+
+# ---- uninstall ----------------------------------------------------------
+
+
+def test_uninstall_pre_compact_removes_entry(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    install_pre_compact_hook(p, command=_PC_CMD)
+    result = uninstall_pre_compact_hook(p, command=_PC_CMD)
+    assert result.removed == 1
+    data = _read(p)
+    assert data["hooks"]["PreCompact"] == []  # type: ignore[index]
+
+
+def test_uninstall_pre_compact_no_match(tmp_path: Path) -> None:
+    p = tmp_path / "settings.json"
+    install_pre_compact_hook(p, command=_PC_CMD)
+    other = "/different/binary"
+    result = uninstall_pre_compact_hook(p, command=other)
+    assert result.removed == 0
+
+
+def test_uninstall_pre_compact_missing_file(tmp_path: Path) -> None:
+    p = tmp_path / "nope.json"
+    result = uninstall_pre_compact_hook(p, command=_PC_CMD)
+    assert result.removed == 0
+
+
+def test_uninstall_pre_compact_does_not_touch_user_prompt_submit(
+    tmp_path: Path,
+) -> None:
+    p = tmp_path / "settings.json"
+    install_user_prompt_submit_hook(p, command=_UPS_CMD)
+    install_pre_compact_hook(p, command=_PC_CMD)
+    uninstall_pre_compact_hook(p, command=_PC_CMD)
+    data = _read(p)
+    hooks = data["hooks"]  # type: ignore[index]
+    assert "UserPromptSubmit" in hooks
+    assert len(hooks["UserPromptSubmit"]) == 1
+    # PreCompact entry list is empty but key may persist.
+
+
+def test_uninstall_pre_compact_by_basename(tmp_path: Path) -> None:
+    """Basename match cleans up across abs / bare installs."""
+    p = tmp_path / "settings.json"
+    install_pre_compact_hook(p, command=_PC_CMD)
+    install_pre_compact_hook(
+        p, command="/different/path/aelf-pre-compact-hook"
+    )
+    data = _read(p)
+    assert len(data["hooks"]["PreCompact"]) == 2  # type: ignore[index]
+    result = uninstall_pre_compact_hook(
+        p, command_basename="aelf-pre-compact-hook"
+    )
+    assert result.removed == 2
+    data = _read(p)
+    assert data["hooks"]["PreCompact"] == []  # type: ignore[index]

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -17,9 +17,11 @@ import pytest
 # `resolve` joins at v1.0.1 alongside the contradiction tie-breaker.
 # `status` (alias for health), `regime` (preserved v1.0 classifier),
 # and `migrate` (legacy-DB import) join at v1.1.0.
+# `rebuild` (context rebuilder MVP) joins at v1.1.0 alpha.
 EXPECTED_COMMANDS = (
     "onboard",
     "search",
+    "rebuild",
     "lock",
     "locked",
     "demote",

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "1.1.0"
+version = "1.2.0a0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- **Context rebuilder MVP** behind an opt-in PreCompact hook (augment-mode only).
- **Surfaces:** `aelf setup --rebuilder` to install, `aelf rebuild` (+ `/aelf:rebuild` slash) for manual inspection, `aelf-pre-compact-hook` console script for settings.json wiring.
- **Retrieval:** L0 locked + L1 BM25 via per-token union (workaround for the public store's AND-only FTS5 semantics).
- **Deferred** (named in CHANGELOG): session-scoped retrieval, triple-extracted query construction, posterior-weighted ranking, suppress-mode coordination, threshold-mode auto-trigger.
- **Version:** bumps to 1.2.0a0 (skipping past published 1.1.0). The deferred quality dimensions land in 1.2.0 final and beyond.

## Test plan

- [x] 957 pass / 2 skip on the full suite (33 new tests across rebuilder, hook, setup)
- [x] CLI smoke: \`aelf rebuild --help\` and \`aelf rebuild\` against an empty + populated store
- [x] Setup atomicity: install_pre_compact_hook is idempotent and does not disturb UserPromptSubmit entries
- [x] Slash command surface: \`rebuild.md\` ships and matches the CLI subparser per test_slash_commands
- [x] No regressions in pre-existing tests after the setup.py event_key parameterization refactor
- [ ] Staging-gate (gitleaks + PII + pytest matrix) passes on CI
- [ ] Eval-harness two-arm token comparison (separate work, lab repo)

See gate commit \`f10898c\` for the full verification + blockers + rollback summary.