### PR TITLE
feat(v1.2.0): ingest enrichment — session_id, anchor_text, DERIVED_FROM

### DIFF
--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -1,23 +1,13 @@
 """Ingest pipeline: split a conversation turn into sentences,
 classify each, and insert classified sentences as beliefs.
 
-This module is a deliberate **shim**, not a literal port of lab
-v2.0.0's ingest pipeline. The public v1.0.0 schema does not model
-observations, sessions, evidence, or audit logs as separate
-tables; lab v2.0.0 does. Rather than invert v1.0.0's deliberate
-slim-down, ingest_turn here lowers conversation turns directly to
-the existing `beliefs` table via the public classification API
-(`classify_sentence`, one sentence at a time) instead of lab's
-`classify_sentences_offline` batch path.
-
-The signature is kept compatible with the lab adapters in
-`benchmarks/` so they import successfully without modification:
+The signature is compatible with the lab adapters in `benchmarks/`:
 
     ingest_turn(store, text, source, session_id, created_at, source_id)
 
-`session_id` and `source_id` are accepted but not persisted at
-v1.0.x. They reappear as belief metadata when (or if) the schema
-gains source-tracking columns.
+`session_id` is persisted on every belief inserted under the call
+(v1.2+). `source_id` is still accepted for adapter parity but
+remains unpersisted pending its own schema slot.
 """
 from __future__ import annotations
 
@@ -52,7 +42,7 @@ def ingest_turn(
     store: MemoryStore,
     text: str,
     source: str,
-    session_id: str | None = None,  # noqa: ARG001
+    session_id: str | None = None,
     created_at: str | None = None,
     source_id: str = "",  # noqa: ARG001
 ) -> int:
@@ -69,8 +59,13 @@ def ingest_turn(
     classification returns `persist=False` (questions, empty text) are
     skipped.
 
-    `session_id` and `source_id` are accepted for adapter parity with
-    lab v2.0.0 but are not stored at v1.0.x.
+    When `session_id` is provided it is written to `beliefs.session_id`
+    on every newly inserted row (v1.2+). Calls without a session leave
+    the column NULL — downstream session-coherent retrieval skips
+    NULL rows, no false positives on legacy data.
+
+    `source_id` is still accepted for adapter parity but is not yet
+    persisted.
 
     Returns the number of beliefs inserted (or that would have been
     inserted if not already present).
@@ -100,6 +95,7 @@ def ingest_turn(
             demotion_pressure=0,
             created_at=ts,
             last_retrieved_at=None,
+            session_id=session_id,
         )
         store.insert_belief(belief)
         inserted += 1

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -28,15 +28,20 @@ EDGE_CITES: Final[str] = "CITES"
 EDGE_CONTRADICTS: Final[str] = "CONTRADICTS"
 EDGE_SUPERSEDES: Final[str] = "SUPERSEDES"
 EDGE_RELATES_TO: Final[str] = "RELATES_TO"
+EDGE_DERIVED_FROM: Final[str] = "DERIVED_FROM"
 
 # Edge-type valence multipliers for propagation.
 # Positive = propagate same sign; negative = invert; 0.0 = no propagation.
+# DERIVED_FROM mirrors CITES (0.5): both indicate B's content depends on A,
+# distinct because DERIVED_FROM carries stronger contextual coupling
+# (sibling becomes stale if A is superseded).
 EDGE_VALENCE: Final[dict[str, float]] = {
     EDGE_SUPPORTS: 1.0,
     EDGE_CITES: 0.5,
     EDGE_CONTRADICTS: -0.5,
     EDGE_SUPERSEDES: 0.0,
     EDGE_RELATES_TO: 0.3,
+    EDGE_DERIVED_FROM: 0.5,
 }
 
 EDGE_TYPES: Final[frozenset[str]] = frozenset(EDGE_VALENCE.keys())

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -72,7 +72,13 @@ class Belief:
     """A unit of memory with Bayesian confidence and lock state.
 
     Fields: id, content, content_hash, alpha, beta, type, lock_level,
-    locked_at, demotion_pressure, created_at, last_retrieved_at.
+    locked_at, demotion_pressure, created_at, last_retrieved_at,
+    session_id.
+
+    `session_id` (v1.2+) tags the belief with the ingest session that
+    inserted it. Optional: ingest paths that don't open a session
+    leave it None and downstream session-coherent retrieval simply
+    does not fire on those rows.
     """
 
     id: str
@@ -86,6 +92,7 @@ class Belief:
     demotion_pressure: int
     created_at: str
     last_retrieved_at: str | None
+    session_id: str | None = None
 
 
 ANCHOR_TEXT_MAX_LEN: Final[int] = 1000

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -88,14 +88,32 @@ class Belief:
     last_retrieved_at: str | None
 
 
+ANCHOR_TEXT_MAX_LEN: Final[int] = 1000
+"""Soft cap on edge anchor_text. Real anchor text is short prose
+(20-200 chars). Cap protects against pathological writes; callers
+truncate with a warning rather than reject."""
+
+
 @dataclass
 class Edge:
-    """A typed, weighted directed link between two beliefs."""
+    """A typed, weighted directed link between two beliefs.
+
+    `anchor_text` is the citing belief's own phrasing of the
+    relationship (e.g. "the WAL discussion" on a CITES edge). Set
+    by ingest paths that have access to source prose at edge-
+    creation time; left None on programmatic / bulk inserts.
+    Truncated to ANCHOR_TEXT_MAX_LEN characters on construction.
+    """
 
     src: str
     dst: str
     type: str
     weight: float
+    anchor_text: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.anchor_text is not None and len(self.anchor_text) > ANCHOR_TEXT_MAX_LEN:
+            self.anchor_text = self.anchor_text[:ANCHOR_TEXT_MAX_LEN]
 
 
 @dataclass

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -82,19 +82,35 @@ _SCHEMA: tuple[str, ...] = (
         completed_at    TEXT
     )
     """,
+    """
+    CREATE TABLE IF NOT EXISTS sessions (
+        id              TEXT PRIMARY KEY,
+        started_at      TEXT NOT NULL,
+        completed_at    TEXT,
+        model           TEXT,
+        project_context TEXT
+    )
+    """,
     "CREATE INDEX IF NOT EXISTS idx_edges_src ON edges(src)",
     "CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst)",
     "CREATE INDEX IF NOT EXISTS idx_feedback_belief ON feedback_history(belief_id)",
     "CREATE INDEX IF NOT EXISTS idx_onboard_state ON onboard_sessions(state)",
 )
 
-# v1.0 -> v1.2 column additions. Each runs after _SCHEMA. Idempotent:
-# a duplicate-column OperationalError on a v1.2-fresh DB is caught and
-# ignored. A v1.0 store opened by v1.2 picks up both columns; a v1.2
-# store reopened sees the columns already and skips.
+# v1.0 -> v1.2 column additions. Each ALTER runs after _SCHEMA. ALTERs
+# are idempotent: a duplicate-column OperationalError on a v1.2-fresh
+# DB is caught and ignored. The CREATE INDEX after the ALTERs
+# references a column that exists only post-migration; placing it here
+# (rather than in _SCHEMA) is what lets a v1.0 store open at all.
 _MIGRATIONS: tuple[str, ...] = (
     "ALTER TABLE beliefs ADD COLUMN session_id TEXT",
     "ALTER TABLE edges ADD COLUMN anchor_text TEXT",
+)
+
+# Indexes that depend on migrated columns. Run after _MIGRATIONS so
+# they see the post-ALTER schema.
+_POST_MIGRATION_INDEXES: tuple[str, ...] = (
+    "CREATE INDEX IF NOT EXISTS idx_beliefs_session ON beliefs(session_id)",
 )
 
 
@@ -134,6 +150,17 @@ def _row_to_belief(row: sqlite3.Row) -> Belief:
         demotion_pressure=row["demotion_pressure"],
         created_at=row["created_at"],
         last_retrieved_at=row["last_retrieved_at"],
+        session_id=row["session_id"],
+    )
+
+
+def _row_to_session(row: sqlite3.Row) -> Session:
+    return Session(
+        id=row["id"],
+        started_at=row["started_at"],
+        completed_at=row["completed_at"],
+        model=row["model"],
+        project_context=row["project_context"],
     )
 
 
@@ -198,6 +225,8 @@ class MemoryStore:
                 # a previous migration pass). Anything else re-raises.
                 if "duplicate column name" not in str(e):
                     raise
+        for stmt in _POST_MIGRATION_INDEXES:
+            self._conn.execute(stmt)
         self._conn.commit()
         self._invalidation_callbacks: list[Callable[[], None]] = []
 
@@ -229,13 +258,13 @@ class MemoryStore:
             INSERT INTO beliefs (
                 id, content, content_hash, alpha, beta, type,
                 lock_level, locked_at, demotion_pressure,
-                created_at, last_retrieved_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                created_at, last_retrieved_at, session_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 b.id, b.content, b.content_hash, b.alpha, b.beta, b.type,
                 b.lock_level, b.locked_at, b.demotion_pressure,
-                b.created_at, b.last_retrieved_at,
+                b.created_at, b.last_retrieved_at, b.session_id,
             ),
         )
         self._conn.execute(
@@ -266,13 +295,14 @@ class MemoryStore:
                 locked_at = ?,
                 demotion_pressure = ?,
                 created_at = ?,
-                last_retrieved_at = ?
+                last_retrieved_at = ?,
+                session_id = ?
             WHERE id = ?
             """,
             (
                 b.content, b.content_hash, b.alpha, b.beta, b.type,
                 b.lock_level, b.locked_at, b.demotion_pressure,
-                b.created_at, b.last_retrieved_at, b.id,
+                b.created_at, b.last_retrieved_at, b.session_id, b.id,
             ),
         )
         self._conn.execute("DELETE FROM beliefs_fts WHERE id = ?", (b.id,))
@@ -683,28 +713,51 @@ class MemoryStore:
         model: str | None = None,
         project_context: str | None = None,
     ) -> Session:
-        """Create an ephemeral Session handle for grouping ingest calls.
+        """Open an ingest session and persist it to the sessions table.
 
-        The public v1.0.0 schema does not persist sessions; this returns
-        a Session dataclass with a fresh id but does not write to any
-        table. Academic-suite adapters use the id to tag belief metadata
-        (and call complete_session at the end of a logical group).
+        Returns a Session handle whose `id` callers pass to ingest_turn /
+        ingest_jsonl as `session_id` to tag every belief inserted under
+        the session. Pair with `complete_session(id)` at the end of a
+        logical group; orphaned sessions are harmless.
+
+        Per the open question in docs/ingest_enrichment.md the session
+        row is written immediately rather than lazily on first belief
+        insert; the rare empty-session row is left to future GC.
         """
-        return Session(
+        s = Session(
             id=secrets.token_hex(16),
             started_at=datetime.now(timezone.utc).isoformat(),
             completed_at=None,
             model=model,
             project_context=project_context,
         )
+        self._conn.execute(
+            """
+            INSERT INTO sessions (id, started_at, completed_at, model, project_context)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (s.id, s.started_at, s.completed_at, s.model, s.project_context),
+        )
+        self._conn.commit()
+        return s
 
-    def complete_session(self, session_id: str) -> None:  # noqa: ARG002
-        """No-op terminator paired with create_session.
+    def complete_session(self, session_id: str) -> None:
+        """Stamp the session row with completed_at. Idempotent.
 
-        Public v1.0.0 does not persist session lifecycle; this exists so
-        adapters porting from lab v2.0.0 do not need conditional logic.
-        Lab v2.0.0 uses this entry point to write completed_at, summary,
-        and velocity metrics; that behavior lands when (or if) the
-        sessions table ports to public.
+        A second call on an already-completed session refreshes the
+        timestamp rather than failing. Calls on unknown ids are silent
+        no-ops (the UPDATE matches zero rows) — this matches the
+        spec's idempotency requirement.
         """
-        return None
+        self._conn.execute(
+            "UPDATE sessions SET completed_at = ? WHERE id = ?",
+            (datetime.now(timezone.utc).isoformat(), session_id),
+        )
+        self._conn.commit()
+
+    def get_session(self, session_id: str) -> Session | None:
+        cur = self._conn.execute(
+            "SELECT * FROM sessions WHERE id = ?", (session_id,)
+        )
+        row = cur.fetchone()
+        return _row_to_session(row) if row else None

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -45,15 +45,17 @@ _SCHEMA: tuple[str, ...] = (
         locked_at           TEXT,
         demotion_pressure   INTEGER NOT NULL DEFAULT 0,
         created_at          TEXT NOT NULL,
-        last_retrieved_at   TEXT
+        last_retrieved_at   TEXT,
+        session_id          TEXT
     )
     """,
     """
     CREATE TABLE IF NOT EXISTS edges (
-        src     TEXT NOT NULL,
-        dst     TEXT NOT NULL,
-        type    TEXT NOT NULL,
-        weight  REAL NOT NULL,
+        src         TEXT NOT NULL,
+        dst         TEXT NOT NULL,
+        type        TEXT NOT NULL,
+        weight      REAL NOT NULL,
+        anchor_text TEXT,
         PRIMARY KEY (src, dst, type)
     )
     """,
@@ -84,6 +86,15 @@ _SCHEMA: tuple[str, ...] = (
     "CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst)",
     "CREATE INDEX IF NOT EXISTS idx_feedback_belief ON feedback_history(belief_id)",
     "CREATE INDEX IF NOT EXISTS idx_onboard_state ON onboard_sessions(state)",
+)
+
+# v1.0 -> v1.2 column additions. Each runs after _SCHEMA. Idempotent:
+# a duplicate-column OperationalError on a v1.2-fresh DB is caught and
+# ignored. A v1.0 store opened by v1.2 picks up both columns; a v1.2
+# store reopened sees the columns already and skips.
+_MIGRATIONS: tuple[str, ...] = (
+    "ALTER TABLE beliefs ADD COLUMN session_id TEXT",
+    "ALTER TABLE edges ADD COLUMN anchor_text TEXT",
 )
 
 
@@ -127,11 +138,14 @@ def _row_to_belief(row: sqlite3.Row) -> Belief:
 
 
 def _row_to_edge(row: sqlite3.Row) -> Edge:
+    # row["anchor_text"] safe: v1.2 migration guarantees the column on
+    # any store this code instantiates. Legacy rows return None.
     return Edge(
         src=row["src"],
         dst=row["dst"],
         type=row["type"],
         weight=row["weight"],
+        anchor_text=row["anchor_text"],
     )
 
 
@@ -175,6 +189,15 @@ class MemoryStore:
         self._conn.execute("PRAGMA foreign_keys=ON")
         for stmt in _SCHEMA:
             self._conn.execute(stmt)
+        for stmt in _MIGRATIONS:
+            try:
+                self._conn.execute(stmt)
+            except sqlite3.OperationalError as e:
+                # "duplicate column name: X" — column already present
+                # (either from CREATE TABLE on a fresh v1.2 DB or from
+                # a previous migration pass). Anything else re-raises.
+                if "duplicate column name" not in str(e):
+                    raise
         self._conn.commit()
         self._invalidation_callbacks: list[Callable[[], None]] = []
 
@@ -476,8 +499,9 @@ class MemoryStore:
 
     def insert_edge(self, e: Edge) -> None:
         self._conn.execute(
-            "INSERT INTO edges (src, dst, type, weight) VALUES (?, ?, ?, ?)",
-            (e.src, e.dst, e.type, e.weight),
+            "INSERT INTO edges (src, dst, type, weight, anchor_text) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (e.src, e.dst, e.type, e.weight, e.anchor_text),
         )
         self._conn.commit()
         self._fire_invalidation()
@@ -492,8 +516,9 @@ class MemoryStore:
 
     def update_edge(self, e: Edge) -> None:
         self._conn.execute(
-            "UPDATE edges SET weight = ? WHERE src = ? AND dst = ? AND type = ?",
-            (e.weight, e.src, e.dst, e.type),
+            "UPDATE edges SET weight = ?, anchor_text = ? "
+            "WHERE src = ? AND dst = ? AND type = ?",
+            (e.weight, e.anchor_text, e.src, e.dst, e.type),
         )
         self._conn.commit()
         self._fire_invalidation()

--- a/tests/test_edge_anchor_text.py
+++ b/tests/test_edge_anchor_text.py
@@ -1,0 +1,96 @@
+"""Edge.anchor_text round-trips and respects the soft cap."""
+from __future__ import annotations
+
+from aelfrice.models import (
+    ANCHOR_TEXT_MAX_LEN,
+    EDGE_CITES,
+    Belief,
+    Edge,
+    LOCK_NONE,
+)
+from aelfrice.store import MemoryStore
+
+
+def _b(id_: str) -> Belief:
+    return Belief(
+        id=id_,
+        content=id_,
+        content_hash=id_,
+        alpha=1.0,
+        beta=1.0,
+        type="factual",
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-27T00:00:00+00:00",
+        last_retrieved_at=None,
+    )
+
+
+def test_default_anchor_text_is_none() -> None:
+    e = Edge(src="a", dst="b", type=EDGE_CITES, weight=1.0)
+    assert e.anchor_text is None
+
+
+def test_anchor_text_persists_through_round_trip() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        store.insert_belief(_b("a"))
+        store.insert_belief(_b("b"))
+        e = Edge(
+            src="a", dst="b", type=EDGE_CITES, weight=1.0,
+            anchor_text="the WAL discussion",
+        )
+        store.insert_edge(e)
+        got = store.get_edge("a", "b", EDGE_CITES)
+        assert got is not None
+        assert got.anchor_text == "the WAL discussion"
+    finally:
+        store.close()
+
+
+def test_none_anchor_text_persists_as_none() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        store.insert_belief(_b("a"))
+        store.insert_belief(_b("b"))
+        store.insert_edge(Edge(src="a", dst="b", type=EDGE_CITES, weight=1.0))
+        got = store.get_edge("a", "b", EDGE_CITES)
+        assert got is not None
+        assert got.anchor_text is None
+    finally:
+        store.close()
+
+
+def test_anchor_text_cap_truncates_with_no_error() -> None:
+    overlong = "x" * (ANCHOR_TEXT_MAX_LEN + 500)
+    e = Edge(src="a", dst="b", type=EDGE_CITES, weight=1.0, anchor_text=overlong)
+    assert e.anchor_text is not None
+    assert len(e.anchor_text) == ANCHOR_TEXT_MAX_LEN
+
+
+def test_anchor_text_at_cap_unchanged() -> None:
+    exact = "y" * ANCHOR_TEXT_MAX_LEN
+    e = Edge(src="a", dst="b", type=EDGE_CITES, weight=1.0, anchor_text=exact)
+    assert e.anchor_text == exact
+
+
+def test_update_edge_persists_new_anchor_text() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        store.insert_belief(_b("a"))
+        store.insert_belief(_b("b"))
+        store.insert_edge(Edge(
+            src="a", dst="b", type=EDGE_CITES, weight=1.0,
+            anchor_text="initial",
+        ))
+        store.update_edge(Edge(
+            src="a", dst="b", type=EDGE_CITES, weight=2.0,
+            anchor_text="updated",
+        ))
+        got = store.get_edge("a", "b", EDGE_CITES)
+        assert got is not None
+        assert got.weight == 2.0
+        assert got.anchor_text == "updated"
+    finally:
+        store.close()

--- a/tests/test_edge_type_derived_from.py
+++ b/tests/test_edge_type_derived_from.py
@@ -1,0 +1,65 @@
+"""DERIVED_FROM edge type — registered in vocabulary, persisted, propagated."""
+from __future__ import annotations
+
+from aelfrice.models import (
+    EDGE_DERIVED_FROM,
+    EDGE_TYPES,
+    EDGE_VALENCE,
+    Belief,
+    Edge,
+    LOCK_NONE,
+)
+from aelfrice.store import MemoryStore
+
+
+def _b(id_: str, content: str = "x", alpha: float = 5.0, beta: float = 1.0) -> Belief:
+    return Belief(
+        id=id_,
+        content=content,
+        content_hash=id_,
+        alpha=alpha,
+        beta=beta,
+        type="factual",
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-27T00:00:00+00:00",
+        last_retrieved_at=None,
+    )
+
+
+def test_derived_from_in_edge_types() -> None:
+    assert EDGE_DERIVED_FROM == "DERIVED_FROM"
+    assert EDGE_DERIVED_FROM in EDGE_TYPES
+
+
+def test_derived_from_valence_is_half() -> None:
+    assert EDGE_VALENCE[EDGE_DERIVED_FROM] == 0.5
+
+
+def test_store_persists_derived_from() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        store.insert_belief(_b("a"))
+        store.insert_belief(_b("b"))
+        e = Edge(src="b", dst="a", type=EDGE_DERIVED_FROM, weight=1.0)
+        store.insert_edge(e)
+        got = store.get_edge("b", "a", EDGE_DERIVED_FROM)
+        assert got is not None
+        assert got.type == EDGE_DERIVED_FROM
+    finally:
+        store.close()
+
+
+def test_propagate_valence_walks_derived_from() -> None:
+    """DERIVED_FROM walks like CITES: positive propagation, broker-attenuated."""
+    store = MemoryStore(":memory:")
+    try:
+        store.insert_belief(_b("src", alpha=10.0, beta=1.0))
+        store.insert_belief(_b("mid", alpha=10.0, beta=1.0))
+        store.insert_edge(Edge(src="src", dst="mid", type=EDGE_DERIVED_FROM, weight=1.0))
+        applied = store.propagate_valence("src", valence=1.0, max_hops=2)
+        assert "mid" in applied
+        assert applied["mid"] > 0.0
+    finally:
+        store.close()

--- a/tests/test_ingest_session.py
+++ b/tests/test_ingest_session.py
@@ -1,0 +1,128 @@
+"""Belief.session_id round-trips and ingest_turn persists it."""
+from __future__ import annotations
+
+from aelfrice.ingest import ingest_turn
+from aelfrice.models import Belief, LOCK_NONE
+from aelfrice.store import MemoryStore
+
+
+def _b(id_: str, session_id: str | None = None) -> Belief:
+    return Belief(
+        id=id_,
+        content=id_ + "-content",
+        content_hash=id_,
+        alpha=1.0,
+        beta=1.0,
+        type="factual",
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-27T00:00:00+00:00",
+        last_retrieved_at=None,
+        session_id=session_id,
+    )
+
+
+def test_default_session_id_is_none() -> None:
+    assert _b("a").session_id is None
+
+
+def test_session_id_persists_through_round_trip() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        store.insert_belief(_b("a", session_id="sess-1"))
+        got = store.get_belief("a")
+        assert got is not None
+        assert got.session_id == "sess-1"
+    finally:
+        store.close()
+
+
+def test_create_session_returns_fresh_non_empty_id() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        s1 = store.create_session(model="haiku")
+        s2 = store.create_session(model="haiku")
+        assert s1.id and s2.id
+        assert s1.id != s2.id
+    finally:
+        store.close()
+
+
+def test_create_session_persists_to_sessions_table() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        s = store.create_session(model="opus", project_context="aelfrice")
+        got = store.get_session(s.id)
+        assert got is not None
+        assert got.id == s.id
+        assert got.model == "opus"
+        assert got.project_context == "aelfrice"
+        assert got.completed_at is None
+    finally:
+        store.close()
+
+
+def test_complete_session_stamps_completed_at() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        s = store.create_session()
+        store.complete_session(s.id)
+        got = store.get_session(s.id)
+        assert got is not None
+        assert got.completed_at is not None
+    finally:
+        store.close()
+
+
+def test_complete_session_idempotent_on_already_completed() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        s = store.create_session()
+        store.complete_session(s.id)
+        store.complete_session(s.id)  # must not raise
+        got = store.get_session(s.id)
+        assert got is not None
+        assert got.completed_at is not None
+    finally:
+        store.close()
+
+
+def test_complete_session_silent_on_unknown_id() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        store.complete_session("nonexistent")  # must not raise
+    finally:
+        store.close()
+
+
+def test_ingest_turn_writes_session_id_on_each_belief() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        text = "Pi is 3.14. Water boils at 100C."
+        n = ingest_turn(
+            store=store, text=text, source="test", session_id="sess-X",
+        )
+        assert n >= 1
+        all_beliefs = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+            "SELECT id, session_id FROM beliefs"
+        ).fetchall()
+        assert all_beliefs
+        for row in all_beliefs:
+            assert row["session_id"] == "sess-X"
+    finally:
+        store.close()
+
+
+def test_ingest_turn_without_session_leaves_session_id_null() -> None:
+    store = MemoryStore(":memory:")
+    try:
+        n = ingest_turn(store=store, text="The sky is blue.", source="test")
+        assert n >= 1
+        rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+            "SELECT session_id FROM beliefs"
+        ).fetchall()
+        for row in rows:
+            assert row["session_id"] is None
+    finally:
+        store.close()

--- a/tests/test_v1_to_v1x_migration.py
+++ b/tests/test_v1_to_v1x_migration.py
@@ -1,0 +1,135 @@
+"""v1.0 -> v1.2 forward-compat: an old store opens, migrates, round-trips.
+
+Builds a v1.0-shaped SQLite file inline (the legacy schema before
+session_id / anchor_text / DERIVED_FROM landed) and verifies that
+opening it with the v1.2 MemoryStore picks up the new columns via
+ALTER TABLE without losing any existing rows.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from aelfrice.models import EDGE_CITES, EDGE_DERIVED_FROM, Edge, LOCK_NONE
+from aelfrice.store import MemoryStore
+
+
+_V1_0_SCHEMA: tuple[str, ...] = (
+    """
+    CREATE TABLE beliefs (
+        id                  TEXT PRIMARY KEY,
+        content             TEXT NOT NULL,
+        content_hash        TEXT NOT NULL,
+        alpha               REAL NOT NULL,
+        beta                REAL NOT NULL,
+        type                TEXT NOT NULL,
+        lock_level          TEXT NOT NULL,
+        locked_at           TEXT,
+        demotion_pressure   INTEGER NOT NULL DEFAULT 0,
+        created_at          TEXT NOT NULL,
+        last_retrieved_at   TEXT
+    )
+    """,
+    """
+    CREATE TABLE edges (
+        src     TEXT NOT NULL,
+        dst     TEXT NOT NULL,
+        type    TEXT NOT NULL,
+        weight  REAL NOT NULL,
+        PRIMARY KEY (src, dst, type)
+    )
+    """,
+)
+
+
+def _seed_v1_0_store(path: Path) -> None:
+    """Create a v1.0-shaped SQLite file with one belief and one edge."""
+    conn = sqlite3.connect(str(path))
+    try:
+        for stmt in _V1_0_SCHEMA:
+            conn.execute(stmt)
+        conn.execute(
+            """
+            INSERT INTO beliefs (
+                id, content, content_hash, alpha, beta, type,
+                lock_level, locked_at, demotion_pressure,
+                created_at, last_retrieved_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("legacy1", "old belief", "h", 1.0, 1.0, "factual",
+             LOCK_NONE, None, 0, "2025-01-01T00:00:00+00:00", None),
+        )
+        conn.execute(
+            """
+            INSERT INTO beliefs (
+                id, content, content_hash, alpha, beta, type,
+                lock_level, locked_at, demotion_pressure,
+                created_at, last_retrieved_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("legacy2", "another", "h2", 1.0, 1.0, "factual",
+             LOCK_NONE, None, 0, "2025-01-02T00:00:00+00:00", None),
+        )
+        conn.execute(
+            "INSERT INTO edges (src, dst, type, weight) VALUES (?, ?, ?, ?)",
+            ("legacy1", "legacy2", EDGE_CITES, 1.0),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_v1_0_store_opens_with_v1_2_reader(tmp_path: Path) -> None:
+    db = tmp_path / "v1_0.db"
+    _seed_v1_0_store(db)
+    # Confirm the legacy file lacks the new columns before migration.
+    raw = sqlite3.connect(str(db))
+    raw.row_factory = sqlite3.Row
+    cols = {r["name"] for r in raw.execute("PRAGMA table_info(beliefs)").fetchall()}
+    assert "session_id" not in cols
+    cols = {r["name"] for r in raw.execute("PRAGMA table_info(edges)").fetchall()}
+    assert "anchor_text" not in cols
+    raw.close()
+    # Open with v1.2 store; ALTER TABLE migration runs.
+    store = MemoryStore(str(db))
+    try:
+        legacy = store.get_belief("legacy1")
+        assert legacy is not None
+        assert legacy.content == "old belief"
+        assert legacy.session_id is None  # nullable column added clean
+        edge = store.get_edge("legacy1", "legacy2", EDGE_CITES)
+        assert edge is not None
+        assert edge.anchor_text is None
+    finally:
+        store.close()
+
+
+def test_v1_0_store_accepts_new_writes_after_migration(tmp_path: Path) -> None:
+    db = tmp_path / "v1_0.db"
+    _seed_v1_0_store(db)
+    store = MemoryStore(str(db))
+    try:
+        store.insert_edge(Edge(
+            src="legacy1", dst="legacy2", type=EDGE_DERIVED_FROM,
+            weight=1.0, anchor_text="ported edge",
+        ))
+        got = store.get_edge("legacy1", "legacy2", EDGE_DERIVED_FROM)
+        assert got is not None
+        assert got.anchor_text == "ported edge"
+    finally:
+        store.close()
+
+
+def test_migration_idempotent_on_re_open(tmp_path: Path) -> None:
+    db = tmp_path / "v1_0.db"
+    _seed_v1_0_store(db)
+    # First open: ALTER TABLE adds columns.
+    s1 = MemoryStore(str(db))
+    s1.close()
+    # Second open: ALTER TABLE catches duplicate-column and proceeds.
+    s2 = MemoryStore(str(db))
+    try:
+        b = s2.get_belief("legacy1")
+        assert b is not None
+    finally:
+        s2.close()


### PR DESCRIPTION
## Summary

Lands the v1.2.0 ingest-enrichment spec ([docs/ingest_enrichment.md](docs/ingest_enrichment.md)). Three coupled schema additions that unblock the v1.2.0 producers (transcript-ingest, commit-ingest, triple-extraction) which all read or write these fields.

- **`DERIVED_FROM` edge type** added with valence `0.5` (mirrors `CITES`).
- **`anchor_text` column on edges** with a 1000-char soft cap; truncated, not rejected.
- **`session_id` column on beliefs** + a real `sessions` table; `create_session` / `complete_session` go from no-op stubs to persisting; `ingest_turn` now writes session_id end-to-end.

Forward-compatible with v1.0 stores: ALTER TABLE adds the columns on first open of a legacy DB. Idempotent on re-open. The new index over `beliefs.session_id` is sequenced after the migration so a v1.0 store can open at all.

## Atomic commits

1. `feat: add DERIVED_FROM edge type to vocabulary` — `src/aelfrice/models.py` only, plus a tiny test.
2. `feat: add anchor_text column to edges` — Edge dataclass, ALTER TABLE migration framework, store CRUD, tests.
3. `feat: persist session_id on beliefs and sessions table` — Belief.session_id, sessions table, ingest_turn plumbing, v1.0→v1.2 migration test.

## Test plan

- [x] 22 new tests across `test_edge_type_derived_from.py`, `test_edge_anchor_text.py`, `test_ingest_session.py`, `test_v1_to_v1x_migration.py`
- [x] Full suite: `uv run pytest` — 943 passed, 0 regressions
- [x] Type check: `uv run pyright src/aelfrice` — no new errors in touched files
- [x] v1.0→v1.2 migration verified by inline-built legacy fixture (no shipped binary fixtures)
- [x] Migration idempotent on re-open

## Follow-ups (not in this PR)

- `feat/transcript-ingest` (next PR) — the live per-turn JSONL logger, `ingest_jsonl()`, PreCompact rotation, `aelf setup --transcript-ingest` flag. Stacks on this branch.
- Commit-ingest hook + triple-extractor port also depend on this PR.