### PR TITLE
docs: v1.0.2 + v1.1.0 release sweep fixes (closes #85, #108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Downloads](https://img.shields.io/pypi/dm/aelfrice.svg)](https://pypi.org/project/aelfrice/)
 
 > [!NOTE]
-> v1.0 ships the surface — local SQLite store, retrieval, the `apply_feedback` endpoint, the onboarding scanner, an 11-command CLI, an MCP server, Claude Code wiring, and a reproducible benchmark harness. **Retrieval ranking is BM25-only at v1.0** — feedback updates the math but doesn't yet move ranking. The v1.x line wires posterior into ranking and closes [known issues](docs/LIMITATIONS.md#known-issues-at-v10).
+> v1.0 ships the surface — local SQLite store, retrieval, the `apply_feedback` endpoint, the onboarding scanner, the CLI, an MCP server, Claude Code wiring, and a reproducible benchmark harness. **Retrieval ranking is BM25-only at v1.0** — feedback updates the math but doesn't yet move ranking. v1.1.0 added per-project DBs (one DB per `.git/`), `aelf migrate` from the legacy global store, and renamed `edges` → `threads` in user-facing surfaces. The v1.x line wires posterior into ranking and closes [known issues](docs/LIMITATIONS.md#known-issues-at-v10).
 
 You had a doc with the conversation. You re-explained your stack last session. You wrote a runbook the agent didn't read. The notes you keep adding don't actually keep your agent from forgetting — they just give you more to maintain.
 
@@ -33,6 +33,8 @@ $ aelf onboard .
 $ aelf lock "Never push directly to main; use scripts/publish.sh"
 $ aelf setup        # wires the UserPromptSubmit hook into Claude Code
 ```
+
+Upgrading from v1.0.x? Run `aelf migrate` to copy beliefs from the legacy global DB at `~/.aelfrice/memory.db` into your project's per-project store at `<repo>/.git/aelfrice/memory.db` (dry-run by default; add `--apply` to write).
 
 Same operations are available as MCP tools and Claude Code slash commands. Full demo: [docs/QUICKSTART.md](docs/QUICKSTART.md).
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -43,6 +43,20 @@ SQLite. Resolution order:
 
 Pin per-project (overriding the chain) with `export AELFRICE_DB=/abs/path/.aelfrice.db` — handy via direnv.
 
+### Migrating from v1.0.x
+
+If you ran v1.0.x you have a single global DB at `~/.aelfrice/memory.db`. v1.1.0+ resolves per-project under `.git/aelfrice/memory.db`. `aelf migrate` ports beliefs forward (added in v1.1.0, [PR #104](https://github.com/robotrocketscience/aelfrice/pull/104)):
+
+```bash
+cd <project-root>
+aelf migrate              # dry-run; reports what would copy
+aelf migrate --apply      # actually copy filtered beliefs into the project DB
+aelf migrate --apply --all  # copy every belief from the legacy global DB
+aelf migrate --from /alt/path/memory.db --apply  # source override
+```
+
+`aelf migrate` opens the source DB read-only (SQLite `mode=ro` URI) so it can never accidentally write back. Idempotent on re-run. Project-mention filtering (default) restricts the copy to beliefs whose content references the active project's name; `--all` skips the filter.
+
 ## Wire into Claude Code
 
 ```bash

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,6 +1,6 @@
 # Limitations
 
-aelfrice at v1.0 ships the surface but has gaps the v1.x line is closing. Library, CLI, MCP server, and benchmark harness are stable (~530 tests passing). The end-to-end Claude Code injection path and the feedback-into-retrieval loop are partially complete.
+aelfrice at v1.0 ships the surface but has gaps the v1.x line is closing. Library, CLI, MCP server, and benchmark harness are stable (~530 tests passing at v1.0; ~1090 at v1.1.0). The end-to-end Claude Code injection path and the feedback-into-retrieval loop are partially complete.
 
 ## Known issues at v1.0
 
@@ -28,7 +28,7 @@ Tracked openly. Each item is mapped to its target version below.
 
 - ✅ **Noise filter wired into synchronous onboard (v1.0.1).** New `aelfrice.noise_filter.is_noise(text, config)` predicate runs on every candidate before classification. Drops markdown heading blocks, checklist blocks, three-word fragments, and license-header boilerplate (seven canonical signatures). `ScanResult.skipped_noise` reports how many candidates were filtered per scan. A paragraph that *mixes* heading-or-checklist with prose is preserved — only pure structural runs are filtered. Power-user configurable via a single `.aelfrice.toml` file at the project root (or any ancestor) — full schema, worked examples, and what each setting affects in [CONFIG.md](CONFIG.md). No regex anywhere in the user-facing schema.
 - ✅ **Onboard performance regression test (v1.0.1).** New `tests/regression/test_onboard_perf_50k_loc.py` generates a synthetic ~55k-LOC project (250 .py files of 200 lines + 60 .md/.rst/.txt docs of 50 lines + 10 `__init__.py` files) and asserts `scan_repo` finishes in under 60s wall clock. Marked `regression` so the default fast suite runs it; per-test `timeout(120)` overrides the default 5s pytest timeout. Held against the `:memory:` store so disk-write contention does not skew the measurement. Current measured time: ~0.8s on Apple Silicon — the budget is a regression alarm, not a target.
-- **No git-recency weighting.** Pre-migration content from old branches surfaces as first-class beliefs. v1.1.0.
+- ✅ **Onboard git-recency weighting (v1.1.0, [#94](https://github.com/robotrocketscience/aelfrice/issues/94)).** Scanner records each source file's most-recent git commit date as the belief's `created_at`, so the existing decay mechanism penalises pre-migration content from old branches without a separate ranking pass. One `git log --name-only --pretty=format:%aI` call per scan. PR [#103](https://github.com/robotrocketscience/aelfrice/pull/103).
 - **No promotion path from `agent_inferred` to `user_validated`.** Beliefs from onboard stay `agent_inferred` unless explicitly locked. Designed in v1.1.0 ([promotion_path.md](promotion_path.md), [#95](https://github.com/robotrocketscience/aelfrice/issues/95)); implemented in v1.2.0.
 
 ### Feedback semantics — v1.0.1
@@ -42,7 +42,7 @@ Tracked openly. Each item is mapped to its target version below.
 ### Cosmetic — v1.1.0
 
 - ✅ **`edges` → `threads` user-facing rename (v1.1.0, [#92](https://github.com/robotrocketscience/aelfrice/issues/92)).** All user-facing surfaces (CLI output labels, slash command descriptions, COMMANDS.md, MCP.md prose) now use `threads`. The internal SQLite schema, the `Edge` Python dataclass, and the `EDGE_*` type constants are unchanged. The MCP `aelf:stats` tool emits **both** `edges` and `threads` keys with the same integer value for the v1.1.0 deprecation window; `edges` is removed in v1.2.0. Same for `aelf:health.features.edge_per_belief` / `thread_per_belief`. Clients should migrate to `threads` now. The `auditor.CHECK_ORPHAN_EDGES` constant is kept as a deprecated alias of `CHECK_ORPHAN_THREADS` for v1.0 importer compatibility; removed in v1.2.0.
-- **`aelf health` and `aelf status` are aliased.** v1.1.0 splits them: `status` = counts snapshot, `health` = real graph auditor (orphan edges, isolated clusters, FTS5 sync, locked-belief contradictions, decay anomalies).
+- ✅ **`aelf health` rewritten as graph auditor (v1.1.0, [#100](https://github.com/robotrocketscience/aelfrice/pull/100)).** `health` now runs a real auditor (orphan threads, FTS5 sync, locked-belief contradictions; corpus-volume warning added in [#116](https://github.com/robotrocketscience/aelfrice/issues/116)) and exits 1 on structural failures so CI can gate on it. The v1.0 regime classifier is preserved as `aelf regime`. `aelf status` is an alias for `aelf health` (not a separate "counts snapshot" — that responsibility lives in `aelf stats`).
 
 ### Auto-capture — v1.2.0
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -16,7 +16,7 @@ How to cut a new version. Maintainer reference.
 5. Update README roadmap status.
 6. Run locally:
    ```bash
-   uv run pytest tests/ -x -q                # ~530 passing at v1.0.0
+   uv run pytest tests/ -x -q                # ~810 passing at v1.0.2 / ~1090 at v1.1.0
    uv run pyright src/                        # strict
    uv run aelf --help                         # spot-check CLI
    uv build                                   # wheels build clean

--- a/docs/SLASH_COMMANDS.md
+++ b/docs/SLASH_COMMANDS.md
@@ -1,6 +1,6 @@
 # Claude Code Slash Commands
 
-Eleven markdown files in `src/aelfrice/slash_commands/`. After `aelf setup`, they appear as `/aelf:*` in Claude Code.
+Twenty-one markdown files in `src/aelfrice/slash_commands/`. After `aelf setup`, they appear as `/aelf:*` in Claude Code. The v1.1.0 user-facing rename of `edges` → `threads` does not surface here — slash commands are 1:1 wrappers over the CLI, which keeps the term unchanged.
 
 Manual install:
 
@@ -21,8 +21,18 @@ Each is a thin shell over the CLI — runs `aelf <subcommand>` against the same 
 | `/aelf:feedback` | `<belief_id> <used\|harmful>` |
 | `/aelf:stats` | (none) |
 | `/aelf:health` | (none) |
+| `/aelf:status` | (none) — alias for `health` |
+| `/aelf:regime` | (none) — v1.0 regime classifier |
+| `/aelf:resolve` | (none) — sweep CONTRADICTS via tie-breaker |
+| `/aelf:doctor` | optional `--user-settings`, `--project-root` |
+| `/aelf:migrate` | optional `--apply`, `--all`, `--from` |
 | `/aelf:setup` | optional `--scope`, `--command`, … |
 | `/aelf:unsetup` | same flags as `setup` |
+| `/aelf:statusline` | (none) — emit Claude Code statusline |
+| `/aelf:upgrade` | (none) — print pip-upgrade hint |
+| `/aelf:uninstall` | optional `--keep-db` |
+| `/aelf:rebuild` | optional `--transcript PATH` (v1.1 alpha rebuilder) |
+| `/aelf:ingest-transcript` | path to `turns.jsonl` |
 | `/aelf:bench` | optional `--db PATH`, `--top-k N` |
 
 Behaviour matches the CLI exactly — see [COMMANDS](COMMANDS.md). The MCP onboard is polymorphic; the slash version is the synchronous regex path (faster, lower-quality classification).


### PR DESCRIPTION
## Summary

Bundled docs-only sweep for the two open release checklists (#85 v1.0.2 and #108 v1.1.0). Eight items flagged across the two; all addressed in this PR. Touches five files.

### v1.0.2 sweep (#85) — 2 fixes
- `docs/RELEASING.md`: pytest count comment was `~530 passing at v1.0.0`; current is ~1090 at v1.1.0. Updated to span v1.0.2 / v1.1.0.
- `docs/SLASH_COMMANDS.md`: said "Eleven markdown files" with an 11-row table; actual is 21 files. Bumped the count and added the missing rows (status, regime, resolve, doctor, migrate, statusline, upgrade, uninstall, rebuild, ingest-transcript). Noted that the v1.1.0 edges→threads rename doesn't surface here (slash files are 1:1 wrappers over the CLI).

### v1.1.0 sweep (#108) — 6 fixes
- `README.md` headline NOTE: dropped the stale "11-command CLI" wording; added a v1.1.0 line about per-project DBs, `aelf migrate`, and the threads rename.
- `README.md` 60-seconds: added an `aelf migrate` upgrade note for users coming from v1.0.x.
- `docs/INSTALL.md`: new "Migrating from v1.0.x" subsection covering `aelf migrate` (dry-run default, `--apply`, `--all`, `--from`).
- `docs/LIMITATIONS.md` L3: pytest count anchor updated for v1.1.0.
- `docs/LIMITATIONS.md` L31: git-recency weighting marked ✅ shipped ([#94](https://github.com/robotrocketscience/aelfrice/issues/94)).
- `docs/LIMITATIONS.md` L45: "aelf health and aelf status are aliased" had been contradictorily described as a v1.1.0 split; rewrite to match what shipped (status is alias for health; regime is the preserved v1.0 classifier).

## Test plan

- [x] `uv run pytest -x -q --ignore=tests/regression` (1032 passing, 2 skipped — docs-only PR, no code touched)
- [x] Manual scan of all 11 sweep checklist items per release; verified each item against actual file content before flagging
- [x] No claim added that's not already in CHANGELOG / shipped PRs

## Out of scope

- v1.0.3 narrative section in ROADMAP.md — already handled in #121.
- Investigating why `post-release-docs-issue.yml` didn't catch any of these — separate operational issue if the user wants to file one.