### PR TITLE
docs: full rewrite of user-facing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,124 +2,152 @@
 
 # aelfrice
 
-> Bayesian memory for AI coding agents. Local-only. Auditable.
+> Lock the rules your AI agent keeps forgetting. SQLite on your laptop. Auditable.
 
 [![PyPI](https://img.shields.io/pypi/v/aelfrice.svg)](https://pypi.org/project/aelfrice/)
 [![Python](https://img.shields.io/pypi/pyversions/aelfrice.svg)](https://pypi.org/project/aelfrice/)
 [![License](https://img.shields.io/pypi/l/aelfrice.svg)](LICENSE)
 [![CI](https://github.com/robotrocketscience/aelfrice/actions/workflows/ci.yml/badge.svg)](https://github.com/robotrocketscience/aelfrice/actions/workflows/ci.yml)
-[![Staging Gate](https://github.com/robotrocketscience/aelfrice/actions/workflows/staging-gate.yml/badge.svg)](https://github.com/robotrocketscience/aelfrice/actions/workflows/staging-gate.yml)
-[![Downloads](https://img.shields.io/pypi/dm/aelfrice.svg)](https://pypi.org/project/aelfrice/)
 
-> [!NOTE]
-> v1.0 ships the surface — local SQLite store, retrieval, the `apply_feedback` endpoint, the onboarding scanner, the CLI, an MCP server, Claude Code wiring, and a reproducible benchmark harness. **Retrieval ranking is BM25-only at v1.0** — feedback updates the math but doesn't yet move ranking. v1.1.0 added per-project DBs (one DB per `.git/`), `aelf migrate` from the legacy global store, and renamed `edges` → `threads` in user-facing surfaces. The v1.x line wires posterior into ranking and closes [known issues](docs/LIMITATIONS.md#known-issues-at-v10).
+You correct your agent. *"Got it,"* it says. Next session, same mistake.
 
-You had a doc with the conversation. You re-explained your stack last session. You wrote a runbook the agent didn't read. The notes you keep adding don't actually keep your agent from forgetting — they just give you more to maintain.
-
-aelfrice is a small SQLite-backed memory that the agent can't skip. Lock the rules you don't want forgotten. Onboard a project once. Every prompt thereafter gets the relevant slice injected before the agent answers.
-
-```
-No GPU. No network. No telemetry. No cloud.
-SQLite at ~/.aelfrice/memory.db. That's the whole runtime.
-```
-
-Every retrieval result is traceable to the beliefs and rules that produced it. Every state of the system is reproducible from its write log. We are not aware of another agent-memory system that combines bit-level reproducibility, named-rule traceability, write-log historical reconstruction, and audit comprehensible to a non-technical reviewer as a single system property. See [PHILOSOPHY § Determinism is the property](docs/PHILOSOPHY.md#determinism-is-the-property).
-
-## 60 seconds
+aelfrice gives the agent a memory you can lock down. You write the rule once. It gets injected into every prompt thereafter. No cross-references for the agent to skip, no markdown files to maintain.
 
 ```bash
-$ pip install aelfrice
-$ aelf onboard .
-$ aelf lock "Never push directly to main; use scripts/publish.sh"
-$ aelf setup        # wires the UserPromptSubmit hook into Claude Code
+pip install aelfrice
+aelf onboard .
+aelf lock "never push directly to main; use scripts/publish.sh"
+aelf setup       # wire the UserPromptSubmit hook into Claude Code
 ```
 
-Upgrading from v1.0.x? Run `aelf migrate` to copy beliefs from the legacy global DB at `~/.aelfrice/memory.db` into your project's per-project store at `<repo>/.git/aelfrice/memory.db` (dry-run by default; add `--apply` to write).
+Restart Claude Code. The next prompt that mentions "push" will already have your rule attached.
 
-Same operations are available as MCP tools and Claude Code slash commands. Full demo: [docs/QUICKSTART.md](docs/QUICKSTART.md).
+---
+
+## What it does
+
+When you submit a prompt in Claude Code, aelfrice's `UserPromptSubmit` hook fires before the model sees your message. It runs a two-layer search:
+
+```
+L0: locked beliefs   -> rules you marked permanent (always returned)
+L1: FTS5 keyword     -> SQLite full-text search, BM25-ranked
+```
+
+The matching beliefs come back as an `<aelfrice-memory>` block prepended to your prompt. The agent reads it as part of the prompt — it doesn't have to remember to check a file.
+
+```text
+<aelfrice-memory>
+[locked] never push directly to main; use scripts/publish.sh
+[locked] commits must be SSH-signed with ~/.ssh/id_rrs
+         the publish script runs gitleaks before tagging
+</aelfrice-memory>
+
+push the release
+```
+
+Default budget is 2,000 tokens per prompt. Locked beliefs always go first; the rest is BM25-ranked and truncated to fit.
+
+---
+
+## What it remembers
+
+| You run | It stores |
+|---|---|
+| `aelf lock "never commit .env files"` | Permanent rule. Returned on every retrieval. |
+| `aelf onboard .` | Walks the project — git log, README headings, code structure — and ingests structural facts. |
+| `aelf feedback <id> used` | Bayesian feedback. Strengthens the belief's posterior. |
+| `aelf feedback <id> harmful` | Weakens it. After enough independent harmfuls, locks auto-demote. |
+
+Each belief carries a `(α, β)` Beta-Bernoulli posterior. `α / (α+β)` is the confidence. Locks short-circuit decay; everything else fades over time so stale beliefs eventually drop out of retrieval.
+
+```bash
+aelf stats
+# beliefs:    142   locked: 8   threads: 67
+# feedback:   31    avg_confidence: 0.71
+```
+
+---
+
+## Why files don't solve this
+
+The standard workaround for "agent keeps forgetting" is more files: `STATE.md`, `DECISIONS.md`, a CLAUDE.md with cross-references to runbooks. Every cross-reference is a bet that the agent will read the file, find the right section, and follow what it says.
+
+The failure modes are predictable. The agent reads the rule and runs `git push` anyway. Cross-references break silently after compaction. State files rot the moment you forget to update them. Each new failure mode begets another file.
+
+aelfrice replaces the chain with a mechanism. The hook injects matched beliefs *as part of your prompt*, before the agent sees it. Nothing voluntary. Nothing the agent can skip.
+
+| Manual approach | What breaks | aelfrice |
+|---|---|---|
+| Rules in CLAUDE.md | Agent reads them, doesn't follow them | Injected per-prompt, not per-session |
+| Cross-references | Agent skips or reads the wrong section | Matched beliefs injected directly |
+| Hand-maintained state files | One missed update breaks the chain | State is the SQLite DB; no manual sync |
+
+---
+
+## Determinism is the property
+
+Every retrieval is reproducible bit-for-bit from the write log and the code. No embeddings, no learned re-rankers, no LLM in the retrieval path. *"Why did this rule surface for this query?"* has a finite answer that bottoms out in named beliefs created by named user actions at named timestamps.
+
+That property is what makes aelfrice usable in regulated contexts. It's also what costs you fuzzy semantic recall — that's a deliberate trade. See [PHILOSOPHY.md](docs/PHILOSOPHY.md).
+
+---
+
+## Your data stays yours
+
+- **100% local.** SQLite at `<repo>/.git/aelfrice/memory.db`. No network calls in the retrieval path.
+- **No telemetry.** No accounts, no signup, no phone-home.
+- **No GPU, no vector DB.** Stdlib + SQLite. The optional `[mcp]` extra adds `fastmcp`. That's it.
+- **Per-project isolation.** Beliefs from project A cannot leak into project B (they live in different `.git/` directories).
+- **Removable.** `aelf uninstall --archive backup.aenc` encrypts the DB to a file, then deletes it. Or `--purge` for a full wipe.
+
+[docs/PRIVACY.md](docs/PRIVACY.md) for verifiable specifics.
+
+---
+
+## What's in the box
+
+| Surface | Count | Where |
+|---|---|---|
+| CLI subcommands | 22 | `aelf <subcommand>` — see [COMMANDS](docs/COMMANDS.md) |
+| MCP tools | 9 | called by the agent automatically — see [MCP](docs/MCP.md) |
+| Slash commands | 22 | `/aelf:*` in Claude Code — see [SLASH_COMMANDS](docs/SLASH_COMMANDS.md) |
+| Hook events | 4 | UserPromptSubmit, PreCompact, Stop, PostToolUse (opt-in) |
+
+The CLI, MCP, and slash command surfaces are 1:1 wrappers over the same library. Anything you can do in one, you can do in the others.
+
+---
 
 ## Roadmap
 
-| | Status | |
+| Version | Status | Theme |
 |---|---|---|
-| v0.1 – v1.0 | **shipped** | core memory, CLI, MCP, hook wiring, synthetic benchmark, PyPI publish |
-| v1.0.1 | **shipped** | launch fix-up — hook→retrieval wiring, onboard noise, `aelf --version` |
-| v1.0.2 | **shipped** | per-project install routing, `aelf doctor`, release-docs CI gate |
-| v1.0.3 | **shipped** | contradiction tie-breaker + `aelf resolve`, onboard perf regression, CONFIG.md |
-| v1.1.0 | **shipped** | project identity (`.git/aelfrice/`), edges→threads, status/health split, `aelf migrate`, git-recency onboard |
-| v1.2.0 | **shipped** | auto-capture pipeline (transcript-ingest, commit-ingest, SessionStart), `agent_inferred → user_validated` promotion, triple extractor, ingest-enrichment schema, `--batch` JSONL ingest, CLI consolidation, `INEDIBLE` per-file opt-out |
+| v1.0.x | shipped | core memory, CLI, MCP, hook wiring, install routing |
+| v1.1.0 | shipped | per-project DBs (`.git/aelfrice/`), `aelf migrate`, `edges`→`threads` rename, `aelf health` rewrite |
+| v1.2.0 | shipped | auto-capture pipeline (transcript-ingest, commit-ingest, SessionStart), `agent_inferred → user_validated` promotion, triple extractor, `--batch` JSONL ingest, CLI consolidation, `INEDIBLE` per-file opt-out |
 | v1.3 | planned | retrieval wave — entity index + BFS multi-hop + LLM classification |
-| v2.0 | planned | feature parity with the earlier research line + full benchmark reproducibility |
+| v2.0 | planned | feature parity with the original research line + benchmark reproducibility |
 
-Per-version detail with deliverables, recovery inventory, and structural-fix rationale: [docs/ROADMAP.md](docs/ROADMAP.md). Per-issue tracking: [docs/LIMITATIONS.md](docs/LIMITATIONS.md#known-issues-at-v10).
+Per-version detail: [docs/ROADMAP.md](docs/ROADMAP.md). Open issues: [docs/LIMITATIONS.md](docs/LIMITATIONS.md).
 
-## Install
+---
 
-```bash
-pip install aelfrice                # core (zero runtime deps)
-pip install "aelfrice[mcp]"         # add MCP server
-pip install "aelfrice[archive]"     # add encrypted DB archive on uninstall
-aelf --version                       # confirm install
-aelf setup                           # wire hook + statusline into Claude Code
-aelf doctor                          # verify hook commands resolve
-aelf health                          # confirm wiring + store init
+## Documentation
+
+- **Getting started:** [Install](docs/INSTALL.md) · [Quickstart](docs/QUICKSTART.md)
+- **Reference:** [Commands](docs/COMMANDS.md) · [MCP](docs/MCP.md) · [Slash commands](docs/SLASH_COMMANDS.md) · [Config](docs/CONFIG.md)
+- **Background:** [Architecture](docs/ARCHITECTURE.md) · [Philosophy](docs/PHILOSOPHY.md) · [Privacy](docs/PRIVACY.md) · [Limitations](docs/LIMITATIONS.md)
+- **Development:** [Releasing](docs/RELEASING.md) · [Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md)
+
+## Citation
+
+```bibtex
+@software{aelfrice2026,
+  author = {robotrocketscience},
+  title  = {aelfrice: deterministic Bayesian memory for AI coding agents},
+  year   = {2026},
+  url    = {https://github.com/robotrocketscience/aelfrice},
+  license = {MIT}
+}
 ```
 
-`aelf setup` wires two things into Claude Code's `settings.json`:
-
-1. The **UserPromptSubmit hook** (`aelf-hook`) which injects relevant beliefs into every Claude Code prompt.
-2. The **statusline notifier** (`aelf statusline`) which shows an orange `⬆ aelfrice X.Y.Z available, run: aelf upgrade` banner *only* when an update is pending. When you're up to date the banner is empty and your statusline looks unchanged.
-
-`aelf setup` auto-routes the install per-project: when run from a project venv it writes `<project>/.claude/settings.json` pointing at `<project>/.venv/bin/aelf-hook`; when run outside any project it writes `~/.claude/settings.json` pointing at the first `aelf-hook` on `$PATH` (typically a `pipx`-installed global). Explicit `--scope user|project` overrides.
-
-If you already have a custom `statusLine` configured, `aelf setup` composes its snippet onto the end of your command (preserving your bar). If your existing command uses pipes, here-docs, `&&`, backticks, or backslashes it's left untouched and you get a one-line hint about manual composition.
-
-`--no-statusline` opts out of the auto-wire if you want hook-only.
-
-[docs/INSTALL.md](docs/INSTALL.md) covers Codex wiring, generic MCP hosts, and troubleshooting.
-
-## Upgrade
-
-```bash
-aelf upgrade           # prints the right pip-upgrade line for your env
-aelf upgrade --check   # yes/no, no command line printed
-```
-
-`aelf upgrade` detects venv vs pipx vs system and tells you the exact line. It does **not** execute pip itself: replacing the running package mid-process is unreliable on Windows and can leave a broken interpreter. You run the line.
-
-When an update is available the output also includes the published wheel SHA-256 plus the PyPI release URL so you can hash-pin the install if you want.
-
-The orange statusline banner appears automatically when an update is pending and disappears once you're up to date — no manual refresh needed.
-
-Opt out of the update notifier at any time with `export AELF_NO_UPDATE_CHECK=1`.
-
-## Uninstall
-
-aelfrice has an explicit teardown command. You **must** pick exactly one disposition for the brain-graph DB:
-
-```bash
-aelf uninstall --keep-db       # leave the resolved DB alone (safe)
-aelf uninstall --archive ~/aelf-backup.aenc   # encrypt then delete
-aelf uninstall --purge         # permanently delete (redundant gates fire)
-pip uninstall aelfrice         # finally, remove the wheel
-```
-
-Verify removal:
-
-```bash
-aelf --version 2>&1 | grep -q "aelfrice" || echo "removed"
-```
-
-Details:
-
-- **`--keep-db`** — DB preserved. Default also runs `unsetup` (removes hook + statusline). Pass `--keep-hook` to keep those too.
-- **`--archive PATH`** — DB encrypted (AES-128-CBC + HMAC via Fernet, scrypt-derived key) to PATH, then original deleted. Password is read interactively (twice, must match) or via `--password-stdin`. Recover later with `python -c "from aelfrice.lifecycle import decrypt_archive; open('out.db','wb').write(decrypt_archive('PATH','pw'))"`. Requires `pip install 'aelfrice[archive]'`.
-- **`--purge`** — Permanently deletes the DB. Three gates fire before deletion: (1) the flag must be passed explicitly, (2) you must type `PURGE` verbatim, (3) a final `[y/N]` confirmation. `--yes` skips the prompts but does **not** auto-pass `--purge`.
-
-[docs/INSTALL.md](docs/INSTALL.md#uninstall) has the full uninstall reference including archive-recovery details.
-
-## Docs
-
-[QUICKSTART](docs/QUICKSTART.md) · [COMMANDS](docs/COMMANDS.md) · [MCP](docs/MCP.md) · [SLASH_COMMANDS](docs/SLASH_COMMANDS.md) · [ARCHITECTURE](docs/ARCHITECTURE.md) · [CONFIG](docs/CONFIG.md) · [PHILOSOPHY](docs/PHILOSOPHY.md) · [PRIVACY](docs/PRIVACY.md) · [LIMITATIONS](docs/LIMITATIONS.md) · [CHANGELOG](CHANGELOG.md)
-
-[CONTRIBUTING](CONTRIBUTING.md) · [SECURITY](SECURITY.md) · [CITATION](CITATION.cff) · [MIT](LICENSE)
+[MIT](LICENSE)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,81 +1,90 @@
-# ARCHITECTURE
+# Architecture
 
-Module map, data flow, design decisions. Maps directly to source under `src/aelfrice/`.
+How aelfrice fits together. Maps directly to source under `src/aelfrice/`.
 
 ## Principles
 
-1. **Determinism end to end.** Every retrieval result is bit-identical given the same write log and the same code. Every result traces to named beliefs and named rules. The four-property commitment (bit-level reproducibility, named-rule traceability, write-log historical reconstruction, non-technical audit) is documented in [PHILOSOPHY § Determinism is the property](PHILOSOPHY.md#determinism-is-the-property). New components must preserve it; non-deterministic steps either run as one-time enrichment whose outputs are stored as deterministic content (see § Enrichment-step boundary below) or are clearly marked as opt-in non-deterministic paths.
-2. **Stdlib + SQLite only.** No vector DB, no embeddings, no cloud, no LLM in the hot path. The `[mcp]` extra is the only non-stdlib runtime dependency, and it's optional.
-3. **Bayesian, not vibes.** Confidence is `α / (α + β)`. Every update has a closed-form rule. (Note: at v1.0 this score does not yet drive retrieval ranking — see [LIMITATIONS](LIMITATIONS.md#known-issues-at-v10).)
+1. **Determinism end to end.** Every retrieval result is bit-identical given the same write log and the same code. Every result traces to named beliefs and named rules. See [PHILOSOPHY § Determinism is the property](PHILOSOPHY.md#determinism-is-the-property).
+2. **Stdlib + SQLite only.** No vector DB, no embeddings, no LLM in the hot path. The `[mcp]` extra (`fastmcp`) is the only optional runtime dep.
+3. **Bayesian, not vibes.** Confidence is `α / (α + β)`. Every update has a closed-form rule. (At v1.0–v1.2 the score does not yet drive ranking — see [LIMITATIONS](LIMITATIONS.md).)
 4. **`apply_feedback` is the central endpoint.** One writer of `(α, β)`. One audit row per successful update.
-5. **Locks are user-asserted ground truth.** A `user`-locked belief short-circuits decay (lock floor) and bypasses L1 budgeting on retrieval. Contradicting positive feedback accumulates `demotion_pressure`; ≥ 5 ⇒ auto-demote.
-6. **Clean by construction, not clean by audit.** Filtering is a tripwire, not a gate.
+5. **Locks are user-asserted ground truth.** A user-locked belief short-circuits decay. Contradicting positive feedback accumulates `demotion_pressure`; ≥5 ⇒ auto-demote.
 
 ### Enrichment-step boundary
 
-The determinism contract applies to retrieval — every read is reproducible from the inputs. Some write-side operations (LLM-driven sentence classification on the v1.3 polymorphic onboard path; future `wonder` / `reason` capabilities in v2.0) involve non-deterministic upstream steps. The boundary is explicit:
+The determinism contract applies to retrieval — every read is reproducible from the inputs. Some write-side operations (LLM-driven sentence classification on the polymorphic onboard path; future research-line capabilities) involve non-deterministic steps. The boundary is explicit:
 
-- **Inputs to enrichment** (raw sentence, source path, host-LLM model id and version, prompt template hash) are recorded deterministically.
-- **Outputs of enrichment** (assigned belief type, type prior, derived edges) are stored as deterministic content with provenance: classifier version, rule-set hash, timestamp.
-- **All retrieval and feedback math downstream** of the enriched store is deterministic. Replaying retrieval against the same enriched corpus produces bit-identical results.
+- Inputs to enrichment (sentence, source, model id + version, prompt template hash) are recorded.
+- Outputs (belief type, prior, derived edges) are stored as deterministic content with provenance.
+- All retrieval and feedback math downstream of the enriched store is deterministic.
 
-The contract is *deterministic substrate + bounded, audited enrichment layer*, not "no model ever touches the data." A reviewer can identify, for any belief, exactly which step was bounded-non-deterministic and inspect the model id, prompt, and output. Replay-from-raw-text reproducibility requires re-running the enrichment with the same model version; replay-from-enriched-corpus reproducibility is unconditional.
+The contract is *deterministic substrate + bounded, audited enrichment layer*, not "no model ever touches the data."
 
 ## Modules
 
-One-directional imports — lower in the table imports from higher.
+Imports are one-directional — modules lower in the table import from higher.
 
 | Module | Responsibility |
 |---|---|
-| `models.py` | `Belief`, `Edge`, `FeedbackEvent`, `OnboardSession` dataclasses; belief / edge / lock / state constants. No I/O. |
-| `scoring.py` | `posterior_mean`, `decay`, `relevance_combiner`. Type-specific half-lives (factual 14d / requirement 30d / preference 12w / correction 24w). Lock-floor short-circuit. Decay target: Jeffreys prior `(0.5, 0.5)`. |
+| `models.py` | `Belief`, `Edge`, `FeedbackEvent`, `OnboardSession` dataclasses; type / lock / origin constants. No I/O. |
+| `scoring.py` | `posterior_mean`, `decay`, `relevance_combiner`. Type half-lives. Lock-floor short-circuit. Decay target: Jeffreys `(0.5, 0.5)`. |
 | `store.py` | SQLite WAL + FTS5 + CRUD. `propagate_valence` BFS with broker-confidence attenuation. |
-| `retrieval.py` | `retrieve(store, query, token_budget=2000)` — L0 locked auto-load + L1 FTS5 BM25. L0 never trimmed. |
-| `feedback.py` | `apply_feedback(store, belief_id, valence, source)` — the only Bayesian-update path. Writes `feedback_history`. Drives demotion-pressure increment + auto-demote. |
+| `retrieval.py` | `retrieve(store, query, token_budget=2000)` — L0 locked + L1 FTS5 BM25. L0 never trimmed. |
+| `feedback.py` | `apply_feedback(store, belief_id, valence, source)` — only Bayesian-update path. Writes `feedback_history`. Drives demotion-pressure + auto-demote. |
+| `contradiction.py` | `resolve_contradiction` — picks a winner per precedence, inserts `SUPERSEDES`, writes audit row. Backs `aelf resolve`. |
 | `correction.py` | No-LLM heuristic correction detector. |
-| `contradiction.py` | `resolve_contradiction` — picks a winner per precedence (user_stated > user_corrected > document_recent; ties broken by recency, then by id), creates a SUPERSEDES edge from winner to loser, writes a `feedback_history` audit row tagged `source='contradiction_tiebreaker:<rule>'`. `auto_resolve_all_contradictions` sweeps the graph. v1.0.1. |
-| `classification.py` | `TYPE_PRIORS` + regex fallback. Polymorphic onboard state machine. |
-| `noise_filter.py` | `is_noise(text, config)` — drops markdown heading blocks, checklist blocks, three-word fragments, and license boilerplate before classification. `NoiseConfig` dataclass + `.aelfrice.toml` discovery via `discover()` walk-up. Power-user surface documented in [CONFIG.md](CONFIG.md). |
-| `scanner.py` | `scan_repo` — filesystem + git log + Python AST extractors, noise filter, classification, persistence. Idempotent against `content_hash`. |
-| `health.py` | v1.0 regime classifier (`supersede` / `ignore` / `mixed` / `insufficient_data`) over confidence, mass, lock density, edge density. Exposed via `aelf regime` since v1.1.0. |
-| `auditor.py` | v1.1.0 structural auditor: three mechanical checks (orphan edges, FTS5 sync drift, locked-belief CONTRADICTS pairs) plus informational metrics (counts, avg confidence, credal gap, edge type breakdown). Backs `aelf health` (exit 1 on any failed check). Pure read-only. |
-| `migrate.py` | v1.1.0 one-shot copy from the legacy global DB (`~/.aelfrice/memory.db`) into the active project's resolved DB. Reads source via SQLite `mode=ro` URI (rejects writes at the SQLite layer). Default project-mention filter; `--all` overrides. Edges follow only when both endpoints land. Pure read on source, write-only on target. Idempotent. Backs `aelf migrate`. |
-| `benchmark.py` | `seed_corpus(store)` + `run_benchmark(store, *, aelfrice_version, top_k=5)` — deterministic 16-belief × 16-query synthetic harness. Frozen `BenchmarkReport` with `hit_at_1` / `hit_at_3` / `hit_at_5` / `mrr` + `p50_latency_ms` / `p99_latency_ms`. |
-| `cli.py` | argparse 19-subcommand CLI (`aelf migrate` added at v1.1.0 alongside `aelf health` rewrite + `status` alias + `regime`). DB resolves from `$AELFRICE_DB` (override), then `<git-common-dir>/aelfrice/memory.db` when `cwd` is in a git work-tree, then `~/.aelfrice/memory.db` as the non-git fallback (v1.1.0). `.git/` is not git-tracked, so the brain graph never crosses the git boundary. Entry: `aelf`. |
-| `mcp_server.py` | FastMCP server, 8 tools. `[mcp]` optional extra. |
-| `setup.py` | Idempotent install/uninstall of the Claude Code `UserPromptSubmit` hook. Atomic write via tempfile + `os.replace`. |
-| `hook.py` | `aelfrice.hook:main` — process Claude Code spawns when the hook fires. Reads JSON from stdin, calls `retrieve()`, emits `<aelfrice-memory>...</aelfrice-memory>` on stdout. Non-blocking by contract. Entry: `aelf-hook`. |
-| `slash_commands/` | One markdown file per CLI subcommand surfaced as a slash command. |
+| `classification.py` | Type priors + regex fallback. Polymorphic onboard state machine. |
+| `noise_filter.py` | `is_noise(text, config)` — filters markdown headings, checklist blocks, three-word fragments, license boilerplate. Tunable via `.aelfrice.toml` — see [CONFIG](CONFIG.md). |
+| `scanner.py` | `scan_repo` — filesystem + git log + Python AST extractors. Idempotent on `content_hash`. |
+| `health.py` | v1.0 regime classifier (`supersede` / `ignore` / `mixed` / `insufficient_data`). Surfaced via `aelf regime`. |
+| `auditor.py` | Structural auditor: orphan threads, FTS5 sync, locked contradictions, corpus volume. Backs `aelf health`. Pure read-only. |
+| `migrate.py` | One-shot port from the legacy global DB into the per-project DB. Reads source via SQLite `mode=ro`. Backs `aelf migrate`. |
+| `doctor.py` | Settings-linter: walks every `command` in `settings.json` and verifies it resolves. Special-cases `bash <script>` wrappers. Backs `aelf doctor`. |
+| `lifecycle.py` | Update notifier (PyPI background check), uninstall machinery, archive encryption. |
+| `transcript_logger.py` | Hook entry-point for v1.2+ transcript capture. Writes one JSONL line per turn under `<git-common-dir>/aelfrice/transcripts/`. |
+| `hook_commit_ingest.py` | `PostToolUse:Bash` hook — ingests commit messages after `git commit`. |
+| `hook_search.py` | UserPromptSubmit retrieval helper that records every hit as a `feedback_history` row tagged `source='hook'`. |
+| `triple_extractor.py` | Pure-regex `(subject, relation, object)` extraction over six relation families. Used by commit-ingest and transcript-ingest. |
+| `context_rebuilder.py` | PreCompact alpha that surfaces aelfrice retrieval before Claude Code summarises. |
+| `benchmark.py` | Deterministic 16-belief × 16-query synthetic harness. Frozen `BenchmarkReport`. |
+| `cli.py` | argparse 22-subcommand CLI. Entry: `aelf`. |
+| `mcp_server.py` | FastMCP server, 9 tools. `[mcp]` optional extra. |
+| `setup.py` | Idempotent install/uninstall of all hooks + statusline. Atomic write via tempfile + `os.replace`. |
+| `hook.py` | `aelfrice.hook:main` — process Claude Code spawns on each prompt. Reads stdin, calls `retrieve()`, emits `<aelfrice-memory>` on stdout. Non-blocking. Entry: `aelf-hook`. |
+| `slash_commands/` | One markdown file per CLI subcommand surfaced in `/aelf:*`. |
 
 ## Data model
 
-**Belief** — `id, content, content_hash, alpha, beta, type, lock_level, locked_at, demotion_pressure, created_at, last_retrieved_at`. `type ∈ {factual, correction, preference, requirement}`. `lock_level ∈ {none, user}`.
+**Belief** — `id, content, content_hash, alpha, beta, type, lock_level, locked_at, demotion_pressure, origin, session_id, created_at, last_retrieved_at`.
 
-**Edge** — `src, dst, type, weight`. Five types with valence multipliers:
+- `type ∈ {factual, correction, preference, requirement}`
+- `lock_level ∈ {none, user}`
+- `origin ∈ {user_stated, user_corrected, user_validated, agent_inferred, agent_remembered, document_recent, unknown}` (v1.2+)
 
-| Type | Mult | |
+**Edge** — `src, dst, type, weight, anchor_text, created_at`. Six edge types with valence multipliers:
+
+| Type | Valence | |
 |---|---|---|
 | `SUPPORTS` | +1.0 | full positive |
 | `CITES` | +0.5 | half positive |
+| `DERIVED_FROM` | +0.5 | half positive (turn-to-turn provenance) |
 | `RELATES_TO` | +0.3 | weak positive |
 | `CONTRADICTS` | -0.5 | half negative |
 | `SUPERSEDES` | 0.0 | structural; no propagation |
 
-**SQLite tables:** `beliefs`, `beliefs_fts` (FTS5 virtual, porter unicode61), `edges` PK `(src, dst, type)`, `feedback_history`, `onboard_sessions`, `schema_meta`.
+**SQLite tables:** `beliefs`, `beliefs_fts` (virtual, porter unicode61), `edges` PK `(src, dst, type)`, `feedback_history`, `sessions`, `onboard_sessions`, `schema_meta`.
 
-## Bayesian update path
+## Bayesian update
 
 `apply_feedback(store, belief_id, valence, source)`:
 
-1. Load belief. Reject zero valence; reject empty source.
-2. **Positive valence:** `α += valence`. Then walk source's outbound `CONTRADICTS` edges; for each `dst` that is `user`-locked, `dst.demotion_pressure += 1`. If pressure ≥ `DEMOTION_THRESHOLD` (default 5), demote (`lock_level → none`, `locked_at → None`, `demotion_pressure → 0`).
-3. **Negative valence:** `β += |valence|`. No pressure walk — a negative signal weakens the contradictor itself, which the β increment already handles.
+1. Load belief. Reject zero valence and empty source.
+2. **Positive valence:** `α += valence`. Walk outbound `CONTRADICTS` edges; user-locked destinations get `demotion_pressure += 1`. If pressure ≥ 5 (default), demote.
+3. **Negative valence:** `β += |valence|`. No pressure walk — the β increment already handles it.
 4. Persist atomically.
 5. Append a `FeedbackEvent` row. Always.
 
-Walk is **1-hop only**. Multi-hop pressure is deferred to v1.x.
-
-> **v1.0 note:** updated `(α, β)` does not currently affect retrieval ranking. `store.search_beliefs` orders L1 hits by `bm25(beliefs_fts)`. The v1.x roadmap consumes the posterior in ranking.
+Walk is 1-hop only. Multi-hop pressure is deferred.
 
 ## Retrieval
 
@@ -96,49 +105,55 @@ Token estimate: `(len(content) + 3) // 4`. Empty query: L0 only. L0 always wins 
 `scan_repo(store, path)`:
 
 1. **Filesystem walk** over `*.md`, `*.rst`, `*.txt`, `*.adoc` → `factual` / `requirement` candidates.
-2. **Git log** → `factual` candidates and edges to touched-file beliefs.
+2. **Git log** → `factual` candidates with file recency (v1.1.0: `belief.created_at` = file's most recent commit, so decay penalises old branches).
 3. **Python AST** → function/class names + docstrings → `factual` candidates.
 
-Classification via `TYPE_PRIORS` + regex fallback. Idempotent: `content_hash` dedupe.
+Classification via priors + regex fallback. Idempotent on `content_hash`.
 
 ## Claude Code hook
 
 ```
-~/.claude/settings.json  hooks.UserPromptSubmit: [{command: "aelf-hook"}]
-                                  ↓ written by aelf setup
-                          Claude Code (LLM)
-                                  ↓ JSON payload on stdin
-                          aelf-hook subprocess (aelfrice.hook:main)
-                                  ↓ retrieve(store, prompt)
-                          .git/aelfrice/memory.db (or ~/.aelfrice/memory.db)
-                                  ↓ <aelfrice-memory> on stdout
-                          Claude Code injects above prompt
+settings.json  hooks.UserPromptSubmit: [{command: "aelf-hook"}]
+                          ↓ written by aelf setup
+                  Claude Code spawns aelf-hook on each prompt
+                          ↓ JSON payload on stdin
+                  aelfrice.hook:main
+                          ↓ retrieve(store, prompt)
+                  .git/aelfrice/memory.db
+                          ↓ <aelfrice-memory> block on stdout
+                  Claude Code injects above your prompt
 ```
 
-Non-blocking contract: every failure path exits 0 with no stdout.
+Non-blocking contract: every failure path exits 0 with no stdout. A hook problem must never block your prompt.
 
-## Benchmark harness
+## v1.2+ hooks
 
-`aelfrice.benchmark` ships a deterministic 16-belief × 16-query synthetic corpus.
+| Hook | Event | Purpose |
+|---|---|---|
+| `aelf-transcript-logger` | `UserPromptSubmit`, `Stop`, `PreCompact`, `PostCompact` | One JSONL line per conversation turn; PreCompact rotates and re-ingests. |
+| `aelf-commit-ingest` | `PostToolUse:Bash` | After `git commit`, ingest the commit message via the triple extractor. |
+| `aelf-session-start-hook` | `SessionStart` | Inject locked beliefs as `<aelfrice-baseline>` once per session. |
+| `aelf-pre-compact-hook` | `PreCompact` | Context rebuilder alpha — surfaces retrieval before Claude Code summarises. |
 
-```bash
-aelf bench                 # in-memory store, fresh seed each run
-aelf bench --db PATH       # against an existing DB
-aelf bench --top-k 5       # override hit-depth
-```
-
-Output is a single JSON document with `BenchmarkReport` fields. Reproducible across runs against fresh in-memory stores. The harness is the **measurement instrument**, not yet a proof of the feedback claim — see the v1.0 note above.
+All opt-in via `aelf setup --<flag>`. All non-blocking.
 
 ## Tests
 
 | Layer | Marker | Coverage |
 |---|---|---|
-| Unit | (default) | One property per test. Pyright strict. ~5s suite timeout. |
-| Property | (default) | Pre-registered invariants: Bayesian inertia, decay-required, lock-floor sharpness, token-budget invariant, broker-attenuation. |
+| Unit | default | One property per test. Pyright strict. |
+| Property | default | Pre-registered invariants: Bayesian inertia, decay-required, lock-floor sharpness, token-budget invariant, broker-attenuation. |
 | Regression | `@pytest.mark.regression` | Cross-module scenarios: retrieval round-trip, feedback loop, onboarding, setup→hook→unsetup, `aelf bench` end-to-end. |
 
-`uv run pytest` (~530 tests, ~7s on Apple Silicon). `uv run pytest -m regression` for integration only.
+`uv run pytest` (~1,150 tests at v1.2, ~15s on Apple Silicon).
 
-## Out of scope through v1.0 (lands in v1.x with evidence)
+## Out of scope through v1.x
 
-Posterior-aware retrieval ranking. HRR retrieval. BFS multi-hop graph retrieval. Entity index/NER. LLM in the hot path. Sentence-transformer embeddings. Multi-source provenance tagging. Bitemporal `event_time`. Rigor-tier metadata. Cross-project knowledge federation.
+These land at v2.0 with evidence (a benchmark, an experiment, a clear case where the existing operations don't suffice):
+
+- Posterior-aware retrieval ranking (gated on the v1.3 retrieval wave)
+- HRR / sentence-transformer embeddings
+- BFS multi-hop graph retrieval
+- Entity index / NER
+- LLM in the hot path
+- Cross-project knowledge federation

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,295 +1,110 @@
-# Benchmarks: contamination-proof evaluation protocol
+# Benchmarks
 
-This document defines the exact protocol for running benchmarks against
-aelfrice. Any deviation from this protocol invalidates the results.
-No exceptions, no "we'll fix it in scoring." If contamination is detected
-at any stage, the result is 0% and the protocol must be revised to
-prevent that contamination mode before re-running.
-
-## Two-suite architecture
-
-aelfrice ships two distinct benchmark surfaces. They have different
-purposes and run on different cadences.
+aelfrice ships two benchmark surfaces with different purposes and cadences.
 
 | Surface | Location | Purpose | Runtime | Cost | Cadence |
 |---|---|---|---|---|---|
-| Synthetic regression | `src/aelfrice/benchmark.py` | Catch retrieval/scoring regressions on a fixed in-tree corpus | <1s | $0 | Every PR (CI) |
-| Academic suite | `benchmarks/` | Reproduce the published headline numbers against external benchmarks (MAB, LoCoMo, LongMemEval, StructMemEval, AMA-Bench) | minutes–hours | LLM API spend | Nightly + on-tag |
+| Synthetic regression | `src/aelfrice/benchmark.py` | Catch retrieval/scoring regressions | <1s | $0 | Every PR (CI) |
+| Academic suite | `benchmarks/` | Reproduce published numbers vs. external benchmarks | minutes–hours | LLM API spend | Nightly + on-tag |
 
-The synthetic harness is the **measurement instrument**, not a proof of
-the central feedback claim — it ships with v0.9.0-rc onward and is
-documented in `src/aelfrice/benchmark.py`.
+The synthetic harness is a measurement instrument. It is **not** a proof of the central feedback claim — at v1.0–v1.2 the posterior doesn't drive ranking yet. See [LIMITATIONS](LIMITATIONS.md).
 
-The academic suite is the **reproducibility deliverable**. Most adapters
-are scaffolded but inert at v1.0.0; they activate as their feature
-dependencies port from the lab repo. See `benchmarks/README.md` for the
-per-adapter activation roadmap.
+The academic suite is the reproducibility deliverable. Most adapters scaffold against MAB, LoCoMo, LongMemEval, StructMemEval, and AMA-Bench but are inert at v1.0; they activate as their feature dependencies port forward. Per-adapter status: [`benchmarks/README.md`](../benchmarks/README.md).
 
-## What we measure and why
-
-aelfrice's task is **known-item search over behavioural directives** — the
-agent has corrected the user, locked a rule, or recorded a decision; on the
-next relevant prompt we want that specific item retrieved. This is a different
-problem from open-ended topical retrieval (Cranfield-paradigm IR), where the
-goal is "documents relevant to a topic." The natural headline metric for
-known-item search is **mean reciprocal rank (MRR)** — how high does the
-correct item appear when the user has one in mind. The synthetic harness
-reports `mrr` alongside `hit_at_k`; the academic suite reports MRR where the
-benchmark protocol allows it.
-
-We also report the metrics each external benchmark *defines* (token-level F1
-on LoCoMo, substring exact match on MAB, GPT-4o binary judge on LongMemEval,
-LLM-judge accuracy on StructMemEval / AMA-Bench) because comparability with
-prior published systems requires it. Those metrics are framed for
-**topical** relevance (Saracevic 1975 — does the document cover the topic)
-rather than **behavioural** or **situational** relevance (does this directive
-apply to what the agent is about to do). The behavioural / situational frame
-is closer to aelfrice's actual contribution; the topical frame is what the
-external benchmarks measure. Both numbers are reported; the headline
-positioning is on MRR.
-
-This is also why the LongMemEval multi-session aggregation gap (see
-[LIMITATIONS § Out of scope by design](LIMITATIONS.md#out-of-scope-by-design))
-shows up as a low number on a topical-relevance benchmark and is *not*
-treated as a v1.x defect: aelfrice's design target is the directive-recall
-slice of the workload, not the cross-session aggregation slice.
-
-## Activation status (v1.0.0)
-
-| Adapter | Status | Activates in |
-|---|---|---|
-| `verify_clean.py` | runnable now | v1.0.0 |
-| `longmemeval_score.py` | runnable now | v1.0.0 |
-| All five academic adapters (MAB, LoCoMo, LongMemEval, StructMemEval, AMA-Bench) | inert (need `aelfrice.ingest`, `MemoryStore`) | v1.2.0 (P2) |
-
-CLI dispatch:
+## Run the synthetic harness
 
 ```bash
-aelf bench                                    # synthetic harness (default)
-aelf bench synthetic                          # alias
-aelf bench verify-clean PATH...               # contamination gate
-aelf bench longmemeval-score PREDS GT JUDGE   # scoring utility
-aelf bench mab|locomo|longmemeval|...         # exit 2 with skip pointer
+aelf bench                   # default top-k=5
+aelf bench --top-k 3
 ```
 
-## Contamination modes (known failure history)
+Output is a single JSON `BenchmarkReport`:
 
-### Mode 1: ground truth in retrieval output (occurred 2x)
-
-**What happened:** the retrieve-only JSON contained answer fields. The
-LLM reader saw correct answers while generating predictions. Results
-were inflated (100% on MAB MH 262K, later invalidated).
-
-**Prevention:** retrieval and ground truth are generated by the adapter
-into TWO separate files. The adapter MUST NOT write any `answer`,
-`ground_truth`, `reference_answer`, or equivalent field into the
-retrieval file. The retrieval file contains only: question text,
-retrieved context, and metadata (question ID, type, etc.).
-
-**Verification:** before any LLM reader touches the retrieval file,
-run the contamination check:
-
-```bash
-aelf bench verify-clean /tmp/benchmark_mab_mh.json
+```json
+{"hit_at_1": 0.875, "hit_at_3": 1.0, "hit_at_5": 1.0,
+ "mrr": 0.92, "p50_latency_ms": 0.4, "p99_latency_ms": 1.1}
 ```
 
-If this check fails, the run is invalid. Period.
+Deterministic against fresh in-memory stores. The corpus is 16 beliefs × 16 queries.
 
-### Mode 2: LLM self-judging with answer visible (occurred 1x)
+## What the academic suite measures
 
-**What happened:** the LLM was asked to both generate an answer AND
-judge it against the ground truth in the same pass. The model could
-see the answer while generating, contaminating the prediction.
+aelfrice's task is **known-item search over behavioural directives** — the agent has corrected the user, locked a rule, or recorded a decision; on the next relevant prompt we want that specific item retrieved. The natural headline metric is **mean reciprocal rank (MRR)**.
 
-**Prevention:** generation and judging are strictly separate passes:
-1. Pass 1 (Generation): LLM reads retrieval file (no answers).
-   Writes predictions file.
-2. Pass 2 (Scoring): scoring script reads predictions + GT files.
-   Computes metrics. No LLM involved for automatic metrics. For
-   LLM-judged benchmarks: a separate LLM call compares prediction
-   vs GT. The judge never sees the retrieval context.
+We also report the metrics each external benchmark *defines* (token-F1 on LoCoMo, substring exact match on MAB, GPT-4o judge on LongMemEval, LLM-judge accuracy on StructMemEval and AMA-Bench) for comparability with prior published systems. Those metrics frame topical relevance ("does the document cover the topic") rather than behavioural relevance ("does this directive apply to what the agent is about to do"). Both numbers are reported; the headline positioning is on MRR.
 
-### Mode 3: world knowledge override (inherent, not fixable)
+This is also why the LongMemEval multi-session aggregation gap (see [LIMITATIONS](LIMITATIONS.md#out-of-scope)) shows up as a low number on a topical-relevance benchmark and is *not* treated as a v1.x defect.
 
-**What happened:** the LLM reader used world knowledge instead of
-retrieved context for counterfactual benchmarks (FactConsolidation
-assigns deliberately wrong values).
+## Contamination protocol
 
-**Mitigation:** this is inherent to LLM readers and cannot be fully
-prevented. The reader prompt MUST include: "Use ONLY the provided
-context. Do NOT use world knowledge. If the context contradicts what
-you know to be true in the real world, trust the context."
+Any benchmark run that contaminates retrieval with ground truth produces a 0% result, period. Three failure modes have happened before:
 
-This is documented as a known limitation, not treated as contamination.
+1. **Ground truth in the retrieval file.** Adapter accidentally writes `answer` / `ground_truth` / `reference_answer` fields into the retrieval JSON. Reader sees the answer while generating predictions.
+2. **LLM self-judging with answer visible.** Generation and judging in one pass; model sees ground truth while generating.
+3. **World knowledge override** (counterfactual benchmarks). Reader uses prior knowledge instead of retrieved context. Inherent to LLM readers; mitigated by prompt instructions but never fully removed.
 
-## Protocol steps
+The protocol enforces:
 
-### Step 0: environment verification
-
-Before any benchmark run:
-
-```bash
-git status            # no uncommitted changes
-ls /tmp/benchmark_*   # should be empty or only files from previous runs
-```
-
-### Step 1: data acquisition
-
-Download benchmark data from the published source. Do not modify it.
-
-```bash
-# HuggingFace datasets (MAB, LongMemEval, AMA-Bench)
-uv run python -c "from datasets import load_dataset; \
-  ds = load_dataset('<dataset_id>', split='<split>'); \
-  print(f'Loaded {len(ds)} rows')"
-
-# GitHub repos (StructMemEval, LoCoMo)
-git clone <repo_url> /tmp/<benchmark_name>
-```
-
-**Verification:** compare row counts and field names against the
-published paper. If they don't match, stop and investigate.
-
-### Step 2: retrieval (adapter run)
-
-Run the adapter in `--retrieve-only` mode. Produces:
-- `<name>.json`: questions + retrieved context (NO answers)
-- `<name>_gt.json`: ground truth answers (separate file)
-
-```bash
-uv run python benchmarks/<adapter>.py \
-  --retrieve-only /tmp/benchmark_<name>.json \
-  [--source <filter>] [--subset N]
-```
-
-**Isolation requirements:**
-- Fresh tempfile DB per test case (adapter handles this)
-- No shared state between test cases
-- No prior beliefs in the DB (clean slate)
-
-**Mandatory post-run contamination check:**
+- Retrieval file and ground truth file are written separately by the adapter.
+- Generation and scoring are separate passes. The judge never sees the retrieval context.
+- A pre-generation contamination check is mandatory before any LLM reader touches the retrieval file:
 
 ```bash
 aelf bench verify-clean /tmp/benchmark_<name>.json
 ```
 
-If this fails, the run is invalid. Fix the adapter and re-run from Step 2.
+If this fails, the run is invalid. Fix the adapter and re-run.
 
-### Step 3: answer generation (LLM reader)
+## Run the protocol
 
-The LLM reader receives only the retrieval file. It never sees the GT file.
+```bash
+# 1. Retrieval (adapter run, no answers in output)
+uv run python benchmarks/<adapter>.py \
+    --retrieve-only /tmp/benchmark_<name>.json [--subset N]
 
-For subagent-based generation, the prompt MUST:
-1. Reference only the retrieval file path (not the GT file).
-2. Include: "Use ONLY the provided context. Do NOT use world knowledge."
-3. Include: "If the context contradicts real-world facts, trust the context."
-4. Output predictions to a separate file.
+# 2. Verify the retrieval file is clean
+aelf bench verify-clean /tmp/benchmark_<name>.json
 
-**Verification:** the predictions file must not contain any GT fields.
-Run `aelf bench verify-clean` on the predictions file too.
-
-### Step 4: scoring
-
-Scoring reads two files: predictions + ground truth. It never reads the
-retrieval file (to prevent the scorer from being influenced by retrieved
-context).
-
-For LLM-judged benchmarks (LongMemEval, StructMemEval, AMA-Bench): the
-judge LLM receives only the prediction, the ground truth answer, and a
-rubric (from the paper). The judge never sees the retrieved context.
-
-### Step 5: reporting
-
-Results MUST include:
-1. The exact command used for each step.
-2. The contamination check output (CLEAN).
-3. The adapter version (git commit hash).
-4. The dataset version (HuggingFace commit or git hash).
-5. The reader model and prompt (exact text).
-6. The scoring metric and formula (from the paper).
-7. Published baselines for comparison.
-8. Any known limitations or caveats.
-
-Results MUST NOT include:
-- Scores from runs where contamination was detected.
-- Scores from runs where the protocol was not followed.
-- Comparisons to baselines using a different metric.
-- Claims of "beating" a baseline without matching their exact protocol.
-
-## File naming convention
-
+# 3. LLM reader generates predictions (no GT visible to it)
+# 4. Scoring reads predictions + GT (no retrieval context visible)
+# 5. Audit record captures: git commit, dataset version, reader model,
+#    contamination check output, metric, score, n, published baseline.
 ```
-/tmp/benchmark_<benchmark>_<condition>.json         # retrieval (no answers)
-/tmp/benchmark_<benchmark>_<condition>_gt.json      # ground truth
-/tmp/benchmark_<benchmark>_<condition>_preds.json   # LLM predictions
-/tmp/benchmark_<benchmark>_<condition>_scores.json  # final scores
-```
+
+Reader prompts must include: *"Use only the provided context. Do not use world knowledge. If the context contradicts what you know to be true, trust the context."*
 
 ## Per-benchmark specifics
 
-### MAB FactConsolidation
-- **Paper:** Hu et al., ICLR 2026, arXiv:2507.05257
-- **Dataset:** `ai-hyz/MemoryAgentBench`, split `Conflict_Resolution`
-- **Metric:** substring_exact_match (SEM) per paper's `eval_other_utils.py`
-- **Normalization:** lowercase, strip punctuation, remove articles (a/an/the)
-- **Multi-answer:** max SEM across all ground truth strings
-- **Chunking:** 4096 tokens, NLTK `sent_tokenize`, tiktoken `gpt-4o` encoding
-- **Reader prompt:** must include serial-number conflict resolution instructions
+| Benchmark | Dataset | Metric | Notes |
+|---|---|---|---|
+| MAB FactConsolidation | `ai-hyz/MemoryAgentBench` Conflict_Resolution | substring exact match (paper's normalisation) | 4,096-token chunks; NLTK `sent_tokenize`; serial-number conflict resolution required in prompt |
+| LoCoMo | `locomo10.json` | token-F1 with Porter stemming | session boundaries preserved on ingest; Category 5 is forced-choice |
+| LongMemEval | `xiaowu0162/longmemeval-cleaned` oracle | GPT-4o binary judge (paper) | question_date passed to retrieval for temporal grounding |
+| StructMemEval | yandex-research/StructMemEval | LLM judge binary | synthetic timestamps + temporal_sort disclosed |
+| AMA-Bench | `AMA-bench/AMA-bench` test | LLM judge accuracy (paper: Qwen3-32B) | alternative judges must be disclosed |
 
-### LoCoMo
-- **Paper:** Maharana et al., ACL 2024
-- **Dataset:** `locomo10.json` from snap-research.github.io/locomo/
-- **Metric:** token-level F1 with Porter stemming
-- **Category 5:** forced-choice adversarial (not free-form)
-- **Session boundaries:** must be preserved during ingestion
+## Audit record
 
-### LongMemEval
-- **Paper:** Wu et al., ICLR 2025
-- **Dataset:** `xiaowu0162/longmemeval-cleaned`, `longmemeval_oracle.json`
-- **Metric:** GPT-4o binary judge (paper protocol)
-- **Alternative:** Opus binary judge (must be disclosed as non-standard)
-- **Question date:** must be provided to retrieval for temporal grounding
-
-### StructMemEval
-- **Paper:** Shutova et al., 2026 (preprint)
-- **Dataset:** github.com/yandex-research/StructMemEval
-- **Metric:** LLM judge binary (correct/incorrect)
-- **Temporal fix:** synthetic timestamps + temporal_sort must be disclosed
-
-### AMA-Bench
-- **Paper:** Zhao et al., ICLR 2026 Workshop
-- **Dataset:** `AMA-bench/AMA-bench`, split test
-- **Metric:** LLM judge accuracy (paper uses Qwen3-32B)
-- **Alternative judge:** must be disclosed
-
-## Audit trail
-
-Every benchmark run should produce an audit record:
+Every academic run produces:
 
 ```json
 {
-  "benchmark": "MAB_FactConsolidation_MH_262K",
-  "condition": "treatment",
-  "git_commit": "<hash>",
-  "timestamp": "<ISO 8601>",
-  "adapter": "benchmarks/mab_triple_adapter.py",
-  "reader_model": "claude-opus-4-7",
+  "benchmark": "...",
+  "git_commit": "...",
+  "adapter": "benchmarks/...",
+  "reader_model": "...",
   "contamination_check": "CLEAN",
-  "retrieval_file": "/tmp/benchmark_mab_mh_262k_treatment.json",
-  "gt_file": "/tmp/benchmark_mab_mh_262k_treatment_gt.json",
-  "predictions_file": "/tmp/benchmark_mab_mh_262k_treatment_preds.json",
-  "metric": "substring_exact_match",
+  "metric": "...",
   "score": 0.XX,
   "n": 100,
-  "published_baseline": "<=7% (all methods)",
-  "notes": ""
+  "published_baseline": "..."
 }
 ```
 
+Required for the run to count. Runs without an audit record do not enter `benchmarks/results/`.
+
 ## See also
 
-- `src/aelfrice/benchmark.py` — synthetic regression harness source.
-- `benchmarks/README.md` — per-adapter activation status.
-- `tests/test_benchmark.py` — synthetic regression unit tests.
-- `tests/regression/test_benchmark_cli_end_to_end.py` — synthetic e2e test.
-- `tests/test_benchmarks_dir.py` — academic-suite scaffold smoke tests.
+- [`src/aelfrice/benchmark.py`](../src/aelfrice/benchmark.py) — synthetic harness source.
+- [`benchmarks/README.md`](../benchmarks/README.md) — per-adapter activation status.
+- [ROADMAP § v2.0.0](ROADMAP.md) — when the academic suite reproduces every headline number.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,52 +1,68 @@
-# CLI Reference
+# Commands
 
-Nineteen subcommands. The first eight (retrieval/feedback) are also available as MCP tools and Claude Code slash commands. The lifecycle commands (`setup`/`unsetup`/`upgrade`/`uninstall`/`statusline`/`doctor`/`migrate`) and `bench` are CLI-only.
-
-DB resolves from `$AELFRICE_DB` (override), then `<git-common-dir>/aelfrice/memory.db` when `cwd` is in a git work-tree, then `~/.aelfrice/memory.db` as the non-git fallback. `.git/` is not git-tracked — the brain graph never crosses the git boundary.
+Twenty-two CLI subcommands. The retrieval/feedback ones are also exposed as MCP tools (see [MCP](MCP.md)) and slash commands (see [SLASH_COMMANDS](SLASH_COMMANDS.md)). Lifecycle commands (`setup`, `doctor`, `migrate`, `upgrade`, `uninstall`, etc.) are CLI-only.
 
 ```
 aelf <subcommand> [args] [options]
+aelf --help
+aelf --version
 ```
 
-## Reference
+DB resolves from `$AELFRICE_DB`, then `<git-common-dir>/aelfrice/memory.db` when `cwd` is in a git work-tree, then `~/.aelfrice/memory.db` as the non-git fallback.
 
-| Command | Args | Behaviour |
-|---|---|---|
-| `onboard <path>` | `path` | Walk filesystem (`.md/.rst/.txt/.adoc`), git log, Python AST. Classify candidates, insert non-duplicates. Power users can tune the noise filter via a `.aelfrice.toml` at the project root — see [CONFIG.md](CONFIG.md). |
-| `search <query> [--budget N]` | `query`, `--budget` (default 2000) | L0 locked + L1 FTS5 BM25, token-budgeted. |
-| `lock <statement>` | `statement` | Insert at `(α, β) = (9.0, 0.5)` with `lock_level=user`. Idempotent — re-lock of identical text upgrades existing. |
-| `locked [--pressured]` | `--pressured` | List locks. With flag, only those with `demotion_pressure > 0`. |
-| `demote <belief_id>` | `belief_id` | `lock_level → none`, `locked_at → null`, `demotion_pressure → 0`. Belief itself remains. |
-| `resolve` | — | Sweep unresolved CONTRADICTS threads. For each pair, pick a winner per precedence (`user_stated > user_corrected > document_recent`; ties broken by recency, then by id) and create a SUPERSEDES thread from winner to loser. Writes one `feedback_history` row per resolution with `source='contradiction_tiebreaker:<rule>'`. Idempotent. |
-| `feedback <belief_id> <used\|harmful> [--source S]` | id, signal, optional source | `used` ⇒ α += 1. `harmful` ⇒ β += 1. Positive feedback flowing through outbound CONTRADICTS threads to user-locks bumps their `demotion_pressure`; ≥ 5 ⇒ auto-demote. |
-| `stats` | — | beliefs / threads / locked / feedback_events counts. |
-| `health` | — | Structural auditor (v1.1.0): three checks fire — orphan threads, FTS5 sync drift, locked-belief CONTRADICTS pairs. Each finding prints `[ok  ]` or `[FAIL]`. Exit 1 if any failure, 0 otherwise. Informational metrics (counts, average confidence, credal gap, thread counts by type) print alongside but don't affect exit. |
-| `status` | — | Alias for `health`. Same output, same exit codes. |
-| `regime` | — | v1.0 regime classifier preserved as a separate command. One of `supersede`, `ignore`, `mixed`, `insufficient_data`. Informational only; always exits 0. |
-| `migrate [--from PATH] [--apply] [--all] [--yes]` | — | Copy beliefs from the legacy global DB (default: `~/.aelfrice/memory.db`) into the active project's resolved DB. Dry-run by default — `--apply` writes. Filter copies only beliefs whose content references the absolute project root path; `--all` skips the filter. Edges follow only when both endpoints land. Reads source via SQLite `mode=ro` URI; never deletes from the source. Idempotent. |
-| `doctor [--user-settings P] [--project-root D]` | — | Verify hook + statusline commands in user and project `settings.json` resolve to executables. Reports broken absolute paths and bare names not on `$PATH`. Special-cases `bash /script.sh` to inspect the script. Exits `1` on any broken finding. |
-| `setup [--scope user\|project] [--project-root D] [--settings-path P] [--command C] [--timeout N] [--status-message M] [--no-statusline]` | various | Install `UserPromptSubmit` hook + `statusLine` notifier in Claude Code `settings.json`. Defaults: `--scope` auto-detects `project` if `cwd/.venv` matches `sys.prefix` else `user`; `--command` auto-resolves to absolute `aelf-hook` (project venv for project scope, `$PATH` for user scope). Also silently removes legacy dangling `/usr/local/bin/aelf{,-hook}` symlinks. Idempotent + atomic. |
-| `unsetup` (same scope flags, `--command`) | — | Remove the hook + our statusline contribution. Default `--command` matches every entry whose program basename is `aelf-hook`, so a bare-name install and an absolute-path install are both cleaned by the same call. Composed statuslines are surgically unwrapped to restore the original command. |
-| `upgrade [--check]` | — | Print the right pip-upgrade command for the running env (venv → `pip install --upgrade`, pipx → `pipx upgrade`, system → `pip install --user --upgrade`). When an update is available, also prints the wheel SHA-256 + PyPI release URL for hash-pinned installs. `--check` suppresses the command line. |
-| `uninstall (--keep-db \| --purge \| --archive PATH) [--password-stdin] [--yes] [--keep-hook] [--settings-path P]` | one disposition flag required | Tear down aelfrice. Disposition modes are mutually exclusive. `--purge` requires typing `PURGE` then `[y/N]` unless `--yes` is passed. `--archive` requires `pip install 'aelfrice[archive]'`. By default also runs `unsetup`; `--keep-hook` opts out. Tail message points at `pip uninstall aelfrice` for wheel removal. |
-| `statusline` | — | Emit the orange update-banner snippet (or empty when no update is pending). Reads cache only, no network. Composes onto an existing statusline via shell `;`. Color: truecolor → 256-color → basic, NO_COLOR honoured. |
-| `bench [--db PATH] [--top-k N]` | — | Run the deterministic 16-belief × 16-query benchmark. Print a single JSON `BenchmarkReport`: `hit_at_1` / `hit_at_3` / `hit_at_5` / `mrr` + `p50_latency_ms` / `p99_latency_ms`. |
-| `--version` (root flag) | — | Print `aelfrice X.Y.Z` and exit. |
+## Memory operations
 
-## Output format
+| Command | What it does |
+|---|---|
+| `onboard <path>` | Walk filesystem, git log, Python AST. Classify candidates, insert non-duplicates. Tunable via `.aelfrice.toml` — see [CONFIG](CONFIG.md). |
+| `search <query> [--budget N]` | L0 locked + L1 FTS5 BM25, token-budgeted (default 2,000). Distinguishes "store empty" from "no match". |
+| `lock <statement>` | Insert at `(α, β) = (9.0, 0.5)` with `lock_level=user`. Idempotent — re-lock upgrades existing. |
+| `locked [--pressured]` | List locks. With `--pressured`, only those with `demotion_pressure > 0`. |
+| `demote <belief_id>` | Drop a user lock. Belief itself remains. |
+| `validate <belief_id> [--source user_validated]` | Promote an `agent_inferred` belief to a user-validated origin (v1.2+). |
+| `feedback <belief_id> <used\|harmful> [--source S]` | `used` ⇒ α += 1; `harmful` ⇒ β += 1. Harmful feedback through outbound `CONTRADICTS` threads to user-locks bumps their demotion_pressure; ≥5 ⇒ auto-demote. |
+| `resolve` | Sweep unresolved `CONTRADICTS` threads. Picks a winner per precedence (`user_stated > user_corrected > document_recent`) and inserts a `SUPERSEDES` thread. Idempotent. |
 
-Human-readable on stdout (CLI), JSON on stdout (`bench`). Errors on stderr.
+## Diagnostics
 
-Exit codes: `0` = success or no-op, `1` = invalid argument or belief not found, `>1` = uncaught exception.
+| Command | What it does |
+|---|---|
+| `stats` | Belief / thread / lock / feedback counts. |
+| `health` | Structural auditor: orphan threads, FTS5 sync, locked contradictions, corpus volume. Exits 1 on structural failure; corpus-volume warnings are informational. |
+| `status` | Alias for `health`. |
+| `regime` | The v1.0 regime classifier output (`supersede` / `ignore` / `mixed` / `insufficient_data`). Informational; always exits 0. |
+| `doctor` | Verify hook + statusline commands resolve. Inspects `bash <script>` wrappers, flags `2>/dev/null \|\| true` patterns. Surfaces empty-store warning. Exits 1 on broken hooks. |
+| `bench [--top-k N]` | Run the deterministic 16-belief × 16-query benchmark. Prints a JSON `BenchmarkReport`. |
+
+## Lifecycle
+
+| Command | What it does |
+|---|---|
+| `setup` | Install the `UserPromptSubmit` hook + statusline notifier. Auto-detects scope (`project` if `cwd/.venv` matches the active interpreter, else `user`). Idempotent + atomic. Optional flags: `--transcript-ingest`, `--commit-ingest`, `--session-start`, `--rebuilder`. |
+| `unsetup` | Remove the hook and our statusline contribution. Composed statuslines are surgically unwrapped. Mirrors `setup` flags. |
+| `upgrade [--check]` | Print the pip-upgrade command for the active env (venv / pipx / system). Includes wheel SHA-256 for hash-pinned installs. Does not run pip. |
+| `uninstall (--keep-db \| --archive PATH \| --purge)` | Tear down aelfrice. One disposition flag required. `--purge` has three confirmation gates. `--archive` writes a Fernet-encrypted file then deletes the original. |
+| `migrate [--from P] [--apply] [--all]` | Port beliefs from the legacy global DB into the active project's per-project DB. Dry-run by default. Read-only on the source. |
+| `statusline` | Emit the update-banner snippet (or empty). Reads cache only, no network. |
+| `ingest-transcript [PATH \| --batch DIR] [--since DATE]` | Ingest one `turns.jsonl` file or batch-walk a directory. Auto-detects aelfrice and Claude Code formats. Idempotent. |
+| `rebuild [--transcript PATH] [--n N] [--budget N]` | Manual context-rebuilder run (alpha; normally fires on `PreCompact`). Prints the rebuild block to stdout. |
+
+## Output and exit codes
+
+- Human-readable on stdout. Errors on stderr.
+- `bench` prints JSON.
+- Exit codes: `0` = success or no-op, `1` = bad argument / belief not found / structural audit failure, `>1` = uncaught exception.
 
 ## Defaults that matter
 
-- Lock initial prior: `(9.0, 0.5)`
-- Decay target: Jeffreys prior `(0.5, 0.5)`
-- Half-lives: factual 14d / requirement 30d / preference 12w / correction 24w
-- Demotion threshold: 5 contradicting events
-- Search token budget: 2000
-- Valence propagation: BFS, max 3 hops, threshold 0.05
-- Benchmark hit-depth: top-5 (override with `--top-k`)
+| Constant | Value |
+|---|---|
+| Lock initial prior | `(α, β) = (9.0, 0.5)` |
+| Decay target | Jeffreys prior `(0.5, 0.5)` |
+| Half-lives | factual 14d, requirement 30d, preference 12w, correction 24w |
+| Demotion threshold | 5 contradicting events |
+| Retrieval token budget | 2,000 |
+| Valence propagation | BFS, max 3 hops, threshold 0.05 |
+| Benchmark hit-depth | top-5 |
 
 All exposed as module-level constants in `aelfrice.feedback`, `aelfrice.scoring`, `aelfrice.retrieval`. See [ARCHITECTURE](ARCHITECTURE.md).

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,224 +1,135 @@
 # Configuration: `.aelfrice.toml`
 
-Most users never need this file. aelfrice is designed to work silently in the background, keeping LLM sessions current with the project's ground truth. The defaults are tuned so that `pip install aelfrice && aelf onboard .` does the right thing for almost every project.
+Most users never need this file. The defaults are tuned so `pip install aelfrice && aelf onboard .` does the right thing.
 
-This document is for the case where the defaults are *not* doing the right thing — when a project has a documentation idiom or naming convention that the default filter mishandles, when a power user wants finer control over what enters the belief store, or when a contributor is debugging onboarding behaviour. If that's not you, close this tab and let the agent do its job.
+This is the reference for power users whose project has a documentation idiom or naming convention the default filter mishandles.
 
----
+## What it does
 
-## What is `.aelfrice.toml`?
+A single optional TOML file at the root of a project (or any ancestor). It changes how `aelf onboard` ingests beliefs — nothing else. Retrieval, hooks, MCP tools, locks, and the Bayesian feedback math are not affected.
 
-A single optional TOML file at the root of a project (or any ancestor directory). Editing it changes how `aelf onboard` ingests beliefs — nothing else. Retrieval, the hook, MCP tools, locks, and the Bayesian feedback math are not affected by anything in this file.
+`scan_repo` walks up from the scan root looking for `.aelfrice.toml`. The first one found wins. The walk stops at the filesystem root — there is no global / per-user config.
 
-If the file does not exist, aelfrice ships with safe defaults; this is the recommended state for almost all projects.
-
-## Where it lives
-
-`scan_repo` (the function backing `aelf onboard`) walks up from the scan root, checking each directory for `.aelfrice.toml`, until it finds one or reaches the filesystem root. The first file found wins.
-
-This means:
-
-- A project with `.aelfrice.toml` at its top directory is configured for any onboard run inside that project.
-- A nested subproject can shadow its parent by placing its own `.aelfrice.toml` inside the subproject directory.
-- A user without the file gets the default behaviour, which is the v1.0 ship behaviour.
-
-The walk stops at filesystem root. There is no global / per-user `.aelfrice.toml` — configuration is per-project (or per-ancestor-of-project) on purpose, so checking out a different repo cannot silently inherit unrelated config.
+If the file does not exist, the noise filter uses defaults. That is the recommended state.
 
 ## Schema
-
-The file has one table at v1.0.1: `[noise]`. Future versions add more (project identity, store path, etc. — see [ROADMAP](ROADMAP.md)). Unknown keys and unknown tables are ignored, so this file is forward-compatible.
 
 ```toml
 # .aelfrice.toml
 [noise]
-# Turn off any of the four built-in categories. Each disabled
-# category will not contribute to skipped_noise; its content
-# may still be filtered out by the classifier or by other
-# categories. Subset of: headings | checklists | fragments | license
+# Turn off any of: headings | checklists | fragments | license
 disable = []
 
-# Below this many whitespace tokens, treat a paragraph as a
-# fragment and drop it. The default catches stubs and labels
-# while leaving real prose alone. Lower this if your project
-# has many terse beliefs you want to keep ("lock fast",
-# "prefer composition"). Set to 0 to disable the check.
+# Drop paragraphs with fewer than this many whitespace tokens.
+# Default 4. Set to 0 to disable the fragment check entirely.
 min_words = 4
 
-# Drop paragraphs that contain any of these whole words. Match
-# is case-insensitive and word-bounded — adding "jso" drops
-# paragraphs containing the standalone token "jso" but NOT
-# "json", "jsonify", or "jsodb". Use this for initials,
-# codenames, internal jargon you don't want surfacing in
-# retrieval.
+# Drop paragraphs containing any of these whole words.
+# Word-bounded, case-insensitive. "jso" does NOT match "json".
 exclude_words = []
 
-# Drop paragraphs that contain any of these substrings. Match
-# is case-insensitive but otherwise literal — punctuation and
-# whitespace inside the phrase are matched verbatim. Use this
-# for status flags, header strings, or templated lines you
-# always want filtered.
+# Drop paragraphs containing any of these substrings.
+# Literal substring match, case-insensitive.
 exclude_phrases = []
 ```
 
-## What each key does and what it affects
+Unknown keys and unknown tables are ignored; the file is forward-compatible.
+
+## Keys
 
 ### `disable`
 
-A list naming the built-in noise categories you want to turn off.
-
-| Token | What it disables | What you'll see |
+| Token | Disables | Effect |
 |---|---|---|
-| `headings` | The "every line is a markdown heading" filter. Pure heading blocks like `# Section\n## Subsection` will pass through. | Markdown headings in your docs become belief candidates. The classifier may still drop them as low-content; if not, expect short labels in your store. |
-| `checklists` | The "every line is `- [ ]`" filter. Pure task-list blocks pass through. | TODO list items become belief candidates. Useful only if your TODO entries actually contain durable behavioural rules. |
-| `fragments` | The `min_words` short-paragraph filter. | Short labels like `INSTRUCTIONS:`, `DRAFT`, terse one-liners pass to the classifier. |
-| `license` | The seven-signature license-preamble filter. | LICENSE.md text and equivalent files become belief candidates. Most projects do not want this; aelfrice deliberately drops legal boilerplate to keep the store about your code. |
+| `headings` | the "every line is a markdown heading" filter | pure heading blocks pass through |
+| `checklists` | the "every line is `- [ ]`" filter | task-list items become belief candidates |
+| `fragments` | the `min_words` short-paragraph filter | short labels like `DRAFT` pass to the classifier |
+| `license` | the seven-signature license-preamble filter | LICENSE.md text becomes belief candidates |
 
-A category disabled here is silent — `ScanResult.skipped_noise` will not count anything from that category, and the candidate flows through to classification. Other categories still fire normally.
-
-Unrecognised tokens are silently ignored. Typos (`fragmints`, `lisence`) do not turn the whole filter off; the misnamed category remains enabled.
+A disabled category is silent — `ScanResult.skipped_noise` will not count anything from it. Other categories still fire. Unrecognised tokens are silently ignored.
 
 ### `min_words`
 
-Integer, default `4`. Any paragraph with fewer than this many whitespace-separated tokens is dropped as a fragment.
+Integer, default `4`. Paragraphs shorter than this are dropped.
 
-| Setting | Behaviour | When to use |
-|---|---|---|
-| `4` (default) | Drops 0–3-word paragraphs. | Most projects. |
-| `3` or lower | Lets 3-word and shorter beliefs through. | Projects that lock terse rules ("prefer composition", "no global state", "fail loud"). |
-| `0` | Disables the fragment check entirely. | Mostly for debugging. Equivalent to `disable = ["fragments"]`. |
-| Negative | Clamped to 0 silently. | — |
+| Setting | Use when |
+|---|---|
+| `4` (default) | Most projects. |
+| `3` or lower | You lock terse rules ("prefer composition", "no global state"). |
+| `0` | Disables the check entirely. |
 
-A non-integer value (string, float, `true`, etc.) is rejected with a warning to stderr and the default of 4 is used.
+A non-integer value is rejected with a stderr warning; default applies.
 
 ### `exclude_words`
 
-A list of strings, default `[]`. Each string is treated as a whole word and matched case-insensitively.
-
-The matching uses word boundaries: a word like `"jso"` matches the standalone token `jso` (or `jso.`, `jso,`, `jso-files` — anywhere `jso` is followed by a non-letter / non-digit / non-underscore). It does *not* match `json`, `jsonify`, `jsodb`, or any longer alphanumeric run that contains `jso` as a substring.
-
-This is the right choice for:
-
-- **Initials / contributor names.** Adding `["jso"]` filters paragraphs naming that contributor without breaking docs that mention `json`.
-- **Codenames.** Internal project codenames you'd rather not surface to the LLM.
-- **Status keywords.** `["DRAFT", "WIP"]` drops paragraphs flagged as work-in-progress.
-
-Empty strings in the list are skipped (would otherwise match every paragraph). Non-string entries are skipped with a warning.
+List of whole-word matches. Word boundaries: `"jso"` matches the standalone token but not `json`, `jsonify`, etc. Useful for initials, codenames, status keywords.
 
 ### `exclude_phrases`
 
-A list of strings, default `[]`. Each string is matched case-insensitively as a literal substring anywhere in the paragraph. Punctuation and whitespace inside the phrase are matched verbatim.
+List of literal substring matches. Case-insensitive but otherwise verbatim. Useful for templated header lines (`Last updated:`, `Generated by`) and inline status flags (`TODO:`, `FIXME`).
 
-This is the right choice for:
-
-- **Templated header lines.** `["Last updated:", "Generated on"]` drops paragraphs that are auto-stamped boilerplate.
-- **Inline status flags.** `["TODO:", "FIXME"]` drops paragraphs that contain a development marker mid-text.
-- **Multi-word fixed strings** that don't follow word-boundary semantics.
-
-The trade-off vs. `exclude_words`: phrase match is literal substring, no word boundaries. `["foo"]` here would drop a paragraph containing `foobar`. If that's not what you want, use `exclude_words` instead.
-
-## When a change takes effect
-
-Edits to `.aelfrice.toml` apply on the next `aelf onboard` run. They do **not** retroactively re-filter beliefs that are already in your store — once a belief is in the database, it stays there until you `aelf demote` or `aelf delete` it (the latter lands in v2.0). This is intentional: the config controls ingestion, not retention.
-
-If you want to remove existing noise from a store, the cleanest path is:
-
-```bash
-rm "$(python -c 'from aelfrice.cli import db_path; print(db_path())')"  # resolves to .git/aelfrice/memory.db inside a repo, ~/.aelfrice/memory.db otherwise, or AELFRICE_DB if set
-aelf onboard /path/to/project   # re-onboard with new config
-```
-
-Project-level locks, manually inserted beliefs, and feedback history will be lost. For a less destructive cleanup, query the store directly with `sqlite3` and `DELETE` rows that match the noise pattern you've added.
-
-## What this file does NOT do
-
-- **Does not affect retrieval.** The `[noise]` table only runs at onboard time. Once a belief is in the store, retrieval (BM25, L0 locks, the hook) treats it identically regardless of how or whether the noise filter would have flagged it.
-- **Does not affect `aelf lock`, `aelf remember`, or the MCP `aelf:remember` tool.** Manually-asserted beliefs bypass the noise filter — you're explicitly saying "this matters."
-- **Does not affect the harness conflict.** The Claude Code auto-memory write path is governed by the harness directive in `~/.claude/CLAUDE.md`, not by this file. See [LIMITATIONS § Harness conflict](LIMITATIONS.md#harness-conflict--claude-code-auto-memory-write-path).
-- **Does not affect classifier behaviour.** Candidates that pass the noise filter go to `aelfrice.classification.classify_sentence`, which has its own (non-configurable at v1.0.1) rules for `persist=False`. If a candidate is being dropped and you don't expect it to, check `ScanResult.skipped_non_persisting` before blaming `[noise]`.
-- **Does not retroactively re-filter.** See above.
-- **Does not redefine the four categories.** You can disable them, not modify what they match. To filter on a custom rule, use `exclude_words` or `exclude_phrases`. If you need true regex semantics, you have to extend the module — that is a deliberate constraint, not an oversight.
-- **Does not load from `pyproject.toml`, environment variables, or CLI flags.** Single surface, single file.
+The trade-off vs. `exclude_words`: phrase match is a literal substring, no word boundaries. `["foo"]` here would drop a paragraph containing `foobar`.
 
 ## Worked examples
 
-### Filter a contributor's initials without breaking `json` mentions
-
 ```toml
+# Filter a contributor's initials without breaking `json` mentions
 [noise]
 exclude_words = ["jso"]
 ```
 
-Drops paragraphs naming the contributor `jso`. Leaves docs about `json`, `jsonify`, etc. untouched.
-
-### Let terse beliefs through on a dense rule project
-
 ```toml
+# Let terse beliefs through on a dense rule project
 [noise]
 min_words = 2
 ```
 
-Two-word beliefs ("lock fast", "fail loud") and longer pass; one-word labels ("DRAFT", "INSTRUCTIONS:") still drop.
-
-### Filter templated boilerplate that the default doesn't catch
-
 ```toml
+# Filter templated boilerplate the default doesn't catch
 [noise]
-exclude_phrases = [
-    "Last updated:",
-    "Generated by tool-x",
-    "DO NOT EDIT",
-]
+exclude_phrases = ["Last updated:", "Generated by tool-x", "DO NOT EDIT"]
 ```
 
-These signatures are project-specific and the default filter doesn't know about them. Adding them here keeps the store free of the auto-stamped lines.
-
-### Disable a category for a license-heavy project
-
 ```toml
+# License-heavy project (a legal-tech tool, an OSS-compliance app)
 [noise]
 disable = ["license"]
 ```
 
-Useful if your project's documentation discusses licenses substantively (a legal-tech project, an OSS-compliance tool). The default would filter genuine prose containing the license preamble phrases; disabling lets it through.
+## When changes apply
 
-### Combine all four
+Edits apply on the next `aelf onboard` run. They do not retroactively re-filter beliefs already in the store — config controls ingestion, not retention.
 
-```toml
-[noise]
-disable = ["headings"]
-min_words = 3
-exclude_words = ["jso", "internal-codename"]
-exclude_phrases = ["TODO:", "FIXME"]
+To remove existing noise: drop and re-onboard.
+
+```bash
+rm "$(python -c 'from aelfrice.cli import db_path; print(db_path())')"
+aelf onboard /path/to/project
 ```
 
-A power user with strong opinions. Keeps headings (maybe their docs use heading-only paragraphs as semantic markers), tightens the fragment threshold, filters internal terminology, and drops dev-marker lines. All four take effect simultaneously.
+Locks, manually inserted beliefs, and feedback history will be lost. For a less destructive cleanup, query the store with `sqlite3` and `DELETE` rows that match.
 
-## Defaults reference
+## What this file does not do
 
-If you write `[noise]` with no fields, you get the v1.0.1 ship behaviour — same as not having a config file at all:
+- Does not affect retrieval. The filter only runs at onboard time.
+- Does not affect `aelf lock` or `aelf:lock`. Manually-asserted beliefs bypass the noise filter.
+- Does not redefine the four built-in categories. You can disable them, not modify what they match. Use `exclude_words` / `exclude_phrases` for custom rules.
+- Does not load from `pyproject.toml`, env vars, or CLI flags.
 
-| Field | Default |
+## Resilience
+
+If the file is malformed, unreadable, or contains wrong-typed values, the filter degrades silently to defaults rather than failing the onboard. Failures trace to stderr.
+
+| Failure | Behaviour |
 |---|---|
-| `disable` | `[]` (all four categories enabled) |
-| `min_words` | `4` |
-| `exclude_words` | `[]` |
-| `exclude_phrases` | `[]` |
-
-## Resilience contract
-
-If `.aelfrice.toml` is malformed (invalid TOML), unreadable (permission error), or contains wrong-typed values for known fields, the noise filter degrades silently to defaults rather than failing the onboard run. Failures are traced to stderr so a power user debugging can see them; a casual user is not blocked.
-
-Specifically:
-
-- Malformed TOML → defaults loaded, `malformed TOML in <path>: <error>` to stderr.
-- Wrong-typed field (e.g. `min_words = "three"`) → that field defaults, `ignoring [noise] <field>` to stderr; other fields still load.
-- Non-string entry in a string-list field → that entry skipped with a warning, list still loads.
-- Unknown field → silently ignored (forward-compat for future schema additions).
-- Missing file → defaults loaded, no warning.
+| Malformed TOML | defaults loaded, `malformed TOML in <path>` to stderr |
+| Wrong-typed field | that field defaults, `ignoring [noise] <field>` to stderr |
+| Non-string entry in a list field | that entry skipped, list still loads |
+| Unknown field | silently ignored (forward-compat) |
+| Missing file | defaults loaded, no warning |
 
 ## See also
 
-- [COMMANDS § `aelf onboard`](COMMANDS.md) — the CLI surface.
-- [ARCHITECTURE § Modules](ARCHITECTURE.md) — `noise_filter.py` placement in the module map.
-- [LIMITATIONS § Onboarding](LIMITATIONS.md) — what's still on the v1.x horizon for onboard behaviour.
-- The module docstring in `src/aelfrice/noise_filter.py` — same schema, slightly more terse, with the regex internals exposed for contributors.
+- [COMMANDS § `onboard`](COMMANDS.md) — the CLI surface.
+- [ARCHITECTURE § Modules](ARCHITECTURE.md) — where `noise_filter.py` sits.
+- [LIMITATIONS § Onboarding scope](LIMITATIONS.md) — what's still on the horizon for onboard behaviour.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,293 +1,197 @@
-# INSTALL
+# Install
 
 ## Prerequisites
 
-- Python 3.12 or 3.13
-- Either `pip` (works) or [`uv`](https://docs.astral.sh/uv/) (recommended, used in CI)
+- Python 3.12 or 3.13.
+- [`uv`](https://docs.astral.sh/uv/) (recommended) or `pip`. `uv` handles the Python version for you.
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code), or any agent that can spawn a hook on `UserPromptSubmit`.
 
-## Install from PyPI
+## 1. Install the package
 
 ```bash
-pip install aelfrice                # core (zero runtime deps)
+pip install aelfrice                # core, zero runtime deps
 pip install "aelfrice[mcp]"         # add the MCP server (fastmcp)
 pip install "aelfrice[archive]"     # add the encrypted-archive uninstall path
 ```
 
-Two console scripts: `aelf` (the CLI) and `aelf-hook` (the Claude Code hook entry-point).
+Or with `uv`:
+
+```bash
+uv tool install aelfrice
+```
+
+Or from source:
+
+```bash
+git clone https://github.com/robotrocketscience/aelfrice.git
+cd aelfrice && uv sync
+```
+
+This installs two console scripts: `aelf` (the CLI) and `aelf-hook` (the hook entry-point Claude Code spawns on each prompt).
 
 Verify:
 
 ```bash
-aelf --version       # prints "aelfrice X.Y.Z"
-aelf health          # prints "brain mode: insufficient_data" on a fresh DB
-which aelf           # confirms which Python env owns the binary
+aelf --version       # aelfrice X.Y.Z
+which aelf           # which env owns the binary
 ```
 
-## Install from source
+## 2. Wire it into Claude Code
 
 ```bash
-git clone https://github.com/robotrocketscience/aelfrice.git
-cd aelfrice
-uv sync                  # core
-uv sync --extra mcp      # add MCP server
-uv sync --extra dev      # add pytest, pyright
+aelf setup
 ```
+
+This is idempotent. Run it again any time you change Python envs or move projects. It writes:
+
+1. **A `UserPromptSubmit` hook** to `settings.json` so each prompt routes through `aelf-hook` for retrieval before the agent sees it.
+2. **A `statusLine` notifier** that surfaces a one-line update banner only when a new release is available (empty otherwise).
+
+Auto-detection picks the right scope and command path:
+
+| Run from… | `--scope` | `--command` |
+|---|---|---|
+| inside a project venv | `project` (writes `<project>/.claude/settings.json`) | `<project>/.venv/bin/aelf-hook` |
+| a `pipx`-installed `aelf` outside any venv | `user` (writes `~/.claude/settings.json`) | first `aelf-hook` on `$PATH` |
+| a venv unrelated to `cwd` | `user` | first `aelf-hook` on `$PATH`, falls back to the active venv |
+
+Override with `--scope user|project` and `--command /abs/path/aelf-hook` when you need to.
+
+## 3. Verify wiring
+
+```bash
+aelf doctor
+```
+
+Walks every `command` in `settings.json` and checks the binary is reachable. Exits 1 on broken entries so CI can gate on it. It also surfaces stale `bash <missing>.sh 2>/dev/null || true` style hooks left over from older installs.
+
+```bash
+aelf health
+```
+
+Runs the structural auditor: orphan threads, FTS5 sync, locked-belief contradictions, corpus volume. Empty store on a fresh project is normal — the warning only fires once the project is at least 7 days old.
+
+## 4. Onboard a project
+
+```bash
+cd <project-root>
+aelf onboard .
+```
+
+Walks the project (filesystem, git log, Python AST) and ingests structural facts as candidate beliefs. Typically under a second on a 50k-LOC project. Re-running is idempotent; it dedupes on `(source, sentence)`.
+
+## 5. Lock the rules you care about
+
+```bash
+aelf lock "never push to main; use scripts/publish.sh"
+aelf lock "all commits SSH-signed with ~/.ssh/id_rrs"
+aelf locked                          # list what's locked
+```
+
+Locked beliefs short-circuit decay and are always returned at L0. They're the ones that survive.
+
+Restart Claude Code. The next prompt that mentions "push" will already have your rules attached.
+
+---
 
 ## Database
 
-SQLite. Resolution order:
+SQLite. Path resolution order:
 
-1. `$AELFRICE_DB` if set (override; use `:memory:` for tests).
-2. `<git-common-dir>/aelfrice/memory.db` when `cwd` is inside a git work-tree (v1.1.0). Two worktrees of one repo share a `--git-common-dir` and therefore one DB. `.git/` is not git-tracked, so the brain graph never crosses the git boundary.
-3. `~/.aelfrice/memory.db` as the fallback for non-git directories.
+1. `$AELFRICE_DB` — explicit override. `:memory:` is honoured (handy for tests).
+2. `<git-common-dir>/aelfrice/memory.db` — when `cwd` is inside a git work-tree (v1.1.0+). Worktrees of one repo share a single DB through `--git-common-dir`. `.git/` is not git-tracked, so the brain graph never crosses the git boundary.
+3. `~/.aelfrice/memory.db` — fallback for non-git directories.
 
-Pin per-project (overriding the chain) with `export AELFRICE_DB=/abs/path/.aelfrice.db` — handy via direnv.
+Pin a project with `export AELFRICE_DB=/abs/path/.aelfrice.db` (works well with `direnv`).
 
 ### Migrating from v1.0.x
 
-If you ran v1.0.x you have a single global DB at `~/.aelfrice/memory.db`. v1.1.0+ resolves per-project under `.git/aelfrice/memory.db`. `aelf migrate` ports beliefs forward (added in v1.1.0, [PR #104](https://github.com/robotrocketscience/aelfrice/pull/104)):
+v1.0.x kept a single global DB at `~/.aelfrice/memory.db`. v1.1.0 resolves per-project. Port beliefs forward with:
 
 ```bash
 cd <project-root>
-aelf migrate              # dry-run; reports what would copy
-aelf migrate --apply      # actually copy filtered beliefs into the project DB
-aelf migrate --apply --all  # copy every belief from the legacy global DB
-aelf migrate --from /alt/path/memory.db --apply  # source override
+aelf migrate                # dry-run; reports what would copy
+aelf migrate --apply        # actually copy filtered beliefs
+aelf migrate --apply --all  # copy every belief from the legacy DB
+aelf migrate --from /alt/path/memory.db --apply
 ```
 
-`aelf migrate` opens the source DB read-only (SQLite `mode=ro` URI) so it can never accidentally write back. Idempotent on re-run. Project-mention filtering (default) restricts the copy to beliefs whose content references the active project's name; `--all` skips the filter.
+`aelf migrate` opens the source DB read-only (SQLite `mode=ro` URI). Project-mention filtering (default) restricts the copy to beliefs that name the active project; `--all` skips it. Idempotent on re-run.
 
 ### Batch ingest of historical sessions
 
-If you have prior Claude Code sessions sitting at `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`, you can backfill them into the active project's belief store with a single batch invocation (added in v1.2.0+; issue [#115](https://github.com/robotrocketscience/aelfrice/issues/115)):
+If you have prior Claude Code sessions sitting at `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`, you can backfill them:
 
 ```bash
-cd <project-root>
-aelf ingest-transcript --batch ~/.claude/projects/                     # ingest everything
-aelf ingest-transcript --batch ~/.claude/projects/ --since 2026-01-01   # only mtime ≥ cutoff
+aelf ingest-transcript --batch ~/.claude/projects/
+aelf ingest-transcript --batch ~/.claude/projects/ --since 2026-01-01
 ```
 
-Auto-detects the JSONL format on a per-line basis: handles both aelfrice's own transcript-logger `turns.jsonl` archives and Claude Code's internal session logs. Idempotent — re-running on the same directory inserts zero new beliefs because `ingest_turn` dedupes per `(source, sentence)`. `aelf setup` prints a one-line hint with the file count and the exact batch command when historical JSONLs are detected during install.
+Auto-detects the JSONL format on a per-line basis (handles both aelfrice's transcript-logger output and Claude Code's internal session shape). Idempotent on re-run.
 
-> **Privacy trade-off.** Session JSONLs may contain pasted secrets, API keys, conversation transcripts, customer data, or anything else you typed at Claude Code in the past. Batch ingestion brings all of that into the local belief graph at `<repo>/.git/aelfrice/memory.db` — same machine, same disk, never leaves the host (no telemetry, no network call), but it does end up in a queryable index. There is no PII scrubber wired into the v1.2 ingest path; secret-stripping during ingestion is a v1.3+ task. Until then, **review the JSONLs before running `--batch` against any directory you wouldn't want re-emitted via retrieval.** Use `--since` to scope to recent sessions if older logs predate your secret-handling discipline.
+> **Privacy.** Session JSONLs may contain pasted secrets, customer data, or anything you typed in chat. Batch ingestion brings all of that into the local belief graph. There is no PII scrubber on the v1.2 ingest path. Review before backfilling.
 
-## Wire into Claude Code
+---
+
+## Optional hooks (v1.2+)
+
+`aelf setup` wires only the `UserPromptSubmit` hook by default. The rest are opt-in:
 
 ```bash
-aelf setup                                        # auto-detect scope + path
-aelf setup --scope user                            # force user-scope (~/.claude/settings.json)
-aelf setup --scope project --project-root .        # force project-scope (.claude/settings.json)
-aelf setup --no-statusline                         # hook only, no statusline
-aelf setup --transcript-ingest                     # opt in to live conversation capture (v1.2+)
-aelf setup --commit-ingest                         # opt in to commit-message ingest (v1.2+)
-aelf unsetup                                       # remove the prompt hook + statusline
-aelf unsetup --transcript-ingest                   # remove the transcript-logger hooks too
-aelf unsetup --commit-ingest                       # also remove the commit-ingest hook
-aelf doctor                                        # verify hook commands resolve
+aelf setup --transcript-ingest      # turn-by-turn capture; PreCompact rotates and re-ingests
+aelf setup --commit-ingest          # PostToolUse:Bash hook ingests commit messages
+aelf setup --session-start          # SessionStart hook injects locked beliefs at session boot
+aelf setup --rebuilder              # PreCompact context rebuilder (alpha)
 ```
 
-Idempotent. `aelf setup` wires two things by default:
+Each is independently uninstallable: `aelf unsetup --transcript-ingest`, etc.
 
-1. **`UserPromptSubmit` hook** (`aelf-hook`). Reads each prompt payload, runs retrieval, emits an `<aelfrice-memory>...</aelfrice-memory>` block above the prompt. Every failure mode exits 0 with no output — the hook can't block a prompt.
-2. **`statusLine` notifier** (`aelf statusline`). Prints an orange one-line update banner in the Claude Code statusbar **only when an update is available**, empty otherwise. Reads the cached PyPI check; never makes network calls. Banner disappears automatically once you've upgraded.
+All hooks are non-blocking. Every failure path returns exit 0 — a hook problem must never break a prompt or a commit.
 
-`--transcript-ingest` (v1.2+) additionally wires four hook events (`UserPromptSubmit`, `Stop`, `PreCompact`, `PostCompact`) to the `aelf-transcript-logger` entry point. Each conversation turn lands as one JSONL line in `<git-common-dir>/aelfrice/transcripts/turns.jsonl`; `PreCompact` rotates the log into a sibling `archive/` directory and spawns `aelf ingest-transcript` detached so the turns enter the brain graph as session-tagged beliefs with `DERIVED_FROM` edges between consecutive turns. Sub-10ms per-turn budget; non-blocking on every failure path. Storage stays under `.git/`, which git does not track — transcripts never cross the git boundary. Opt-in at v1.2; the default may flip on once disk-footprint and latency telemetry are in.
-
-`--commit-ingest` (v1.2+) additionally wires a `PostToolUse:Bash` entry to the `aelf-commit-ingest` entry point. After every successful `git commit`, the hook parses the commit message, runs the triple extractor on the prose, and persists the resulting beliefs and edges under a session id derived as `sha256(branch + ":" + commit_hash)[:16]` (stable across re-fires; idempotent against the same commit). Median-latency budget is 30 ms; the hook bails non-blockingly on every failure mode so a `git commit` never feels broken. Opt-in at v1.2; default-flip candidate at v1.3 once production-corpus latency telemetry confirms the budget holds.
-
-### How `aelf setup` picks scope and command path
-
-Without explicit flags, `aelf setup` looks at the active interpreter and current directory and routes the install correctly so the same command works in three layouts:
-
-| You ran `aelf setup` from… | `--scope` resolves to | `--command` resolves to |
-|---|---|---|
-| inside a project venv (e.g. `cd ~/projects/foo && .venv/bin/aelf setup`) | `project` (writes `<project>/.claude/settings.json`) | absolute path: `<project>/.venv/bin/aelf-hook` |
-| a pipx-installed `aelf` outside any project venv | `user` (writes `~/.claude/settings.json`) | first `aelf-hook` on `$PATH` (typically `~/.local/bin/aelf-hook`) |
-| a venv in some other repo | `user` | first `aelf-hook` on `$PATH`, falling back to the active venv |
-
-Effect: when Claude Code is launched in `~/projects/foo`, the `UserPromptSubmit` hook runs that project's venv `aelf-hook`. When launched anywhere else, the global pipx hook runs. No `$PATH` collision, no dangling symlinks, no per-machine scripting needed.
-
-**Recommended setup for working on multiple projects:**
-
-```bash
-pipx install aelfrice                                 # global default lives in ~/.local/bin/
-aelf setup                                            # writes ~/.claude/settings.json -> ~/.local/bin/aelf-hook
-
-cd ~/projects/foo && uv sync                          # project venv
-.venv/bin/aelf setup                                  # writes <project>/.claude/settings.json -> <project>/.venv/bin/aelf-hook
-```
-
-Override either resolution at any time with explicit `--scope` / `--command`.
-
-`aelf setup` also silently removes the legacy `/usr/local/bin/aelf{,-hook}` symlinks if they point at a deleted target — these were written by older install scripts and otherwise shadow a healthy `pipx`-managed `aelf` on `$PATH`. Real files and live symlinks are never touched.
-
-### `aelf doctor`
-
-Run after any setup (or at any time) to verify wiring. Walks `~/.claude/settings.json` and `<cwd>/.claude/settings.json` (when present), inspects every hook command and the top-level `statusLine`, and reports any program token whose absolute path is missing or whose bare name isn't on `$PATH`. Exits `1` when at least one broken command is found, so you can gate CI on it.
-
-```bash
-aelf doctor                                  # scan both scopes
-aelf doctor --user-settings /tmp/test.json   # explicit user settings file
-aelf doctor --project-root /path/to/repo     # explicit project root
-```
-
-Composition with an existing `statusLine`:
-
-| Existing command shape | What `aelf setup` does |
-|---|---|
-| empty / not configured | install standalone `aelf statusline` |
-| already `aelf statusline` (any form) | idempotent no-op |
-| simple existing command (e.g. `echo my-bar`) | append ` ; aelf statusline 2>/dev/null` to it |
-| complex (`\|`, `<<`, `&&`, `\|\|`, `` ` ``, `\`) | left untouched, hint printed to stderr |
-
-`aelf unsetup` reverses surgically: drops the `statusLine` field if it's just ours, strips the `; aelf statusline ...` suffix to restore the original command otherwise.
+---
 
 ## Update notifier
 
-Every `aelf <cmd>` invocation and every `UserPromptSubmit` hook fire kicks off a TTL-gated **fire-and-forget** background check against `https://pypi.org/pypi/aelfrice/json`. The result lands at `~/.cache/aelfrice/update_check.json`. Cache is good for 24 hours; subsequent calls within the window are no-ops.
-
-Opt out:
-
 ```bash
-export AELF_NO_UPDATE_CHECK=1     # disables the check globally
-```
-
-When the cache says an update is available you'll see two things:
-
-1. The orange `⬆ aelfrice X.Y.Z available, run: aelf upgrade │ ` snippet in your Claude Code statusline (if wired).
-2. The same banner printed to stderr after most `aelf` CLI commands. Skipped for `aelf upgrade`, `aelf uninstall`, and `aelf statusline` so it doesn't double-print or stomp on machine-readable output.
-
-To upgrade:
-
-```bash
-aelf upgrade           # prints the right pip-upgrade line for this env
+aelf upgrade           # prints the right pip-upgrade line for your env
 aelf upgrade --check   # yes/no, no command line printed
 ```
 
-`aelf upgrade` detects venv vs pipx vs system and adjusts:
+`aelf upgrade` detects venv vs pipx vs system and tells you the line. It does not run pip itself — replacing the running interpreter mid-process is unreliable on Windows.
 
-| Context | Command emitted |
-|---|---|
-| pipx-managed install | `pipx upgrade aelfrice` |
-| generic venv (incl. `uv venv`, conda) | `pip install --upgrade aelfrice` |
-| system / user-site | `pip install --user --upgrade aelfrice` |
+The orange statusline banner appears automatically when an update is available. Disable with `export AELF_NO_UPDATE_CHECK=1`.
 
-When an update is available, the output also shows the wheel's published SHA-256 plus the PyPI release URL so you can hash-pin the install:
+---
 
-```bash
-pip install aelfrice==1.2.3 --hash=sha256:abc123…  # pip-side strong integrity
-```
+## Uninstall
 
-pip already verifies SHA-256 on every download against PyPI's JSON API; surfacing the hash here just lets the security-conscious user feed it into `--require-hashes` mode if they want.
-
-## Wire into Codex / generic MCP hosts
-
-Don't run `aelf setup` — that writes Claude-specific entries. Register the server directly:
-
-```json
-{
-  "mcpServers": {
-    "aelfrice": {
-      "command": "aelf",
-      "args": ["serve"]
-    }
-  }
-}
-```
-
-Or, from a checkout: `["uv", "run", "--project", "/abs/path/to/aelfrice", "python", "-m", "aelfrice.mcp_server"]`. The `[mcp]` extra is required. Tools register under `aelf:*`.
-
-## Run the benchmark
+You must pick a disposition for the DB:
 
 ```bash
-aelf bench
+aelf uninstall --keep-db              # leave the DB in place (safe default)
+aelf uninstall --archive backup.aenc  # encrypt to file then delete
+aelf uninstall --purge                # permanently delete (three confirmation gates)
+pip uninstall aelfrice                # finally remove the wheel
 ```
 
-Prints a single JSON document with `hit_at_1` / `hit_at_3` / `hit_at_5` / `mrr` and `p50_latency_ms` / `p99_latency_ms` against a deterministic 16-belief × 16-query corpus. `--db PATH` to use a real DB; `--top-k N` to override hit-depth.
+`--archive` uses Fernet (AES-128-CBC + HMAC, scrypt-derived key). Recover later:
 
-## Development
-
-```bash
-uv sync --extra dev
-uv run pytest                # ~530 tests, ~7s
-uv run pyright               # strict
-uv run pytest -m regression  # cumulative integration scenarios
+```python
+from aelfrice.lifecycle import decrypt_archive
+open("out.db","wb").write(decrypt_archive("backup.aenc","password"))
 ```
+
+Requires the `[archive]` extra.
+
+---
 
 ## Troubleshooting
 
 | Symptom | Fix |
 |---|---|
-| `aelf: command not found` | run via `uv run aelf …` or `pipx install aelfrice` |
-| `ModuleNotFoundError: fastmcp` | `pip install "aelfrice[mcp]"` |
-| `unable to open database file` | parent dir of `$AELFRICE_DB` doesn't exist |
-| Hook registered, no memory block | DB is empty — run `aelf onboard <project>` |
-| MCP tools not visible in host | restart the host — MCP servers load at launch |
-| Hook silently fails outside a project venv | run `aelf doctor` — most likely a stale absolute path or bare `aelf-hook` not on `$PATH`. Re-run `aelf setup` from the matching install context |
-| Wrong project's memory shows up in another project | each project should have its own `.claude/settings.json`. From inside the project venv: `.venv/bin/aelf setup` (auto-routes to project scope) |
-
-## Uninstall
-
-aelfrice ships an explicit teardown command. You **must** pick exactly one of `--keep-db`, `--purge`, or `--archive PATH` so the brain-graph SQLite DB doesn't get accidentally lost or accidentally retained. The command operates on the resolved DB path for the current `cwd` (see [§ Database](#database) for the resolution chain).
-
-```bash
-aelf uninstall --keep-db                           # safe default for review
-aelf uninstall --archive ~/aelf-backup.aenc        # encrypt then delete
-aelf uninstall --purge                              # permanently delete (gates fire)
-pip uninstall aelfrice                              # finally, remove the wheel
-```
-
-Verification:
-
-```bash
-aelf --version 2>&1 | grep -q aelfrice || echo "wheel removed"
-# Resolve DB path for current cwd, then test it:
-DB=$(uv run python -c "from aelfrice.cli import db_path; print(db_path())")
-test -f "$DB" && echo "db still there at $DB" || echo "db gone"
-```
-
-### `--keep-db`
-
-DB preserved at the resolved path. The default also runs `unsetup` so the Claude Code hook + statusline are removed from `~/.claude/settings.json`. Pass `--keep-hook` if you want to keep those wired (e.g. you plan to reinstall and skip onboarding).
-
-### `--archive PATH`
-
-Encrypts the DB to PATH and deletes the original. Format:
-
-```
-8 bytes:   "AELFENC1" magic
-16 bytes:  scrypt salt
-remainder: Fernet-encrypted SQLite bytes (AES-128-CBC + HMAC-SHA256)
-```
-
-Key derivation: `scrypt(password, salt, N=2**14, r=8, p=1, len=32)`, base64-urlsafe-encoded for Fernet. The salt is embedded so only the password is needed for recovery — no metadata to remember.
-
-Password input:
-
-```bash
-aelf uninstall --archive PATH                       # interactive prompt (twice, must match)
-echo -n "secret" | aelf uninstall --archive PATH --password-stdin
-```
-
-Never pass the password on argv — it would leak via `ps` / `/proc/cmdline`.
-
-Recovery later:
-
-```python
-from aelfrice.lifecycle import decrypt_archive
-data = decrypt_archive(Path("/tmp/aelf-backup.aenc"), "secret")
-Path("/tmp/restored.db").write_bytes(data)
-# Now AELFRICE_DB=/tmp/restored.db aelf search "..." works.
-```
-
-Wrong password raises `cryptography.fernet.InvalidToken`. Requires `pip install 'aelfrice[archive]'`; without the extra, the CLI prints a clear install hint and exits non-zero.
-
-### `--purge`
-
-Permanently deletes the resolved DB. Three gates fire before deletion:
-
-1. The `--purge` flag must be passed explicitly. Default behavior is an error pointing at `--help`.
-2. Print the target path + size, then require the user to type `PURGE` verbatim (case-sensitive).
-3. Final `[y/N]` confirmation.
-
-`--yes` skips prompts (1)–(3). It does **not** auto-pass `--purge`. There is no env-var override for the `--purge` flag; if you want to script unattended teardown you must explicitly add both `--purge --yes`.
+| `aelf: command not found` | Confirm `~/.local/bin` (pipx) or `<venv>/bin` is on `$PATH`. |
+| Hook fires but no `<aelfrice-memory>` block appears | `aelf doctor` — usually the hook command points at a deleted script. |
+| `aelf doctor` says "skipped (shell metacharacters)" on a hook line | Stale install. `aelf setup` rewrites the hook in place. |
+| Two worktrees of the same repo see the same beliefs | Working as designed — they share `--git-common-dir`. Pin one with `AELFRICE_DB`. |
+| `aelf search` returns "store is empty" | Run `aelf onboard .` from the project root. |
+| `SQLite database is locked` under heavy concurrent writes | v1.1.0+ uses WAL + `busy_timeout=5000`. If you still see it, file an issue with the repro. |

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,144 +1,66 @@
 # Limitations
 
-aelfrice at v1.0 ships the surface but has gaps the v1.x line is closing. Library, CLI, MCP server, and benchmark harness are stable (~530 tests passing at v1.0; ~1090 at v1.1.0). The end-to-end Claude Code injection path and the feedback-into-retrieval loop are partially complete.
+What aelfrice doesn't do yet. Tracked openly.
 
-## Known issues at v1.0
+## The big one: feedback doesn't drive ranking
 
-Tracked openly. Each item is mapped to its target version below.
+`apply_feedback` updates `(α, β)` and writes an audit row. The posterior mean is exposed via `aelf stats` and the MCP. But L1 retrieval still orders hits by `bm25(beliefs_fts)` alone, not by posterior.
 
-| Bucket | Theme | Lands |
-|---|---|---|
-| **v1.0.1** | launch fix-up — hook layer + onboard noise + regression baseline | patch |
-| **v1.1.0** | project identity + onboard behavior + cosmetic surface | minor |
-| **v1.2.0** | commit-ingest hook + hook perf + seed files | minor |
-| **v1.3** | retrieval wave (HRR + LLM classification + cross-project federation) | minor, 6-9 wks |
-| **v2.0** | full benchmark suite (LoCoMo, MAB, LongMemEval) + feature parity with the legacy v3 codebase | major |
+Concretely: marking a belief `harmful` weakens its math, but the next retrieval that matches its keywords will still surface it. Ranking that consumes the posterior lands in the v1.3 retrieval wave.
 
-### Feedback in retrieval (the big one) — v1.3
+The benchmark harness ships at v1.0 as the measurement instrument. It is not yet a proof of the feedback claim.
 
-**Posterior `α` / `β` does not currently drive retrieval ranking.** `store.search_beliefs` orders L1 hits by `bm25(beliefs_fts)` only. So `apply_feedback` updates the math (and the audit log) but doesn't yet move what the agent sees. The synthetic benchmark harness ships at v1.0 as the measurement instrument; the v1.3 retrieval wave wires the posterior into ranking, which is the precondition for claiming feedback drives accuracy.
+## No semantic similarity
 
-### Hook layer — v1.0.1
+Retrieval is BM25 keyword search over FTS5 (porter unicode61 stemming). "deploy" will not surface "publish to prod" without tokenizable substring overlap.
 
-- ✅ **`aelf --version` (v1.0.1).** Prints `aelf <__version__>` and exits 0. Short-circuits the required-subcommand check via argparse's standard version action.
-- **The `aelf-hook` UserPromptSubmit hook may return empty results despite a populated FTS5 index.** Hook fires; no `<aelfrice-memory>` block appears. Workaround: drop to CLI.
-- ✅ **Hook records retrievals as feedback events (v1.0.1).** The `aelf-hook` UserPromptSubmit entry-point now routes through `aelfrice.hook_search.search_for_prompt`, which wraps `aelfrice.retrieval.retrieve()` and writes one `feedback_history` row per returned belief, tagged `source='hook'` with valence `HOOK_RETRIEVAL_VALENCE` (0.1) and `propagate=False` so implicit retrieval-time exposure does not pressure-walk locked beliefs. The "feedback updates the math" loop is closed on the retrieval side; ranking still uses BM25 only at v1.0.1 (the v1.3 retrieval wave wires posterior into ranking).
+This is a deliberate scope choice, not a roadmap item. Adding embeddings would break determinism end-to-end — see [PHILOSOPHY § Determinism is the property](PHILOSOPHY.md#determinism-is-the-property). The principled response to fuzzy semantic recall queries is to pair aelfrice with a separate tool, not blend embeddings into the retrieval path.
 
-### Onboarding — v1.0.1 + v1.1.0
+## Onboarding scope
 
-- ✅ **Noise filter wired into synchronous onboard (v1.0.1).** New `aelfrice.noise_filter.is_noise(text, config)` predicate runs on every candidate before classification. Drops markdown heading blocks, checklist blocks, three-word fragments, and license-header boilerplate (seven canonical signatures). `ScanResult.skipped_noise` reports how many candidates were filtered per scan. A paragraph that *mixes* heading-or-checklist with prose is preserved — only pure structural runs are filtered. Power-user configurable via a single `.aelfrice.toml` file at the project root (or any ancestor) — full schema, worked examples, and what each setting affects in [CONFIG.md](CONFIG.md). No regex anywhere in the user-facing schema.
-- ✅ **Onboard performance regression test (v1.0.1).** New `tests/regression/test_onboard_perf_50k_loc.py` generates a synthetic ~55k-LOC project (250 .py files of 200 lines + 60 .md/.rst/.txt docs of 50 lines + 10 `__init__.py` files) and asserts `scan_repo` finishes in under 60s wall clock. Marked `regression` so the default fast suite runs it; per-test `timeout(120)` overrides the default 5s pytest timeout. Held against the `:memory:` store so disk-write contention does not skew the measurement. Current measured time: ~0.8s on Apple Silicon — the budget is a regression alarm, not a target.
-- ✅ **Onboard git-recency weighting (v1.1.0, [#94](https://github.com/robotrocketscience/aelfrice/issues/94)).** Scanner records each source file's most-recent git commit date as the belief's `created_at`, so the existing decay mechanism penalises pre-migration content from old branches without a separate ranking pass. One `git log --name-only --pretty=format:%aI` call per scan. PR [#103](https://github.com/robotrocketscience/aelfrice/pull/103).
-- **No promotion path from `agent_inferred` to `user_validated`.** Beliefs from onboard stay `agent_inferred` unless explicitly locked. Designed in v1.1.0 ([promotion_path.md](promotion_path.md), [#95](https://github.com/robotrocketscience/aelfrice/issues/95)); implemented in v1.2.0.
+The CLI scanner walks three sources: prose files (`*.md`, `*.rst`, `*.txt`, `*.adoc`), `git log`, and Python AST. Not yet wired: JavaScript / TypeScript / Rust / Go ASTs.
 
-### Feedback semantics — v1.0.1
-
-- ✅ **Contradiction tie-breaker (v1.0.1).** New `aelfrice.contradiction` module: `resolve_contradiction(store, a_id, b_id)` picks a winner per precedence — `user_stated` (lock_level=user) > `user_corrected` (type=correction) > `document_recent` (everything else). Ties within a class break by `created_at` recency; final tiebreak by belief id (deterministic). Inserts a SUPERSEDES edge from winner to loser and writes one `feedback_history` row tagged `source='contradiction_tiebreaker:<rule>'`. `aelf resolve` (CLI) sweeps all unresolved CONTRADICTS edges in the store. Idempotent — re-running the command on a resolved store does no edge work but writes no audit rows either. The fourth class named in the original spec (`agent_inferred`) requires a `Belief.origin` field not in the v1.0 schema; in practice no v1.0 path produces beliefs that map to it, so v1.0.1 collapses to three classes. v1.1.0 adds the `origin` field alongside project-identity work and the four-class split becomes faithful.
-
-### Project identity — v1.1.0
-
-- ✅ **Per-project DB resolution (v1.1.0, [#88](https://github.com/robotrocketscience/aelfrice/issues/88)).** v1.0.x shipped a single global DB at `~/.aelfrice/memory.db` shared across every project on the machine — onboarding repo A and repo B writes both projects' beliefs into one file. v1.1.0 introduces a resolution chain in `cli.db_path()`: `$AELFRICE_DB` (override, honoured even inside a git repo) → `<git-common-dir>/aelfrice/memory.db` (when `cwd` is inside a git work-tree; resolved via `git rev-parse --path-format=absolute --git-common-dir`, so worktrees of one repo share one DB) → `~/.aelfrice/memory.db` (legacy global fallback for non-git dirs). `.git/` is not git-tracked, so the brain graph never crosses the git boundary. `aelf migrate` ([#93](https://github.com/robotrocketscience/aelfrice/issues/93)) ports beliefs from the legacy global store into per-project stores. Fresh clones intentionally start with an empty store — the brain graph stays on the machine it was written on (see [§ Sharing or sync of brain-graph content](#sharing-or-sync-of-brain-graph-content)); bootstrap a clone with `aelf onboard .`.
-
-### Cosmetic — v1.1.0
-
-- ✅ **`edges` → `threads` user-facing rename (v1.1.0, [#92](https://github.com/robotrocketscience/aelfrice/issues/92)).** All user-facing surfaces (CLI output labels, slash command descriptions, COMMANDS.md, MCP.md prose) now use `threads`. The internal SQLite schema, the `Edge` Python dataclass, and the `EDGE_*` type constants are unchanged. The MCP `aelf:stats` tool emits **both** `edges` and `threads` keys with the same integer value for the v1.1.0 deprecation window; `edges` is removed in v1.2.0. Same for `aelf:health.features.edge_per_belief` / `thread_per_belief`. Clients should migrate to `threads` now. The `auditor.CHECK_ORPHAN_EDGES` constant is kept as a deprecated alias of `CHECK_ORPHAN_THREADS` for v1.0 importer compatibility; removed in v1.2.0.
-- ✅ **`aelf health` rewritten as graph auditor (v1.1.0, [#100](https://github.com/robotrocketscience/aelfrice/pull/100)).** `health` now runs a real auditor (orphan threads, FTS5 sync, locked-belief contradictions; corpus-volume warning added in [#116](https://github.com/robotrocketscience/aelfrice/issues/116)) and exits 1 on structural failures so CI can gate on it. The v1.0 regime classifier is preserved as `aelf regime`. `aelf status` is an alias for `aelf health` (not a separate "counts snapshot" — that responsibility lives in `aelf stats`).
-
-### Auto-capture — v1.2.0
-
-- **No commit-ingest PostToolUse hook.** Beliefs accumulate only on explicit `onboard` / `lock` / `feedback`. v1.2.0 adds an automatic capture path so the graph grows during normal sessions.
-- **Seed files for git-tracked knowledge bootstrapping.** `.aelfrice/seed.md` committed to a repo, auto-ingested on first onboard. v1.2.0.
-
-### Harness conflict — Claude Code auto-memory write path
-
-**Behavior.** When `aelfrice` is installed alongside Claude Code's built-in file-based auto-memory system, the harness directive routes any "save a memory" intent to its own file-based store (under `.claude/projects/.../memory/*.md` plus a `MEMORY.md` index), not to the `aelfrice` MCP server. The MCP server stays connected and remains queryable for retrieval, but it does not receive new beliefs from normal session activity. New beliefs only enter the `aelfrice` store via explicit tool calls (`aelf remember`, `aelf onboard`, MCP `aelf:remember`) or bulk import.
-
-**Why this is a limitation.** The README's central claim is that `apply_feedback` is the endpoint that makes `aelfrice` distinct from plain RAG: a memory which actually applies feedback should outperform one that doesn't. If the MCP receives no new beliefs during a conversation, then `apply_feedback` is firing against a snapshot written at install time (or at the most recent explicit `aelf onboard` / `aelf remember` call), not against beliefs the agent forms during current work. The feedback loop is intact mathematically but starved of fresh inputs.
-
-**v1.0.1 partial mitigation.** v1.0.1 closes the retrieval-side of the loop: the `UserPromptSubmit` hook records every retrieval as a `feedback_history` row tagged `source='hook'`, and `apply_feedback` moves posteriors based on actual hook-driven retrievals. This means even without a new write path, beliefs already in the store are exercised by feedback during normal use. The write path itself remains gated by the harness directive at v1.0.1.
-
-**Workaround today.** To make the `aelfrice` MCP the canonical write path, edit your `~/.claude/CLAUDE.md` to remove or rephrase the auto-memory harness directive, and rely on `aelf remember` (CLI) or the MCP `aelf:remember` tool for new beliefs. This is a user-side configuration change; `aelfrice` does not attempt to override the harness in code.
-
-**v1.2.0 mitigation.** The transcript-ingest, commit-ingest, and SessionStart hooks (all opt-in via `aelf setup --transcript-ingest --commit-ingest --session-start`) write to aelfrice from normal session activity without involving the auto-memory directive. The two stores coexist as parallel pipelines; aelfrice is no longer starved of fresh inputs. See [HARNESS_INTEGRATION.md](HARNESS_INTEGRATION.md) for the three coexistence modes (default coexistence, aelfrice-canonical, aelfrice-only) and a migration recipe for moving existing `~/.claude/projects/<slug>/memory/*.md` content into aelfrice via `aelf onboard`.
-
-## Deferred to v1.3 / v2.0 (with evidence required)
-
-These existed in the legacy v2.0 codebase. Each will be reintroduced with a benchmark, an experiment, or a clear use case justifying inclusion.
-
-- **v1.3 retrieval wave:** HRR / vocabulary bridging, multi-hop graph retrieval, LLM-Haiku classification (~$0.005/session), cross-project knowledge federation (#109).
-- **v2.0:** full academic benchmark suite (LoCoMo, MAB, LongMemEval, StructMemEval, AmaBench) + the `wonder`, `reason`, `core`, `unlock`, `delete`, `confirm` commands. Snapshot / timeline / evolution / diff tools. Obsidian export/sync. Vector embeddings and ANN are NOT planned for v2.0 — `aelfrice` stays SQLite + FTS5 by default at every milestone in this list.
-
-## Out of scope by design
-
-Some properties are **not** v1.x gaps to close — they are scope choices that follow from aelfrice's architectural commitments. Listed here so users evaluating the project know what it is *not* trying to be.
-
-### Multi-session aggregation / counting / fuzzy semantic recall
-
-aelfrice's retrieval is BM25 lexical plus a typed graph walk. This is the right substrate for known-item search over behavioural directives — the core design target — and it has known limitations on aggregative or counting queries spanning many sessions ("how many times did the user mention X across last quarter?", "summarise all my preferences about testing"). On benchmarks like LongMemEval multi-session, embedding-based systems will outperform aelfrice on this query category, and that is a real performance gap on those queries.
-
-The principled response is **not** to add embeddings as a fallback retrieval path. Doing so would break the determinism contract documented in [PHILOSOPHY § Determinism is the property](PHILOSOPHY.md#determinism-is-the-property): one non-deterministic retrieval step destroys bit-level reproducibility, named-rule traceability, and write-log historical reconstruction for every result the system returns, not just the embedding-routed ones. The trade is structurally bad — the deterministic guarantees are the property that makes the entire system valuable for high-stakes deployment, and they hold compositionally only.
-
-The principled response **is** one of:
-
-1. **Improve the lexical layer for aggregative cases.** Detect aggregative query intent at Layer 0 (structural query analysis) and route to a specialised handler that operates over the deterministic store: SQL aggregations over `feedback_history`, scoped graph walks, time-bucketed COUNT queries.
-2. **Document the scope choice.** This section. aelfrice is for behavioural directive recall, lock enforcement, and correction memory — not for general-purpose long-context QA over conversational history.
-3. **Pair aelfrice with a separate tool when the use case demands fuzzy semantic recall.** The two have different trust profiles and different deployment stories; pairing them is fine, blending them inside a single retrieval pipeline is not.
-
-### General-purpose long-context QA
-
-aelfrice is not optimised for "answer arbitrary questions over a large conversation history." That is the LLM-with-RAG-and-summary-buffer task. aelfrice is optimised for *the agent doesn't forget the rule you gave it*. These are different problems with different success criteria; separating them is the cleaner architectural stance.
-
-### Probabilistic retrieval-relevance
-
-Retrieval relevance is computed deterministically from BM25 scores plus typed-edge weights. There is no learned re-ranker, no neural relevance model, and no fine-tuning path. Relevance quality is improved by: better tokenisation, better Layer 0 query analysis, better edge inference at write time. None of these introduce non-determinism into the retrieval path.
-
-### Sharing or sync of brain-graph content
-
-aelfrice ships no mechanism for exporting, syncing, or distributing memory contents between users, machines, or projects. The brain graph stays on the machine it was written on. There is no `aelf seed export`, no `.aelfrice/seed/` git-tracked directory, no cross-machine sync, no team-shared store, and no cross-project federation in the default install or any planned release.
-
-This is a scope choice, not a missing feature. The local-only contract is what makes aelfrice's privacy, determinism, and audit guarantees meaningful:
-
-- **Privacy.** A brain graph derived from real session activity contains absolute filesystem paths, hostnames, internal URLs, identifiers from git config, project-internal architecture details, names from commit history, and content the agent inferred from chat context. None of that is suitable for cross-machine or cross-user distribution by default, and no per-belief allowlist mechanism is reliable enough to make automated export safe by construction.
-- **Determinism.** Every state of the store must be reproducible from its local write log. Importing curated content from another store breaks the property that the local write log is the single source of truth.
-- **Audit.** Every retrieval result must be traceable to the locally-recorded events that produced it. Imported content has no local provenance and breaks the audit chain.
-
-The principled response **is** one of:
-
-1. **Bootstrap new collaborators with `aelf onboard .`** — re-extract from the repo's prose, git log, and AST on each new clone. This produces a graph derived from the publicly visible repo content only; nothing private leaks.
-2. **Lock rules in CLAUDE.md, CONTRIBUTING.md, or other repo-tracked prose.** The onboarding scanner picks them up. The repo file is the source of truth; the brain graph is one machine's local index of it.
-3. **Pair aelfrice with a separate tool when the use case demands shared memory.** A tool that distributes memory contents has a fundamentally different trust profile and deployment story. Mixing the two inside aelfrice would weaken aelfrice's guarantees for the use cases it does serve well.
-
-This applies to the v2.0.0 release also: there is no "cross-project shared store," "shared scopes," or federation primitive on any planned release.
-
-## Surface limits at v1.0
-
-- **Retrieval is keyword only.** No stemming beyond porter+unicode61. No synonym expansion. "deploy" won't surface "publish to prod" without a tokenizable substring overlap.
-- **One DB at a time.** No multi-project query. Use `AELFRICE_DB` to scope per-project.
-- **Onboarding is shallow.** Three sources: prose, git log, Python AST. JS/TS/Rust/Go AST parsing not yet wired.
-- **Classifier is regex-based on the CLI path.** Only the polymorphic MCP onboard uses host-LLM classification.
-- **No bulk operations.** No batch lock, no `delete <pattern>`, no merge.
-- **No edit.** Wrong belief → insert corrected one with `SUPERSEDES` edge; original stays.
-- **No graph viz.** Inspect with `sqlite3 "$(python -c 'from aelfrice.cli import db_path; print(db_path())')"`.
-
-## Performance caveats
-
-- **`aelf bench` ships, but it's a small harness** (16 beliefs × 16 queries). Useful for regression on retrieval mechanics; not yet a real-world workload.
-- **FTS5 ranking is BM25 only.** Confidence does not currently weight retrieval order — see the "feedback in retrieval" gap above.
-- **Valence propagation walks BFS** to 3 hops, threshold 0.05. Cheap on thousands of beliefs; not measured at much larger scale.
+Classification on the CLI path is regex-based. Higher-quality classification requires the MCP `aelf:onboard` polymorphic flow, which routes through the host LLM.
 
 ## Sharp edges
 
-- **Locks are stronger than you may expect.** Fresh lock = `(α, β) = (9.0, 0.5)`. Five contradictions required to auto-demote. If you lock a wrong rule and only correct it once or twice, the lock keeps winning. `aelf demote <id>` drops it immediately.
-- **CONTRADICTS edges drive demotion pressure.** If your graph has no CONTRADICTS edges (the regex classifier rarely produces them), pressure won't accumulate — only manual contradicting feedback does.
-- **Jeffreys prior reads as 0.5.** A new belief with no feedback reports posterior mean exactly `0.5` — that means "no evidence yet," not "coin-flip true."
-- **`aelf onboard` is non-incremental on duplicates.** Re-runs are idempotent; existing beliefs aren't re-scored or refreshed.
+- **Locks are durable.** Fresh lock = `(α, β) = (9.0, 0.5)`. Five independent contradicting feedback events are required to auto-demote. If you lock a wrong rule and correct it only once or twice, the lock keeps winning. `aelf demote <id>` drops it immediately.
+- **`CONTRADICTS` edges drive demotion pressure.** The regex classifier rarely produces them, so demotion pressure accumulates only from manual feedback unless you wire commit-ingest or transcript-ingest.
+- **Jeffreys prior reads as 0.5.** A belief with no feedback reports posterior mean exactly `0.5`. That means "no evidence yet," not "coin-flip true."
+- **`aelf onboard` is non-incremental on duplicates.** Re-runs are idempotent; existing beliefs are not re-scored or refreshed.
+- **No bulk operations.** No batch lock, no `delete <pattern>`, no merge.
+- **No edit.** A wrong belief is corrected by inserting a new one with a `SUPERSEDES` edge; the original stays.
+- **No graph viz.** Inspect with `sqlite3 "$(python -c 'from aelfrice.cli import db_path; print(db_path())')"`.
+- **JSONL batch ingest has no PII scrubber.** `aelf ingest-transcript --batch ~/.claude/projects/` will pull whatever you typed in chat into the local belief graph. Review before backfilling.
+
+## Out of scope
+
+These are scope choices that follow from aelfrice's commitments. They are *not* roadmap items.
+
+### Sharing, sync, or federation
+
+aelfrice ships no mechanism for exporting, syncing, or distributing memory contents between users, machines, or projects. The brain graph stays on the machine it was written on.
+
+This is a privacy and audit choice. A graph derived from real session activity contains filesystem paths, hostnames, internal URLs, names from git config, project architecture details, and content the agent inferred from chat. None of that is suitable for cross-machine distribution by default. Per-belief allowlists are not reliable enough to make automated export safe.
+
+To bootstrap a new clone or collaborator: run `aelf onboard .`. The graph is re-extracted from publicly-visible repo content. To share rules: lock them in CLAUDE.md, CONTRIBUTING.md, or other repo-tracked prose, and the onboard scanner picks them up.
+
+### Multi-session aggregation
+
+aelfrice is not optimised for "how many times did the user mention X across last quarter?" queries. That is the LLM-with-RAG-and-summary-buffer task, not a behavioural-directive recall task. On benchmarks like LongMemEval multi-session, embedding systems will outperform aelfrice for that query category.
+
+The principled response is to add aggregative-query routing at the structural-analysis layer (SQL aggregations over `feedback_history`, scoped graph walks, time-bucketed COUNT queries) — not to add embeddings.
+
+### Multi-project query
+
+One DB at a time. Beliefs from project A do not surface in project B (different `.git/` directories). Use `AELFRICE_DB` to scope per-project explicitly.
 
 ## Compatibility
 
-- **Python 3.12+ only.** Uses `Final`, `Self`, structural pattern matching, PEP 695.
-- **No Windows-native testing.** Should work; not exercised on every release.
-- **uv recommended; pip works.**
+- Python 3.12 or 3.13.
+- macOS and Linux are routinely tested. Windows should work but is not exercised on every release.
+- `uv` recommended; `pip` works.
 
-## Where the list grows
+## Reporting
 
-This doc updates each milestone. File issues tagged `limitations` for additions.
+File an issue tagged `limitations` for additions or corrections.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,13 +1,17 @@
-# MCP Tool Reference
+# MCP
 
-aelfrice exposes the same eight retrieval/feedback operations as the CLI through a [Model Context Protocol](https://modelcontextprotocol.io) server. `setup`/`unsetup` are CLI-only.
+aelfrice exposes nine memory tools through a [Model Context Protocol](https://modelcontextprotocol.io) server. The agent calls them mid-turn; you don't have to invoke them yourself.
+
+Lifecycle commands (`setup`, `unsetup`, `migrate`, `doctor`, `upgrade`, `uninstall`) are CLI-only.
+
+## Install + run
 
 ```bash
-uv sync --extra mcp
-uv run python -m aelfrice.mcp_server
+pip install "aelfrice[mcp]"
+uv run python -m aelfrice.mcp_server     # or just `aelf-mcp` after install
 ```
 
-Host config (Claude Code, Codex, any MCP host):
+Host config — Claude Code, Codex, any MCP-capable host:
 
 ```json
 {
@@ -27,35 +31,42 @@ Tools register under the `aelf:` namespace.
 | Tool | Required | Optional | Returns |
 |---|---|---|---|
 | `aelf:onboard` | — | `path`, `session_id`, `classifications` | polymorphic — see below |
-| `aelf:search` | `query` | `budget` (default 2000) | `{kind, n_hits, hits[]}` |
+| `aelf:search` | `query` | `budget` (default 2,000) | `{kind, n_hits, hits[]}` |
 | `aelf:lock` | `statement` | — | `{kind, id, action}` |
 | `aelf:locked` | — | `pressured` | `{kind, n, locked[]}` |
 | `aelf:demote` | `belief_id` | — | `{kind, id, demoted}` |
+| `aelf:validate` | `belief_id` | `source` (default `user_validated`) | `{kind, id, origin, source}` |
 | `aelf:feedback` | `belief_id`, `signal` | `source` | `{kind, id, signal, prior_alpha, new_alpha, prior_beta, new_beta, pressured_locks, demoted_locks}` |
-| `aelf:stats` | — | — | `{kind, beliefs, edges, threads, locked, feedback_events, onboard_sessions_total}` — `threads` is the v1.1.0 alias for `edges` (same integer value); `edges` is **deprecated** and removed in v1.2.0. |
-| `aelf:health` | — | — | `{kind, regime, description, classification_confidence?, features?}` — `features` includes both `edge_per_belief` and `thread_per_belief` (same value) for the v1.1.0 deprecation window; `edge_per_belief` removed in v1.2.0. |
+| `aelf:stats` | — | — | `{kind, beliefs, threads, locked, feedback_events, ...}` |
+| `aelf:health` | — | — | `{kind, regime, description, classification_confidence?, features?}` |
+
+`signal` is `"used"` or `"harmful"`. Validation promotes an `agent_inferred` belief to a user-validated origin tier (v1.2+).
 
 ## `aelf:onboard` polymorphism
 
-Three input shapes dispatched by which fields the caller supplied:
+Three input shapes, dispatched by which fields the caller supplied:
 
 | Input | Phase | Returns |
 |---|---|---|
 | `{path}` | start | `{kind: "onboard.session_started", session_id, sentences[]}` for the host LLM to classify |
-| `{session_id, classifications}` | finish | `{kind: "onboard.session_completed", inserted, skipped_*}` after host posts back classifications |
+| `{session_id, classifications}` | finish | `{kind: "onboard.session_completed", inserted, skipped_*}` |
 | `{}` | status | `{kind: "onboard.status", n_pending, pending_session_ids}` |
 
-Unlike the CLI's regex-based `scan_repo`, the MCP onboard uses the host LLM for higher-quality classification.
+Unlike the CLI's synchronous regex `scan_repo`, the MCP onboard uses the host LLM for higher-quality classification.
 
-## Pure handlers (testing)
+## Pure handlers
+
+Every tool is a pure function `(store, **kwargs) -> dict`. You can call them in tests without `fastmcp`:
 
 ```python
-from aelfrice.store import Store
+from aelfrice.store import MemoryStore
 from aelfrice.mcp_server import tool_search, tool_lock
 
-store = Store(":memory:")
-tool_lock(store, statement="Never push directly to main")
+store = MemoryStore(":memory:")
+tool_lock(store, statement="never push directly to main")
 tool_search(store, query="push", budget=500)
 ```
 
-No `fastmcp` dependency needed for handler-level use.
+## Backward compatibility
+
+`aelf:stats` and `aelf:health` emit both `edges` (the v1.0 schema name) and `threads` (the v1.1.0 user-facing name) with the same integer value during the v1.1.0 deprecation window. `edges` and `edge_per_belief` are removed in v1.2.0; clients should migrate to `threads` and `thread_per_belief`.

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -2,44 +2,54 @@
 
 Design principles. Receipts in the code.
 
-## Files aren't enough
+## From low-context to high-context
 
-Power users converge on the same workaround: externalize state into markdown files. A config for rules. A state file. A roadmap. A decisions log. Then forty-six more, with cross-references that hold only when the agent decides to read them.
+A fresh Claude session is low-context. Every conversation starts from zero: your stack, your conventions, the rule you set last week, the decision you reversed last month. The agent is a new hire on day one, every day. You spend the first ten minutes of every session restating things you've already said.
 
-The failure modes are predictable: the agent reads the rule and ignores it; cross-references break silently after compaction; manual state rots after one missed update; files multiply faster than discipline can maintain them.
+aelfrice changes that. You correct the agent once. You lock the constraint that matters. The next session starts with that context already attached. After a few weeks of small corrections, the agent operates with months of accumulated rules, and you stop noticing the friction is gone.
 
-aelfrice is a different mechanism, not a tidier file layout. It finds context itself and injects it into the prompt before the agent answers. The agent never has to remember to check a file or follow a cross-reference. Knowledge is already there.
+In linguistics this is [high-context communication](https://en.wikipedia.org/wiki/High-context_and_low-context_cultures): three words convey a full procedure because the listener already carries the background. The more sessions you work together, the less you need to explain.
+
+## Files don't solve this
+
+The standard workaround is more markdown. `STATE.md`. `DECISIONS.md`. A CLAUDE.md that cross-references runbooks. Some projects have seven files the agent is *supposed* to follow.
+
+The failure modes are predictable:
+
+- **The agent reads but doesn't follow.** You write "always use the publish script, never push directly." It reads it, acknowledges it, runs `git push` anyway. The rule was in context. The agent treated it as a suggestion.
+- **Cross-references break silently.** "See `docs/deploy-runbook.md` for deployment." The agent skips the reference, or reads the wrong section, or reads it but loses it after compaction. You don't find out until production.
+- **State rots.** State files require discipline. One missed update and downstream sessions operate on stale information.
+- **Files multiply.** What starts as one config becomes five, then ten. Each new failure mode begets a new file.
+
+aelfrice is a different mechanism. The hook injects matched beliefs *as part of your prompt*, before the agent sees it. Nothing voluntary, nothing the agent can skip.
 
 ## Determinism is the property
 
-The architectural commitment that organizes everything else.
+Every retrieval result is a deterministic function of beliefs and rules. Given the same write log and the same code, every retrieval returns the same answer, bit-for-bit, across runs and machines and time.
 
-aelfrice commits to four things, and the commitments interlock:
+Four commitments interlock to make that hold:
 
-1. **Bit-level reproducibility.** Given the same write log and the same code, every retrieval result is bit-identical across runs, machines, and time. No model checkpoint, no learned representation that drifts between releases.
-2. **Named-rule traceability.** Every retrieval result is a function of named beliefs and named rules. Asking *"why did this directive surface for this query?"* produces a chain that bottoms out in specific user actions at specific timestamps via specific extraction patterns. The chain is finite, inspectable, and human-readable at every step.
-3. **Write-log historical reconstruction.** Because the log of writes is the source of truth and the queryable structure is derived, any past state of the system is reconstructible. *"What would the agent have retrieved on this query last March, before that lock was set?"* is an answerable question.
-4. **Audit comprehensible to a non-technical reviewer.** "BM25 matched these terms, which retrieved these beliefs, which were filtered by these locked directives, which were created by these user actions at these timestamps" — the chain holds for a regulator, an auditor, or a user, not just for the developer.
+1. **Bit-level reproducibility.** No embeddings, no learned re-rankers, no LLM in the retrieval path. Replay the write log on the same code; you get the same result.
+2. **Named-rule traceability.** *"Why did this rule surface for this query?"* has a finite answer. It bottoms out in named beliefs, with timestamps, created by named user actions, via named extraction patterns.
+3. **Write-log reconstruction.** The log is the source of truth; the queryable structure is derived. *"What would the agent have retrieved last March, before that lock was set?"* is an answerable question.
+4. **Audit comprehensible to a non-technical reviewer.** "BM25 matched these terms, returned these beliefs, filtered by these locked directives, created by these user actions at these timestamps." The chain holds for an auditor, not just a developer.
 
-These properties hold compositionally only if every component preserves them. A single non-deterministic step in any retrieval path destroys the property for the whole pipeline. There is no "mostly deterministic" — either the property holds end to end or it does not. Embeddings, learned re-rankers, and LLM-driven retrieval steps trade this property for retrieval-quality gains on certain query categories. aelfrice trades the other way, deliberately.
+These hold compositionally. A single non-deterministic step in the retrieval path destroys the property for the whole pipeline. There is no "mostly deterministic" — either it holds end-to-end or it does not.
 
-We are not aware of another agent-memory system that combines all four of these guarantees as a single system property.
+The trade-off is real. Embedding systems beat aelfrice on fuzzy semantic recall and multi-session aggregation. We treat that as a clarification of what aelfrice is for, not a gap to close at the cost of the property.
 
 What it buys, beyond the obvious:
 
-- **Debugging is bounded.** A wrong retrieval is the result of a specific rule that can be identified and fixed. Compare with embedding systems where "wrong result" gets answered with similarity scores.
-- **Provenance composes.** Every belief carries provenance; every retrieval result is a deterministic function of beliefs and rules; every retrieval result therefore inherits provenance from its sources.
-- **Acceptance tests are precise behavioural specifications, not regression detectors with tolerances.**
-- **Counterfactual evaluation becomes tractable.** Replay history with and without specific corrections; measure the differential. Determinism is what makes the differential meaningful.
-- **High-stakes deployment is structurally admitted.** Medical, legal, financial contexts need explainability that survives an audit. Most agent-memory systems are structurally locked out of these settings; aelfrice is structurally admitted.
-
-There are categories of query — multi-session aggregation, fuzzy semantic recall — where the deterministic stack underperforms an embedding system. We treat that as a clarification of what aelfrice is for, not a gap to close at the cost of the property. See [LIMITATIONS](LIMITATIONS.md) for the current scope.
+- **Debugging is bounded.** A wrong retrieval is one specific rule. Compare with embedding systems where "wrong result" gets answered with similarity scores.
+- **Provenance composes.** Every belief carries provenance; every retrieval inherits it.
+- **Counterfactual evaluation is tractable.** Replay history with and without specific corrections. Determinism is what makes the differential meaningful.
+- **High-stakes deployment is structurally admitted.** Medical, legal, financial — domains that need explainability that survives an audit. Most agent-memory systems are structurally locked out; aelfrice is structurally admitted.
 
 ## Bayesian, not vector
 
-Vector RAG remembers documents. It doesn't remember _outcomes_ — which retrievals helped, which hurt, which were corrected. Two beliefs with similar embeddings rank equally even when one has been right ten times and the other was retrieved once and harmful.
+Vector RAG remembers documents. It doesn't remember *outcomes* — which retrievals helped, which hurt, which were corrected. Two beliefs with similar embeddings rank equally even when one has been right ten times and the other was harmful once.
 
-aelfrice scores every belief with a Beta–Bernoulli posterior over feedback events. Twenty lines in `scoring.py`:
+aelfrice scores every belief with a Beta-Bernoulli posterior. Twenty lines:
 
 ```
 posterior_mean = α / (α + β)
@@ -47,9 +57,11 @@ used    ⟹ α += 1
 harmful ⟹ β += 1
 ```
 
-No embedding model. No hyperparameter search. No opaque ranking. Every score is one division and the audit trail is one table. The Bayesian update is itself one of the named rules that traceability bottoms out in.
+No embedding model. No hyperparameter search. No opaque ranking. Every score is one division and the audit trail is one table. The Bayesian update is itself one of the named rules traceability bottoms out in.
 
-The cost: dense semantic similarity is gone. The benefit: a learning loop that converges on what _works for you_, not what's textually similar — and a retrieval pipeline that preserves the determinism property end to end.
+The cost: dense semantic similarity is gone. The benefit: a learning loop that converges on what works *for you*, not what's textually similar — and a retrieval pipeline that preserves determinism end to end.
+
+> At v1.0–v1.2 the posterior is computed and stored, but L1 retrieval still ranks by BM25 alone. The v1.3 retrieval wave wires the posterior into ranking. Until then, feedback updates the audit trail but doesn't yet move what the agent sees. See [LIMITATIONS](LIMITATIONS.md).
 
 ## Locks, not just decay
 
@@ -57,37 +69,39 @@ Pure decay drifts trusted ground-truth toward the prior unless you keep restatin
 
 A user lock short-circuits decay. The function returns `(α, β)` unchanged regardless of age. You don't ping it monthly to keep it alive.
 
-But hard locks ossify. So locks accumulate _demotion pressure_ when contradicting evidence arrives; after enough independent contradictions (default 5), the lock auto-demotes back to a normal belief. Durable when stable, self-correcting when wrong.
+Hard locks ossify, though. So locks accumulate **demotion pressure** when contradicting evidence arrives; after enough independent contradictions (default 5), the lock auto-demotes to a regular belief. Durable when stable, self-correcting when wrong.
 
 ## Local, always
 
-Your corrections live in one SQLite file on your machine. No cloud sync, no telemetry, no API calls in the retrieval path. The cloud LLM at the other end of your prompt sees whatever aelfrice injects — that's inherent. aelfrice limits the slice (default 2000 tokens, scoped to the current query) rather than dumping the whole memory.
+Your corrections live in one SQLite file on your machine. No cloud sync, no telemetry, no API calls in the retrieval path. The cloud LLM at the other end of your prompt sees whatever aelfrice injects — that's inherent — but aelfrice limits the slice (default 2,000 tokens, scoped to the current query) rather than dumping the whole memory.
+
+[PRIVACY.md](PRIVACY.md) for verifiable specifics.
 
 ## Small surface, on purpose
 
-The v1.0 surface is ten operations. Every belief mutation goes through `apply_feedback`. Every lock through one path. There is one writer of `(α, β)`, one place that runs decay, one entry point for retrieval. When the system misbehaves, there is one place to look.
+The v1 surface is small. Every belief mutation goes through `apply_feedback`. Every lock through one path. There is one writer of `(α, β)`, one place that runs decay, one entry point for retrieval. When the system misbehaves, there is one place to look.
 
-The previous codebase (v2.0) had a much bigger surface — thirty MCP tools, `wonder`, `reason`, snapshot/diff. It delivered value but also delivered ambiguity. The rebuild starts narrow on purpose. v1.x reintroduces breadth, each addition with evidence — a benchmark, an experiment, a clear case where the existing operations don't suffice.
+The earlier research line had a much bigger surface — twenty-nine MCP tools, `wonder`, `reason`, snapshot/diff. It delivered value but also delivered ambiguity. The rebuild starts narrow on purpose. v1.x reintroduces breadth, each addition gated on evidence — a benchmark, an experiment, a clear case where the existing operations don't suffice.
 
 ## Pure stdlib
 
-Zero hard dependencies. Python stdlib plus SQLite (which the stdlib already wraps). The optional `[mcp]` extra adds `fastmcp`; nothing else.
+Zero hard runtime dependencies. Python stdlib plus SQLite (the stdlib already wraps it). The optional `[mcp]` extra adds `fastmcp`; nothing else.
 
 Every dependency is maintenance debt and attack surface. Heavier machinery — vector indices, embedding services, neural rerankers — earns its way in only when an experiment shows the existing stack is the bottleneck.
 
 ## What this design buys
 
 - **Continuity.** Close the terminal, come back next week, "where were we?" — the memory restores it.
-- **Compounding (by design).** At v1.0 the graph fills during explicit `onboard`/`lock`/`feedback` calls. v1.0.1 closes the hook→feedback-history loop so retrievals leave an audit trail. v1.2.0 adds the commit-ingest hook for automatic capture. v1.3 wires the posterior into retrieval ranking. See [LIMITATIONS](LIMITATIONS.md#known-issues-at-v10).
-- **Self-correction.** Stale rules decay. Wrong locks demote. The mechanism notices when reality has moved.
-- **Auditability.** Every belief has a content hash and timestamp. Every feedback event has an audit row. Every score is `α / (α + β)`. Every retrieval result is reproducible bit-for-bit from the write log and the code. Read the database; reproduce the system's claims about itself. See [Determinism is the property](#determinism-is-the-property).
+- **Compounding.** At v1.0 the graph fills on explicit `onboard`/`lock`/`feedback`. v1.1 closes the hook→feedback loop. v1.2 adds commit-ingest and transcript-ingest hooks. v1.3 wires the posterior into ranking.
+- **Self-correction.** Stale rules decay. Wrong locks demote.
+- **Auditability.** Every belief has a content hash and timestamp. Every feedback event has an audit row. Every score is `α / (α + β)`. Read the database; reproduce the system's claims about itself.
 - **Locality.** No service to fail, no account to lose, no quota to exceed.
 
 ## What it isn't
 
 - Not a notebook. Not a team knowledge base.
-- Not a vector store. Semantic similarity is not in v1.0 retrieval.
+- Not a vector store. Semantic similarity isn't in v1 retrieval.
 - Not a planner. Decisions belong in your head.
-- Not a replacement for documentation, conventions, or runbooks. Complement.
+- Not a replacement for documentation, conventions, or runbooks. A complement.
 
 A small, sharp tool for one job: keeping the agent that helps you build software from forgetting what you said.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,8 +1,8 @@
-# Privacy
+# Privacy and Security
 
-Verifiable properties of the codebase, not marketing claims.
+Verifiable properties of the codebase, not marketing claims. Each can be confirmed by reading the source.
 
-## Local only
+## Your data never leaves your machine
 
 The store, retrieval, scoring, scanner, and feedback paths run locally against SQLite. No network code in `store.py`, `retrieval.py`, `scoring.py`, `feedback.py`, `scanner.py`, or `cli.py`. Confirm:
 
@@ -10,34 +10,50 @@ The store, retrieval, scoring, scanner, and feedback paths run locally against S
 grep -rE "requests|httpx|urllib|aiohttp|socket\.|http\." src/aelfrice/
 ```
 
-The optional `[mcp]` extra (`fastmcp`) speaks MCP over **stdio** to the host on the same machine. No remote sockets.
+The optional `[mcp]` extra (`fastmcp`) speaks MCP over stdio to the host on the same machine. No remote sockets.
+
+The single exception: the update notifier (`lifecycle.py`) makes one TTL-gated GET to `https://pypi.org/pypi/aelfrice/json` to check for new releases. Disable with `export AELF_NO_UPDATE_CHECK=1`. The notifier never transmits anything; it only reads.
 
 ## No telemetry
 
-There is no usage tracking. No analytics. No phone-home. Not opt-out — **the capability does not exist in the shipped package.** No conditional import, no commented-out endpoint, no env-var toggle. Confirm by reading `pyproject.toml` — only `[mcp]` adds anything beyond stdlib.
+No usage tracking. No analytics. No phone-home. **Not opt-out — the capability does not exist in the shipped package.** No conditional import, no commented-out endpoint, no env-var toggle to enable it. Confirm by reading `pyproject.toml`: only `[mcp]` adds anything beyond stdlib.
 
 ## No accounts
 
-No sign-in, no API key, no sync server. Everything is one local SQLite file. To back up: copy the file. aelfrice ships no mechanism for sharing memory contents between users, machines, or projects — see [LIMITATIONS § Sharing or sync of brain-graph content](LIMITATIONS.md#sharing-or-sync-of-brain-graph-content).
+No sign-in, no API key, no sync server. Everything is one local SQLite file. Back up by copying the file. aelfrice ships no mechanism for sharing memory contents between users, machines, or projects — see [LIMITATIONS](LIMITATIONS.md).
 
-## Data location
+## Per-project isolation
 
-A single SQLite file with WAL journaling. Six tables: `beliefs`, `beliefs_fts`, `edges`, `feedback_history`, `onboard_sessions`, `schema_meta`.
+Each project gets its own DB at `<repo>/.git/aelfrice/memory.db`. Beliefs from project A cannot leak into project B — they live in different `.git/` directories. Worktrees of one repo share a DB through `--git-common-dir`, by design.
 
-Resolution order (v1.1.0):
+`.git/` is not git-tracked. The brain graph never crosses the git boundary.
 
-1. `$AELFRICE_DB` if set (override; use `:memory:` for ephemeral).
-2. `<git-common-dir>/aelfrice/memory.db` when `cwd` is inside a git work-tree. `.git/` is not git-tracked — the brain graph never crosses the git boundary.
-3. `~/.aelfrice/memory.db` for non-git directories.
+Resolution order:
 
-## What aelfrice doesn't control
+1. `$AELFRICE_DB` if set (override; `:memory:` is honoured).
+2. `<git-common-dir>/aelfrice/memory.db` inside any git work-tree.
+3. `~/.aelfrice/memory.db` outside git (legacy fallback).
+
+## You control all writes
+
+- New beliefs from `onboard` and ingest hooks are inserted unlocked. Only an explicit `aelf lock` (or MCP `aelf:lock`) marks something permanent.
+- Lock prior is `(α, β) = (9.0, 0.5)` — durable but not unkillable. Five contradicting feedback events auto-demote the lock.
+- `aelf demote` removes a lock immediately. The belief itself remains; you can also delete it via the store API.
+- Every Bayesian update goes through `apply_feedback` and writes one `feedback_history` audit row. Provenance is queryable.
+
+## What aelfrice does not control
 
 The cloud LLM at the other end of your prompt sees whatever aelfrice injects. That's inherent to using a cloud LLM. Mitigations:
 
-- **Per-query token budget** (default 2000). The full memory is never injected.
-- **L0/L1 ordering** surfaces locks + today's relevance, not a memory dump.
+- **Per-query token budget** (default 2,000). The full memory is never injected.
+- **L0/L1 ordering** surfaces locks plus query-relevant matches, not a memory dump.
+- **Per-project isolation** means cross-project context cannot bleed in.
 
-If a fact must never leave your machine, don't store it.
+If a fact must never leave your machine, do not store it.
+
+## Batch ingest of historical sessions
+
+`aelf ingest-transcript --batch ~/.claude/projects/` pulls existing Claude Code session JSONLs into the local belief graph. Those JSONLs may contain pasted secrets, customer data, or anything you typed in chat. There is no PII scrubber on the v1.2 ingest path. Review before backfilling. Use `--since` to scope to recent sessions if older logs predate your secret-handling discipline.
 
 ## Per-file opt-out: `INEDIBLE` marker (v1.3+)
 
@@ -57,7 +73,11 @@ Mechanism: see [`src/aelfrice/inedible.py`](../src/aelfrice/inedible.py). The pr
 
 ## Reproducible from source
 
-All beliefs come from files you already have: code, docs, git history. After `rm <resolved-db-path>`, re-running `aelf onboard .` is deterministic up to the classifier. The state of the world is your codebase, not the memory.
+All `onboard` beliefs come from files you already have: code, docs, git history. After `rm <resolved-db-path>`, re-running `aelf onboard .` is deterministic up to the classifier. The state of the world is your codebase, not the memory.
+
+## SQLite only
+
+No external database, no vector DB, no cloud storage. WAL journaling for crash safety. Fully rebuildable from your source files plus your lock list.
 
 ## Reporting
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Five minutes from `pip install` to your first feedback loop.
+Five minutes from `pip install` to your first locked rule.
 
 ```bash
 pip install aelfrice
@@ -9,60 +9,78 @@ pip install aelfrice
 ## 1. Onboard
 
 ```bash
-$ aelf onboard ~/projects/my-app
-onboarded: 287 added, 14 skipped (non-persisting), 412 candidates
+$ cd ~/projects/my-app
+$ aelf onboard .
+onboarded .: 287 added, 14 skipped (non-persisting), 412 candidates
 ```
 
-The scanner reads three sources: `.md`/`.rst`/`.txt`/`.adoc` prose, git log, Python AST. Everything else is ignored.
+The scanner reads three sources: `.md` / `.rst` / `.txt` / `.adoc` prose, `git log`, and Python AST. Everything else is ignored. Markdown headings, license boilerplate, and three-word fragments are filtered out.
 
-> v1.0 caveat: the synchronous onboard path's noise filter isn't yet wired. Expect markdown headings and short fragments in the output until v1.x. See [LIMITATIONS](LIMITATIONS.md#known-issues-at-v10).
+## 2. Lock the rules that matter
 
-## 2. Search
+```bash
+$ aelf lock "never push to main; use scripts/publish.sh"
+locked: a1f3c2d09e1b4f7a
+
+$ aelf locked
+[locked] a1f3c2d09e1b4f7a  never push to main; use scripts/publish.sh
+```
+
+Fresh locks start at `(α, β) = (9.0, 0.5)` ≈ 0.95 posterior. They short-circuit decay and always come back at L0.
+
+## 3. Search
 
 ```bash
 $ aelf search "deploy to production"
-[locked] a1f3c2…  Never push directly to main; use scripts/publish.sh
-         91e02d…  scripts/publish.sh wraps gitleaks + PII scan + tag verify
+[locked] a1f3c2d09e1b4f7a  never push to main; use scripts/publish.sh
+         91e02d3c          scripts/publish.sh wraps gitleaks + PII scan + tag verify
 ```
 
-L0 = locked beliefs (always first). L1 = FTS5 BM25 hits, token-budgeted (default 2000).
+L0 (locked) is always returned first. L1 is BM25-ranked FTS5 hits, token-budgeted (default 2,000).
 
-## 3. Lock + feedback
-
-```bash
-$ aelf lock "Never push directly to main; use scripts/publish.sh"
-locked: a1f3c2d09e1b4f7a
-
-$ aelf feedback a1f3c2d09e1b4f7a used
-α 9.0→10.0, β 0.5→0.5
-```
-
-Fresh locks start at `(α, β) = (9.0, 0.5)` ≈ 0.95 confidence. `used` bumps α; `harmful` bumps β. Locks short-circuit decay; auto-demote after 5 contradictions.
-
-> v1.0 caveat: the updated posterior is recorded but doesn't yet drive retrieval ranking. The math is in place; v1.x wires it into ordering.
-
-## 4. Wire it up
+## 4. Wire into Claude Code
 
 ```bash
 $ aelf setup
-installed UserPromptSubmit hook in ~/.claude/settings.json
+installed UserPromptSubmit hook in <project>/.claude/settings.json
 ```
 
-Every prompt to Claude Code is now preceded by an `<aelfrice-memory>` block.
+Restart Claude Code. The next prompt mentioning "deploy" or "push" will already have the locked rule attached as `<aelfrice-memory>` above your message.
 
 ## 5. Inspect
 
 ```bash
 $ aelf stats
-beliefs=287  edges=42  locked=1  feedback_events=1
+beliefs=287  threads=42  locked=1  feedback_events=0  avg_confidence=0.71
 
 $ aelf health
-brain mode: early-onboarding (confidence 0.78)
+audit:
+  [ok ] orphan_threads     all threads resolve to existing beliefs
+  [ok ] fts_sync           FTS5 mirror in sync (287 rows)
+  [ok ] locked_contradicts no unresolved contradictions between locked beliefs
+  [ok ] corpus_volume      287 belief(s) (>= 50; project ~12d old)
 
-$ aelf bench
-{"hit_at_1": 0.875, "hit_at_3": 1.0, ..., "p50_latency_ms": 0.4, ...}
+$ aelf doctor
+scanned user: ~/.claude/settings.json
+summary: 1 ok, 0 broken, 0 skipped
 ```
+
+## 6. Feedback
+
+When a belief proves useful or harmful:
+
+```bash
+$ aelf feedback a1f3c2d09e1b4f7a used
+α 9.0→10.0, β 0.5→0.5
+
+$ aelf feedback 91e02d3c harmful
+α 1.0→1.0, β 0.5→1.5
+```
+
+`used` bumps α; `harmful` bumps β. Five harmful events through `CONTRADICTS` edges to a lock auto-demote it.
+
+> The math is in place at v1.0–v1.2; ranking still uses BM25 only. Posterior weight in retrieval ordering lands in v1.3 — see [LIMITATIONS](LIMITATIONS.md).
 
 ## Next
 
-[COMMANDS](COMMANDS.md) · [MCP](MCP.md) · [SLASH_COMMANDS](SLASH_COMMANDS.md) · [ARCHITECTURE](ARCHITECTURE.md) · [PHILOSOPHY](PHILOSOPHY.md)
+[Install](INSTALL.md) · [Commands](COMMANDS.md) · [Architecture](ARCHITECTURE.md) · [Philosophy](PHILOSOPHY.md)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -16,10 +16,10 @@ How to cut a new version. Maintainer reference.
 5. Update README roadmap status.
 6. Run locally:
    ```bash
-   uv run pytest tests/ -x -q                # ~810 passing at v1.0.2 / ~1090 at v1.1.0
-   uv run pyright src/                        # strict
-   uv run aelf --help                         # spot-check CLI
-   uv build                                   # wheels build clean
+   uv run pytest tests/ -x -q     # ~1,150 passing at v1.2 (track the actual count in CI)
+   uv run pyright src/             # strict
+   uv run aelf --help              # spot-check CLI
+   uv build                        # wheels build clean
    ```
 7. Open PR `release: vX.Y.Z`. Body = CHANGELOG entries.
 8. `staging-gate` must be green: gitleaks, PII pattern scan, history audit, pytest matrix.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,181 +1,128 @@
 # Roadmap
 
-How aelfrice gets from v1.0.0 to v2.0.0, in user-facing terms.
+How aelfrice gets from v1.0 to v2.0.
 
-For per-issue tracking see [LIMITATIONS.md](LIMITATIONS.md). For benchmark adapter activation status see [`benchmarks/README.md`](../benchmarks/README.md). The release log lives in [CHANGELOG.md](../CHANGELOG.md).
+Per-issue tracking: [LIMITATIONS.md](LIMITATIONS.md). Release log: [CHANGELOG.md](../CHANGELOG.md).
 
 ## Origin
 
-aelfrice is a rewrite of [`agentmemory`](http://www.robotrocketscience.com/projects/agentmemory), an earlier research line on Bayesian + graph-backed memory for AI coding agents. The research codebase explored FTS5 keyword retrieval, HRR (Holographic Reduced Representations) vocabulary bridging, BFS multi-hop graph traversal, entity-indexed retrieval, type-aware compression, correction detection, and a multi-tool MCP surface, with published results against MAB, LoCoMo, LongMemEval, StructMemEval, and AMA-Bench.
+aelfrice is a rebuild of an earlier research line on Bayesian + graph-backed memory for AI coding agents. The research codebase explored FTS5 retrieval, vocabulary bridging, BFS multi-hop traversal, entity-indexed retrieval, type-aware compression, correction detection, and a multi-tool MCP surface, with results against MAB, LoCoMo, LongMemEval, StructMemEval, and AMA-Bench.
 
-Public aelfrice **v1.0.0 is the foundation for that surface, not the surface itself.** v1.0 ships a stable core (SQLite store, Beta-Bernoulli scoring, BM25 retrieval, 11-command CLI, 8 MCP tools, Claude Code wiring, a synthetic benchmark harness). The v1.x line recovers the remaining features incrementally with evidence required for each addition. v2.0.0 is the planned feature-parity release with the published claim set.
+aelfrice **v1.0 is the foundation for that surface, not the surface itself.** v1.0 ships a stable core (SQLite store, Beta-Bernoulli scoring, BM25 retrieval, CLI, MCP, Claude Code wiring, a synthetic benchmark harness). The v1.x line recovers the remaining features incrementally with evidence required for each. v2.0 is the planned feature-parity release.
 
-This is a rebuild, not a port. Structural issues that survived agentmemory are being fixed at the foundation layer where each was originally introduced rather than patched forward. The intent is to leave aelfrice in a state where every behavioural claim is backed by a test or a benchmark, with a transparent issue trail for items that are not.
+This is a rebuild, not a port. Structural issues that survived the research line are being fixed at the foundation layer. Every behavioural claim is backed by a test or a benchmark, with a transparent issue trail for items that are not.
 
 ## Versions at a glance
 
 | Version | Status | Theme |
 |---|---|---|
-| v0.1 – v1.0 | shipped | core memory, CLI, MCP, hook wiring, synthetic benchmark, PyPI publish |
-| **v1.0.1** | shipped | launch fix-up — hook→retrieval wiring, onboard noise, `aelf --version` |
-| **v1.0.2** | shipped | per-project install routing, `aelf doctor`, release-docs CI gate |
-| **v1.1.0** | shipped | project identity, edges→threads, status/health split, `aelf migrate`, git-recency onboard |
-| **v1.2.0** | shipped | auto-capture pipeline, `user_validated` promotion, triple extractor, ingest-enrichment schema, `--batch` JSONL ingest, CLI consolidation, `INEDIBLE` per-file opt-out |
-| **v1.3.0** | planned | retrieval wave — entity index + BFS multi-hop + LLM classification |
-| **v1.4.0** | planned | context rebuilder — automatic PreCompact-driven retrieval-curated context |
-| **v2.0.0** | planned | feature parity with the earlier research line + full benchmark reproducibility |
+| v1.0.x | shipped | core memory, CLI, MCP, hook wiring, install routing, contradiction tie-breaker |
+| **v1.1.0** | shipped | per-project DBs, `aelf migrate`, `edges`→`threads` rename, `aelf health` rewrite |
+| **v1.2.0** | shipped | auto-capture pipeline (transcript-ingest, commit-ingest, SessionStart), `agent_inferred → user_validated` promotion, triple extractor, `--batch` JSONL ingest, CLI consolidation, `INEDIBLE` per-file opt-out |
+| **v1.3.0** | planned | retrieval wave — entity index + BFS multi-hop + LLM classification + posterior-weighted ranking |
+| **v1.4.0** | planned | context rebuilder — PreCompact retrieval-curated continuation |
+| **v2.0.0** | planned | feature parity with the research line + benchmark reproducibility |
 
-## v1.0.0 — shipped
+## What shipped
 
-See [CHANGELOG.md § v1.0.0](../CHANGELOG.md) for the full surface. In one paragraph: SQLite-backed Belief / Edge store with FTS5 BM25 search; Beta-Bernoulli confidence with type-specific decay and lock-floor short-circuit; L0 (locked) + L1 (FTS5) retrieval at a 2000-token budget; `apply_feedback` endpoint with audit log and demotion-pressure auto-demote; onboarding scanner with three extractors (filesystem walk, git log, Python AST); 11-command CLI; 8-tool MCP server (under the `[mcp]` optional extra); Claude Code `UserPromptSubmit` hook wiring; reproducible synthetic regression harness (`aelf bench`); academic benchmark adapter scaffolds (inert at v1.0 — see [`benchmarks/README.md`](../benchmarks/README.md) for the activation schedule).
+### v1.0.x — surface
 
-## v1.0.1 — launch fix-up
+Stable core: SQLite + FTS5 store, Beta-Bernoulli scoring, L0+L1 retrieval at a 2,000-token budget, `apply_feedback` with audit log, onboarding scanner (filesystem + git log + Python AST), CLI, MCP server, Claude Code hook wiring, synthetic benchmark harness, contradiction tie-breaker (`aelf resolve`), per-project install routing (`aelf doctor`), release-docs CI gate.
 
-The first patch closes the highest-visibility gaps from launch. Each item is tracked in [LIMITATIONS.md § known issues at v1.0](LIMITATIONS.md#known-issues-at-v10).
+### v1.1.0 — project identity
 
-- **Hook layer.** Replace the `UserPromptSubmit` hook's inline FTS5 shim with a thin `hook_search` module (`search_for_prompt` + `record_retrieval`). The hook routes through `aelfrice.retrieval.retrieve()` and writes a `feedback_history` row tagged `source='hook'` for every retrieval. Closes the loop between hook-time retrievals and the Bayesian feedback math.
-- **Onboard noise filter.** A dedicated module that removes Markdown headings, checklist items, three-word fragments, and license-header boilerplate before they enter as candidate beliefs.
-- **Onboard performance.** A regression test verifying < 60s on a 50k-LOC project.
-- **Contradiction tie-breaker.** Default precedence `user_stated > user_corrected > document_recent > agent_inferred`, with ISO timestamp as the deciding fallback. The loser is auto-superseded; the audit row records which rule fired.
-- **`aelf --version`.** Reads from `aelfrice.__version__`. Trivial, but currently raises an argparse error.
-- **Query result cache.** A bounded LRU cache wrapping `aelfrice.retrieval.retrieve()`, keyed on a canonicalized form of `(query, token_budget, l1_limit)` and invalidated on every store mutation. Skips a full L0+L1 pass when an agent loop re-issues the same query. Spec: [`lru_query_cache.md`](lru_query_cache.md).
+- Per-project DB resolution: `<git-common-dir>/aelfrice/memory.db` inside any git work-tree, falls back to `~/.aelfrice/memory.db` outside.
+- `aelf migrate` ports beliefs from the legacy global store. Read-only on the source.
+- Worktree concurrency tested under WAL + `busy_timeout=5000`.
+- `aelf health` rewritten as the structural auditor (orphan threads, FTS5 sync, locked contradictions). v1.0 regime classifier preserved as `aelf regime`. `aelf status` aliases `aelf health`.
+- `edges` → `threads` user-facing rename. Internal schema unchanged. Deprecation window covered both keys.
+- Onboard git-recency weighting: `belief.created_at` is the source file's most recent commit, so decay penalises stale branches.
+- `agent_inferred → user_validated` promotion path designed (implemented in v1.2).
 
-## v1.0.2 — install routing + release guardrails
+### v1.2.0 — auto-capture and triple extraction
 
-Second patch. Two threads:
+- **Commit-ingest hook.** `PostToolUse:Bash` ingests every successful `git commit` through the triple extractor under a deterministic git-derived session id. Densely populates `Edge.anchor_text`, `Belief.session_id`, and `DERIVED_FROM` edges. Wired via `aelf setup --commit-ingest`.
+- **Transcript-ingest hook.** Four-event hook captures every conversation turn to `<root>/.git/aelfrice/transcripts/turns.jsonl`; `PreCompact` rotates and ingests. Closes the harness-conflict gap that previously starved the MCP of new beliefs from normal sessions.
+- **Triple extractor.** Pure regex over six relation families (`SUPPORTS`, `CITES`, `CONTRADICTS`, `SUPERSEDES`, `RELATES_TO`, `DERIVED_FROM`). Reusable by every prose-ingesting caller.
+- **`agent_inferred → user_validated` promotion.** New `Belief.origin` column with seven tier values. `aelf validate <id>` graduates onboard-derived beliefs without requiring a lock.
+- **SessionStart hook.** Injects locked beliefs as `<aelfrice-baseline>` once per session.
+- **Ingest enrichment schema.** `DERIVED_FROM` edges, `anchor_text`, `session_id`, real `sessions` table. Forward-compatible with v1.0 stores.
+- **`aelf ingest-transcript --batch DIR [--since DATE]`.** Backfill historical Claude Code session JSONLs into the local belief graph. Auto-detects transcript-logger and Claude Code session formats.
+- **CLI consolidation + `INEDIBLE` per-file opt-out.** v1.3 prep: surface tightened, per-file privacy marker added.
+- **Harness integration guide.** Three operational modes for coexisting with Claude Code's auto-memory directive.
 
-- **Per-project install routing + `aelf doctor`.** `aelf setup` auto-detects scope (`project` if `cwd/.venv` matches the active interpreter, else `user`) and writes an absolute `aelf-hook` path so one machine can route per-project venvs to their own hook alongside a global `pipx`-installed fallback without bare-name `$PATH` collisions. `aelf doctor` is a settings linter that scans user- and project-scope `settings.json` for hook + statusline commands whose program token doesn't resolve, exits `1` on findings so it can gate CI. Closes [#81](https://github.com/robotrocketscience/aelfrice/issues/81).
-- **Release-docs CI gate + post-release docs sweep.** The v1.0.1 cut shipped to PyPI with the README roadmap row still saying `v1.0.1 | next`. New `staging-gate.yml` `release-docs-check` job enforces, on any version-bump PR, that `CHANGELOG.md` has the matching `[X.Y.Z]` section + compare-link footnote and that `README.md` has no roadmap row marking the released version as `next` / `planned`. New `post-release-docs-issue.yml` opens a tracking issue on `release.published` for second-order docs the gate can't verify (RELEASING.md test counts, ROADMAP.md narrative).
+## Planned
 
-## v1.0.3 — contradiction tie-breaker + onboard perf + CONFIG.md
-
-Third patch. Three feature PRs and a docs PR landed between v1.0.2 and v1.0.3, surfaced to PyPI as v1.0.3. See [CHANGELOG § v1.0.3](../CHANGELOG.md#103---2026-04-27) for the full surface.
-
-- **Contradiction tie-breaker.** New `aelfrice.contradiction` module (`resolve_contradiction`, `find_unresolved_contradictions`, `auto_resolve_all_contradictions`). When the graph holds a `CONTRADICTS` edge, the tie-breaker picks a winner via precedence (`user_stated > user_corrected > document_recent`; ties broken by recency, then id), creates a `SUPERSEDES` edge from winner to loser, and writes a `feedback_history` audit row tagged `source='contradiction_tiebreaker:<rule>'`. v1.0.x collapses to three precedence classes; the fourth `agent_inferred` class needs a `Belief.origin` field that lands in v1.1.0. PR [#75](https://github.com/robotrocketscience/aelfrice/pull/75).
-- **`aelf resolve` CLI subcommand (12th).** Sweeps unresolved `CONTRADICTS` edges and runs the tie-breaker on each. Matching `slash_commands/resolve.md`; the 1:1 CLI ↔ slash invariant is preserved at 12/12. PR [#75](https://github.com/robotrocketscience/aelfrice/pull/75).
-- **Onboard performance regression test.** `tests/regression/test_onboard_perf_50k_loc.py` asserts `scan_repo` finishes in under 60s on a synthetic ~55k-LOC project (250 .py + 60 doc files), held against the `:memory:` store. Current measured time ~0.8s on Apple Silicon; the 60s budget is a regression alarm, not a target. PR [#76](https://github.com/robotrocketscience/aelfrice/pull/76).
-- **`docs/CONFIG.md`.** Power-user reference for `.aelfrice.toml` — full schema, worked examples, and what each setting affects. Linked from the noise-filter LIMITATIONS entry, the onboard CLI help, and ARCHITECTURE.md. PR [#74](https://github.com/robotrocketscience/aelfrice/pull/74).
-
-Release cut: PR [#97](https://github.com/robotrocketscience/aelfrice/pull/97).
-
-## v1.1.0 — project identity and cosmetic surface
-
-Minor release. Eight PRs landed between v1.0.3 and v1.1.0. See [CHANGELOG § v1.1.0](../CHANGELOG.md) for the full surface.
-
-- ✅ **Per-project DB resolution.** v1.0.x shipped a single global DB at `~/.aelfrice/memory.db` shared across every project on the machine. v1.1.0 lands a resolution chain: `$AELFRICE_DB` (override) → `<git-common-dir>/aelfrice/memory.db` (when `cwd` is inside a git work-tree) → `~/.aelfrice/memory.db` (non-git fallback). Worktrees of one repo share one DB via the git-common-dir. `.git/` is not git-tracked — the brain graph never crosses the git boundary. Shipped at [#88](https://github.com/robotrocketscience/aelfrice/issues/88) / PR [#96](https://github.com/robotrocketscience/aelfrice/pull/96).
-- ✅ **`aelf migrate` from legacy global store.** One-shot copy from `~/.aelfrice/memory.db` (the v1.0 single global DB) into the active project's `.git/aelfrice/memory.db`. Dry-run by default; `--apply` writes. `--all` skips the project-mention filter. Idempotent. PR [#104](https://github.com/robotrocketscience/aelfrice/pull/104).
-- ✅ **Worktree concurrency tests + `busy_timeout=5000`.** Multiple worktrees share one `.git/aelfrice/memory.db` without corruption under WAL mode + the new busy_timeout. PR [#102](https://github.com/robotrocketscience/aelfrice/pull/102).
-- ✅ **`aelf health` rewritten as diagnostic auditor.** Replaces the v1.0 regime classifier output (preserved as `aelf regime`). Reports credal gap, orphan threads, thread type counts, feedback coverage, FTS5 sync, locked-belief contradictions. Exits 1 on structural failures (orphan threads, FTS5 mismatch, locked-belief contradictions); informational metrics stay exit 0. `aelf status` aliases `aelf health`. PR [#100](https://github.com/robotrocketscience/aelfrice/pull/100).
-- ✅ **`edges` → `threads` user-facing rename.** All user-facing surfaces use "threads"; internal schema, `Edge` dataclass, and `EDGE_*` type constants unchanged. MCP `aelf:stats` emits both `edges` and `threads` keys for one minor; `edges` removed in v1.2.0. PR [#105](https://github.com/robotrocketscience/aelfrice/pull/105).
-- ✅ **Onboard git-recency weighting.** Scanner records source file's most-recent git commit date as `belief.created_at`, so the existing decay mechanism penalises pre-migration content from old branches. One `git log --name-only --pretty=format:%aI` call per scan. PR [#103](https://github.com/robotrocketscience/aelfrice/pull/103).
-- ✅ **`agent_inferred` → `user_validated` promotion path designed.** [docs/promotion_path.md](promotion_path.md) — schema bump, conservative backfill, flag-only flip mechanism, `aelf validate` surface, tie-breaker slot. Implementation lands in v1.2.0. PR [#101](https://github.com/robotrocketscience/aelfrice/pull/101).
-- **Query result cache.** A bounded LRU cache wrapping `aelfrice.retrieval.retrieve()`, keyed on a canonicalized form of `(query, token_budget, l1_limit)` and invalidated on every store mutation. Skips a full L0+L1 pass when an agent loop re-issues the same query. Spec: [`lru_query_cache.md`](lru_query_cache.md). Shipped pre-v1.1.0 in [#69](https://github.com/robotrocketscience/aelfrice/pull/69).
-
-## v1.2.0 — auto-capture and triple extraction
-
-- ✅ **Commit-ingest `PostToolUse` hook** ([commit_ingest_hook.md](commit_ingest_hook.md)). PostToolUse:Bash hook that turns each successful `git commit` into a triple-extraction ingest under a deterministic git-derived session id. The first ingest path that densely populates `Edge.anchor_text`, `Belief.session_id`, and `DERIVED_FROM` edges in production data. Wired via `aelf setup --commit-ingest`; opt-in at v1.2 (default-on candidate at v1.3 once latency telemetry confirms the budget holds). Writes are local-only — the hook never crosses the git boundary or any network boundary.
-- ✅ **Ingest enrichment schema** ([ingest_enrichment.md](ingest_enrichment.md)). `DERIVED_FROM` edge type, `anchor_text` on edges, `session_id` on beliefs plus a real `sessions` table. Forward-compatible with v1.0 stores via idempotent `ALTER TABLE`. Producers (transcript-ingest, commit-ingest, triple-extraction) populate the new fields.
-- ✅ **Transcript-ingest hooks.** A four-event hook (`UserPromptSubmit` + `Stop` + `PreCompact` + `PostCompact`) appends every conversation turn to a per-project `<root>/.git/aelfrice/transcripts/turns.jsonl` log; the `PreCompact` rotation triggers `ingest_jsonl()` which lowers each turn into the brain graph as beliefs and edges. Closes the harness-conflict write-path gap (the MCP no longer depends on the harness's auto-memory directive to receive new beliefs from normal session activity) and densifies production data with `session_id` and `DERIVED_FROM` edges from real conversations. Writes land under `.git/aelfrice/`, which git does not track — transcripts and ingested beliefs never cross the git boundary. Wired via `aelf setup --transcript-ingest` (opt-in at v1.2; default flip pending telemetry). Required prerequisite for the v1.4.0 context rebuilder.
-- ✅ **Triple-extraction port** ([triple_extractor.md](triple_extractor.md)). Pure-regex `extract_triples` + side-effecting `ingest_triples` over six relation families (active and passive forms). All triple-derived beliefs share a canonical id space; `anchor_text` is populated from the citing prose. Reusable by every prose-ingesting caller in v1.2+ and by the v1.3.0 entity-index path. Migration is forward-compatible against v1.0 stores — existing rows continue to read.
-- ✅ **`agent_inferred → user_validated` promotion** ([promotion_path.md](promotion_path.md)). Onboard-derived beliefs can graduate to user-validated via `aelf validate <id>` (CLI) or `aelf:validate` (MCP) under explicit user action, without being re-locked. New `Belief.origin` column with seven tier values; v1.0/v1.1 stores migrate forward via `ALTER TABLE` plus a one-shot backfill (locked → `user_stated`, correction → `user_corrected`, rest stay `unknown`). Provenance flip only — alpha/beta unchanged on promotion. Reversible via `aelf demote` which flips `user_validated` back to `agent_inferred` (one tier per call: lock first, then validation). Contradiction tie-breaker expands to five classes (`user_stated > user_corrected > user_validated > document_recent > agent_inferred`); `lock_level=user` short-circuits to `user_stated` so locks always win regardless of origin. Audit rows under `promotion:` source prefix.
-- ✅ **`docs/HARNESS_INTEGRATION.md`** ([HARNESS_INTEGRATION.md](HARNESS_INTEGRATION.md)). User-facing operational guide covering the auto-memory + aelfrice coexistence story. Documents three modes (default coexistence; aelfrice-canonical with a small `~/.claude/CLAUDE.md` edit; aelfrice-only after disabling auto-memory) and a migration recipe (`aelf onboard ~/.claude/projects/<slug>/memory`) for users who want existing `.md` content brought into the brain graph as `agent_inferred` beliefs. Rewrites [LIMITATIONS.md § harness conflict](LIMITATIONS.md) to point to the v1.2.0 hook mitigation instead of the v1.0/v1.1 manual workaround.
-- **First academic benchmark activations.** `mab_triple_adapter` activates in `benchmarks/`.
-
-## v1.3.0 — retrieval wave
+### v1.3.0 — retrieval wave
 
 This is the release where retrieval moves beyond BM25-only.
 
-- **Entity-index retrieval.** The L2.5 entity-index from the earlier research line ports forward, including the regex extraction patterns. Reproduces the multi-hop chain-valid target from published baselines on the MAB benchmark.
-- **BFS multi-hop graph traversal.** Edge-type-weighted graph walks layer on top of FTS5 hits. Bounded depth, bounded budget.
-- **LLM-classification onboard path.** A Haiku-backed classifier becomes an opt-in alternative to the regex classifier. Cost is documented per-session in the published claims.
-- **Bayesian-weighted ranking — partial.** Retrieval scoring begins to incorporate posterior confidence on top of BM25. The full feedback-into-ranking eval lands in v2.0.0.
-- **Benchmark activations.** `mab_entity_index_adapter` and `mab_llm_entity_adapter` activate in `benchmarks/`.
+- **Entity-index retrieval.** L2.5 entity-index ports forward, including the regex extraction patterns.
+- **BFS multi-hop graph traversal.** Edge-type-weighted graph walks layered on top of FTS5 hits. Bounded depth, bounded budget.
+- **LLM-classification onboard path.** Haiku-backed classifier as an opt-in alternative to the regex classifier.
+- **Posterior-weighted ranking (partial).** Retrieval scoring begins to incorporate `α / (α+β)` on top of BM25. Full feedback-into-ranking eval lands at v2.0.0.
 
-## v1.4.0 — context rebuilder
+### v1.4.0 — context rebuilder
 
-The release that makes long-running sessions cheaper without a visible seam to the user.
+Long-running sessions cheaper without a visible seam.
 
-- **`PreCompact`-driven context rebuild.** When the harness signals an approaching context limit, an aelfrice hook intercepts and queries the brain graph for the highest-value beliefs against the tail of the session transcript. The rebuild emits as `additionalContext`: locked beliefs first, then session-scoped beliefs from the same `session_id`, then BM25 / posterior-weighted hits, packed to a configurable token budget. The user's next prompt is answered against a leaner, retrieval-curated working set instead of the harness's generic compaction summary.
-- **Augment mode at v1.4.0.** The hook augments the harness's default compaction; both summaries land in the new context. Suppress mode (replacing the harness's compaction entirely) is parked as a v2.x candidate gated on continuation-fidelity evidence.
-- **Trigger modes.** Manual (`/aelf-rebuild` slash command) ships first as the explicit testing surface. Threshold mode (auto-fire at a configurable fraction of the model's window) ships with calibration data — the default threshold is derived from the eval harness, not hardcoded. Dynamic mode (heuristic-driven trigger) is gated on showing it tracks fidelity better than a fixed threshold.
-- **Continuation-fidelity eval harness.** A new harness in `benchmarks/context-rebuilder/` replays captured transcripts, forces a midpoint clear, runs the rebuilder, and measures: (a) fraction of post-clear turns where the agent's answer matches the original session's answer, (b) rebuild block size as a fraction of the full-replay baseline, (c) PreCompact hook latency. Headline regression band: ≥80% continuation fidelity at ≤30% token cost on the v1.0.0 baseline. Higher targets land at v1.5.x and v2.0.0.
-- **Hard prerequisites.** v1.2.0 transcript-ingest (the rebuilder reads `<root>/.git/aelfrice/transcripts/turns.jsonl`) and the v1.2.0 `session_id` schema addition.
-- **Soft prerequisites.** v1.3.0 partial Bayesian-weighted ranking improves rebuild quality; without it the rebuilder ships against BM25-only retrieval.
+- **PreCompact-driven rebuild.** When the harness signals an approaching context limit, an aelfrice hook queries the brain graph for the highest-value beliefs against the session tail and emits them as `additionalContext`. Locked beliefs first, then session-scoped, then BM25 / posterior-weighted hits, packed to a configurable token budget.
+- **Augment mode.** The hook augments the harness's compaction; both summaries land in the new context. Replace mode is parked for v2.x.
+- **Trigger modes.** Manual (`/aelf-rebuild`) ships first; threshold mode ships with calibration data.
+- **Continuation-fidelity eval.** `benchmarks/context-rebuilder/` replays captured transcripts, forces a midpoint clear, runs the rebuilder, and measures continuation fidelity vs. the full-replay baseline.
 
-The central claim of v1.4.0: long-running sessions use less context per steady-state turn without measurable continuation regression. The eval harness is what makes that claim falsifiable.
+Hard prerequisites: v1.2 transcript-ingest, v1.2 `session_id` schema. Alpha shipped in v1.2.0a0.
 
-## v2.0.0 — feature parity and reproducibility
+### v2.0.0 — feature parity and reproducibility
 
-The release that re-anchors every published claim. After v2.0.0, the benchmark harness in `benchmarks/` reproduces the headline numbers on a fresh clone with `uv sync && aelf bench all`, within documented tolerance bands.
+After v2.0.0, `benchmarks/` reproduces every published headline number on a fresh clone with `uv sync && aelf bench all`, within documented tolerance bands.
 
-- **HRR vocabulary bridge.** Closes the vocabulary-gap-recovery claim against a corpus checked into the repository.
-- **Type-aware compression.** Tokens-per-belief reductions on retrieved output. Reproduces the published compression ratio on a fixed input corpus.
-- **Intentional clustering.** Co-locating related beliefs in the graph for higher retrieval coherence on multi-fact queries.
-- **Correction-detection eval.** A five-codebase labeled fixture, scored by both the zero-LLM detector and the LLM-judge path. Reproduces the published 92% / 99% targets.
-- **Bayesian feedback drives ranking.** The full feedback-into-retrieval loop. The 10-round MRR uplift eval and ECE calibration scorer are part of this release.
-- **Expanded MCP surface and CLI.** `wonder`, `reason`, `core`, `unlock`, `delete`, `confirm`, plus graph-metrics and document-linking tools that exist in the earlier research line.
-- **Reproducibility harness.** `benchmarks/results/v2.0.0.json` is the canonical results file; CI runs the academic suite nightly (Haiku) and on each tag (Opus, manual approval).
+- HRR vocabulary bridge — closes the vocabulary-gap-recovery claim against a corpus checked into the repo.
+- Type-aware compression — tokens-per-belief reductions on retrieved output.
+- Intentional clustering — co-locating related beliefs for higher coherence on multi-fact queries.
+- Correction-detection eval — five-codebase labeled fixture, scored by both the zero-LLM detector and the LLM-judge path.
+- Posterior drives ranking, end to end. The 10-round MRR uplift eval and ECE calibration scorer ship with this release.
+- Expanded surface: `wonder`, `reason`, `core`, `unlock`, `delete`, `confirm`, plus graph-metrics and document-linking.
+- Reproducibility harness: `benchmarks/results/v2.0.0.json` is canonical; CI runs the academic suite nightly.
 
-## What is being recovered, in detail
+## Recovery inventory
 
-The earlier research line implemented these modules. They are not in v1.0.0; each is queued for the version listed below. The names are working titles for the public ports — the implementation is being re-validated rather than copied.
+What the research line had, when each piece returns:
 
 | Capability | Public version |
 |---|---|
-| Triple extraction (`triple_extraction`) | v1.2.0 |
-| Commit-ingest `PostToolUse` integration (`commit_tracker`) | v1.2.0 |
-| Transcript-ingest hooks + `ingest_jsonl()` (`transcript_ingest`) | v1.2.0 |
-| Context rebuilder + continuation-fidelity eval (`context_rebuilder`) | v1.4.0 |
-| Graph metrics + status/health split (`graph_metrics`) | v1.1.0 |
-| Entity-index retrieval (regex + entity patterns) | v1.3.0 |
+| Triple extraction | v1.2.0 |
+| Commit-ingest hook | v1.2.0 |
+| Transcript-ingest + `ingest_jsonl()` | v1.2.0 |
+| `agent_inferred → user_validated` promotion | v1.2.0 |
+| Context rebuilder + continuation eval | v1.4.0 (alpha in v1.2) |
+| Graph metrics + status/health split | v1.1.0 |
+| Entity-index retrieval | v1.3.0 |
 | BFS multi-hop graph traversal | v1.3.0 |
 | LLM-Haiku onboard classifier | v1.3.0 |
-| Hook-driven retrieval audit (`hook_search`) | v1.0.1 |
-| Update-check / `aelf --version` (`update_check`) | v1.0.1 |
-| Onboard noise filter (`noise_filter`) | v1.0.1 |
-| HRR vocabulary bridge (`hrr`) | v2.0.0 |
-| Type-aware compression (`compression`) | v2.0.0 |
-| Doc / semantic linker (`doc_linker`, `semantic_linker`) | v2.0.0 |
-| Full edge-type vocabulary (`SUPPORTS`, `TESTS`, `IMPLEMENTS`, `TEMPORAL_NEXT`, `POTENTIALLY_STALE`, `DERIVED_FROM`) | v1.2.0 partial; v2.0.0 complete |
-| Relationship detector / supersession (`relationship_detector`, `supersession`) | v1.2.0 partial; v2.0.0 complete |
-| Wonder / reason / core / unlock / delete / confirm CLI commands | v2.0.0 |
-| Correction-detection module (production path) | v1.2.0 |
-| Correction-detection eval corpus | v2.0.0 |
+| Posterior-weighted ranking | v1.3.0 (partial) / v2.0.0 (full) |
+| HRR vocabulary bridge | v2.0.0 |
+| Type-aware compression | v2.0.0 |
+| Doc / semantic linker | v2.0.0 |
+| `wonder` / `reason` / `core` / `unlock` / `delete` / `confirm` | v2.0.0 |
 
-## Built fresh, not copied
+## Compatibility
 
-The rewrite is fixing the following structural issues at the foundation rather than patching them forward.
+aelfrice follows semver:
 
-- **No per-project DB identity.** v1.0 shipped a single global DB at `~/.aelfrice/memory.db` shared across every project on the machine; onboarding repo A and repo B mixed their beliefs in one file. Fixed in v1.1.0 ([#88](https://github.com/robotrocketscience/aelfrice/issues/88)) by introducing per-project resolution: the DB defaults to `.git/aelfrice/memory.db` for git repos (keyed off the git-common-dir so worktrees share one DB) and falls back to `~/.aelfrice/memory.db` for non-git directories. `.git/` is not git-tracked, so the brain graph never crosses the git boundary. A one-shot `aelf migrate` copies beliefs from the legacy global store into the active project's in-repo store.
-- **Hook → retrieval coupling** missed the feedback-history audit row, so retrievals did not exercise posteriors and were not auditable. Fixed in v1.0.1 by routing the hook through the same `retrieval.retrieve()` codepath as the CLI / MCP, with one `feedback_history` row per retrieval.
-- **Contradictions** were detected but never resolved — both beliefs remained equally retrievable, with a warning logged. Fixed in v1.0.1 by a default tie-breaker that auto-supersedes the loser and records the rule that fired.
-- **Onboard noise** (Markdown headings, license boilerplate, three-word fragments) entered as first-class beliefs and depressed signal-to-noise on every subsequent retrieval. Fixed in v1.0.1 by the `noise_filter` module wired into the synchronous onboard path.
-- **BFS multi-hop temporal coherence.** Each hop in a multi-hop chain currently resolves to the globally latest serial independently; this misses chains where intermediate hops should follow earlier serials. Open research as of v1.3.0; documented openly. Will not be patched into v1.x without a benchmark delta to justify the design.
-- **`apply_feedback` write authority under Claude Code.** The harness directive currently routes "save a memory" intents to a separate file-based store, so the MCP receives no new beliefs from normal sessions. Documented in [LIMITATIONS.md § harness conflict](LIMITATIONS.md). v1.0.1 closes the read-side of the loop (hook-driven retrievals exercise posteriors); v1.2 publishes a documented procedure for users who want the MCP to be canonical.
-
-## Validation commitment
-
-Every release with a behavioural claim ships with a benchmark or test that demonstrates it. v1.0.0's central claim is that `apply_feedback` updates posteriors mathematically — proven by `tests/test_scoring.py` and the synthetic harness. v1.0.0 makes *no* claim that BM25 ranking moves under feedback, because it doesn't yet. v1.3.0 is the release where that claim becomes testable; v2.0.0 is where the published MRR uplift is reproduced or retracted.
-
-This is what "early access" means in the v1.0 announcement: the surface is stable, the central feedback-into-ranking claim is a future deliverable, and the benchmark harness ships now so the eventual delivery is auditable.
-
-## Compatibility commitment
-
-aelfrice follows semver. Within the v1.x series:
-
-- **Patch releases (v1.0.x)** preserve API and database schema.
-- **Minor releases (v1.x.0)** preserve API; database migrations are forward-compatible (new columns / new tables only). Schema changes that read forward-compatibly require no user action.
-- **v2.0.0** may break the v1 API only where a benchmark or eval justifies the break. Migrations from v1 to v2 are documented and tested before tag.
-
-Each version above ships as a real tagged release on PyPI. Users on a working v1.x release are not blocked behind v2.0.0 development.
+- **Patch (v1.0.x):** API and schema preserved.
+- **Minor (v1.x.0):** API preserved; migrations are forward-compatible (new columns/tables only).
+- **v2.0.0:** may break the v1 API only where a benchmark or eval justifies the break. Migrations are documented and tested before tag.
 
 ## Non-goals
 
-- **Vector database / embedding-based retrieval.** aelfrice stays SQLite + FTS5 at every milestone in this roadmap. The HRR bridge in v2.0.0 is a structural retrieval layer, not an embedding layer.
-- **Cloud sync.** The runtime stays local. No release in this roadmap introduces network IO in the retrieval path or the write path.
-- **Telemetry.** No release in this roadmap adds outbound network calls in the default install. The optional `[mcp]` extra adds the MCP transport (local).
-- **Brain-graph sharing, sync, or export between users / machines / projects.** No release in this roadmap ships a mechanism for distributing memory contents outside the machine they were written on. See [LIMITATIONS.md § Sharing or sync of brain-graph content](LIMITATIONS.md#sharing-or-sync-of-brain-graph-content) for the architectural rationale.
+- **Vector database / embedding retrieval.** aelfrice stays SQLite + FTS5 at every milestone. The HRR bridge in v2.0 is a structural retrieval layer, not an embedding layer.
+- **Cloud sync.** The runtime stays local. No release introduces network I/O in the retrieval or write path.
+- **Telemetry.** No release adds outbound network calls in the default install.
+- **Brain-graph sharing or sync.** No release ships a mechanism for distributing memory contents between users, machines, or projects. See [LIMITATIONS § Sharing, sync, or federation](LIMITATIONS.md).
 
-## Where this list grows
+## Validation
 
-Issues filed against this repository drive the roadmap. Each release closes a list of issues mapped at [LIMITATIONS.md § known issues at v1.0](LIMITATIONS.md#known-issues-at-v10). Roadmap drift between this document and the issue tracker is itself a bug — file it.
+Every release with a behavioural claim ships with a benchmark or test that demonstrates it. v1.0's central claim is that `apply_feedback` updates posteriors mathematically — proven by tests and the synthetic harness. v1.0 makes *no* claim that BM25 ranking moves under feedback, because it doesn't yet. v1.3 is the release where that claim becomes testable; v2.0 is where the published MRR uplift is reproduced or retracted.
+
+That is what "early access" means: the surface is stable, the central feedback-into-ranking claim is a future deliverable, and the benchmark harness ships now so the eventual delivery is auditable.

--- a/docs/SLASH_COMMANDS.md
+++ b/docs/SLASH_COMMANDS.md
@@ -1,6 +1,6 @@
-# Claude Code Slash Commands
+# Slash Commands
 
-Twenty-one markdown files in `src/aelfrice/slash_commands/`. After `aelf setup`, they appear as `/aelf:*` in Claude Code. The v1.1.0 user-facing rename of `edges` → `threads` does not surface here — slash commands are 1:1 wrappers over the CLI, which keeps the term unchanged.
+Twenty-two markdown files in `src/aelfrice/slash_commands/`. After `aelf setup`, they appear as `/aelf:*` in Claude Code. Each is a thin wrapper over the CLI — `/aelf:foo` invokes `aelf foo` against the active project's DB.
 
 Manual install:
 
@@ -9,7 +9,7 @@ mkdir -p ~/.claude/commands/aelf
 cp src/aelfrice/slash_commands/*.md ~/.claude/commands/aelf/
 ```
 
-Each is a thin shell over the CLI — runs `aelf <subcommand>` against the same DB.
+## Reference
 
 | Slash | Argument hint |
 |---|---|
@@ -17,33 +17,34 @@ Each is a thin shell over the CLI — runs `aelf <subcommand>` against the same 
 | `/aelf:search` | keyword query |
 | `/aelf:lock` | statement to lock |
 | `/aelf:locked` | optional `--pressured` |
-| `/aelf:demote` | belief id (16-hex) |
+| `/aelf:demote` | belief id |
+| `/aelf:validate` | belief id |
 | `/aelf:feedback` | `<belief_id> <used\|harmful>` |
+| `/aelf:resolve` | (none) — sweep CONTRADICTS via tie-breaker |
 | `/aelf:stats` | (none) |
 | `/aelf:health` | (none) |
 | `/aelf:status` | (none) — alias for `health` |
 | `/aelf:regime` | (none) — v1.0 regime classifier |
-| `/aelf:resolve` | (none) — sweep CONTRADICTS via tie-breaker |
 | `/aelf:doctor` | optional `--user-settings`, `--project-root` |
 | `/aelf:migrate` | optional `--apply`, `--all`, `--from` |
-| `/aelf:setup` | optional `--scope`, `--command`, … |
+| `/aelf:ingest-transcript` | path or `--batch DIR` |
+| `/aelf:rebuild` | optional `--transcript PATH` (alpha) |
+| `/aelf:setup` | optional `--scope`, `--command`, `--transcript-ingest`, etc. |
 | `/aelf:unsetup` | same flags as `setup` |
 | `/aelf:statusline` | (none) — emit Claude Code statusline |
 | `/aelf:upgrade` | (none) — print pip-upgrade hint |
-| `/aelf:uninstall` | optional `--keep-db` |
-| `/aelf:rebuild` | optional `--transcript PATH` (v1.1 alpha rebuilder) |
-| `/aelf:ingest-transcript` | path to `turns.jsonl` |
-| `/aelf:bench` | optional `--db PATH`, `--top-k N` |
+| `/aelf:uninstall` | one of `--keep-db`, `--archive`, `--purge` |
+| `/aelf:bench` | optional `--top-k N` |
 
-Behaviour matches the CLI exactly — see [COMMANDS](COMMANDS.md). The MCP onboard is polymorphic; the slash version is the synchronous regex path (faster, lower-quality classification).
+Behaviour matches the CLI exactly — see [COMMANDS](COMMANDS.md). The v1.1.0 `edges` → `threads` user-facing rename does not surface here; the program name remains `aelf`.
 
 ## Pick a surface
 
 | Caller | Use |
 |---|---|
 | You, in Claude Code | `/aelf:*` slash command |
-| The agent, mid-turn | `aelf:*` MCP tool |
-| Shell or script | `aelf` CLI |
+| The agent, mid-turn | `aelf:*` MCP tool — see [MCP](MCP.md) |
+| Shell or script | `aelf` CLI — see [COMMANDS](COMMANDS.md) |
 | Tests / embedded | `tool_*` handlers from `aelfrice.mcp_server` |
 
-Remove with `rm -rf ~/.claude/commands/aelf/` plus `aelf unsetup` (independent — slash commands and the MCP hook are separate registrations).
+Remove with `rm -rf ~/.claude/commands/aelf/` plus `aelf unsetup`. The two are independent registrations.


### PR DESCRIPTION
## Summary

Full rewrite of aelfrice's user-facing documentation. Borrows the structure and warmth of agentmemory v3.0.2's docs, but keeps every claim verified against aelfrice's actual code (different scope, different surface).

Net: 14 files, **+758 / -1122 lines.**

## Files rewritten

| File | Notable cuts |
|---|---|
| `README.md` | "11-command CLI" stale claim → "22 CLI subcommands"; trimmed roadmap table; warmer opening |
| `docs/INSTALL.md` | reorganised into a 5-step flow with verification at each step |
| `docs/PHILOSOPHY.md` | tightened; preserved Determinism / Bayesian-not-vector / Locks-not-decay sections |
| `docs/COMMANDS.md` | grouped into Memory / Diagnostics / Lifecycle; added missing `validate`, `rebuild`, `ingest-transcript` rows |
| `docs/SLASH_COMMANDS.md` | bumped count to 22 (was 11); added missing `status`, `regime`, `resolve`, `doctor`, `migrate`, `validate`, `statusline`, `upgrade`, `uninstall`, `rebuild`, `ingest-transcript` rows |
| `docs/MCP.md` | bumped tool count to 9 (added `validate`); fixed `aelf-mcp` invocation |
| `docs/ARCHITECTURE.md` | added v1.2 modules (`transcript_logger`, `hook_commit_ingest`, `triple_extractor`, `context_rebuilder`, etc.); cut "out of scope" essay |
| `docs/PRIVACY.md` | added per-project isolation section; called out the update-notifier as the single network egress; documented JSONL ingest privacy trade-off |
| `docs/LIMITATIONS.md` | pruned from 144 lines of shipped+pending items to 4 actual limitations + 2 out-of-scope items + sharp edges |
| `docs/ROADMAP.md` | per-version sections collapsed to terse bullet lists; cut policy essays; kept recovery inventory table |
| `docs/QUICKSTART.md` | refreshed against current `aelf health` / `aelf doctor` / `aelf onboard` output formats |
| `docs/CONFIG.md` | trimmed prose around the noise-filter schema; tables and worked examples preserved |
| `docs/BENCHMARKS.md` | down from 295 to ~95 lines; kept the contamination protocol; cut ceremony |
| `docs/RELEASING.md` | light pass — updated test count anchor |

## Claim verification

Every claim was checked against the actual code on `main`:

- Retrieval: L0 locked + L1 FTS5 BM25 (not 7-layer)
- CLI subcommands: 22 (`grep -c '^\s*p_.* = sub.add_parser' src/aelfrice/cli.py`)
- MCP tools: 9 (`onboard`, `search`, `lock`, `locked`, `demote`, `validate`, `feedback`, `stats`, `health`)
- Slash command files: 22 (`ls src/aelfrice/slash_commands/ | wc -l`)
- Edge types: 6 (`SUPPORTS`, `CITES`, `CONTRADICTS`, `SUPERSEDES`, `RELATES_TO`, `DERIVED_FROM`)
- Belief types: 4 (`factual`, `correction`, `preference`, `requirement`)
- Origin tiers: 7 (`user_stated`, `user_corrected`, `user_validated`, `agent_inferred`, `agent_remembered`, `document_recent`, `unknown`)

Posterior-not-driving-ranking gap is called out consistently in README, PHILOSOPHY, ARCHITECTURE, LIMITATIONS, ROADMAP, QUICKSTART, and BENCHMARKS so users have a single message rather than mixed signals.

## Out of scope (per direction)

Spec files were left alone:

- `docs/commit_ingest_hook.md`
- `docs/context_rebuilder.md`
- `docs/HARNESS_INTEGRATION.md`
- `docs/ingest_enrichment.md`
- `docs/lru_query_cache.md`
- `docs/promotion_path.md`
- `docs/transcript_ingest.md`
- `docs/triple_extractor.md`

## Test plan

- [x] `uv run pytest -x -q --ignore=tests/regression` (1,089 passing — docs-only PR, no code touched)
- [x] Cross-doc link consistency: every doc-to-doc reference uses the new structure
- [x] Capability claims cross-checked against the running CLI output (`aelf --help`, `aelf doctor`, `aelf health`)