### PR TITLE
ci: publish workflow auto-creates GitHub Release on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   id-token: write
   attestations: write
-  contents: read
+  contents: write  # write needed for `gh release create` below
 
 jobs:
   publish:
@@ -16,6 +16,8 @@ jobs:
     environment: pypi
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so --generate-notes can diff against the prior tag
       - uses: astral-sh/setup-uv@v5
       - run: uv sync --frozen --extra dev --extra archive
       - run: uv run pytest tests/ -q
@@ -24,3 +26,16 @@ jobs:
         with:
           subject-path: 'dist/*'
       - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "release $tag already exists; skipping"
+            exit 0
+          fi
+          gh release create "$tag" \
+            --title "$tag" \
+            --generate-notes \
+            --verify-tag


### PR DESCRIPTION
## Summary

The PyPI publish workflow was firing on every `v*` tag, but the **Releases** sidebar on the repo page only showed Releases that had been manually created. v1.0.3 and v1.2.0 both shipped to PyPI but never showed up as Release objects (you backfilled them manually). This PR closes that gap for future tags.

## Changes to `.github/workflows/publish.yml`

- **`contents: write`** (was `read`). Required so the workflow can call `gh release create`. PyPI Trusted Publishing's `id-token: write` scope is unaffected.
- **`fetch-depth: 0`** on the checkout step. `--generate-notes` needs the prior tag in history to diff against; default fetch-depth=1 strips it.
- **New "Create GitHub Release" step** at the end of the job. Runs `gh release create <tag> --generate-notes --verify-tag`. Idempotent — `gh release view` first; skip if a Release for the tag already exists.

## Why this and not a separate workflow

Keeping the Release creation in the same job that built and published the wheel means: same checkout, same tag, same authorisation surface, same observability point. If PyPI publishing ever fails, the GitHub Release isn't created either, which is the correct behaviour — they should ship together or not at all.

## Test plan

- [ ] Next `v*` tag push will exercise the new step. The skip-if-exists guard means re-running the workflow on an existing tag is safe.
- [x] YAML linted (`yamllint .github/workflows/publish.yml`)
- [x] Backfilled v1.0.3 and v1.2.0 Releases manually (separate from this PR; already done)

## Out of scope

- Backfilling v1.0.3 / v1.2.0 — already done manually via `gh release create`.
- Reconciling release notes formatting against `CHANGELOG.md` — `--generate-notes` uses GitHub's PR-list-since-prior-tag format. If you want the CHANGELOG section embedded instead, that's a follow-up.