### PR TITLE
feat(v1.2.x): search-tool PreToolUse hook for memory-first context retrieval

### DIFF
--- a/docs/search_tool_hook.md
+++ b/docs/search_tool_hook.md
@@ -1,8 +1,9 @@
 # Search-tool hook
 
 **Status:** spec.
-**Target milestone:** v1.3.0 (named on the public roadmap as
-"search-tool `PreToolUse` hook for memory-first context retrieval").
+**Target milestone:** v1.2.x patch (pulled forward from v1.3.0 — it ships
+independently of the v1.3 retrieval wave and validates the `PreToolUse`
+retrieval surface ahead of the bigger work). Default-on candidate at v1.3.0.
 **Dependencies:** stdlib only. Consumes the v1.0 retrieval pipeline
 ([`aelfrice.retrieval.retrieve`](../src/aelfrice/retrieval.py)) and
 the v1.1.0 per-project DB resolution
@@ -252,10 +253,10 @@ on fresh install: opt-in (consistency with v1.2.0 hook surface).
 
 ## Out of scope
 
-- LLM-augmented query expansion. v1.3.0 ships the mechanical
+- LLM-augmented query expansion. v1.2.x ships the mechanical
   token-OR-join only. Smarter query rewriting (synonyms, entity
-  extraction) is a v1.4+ candidate.
-- Read tool / WebFetch / WebSearch matching. v1.3.0 ships
+  extraction) is a v1.3+ candidate (entity-index lands in v1.3.0).
+- Read tool / WebFetch / WebSearch matching. v1.2.x ships
   `Grep|Glob` only — those are the two tools whose `tool_input`
   cleanly maps to a search query. Other matchers can be added once
   the hook surface is validated in production.
@@ -265,8 +266,8 @@ on fresh install: opt-in (consistency with v1.2.0 hook surface).
   cache reuse, but cache lifetime across hook invocations is non-
   trivial and is deferred until production data shows a hit rate
   worth pursuing.
-- Confidence threshold filtering. v1.3.0 emits all matched beliefs
-  (subject to `l1_limit=10`); a min-confidence floor is a v1.4+
+- Confidence threshold filtering. v1.2.x emits all matched beliefs
+  (subject to `l1_limit=10`); a min-confidence floor is a v1.3+
   candidate once the format is validated.
 
 ## What unblocks when this lands
@@ -289,12 +290,12 @@ The hook closes the gap on the agent-search code path.
 ## Open questions
 
 - Should `aelf setup --search-tool` be the default on install at
-  v1.3.0, or stay opt-in like v1.2.0's commit-ingest? Recommendation:
-  opt-in at v1.3.0; flip to default-on at v1.4.0 once a representative
+  v1.2.x, or stay opt-in like v1.2.0's commit-ingest? Recommendation:
+  opt-in at v1.2.x; flip to default-on at v1.3.0 once a representative
   corpus shows the latency budget holds in the wild.
 - Should the matcher set extend to `Read` (file path → search the
   store for beliefs about that file)? The `tool_input.file_path`
-  surface differs enough that v1.3.0 keeps `Grep|Glob` only and
+  surface differs enough that v1.2.x keeps `Grep|Glob` only and
   defers the Read variant. Worth reserving the design space.
 - Token-budget tuning: 600 was picked to roughly half the default
   user-prompt budget. Worth measuring real-world injection size

--- a/docs/search_tool_hook.md
+++ b/docs/search_tool_hook.md
@@ -1,0 +1,302 @@
+# Search-tool hook
+
+**Status:** spec.
+**Target milestone:** v1.3.0 (named on the public roadmap as
+"search-tool `PreToolUse` hook for memory-first context retrieval").
+**Dependencies:** stdlib only. Consumes the v1.0 retrieval pipeline
+([`aelfrice.retrieval.retrieve`](../src/aelfrice/retrieval.py)) and
+the v1.1.0 per-project DB resolution
+([`aelfrice.cli.db_path`](../src/aelfrice/cli.py)).
+**Risk:** medium. Hook fires on every Grep/Glob tool call, so the
+latency budget must be tight enough that the user does not perceive
+the hook as making search "feel slow."
+
+## Summary
+
+A Claude Code `PreToolUse` hook that fires before a `Grep` or `Glob`
+tool call, lifts the agent's search query out of the tool input,
+runs the same query against the per-project belief store, and emits
+the results back as `additionalContext` so the agent sees them
+*before* the tool runs. If memory already has the answer the agent
+can skip or refine the tool call; if not, the agent uses the tool to
+fill in gaps the memory does not cover.
+
+```
+Claude wants to Grep "directive-gate" in the project
+        ↓
+  PreToolUse hook fires (tool_name in {Grep, Glob})
+        ↓
+  extract query tokens from tool_input.pattern
+        ↓
+  retrieve(store, query, token_budget=...) → beliefs
+        ↓
+  emit additionalContext = "<aelfrice-search query=...>{results}</aelfrice-search>"
+        ↓
+  Claude reads context AND runs Grep
+```
+
+## Motivation
+
+Every retrieval-shaped tool call is an opportunity to surface
+already-stored context. Without this hook, the only retrieval
+trigger today is `UserPromptSubmit` — which fires once per user
+turn, against the user's natural-language prompt. That is a
+different and complementary surface from the agent's *own*
+retrieval intent.
+
+When Claude reaches for `Grep` in the middle of a multi-tool turn,
+the search query is a precise, agent-formulated probe. Two payoffs:
+
+1. **Skip-or-pivot.** If the project's belief store already
+   contains the answer (a prior decision, a locked correction, a
+   relevant past finding), the agent sees it before the
+   filesystem-walking Grep returns. The agent can then skip the
+   Grep entirely, or use it for follow-up rather than discovery.
+2. **Fill-the-gap.** When the store has nothing relevant, the
+   hook surfaces "no matching beliefs" explicitly, distinguishing
+   *consulted-and-empty* from *not-consulted*. This signals that
+   the Grep result is the new substrate to learn from, and removes
+   the ambiguity the agent currently faces ("did the memory check
+   not happen, or was there no match?").
+
+This hook is the inverse of the v1.2.0 commit-ingest hook. That one
+*writes* the graph after the agent acts. This one *reads* the graph
+before the agent acts. Together they close the loop: information
+generated during normal session activity becomes context for the
+next session's tool-decision points.
+
+## Design
+
+### Hook registration
+
+A new entry point `aelfrice.hook_search_tool:main`, registered as
+a Claude Code `PreToolUse` hook with matcher `Grep|Glob`. The hook
+configuration matches on tool calls and emits a JSON object with
+`hookSpecificOutput.additionalContext` to inject results.
+
+Configuration lives under the user's `~/.claude/settings.json`. The
+opt-in surface is `aelf setup --search-tool`, mirroring `aelf setup
+--commit-ingest` from v1.2.0.
+
+### Hook contract (PreToolUse)
+
+stdin (one JSON object):
+
+```json
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Grep" | "Glob",
+  "tool_input": { "pattern": "...", ... },
+  "cwd": "...",
+  "session_id": "..."
+}
+```
+
+stdout (one JSON object on success; empty on no-op skip):
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "additionalContext": "<aelfrice-search query=\"...\">...</aelfrice-search>"
+  }
+}
+```
+
+Exit code: always 0. The hook is non-blocking. Any failure path
+(empty query, store missing, retrieval exception) returns silently
+without an `additionalContext` block.
+
+### Query extraction
+
+Both `Grep` and `Glob` tool inputs use the field `tool_input.pattern`.
+Patterns range from raw regexes (`r"^\\s*git\\s+commit\\b"`) to
+glob expressions (`"src/**/*.py"`) to plain phrases
+(`"directive-gate"`). The hook extracts alphanumeric word tokens
+of length ≥ 3 from the pattern and joins the first 5 with FTS5
+`OR` to form a search query:
+
+```
+pattern = "experiments/*/HYPOTHESES.md"
+tokens  = ["experiments", "HYPOTHESES"]   (3+ chars, alphanumeric)
+query   = "experiments OR HYPOTHESES"
+```
+
+```
+pattern = "src/aelfrice/hook_*.py"
+tokens  = ["src", "aelfrice", "hook"]
+query   = "src OR aelfrice OR hook"
+```
+
+Empty token sets (e.g., a pure-character glob like `"**/*.rs"`)
+produce no query and the hook returns silently. The 5-token cap
+prevents pathological queries from blowing FTS5 budget. The 3-char
+minimum filters single-letter regex anchors and short noise.
+
+### Budget framing
+
+The hook calls `retrieve(store, query, token_budget=600,
+l1_limit=10)`. Token budget is half the default to keep the
+injection light — this is auxiliary context, not the user's
+turn-level retrieval. L1 limit is also lower for the same reason.
+
+The output block uses an XML-shaped envelope keyed on the *query
+that was run*, so multiple search-tool injections in the same
+turn can be distinguished:
+
+```
+<aelfrice-search query="...">{l0+l1 results, one per line}</aelfrice-search>
+```
+
+When `retrieve()` returns the L0-only set (empty query) or zero
+results, the hook emits an explicit "no matching beliefs in store"
+sentinel so the agent learns *the check ran*. Empty stdout would be
+ambiguous with hook-skipped (e.g., empty-query path).
+
+### Latency budget
+
+The hook runs synchronously before every Grep and Glob. User-facing
+latency matters even more than commit-ingest — search tools are
+tight loops, and an unbudgeted hook would feel like the search
+itself slowed down. Budget: **median ≤ 50 ms, p95 ≤ 200 ms** on a
+populated store (~10k beliefs) for a 5-token query.
+
+Tactics:
+
+1. **Lazy import** of `aelfrice.retrieval` and `aelfrice.store`.
+   Cold-start a Python interpreter dominates on most systems.
+2. **Skip work on empty token sets.** Pure-glob patterns and
+   single-character regexes exit immediately.
+3. **Cap token count and per-token length.** First 5 tokens, ≥ 3
+   chars each. Bounds FTS5 query complexity.
+4. **Reduced retrieval budget.** `token_budget=600`, `l1_limit=10` —
+   well below the user-facing default 2000 / 50.
+5. **Read-only access.** No write paths — the hook only reads the
+   FTS5 index and the locked-beliefs table.
+
+A regression test verifies the budget on a fixture store with
+representative volume.
+
+### What gets emitted
+
+- Always: an `additionalContext` block keyed by the extracted query.
+- On match: one line per belief in `<aelfrice-search>...</aelfrice-search>`,
+  format `[L0|L1] {id-prefix}: {content}` truncated to 200 chars
+  per line.
+- On no-match: a single sentinel line explaining "no matching
+  beliefs in store; the tool result will fill the gap."
+
+What does NOT get emitted:
+
+- The full Grep/Glob result (the tool runs after the hook; its
+  output is the agent's responsibility).
+- Beliefs above the per-line truncation cap.
+- Confidence scores (these are L0 locks + L1 BM25; ranking is
+  preserved by ordering, not by numeric annotation).
+
+### Failure modes
+
+- **Empty token set.** Hook exits with no `additionalContext`. Tool
+  runs as if the hook were absent.
+- **Store missing or locked.** Hook returns silently with one log
+  line. Tool runs unaffected.
+- **`retrieve()` raises.** Caught at the entry-point boundary;
+  traceback printed to stderr; hook returns 0. Tool runs unaffected.
+- **JSON encode error on output.** Should not happen — payload is
+  small, ASCII-safe with `\u`-escaping. Caught at boundary.
+
+The principle, mirroring commit-ingest: the hook may NEVER cause a
+`Grep` or `Glob` to feel broken. Worst case is "no aelfrice context
+this call," same as if the hook were uninstalled.
+
+### Opt-in surface
+
+`aelf setup --search-tool` writes the hook configuration. Default
+on fresh install: opt-in (consistency with v1.2.0 hook surface).
+
+`aelf setup --no-search-tool` removes it.
+
+## Acceptance criteria
+
+1. The hook fires on `Grep` and `Glob` tool calls and does NOT fire
+   on other tool calls (`Read`, `Bash`, `Edit`, etc.).
+2. A pattern containing extractable tokens produces an
+   `additionalContext` block with the query and at least the L0
+   locked beliefs.
+3. A pattern with no extractable tokens (pure glob like
+   `"**/*.rs"`, single-letter regex like `"\\b"`) is a no-op; the
+   hook emits no `additionalContext`.
+4. Re-running the hook with the same payload produces the same
+   `additionalContext` block (deterministic given store state).
+5. With an empty store: hook emits the "no matching beliefs"
+   sentinel rather than empty stdout.
+6. Median latency on a 10k-belief store, 5-token query ≤ 50 ms;
+   p95 ≤ 200 ms. Verified by a regression test.
+7. Store-missing / locked / `retrieve()`-raises conditions exit
+   silently with a single stderr line; the tool call itself is not
+   affected.
+8. `aelf setup --search-tool` writes the hook config and
+   `aelf setup --no-search-tool` removes it. Idempotent in both
+   directions.
+
+## Test plan
+
+- `tests/test_search_tool_hook.py` covering criteria 1–5 + 7–8.
+- `tests/regression/test_search_tool_latency.py` for criterion 6.
+  Uses `time.perf_counter`, runs N=20, asserts median + p95 against
+  a fixture store with 10k beliefs.
+- All deterministic. Tests use `:memory:` store with synthetic
+  beliefs; the regression test uses a temp on-disk store.
+- Wall-clock budget: < 2 s per test (the regression test is the
+  longest at ~1 s for N=20 retrievals).
+
+## Out of scope
+
+- LLM-augmented query expansion. v1.3.0 ships the mechanical
+  token-OR-join only. Smarter query rewriting (synonyms, entity
+  extraction) is a v1.4+ candidate.
+- Read tool / WebFetch / WebSearch matching. v1.3.0 ships
+  `Grep|Glob` only — those are the two tools whose `tool_input`
+  cleanly maps to a search query. Other matchers can be added once
+  the hook surface is validated in production.
+- Hook-side caching. The retrieval layer's existing `RetrievalCache`
+  is opt-in for callers; the hook does not maintain its own.
+  Repeated identical queries within a session would benefit from
+  cache reuse, but cache lifetime across hook invocations is non-
+  trivial and is deferred until production data shows a hit rate
+  worth pursuing.
+- Confidence threshold filtering. v1.3.0 emits all matched beliefs
+  (subject to `l1_limit=10`); a min-confidence floor is a v1.4+
+  candidate once the format is validated.
+
+## What unblocks when this lands
+
+This is the first retrieval-shaped hook on the agent's *own* tool
+intent. Together with the v1.0.1 `UserPromptSubmit` retrieval hook
+(which fires on user turns), it covers the two natural retrieval
+trigger points: user-initiated and agent-initiated. Future
+retrieval improvements (BM25F augmentation, HRR, entity-index)
+benefit from both surfaces.
+
+It also closes a CS-class observability gap: when the agent runs
+`Grep "X"` and the project's belief store *does* contain a relevant
+prior decision about X, the absence of that context in the agent's
+view today is exactly the kind of "memory said something but it
+didn't reach the action path" failure the case-studies series
+documents (see CS-028 for the strongest version of this problem).
+The hook closes the gap on the agent-search code path.
+
+## Open questions
+
+- Should `aelf setup --search-tool` be the default on install at
+  v1.3.0, or stay opt-in like v1.2.0's commit-ingest? Recommendation:
+  opt-in at v1.3.0; flip to default-on at v1.4.0 once a representative
+  corpus shows the latency budget holds in the wild.
+- Should the matcher set extend to `Read` (file path → search the
+  store for beliefs about that file)? The `tool_input.file_path`
+  surface differs enough that v1.3.0 keeps `Grep|Glob` only and
+  defers the Read variant. Worth reserving the design space.
+- Token-budget tuning: 600 was picked to roughly half the default
+  user-prompt budget. Worth measuring real-world injection size
+  before defaulting; could be 400 or 800 depending on observed
+  signal-to-noise.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ aelf-hook = "aelfrice.hook:main"
 aelf-transcript-logger = "aelfrice.transcript_logger:main"
 aelf-pre-compact-hook = "aelfrice.hook:main_pre_compact"
 aelf-commit-ingest = "aelfrice.hook_commit_ingest:main"
+aelf-search-tool-hook = "aelfrice.hook_search_tool:main"
 aelf-session-start-hook = "aelfrice.hook:main_session_start"
 
 [project.optional-dependencies]

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -84,6 +84,7 @@ from aelfrice.retrieval import DEFAULT_TOKEN_BUDGET, retrieve
 from aelfrice.scanner import scan_repo
 from aelfrice.setup import (
     COMMIT_INGEST_SCRIPT_NAME,
+    SEARCH_TOOL_SCRIPT_NAME,
     SESSION_START_HOOK_SCRIPT_NAME,
     SettingsScope,
     TRANSCRIPT_LOGGER_SCRIPT_NAME,
@@ -91,17 +92,20 @@ from aelfrice.setup import (
     default_settings_path,
     detect_default_scope,
     install_commit_ingest_hook,
+    install_search_tool_hook,
     install_pre_compact_hook,
     install_session_start_hook,
     install_statusline,
     install_transcript_ingest_hooks,
     install_user_prompt_submit_hook,
     resolve_commit_ingest_command,
+    resolve_search_tool_command,
     resolve_hook_command,
     resolve_pre_compact_hook_command,
     resolve_session_start_hook_command,
     resolve_transcript_logger_command,
     uninstall_commit_ingest_hook,
+    uninstall_search_tool_hook,
     uninstall_pre_compact_hook,
     uninstall_session_start_hook,
     uninstall_statusline,
@@ -777,6 +781,23 @@ def _cmd_setup(args: argparse.Namespace, out: object) -> int:
                 f"(command={ci_command!r})",
                 file=out,  # type: ignore[arg-type]
             )
+    if getattr(args, "search_tool", False):
+        st_command = resolve_search_tool_command(scope)
+        st_result = install_search_tool_hook(
+            path, command=st_command, timeout=args.timeout,
+        )
+        if st_result.already_present:
+            print(
+                f"search-tool hook already installed in {st_result.path} "
+                f"(command={st_command!r})",
+                file=out,  # type: ignore[arg-type]
+            )
+        else:
+            print(
+                f"installed search-tool PreToolUse hook in {st_result.path} "
+                f"(command={st_command!r})",
+                file=out,  # type: ignore[arg-type]
+            )
     _print_setup_next_step(out)
     _print_setup_jsonl_history_hint(out)
     return 0
@@ -940,6 +961,21 @@ def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
             print(
                 f"removed {ci_result.removed} commit-ingest entr"
                 f"{'y' if ci_result.removed == 1 else 'ies'} from {ci_result.path}",
+                file=out,  # type: ignore[arg-type]
+            )
+    if getattr(args, "search_tool", False):
+        st_result = uninstall_search_tool_hook(
+            path, command_basename=SEARCH_TOOL_SCRIPT_NAME,
+        )
+        if st_result.removed == 0:
+            print(
+                f"no search-tool hook in {st_result.path}",
+                file=out,  # type: ignore[arg-type]
+            )
+        else:
+            print(
+                f"removed {st_result.removed} search-tool entr"
+                f"{'y' if st_result.removed == 1 else 'ies'} from {st_result.path}",
                 file=out,  # type: ignore[arg-type]
             )
     return 0
@@ -1843,6 +1879,17 @@ def build_parser() -> argparse.ArgumentParser:
             "Coexists with the UserPromptSubmit and transcript-ingest hooks."
         ),
     )
+    p_setup.add_argument(
+        "--search-tool", dest="search_tool", action="store_true",
+        help=(
+            "additionally wire the PreToolUse:Grep|Glob hook so the agent's "
+            "own search queries first run against the per-project belief "
+            "store and the results are injected as additionalContext. "
+            "If memory has the answer the agent can skip / refine the tool "
+            "call; if not, the tool result fills the gap. See "
+            "docs/search_tool_hook.md."
+        ),
+    )
     p_setup.set_defaults(func=_cmd_setup)
 
     p_uninstall = sub.add_parser(
@@ -1935,6 +1982,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_unsetup.add_argument(
         "--session-start", dest="session_start", action="store_true",
         help="also remove the SessionStart hook entry.",
+    )
+    p_unsetup.add_argument(
+        "--search-tool", dest="search_tool", action="store_true",
+        help="also remove the PreToolUse:Grep|Glob search-tool hook entry.",
     )
     p_unsetup.set_defaults(func=_cmd_unsetup)
 

--- a/src/aelfrice/hook_search_tool.py
+++ b/src/aelfrice/hook_search_tool.py
@@ -1,0 +1,228 @@
+"""PreToolUse hook that runs `aelf search` against the per-project belief
+store before a `Grep` or `Glob` tool call fires, and emits the results as
+`additionalContext` so the agent sees them and can decide to skip / refine
+the tool call or use the tool to fill in gaps.
+
+Hook contract (Claude Code PreToolUse):
+- payload includes `tool_name`, `tool_input`, `cwd`, plus the standard
+  event fields. We act only when:
+    * tool_name in {"Grep", "Glob"}
+    * tool_input.pattern is a string with at least one extractable token
+- All failure modes return exit 0 silently. The hook may NEVER cause a
+  `Grep` or `Glob` to feel broken.
+
+Latency budget per docs/search_tool_hook.md:
+    median <= 50 ms, p95 <= 200 ms
+
+Tactics:
+- Lazy imports of retrieval / store (cold-start dominates).
+- Skip on empty token sets up front.
+- Cap query at 5 tokens; require 3+ chars per token.
+- Lower retrieval budget (token_budget=600, l1_limit=10) than the
+  user-facing default — this is auxiliary context.
+
+Local-only: brain-graph reads never cross the git boundary or any
+network boundary.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import traceback
+from typing import IO, Final, cast
+
+QUERY_TOKEN_LIMIT: Final[int] = 5
+"""Maximum number of tokens joined into the FTS5 OR query.
+Bounds query complexity; longer patterns rarely add useful signal."""
+
+MIN_TOKEN_LEN: Final[int] = 3
+"""Minimum token length to be considered a query term.
+Filters single-letter regex anchors (\\b, \\d) and 2-char noise."""
+
+INJECTED_TOKEN_BUDGET: Final[int] = 600
+"""Token budget for retrieve() — half the user-facing default. Auxiliary
+context should not crowd out the user's primary turn budget."""
+
+INJECTED_L1_LIMIT: Final[int] = 10
+"""L1 result cap. Lower than retrieval default to bound injection size."""
+
+PER_LINE_CHAR_CAP: Final[int] = 200
+"""Truncate each emitted belief line to this many chars. Keeps the
+injection bounded even when individual beliefs have long content."""
+
+_TOKEN_RE: Final[re.Pattern[str]] = re.compile(
+    rf"[A-Za-z][A-Za-z0-9_-]{{{MIN_TOKEN_LEN - 1},}}"
+)
+
+
+def _read_payload(stdin: IO[str]) -> dict[str, object] | None:
+    raw = stdin.read()
+    if not raw.strip():
+        return None
+    try:
+        parsed = json.loads(raw)  # pyright: ignore[reportAny]
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return cast(dict[str, object], parsed)
+
+
+def _is_search_tool_call(payload: dict[str, object]) -> bool:
+    tool_name = payload.get("tool_name")
+    return tool_name in ("Grep", "Glob")
+
+
+def _extract_query(payload: dict[str, object]) -> str | None:
+    """Lift the search query out of tool_input.pattern.
+
+    Both Grep and Glob use the field name `pattern`. Strips regex/glob
+    metacharacters by extracting only alphanumeric word tokens, then
+    joins the first QUERY_TOKEN_LIMIT with FTS5 ` OR ` to form a query.
+    Returns None when no usable tokens are present (pure-glob patterns,
+    single-character regexes, etc.) — caller treats None as "skip".
+    """
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+    raw = cast(dict[str, object], tool_input).get("pattern")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    tokens = _TOKEN_RE.findall(raw)
+    if not tokens:
+        return None
+    return " OR ".join(tokens[:QUERY_TOKEN_LIMIT])
+
+
+def _format_results(
+    query: str, beliefs: list[object], locked_ids: set[str]
+) -> str:
+    """Render retrieve() output as a flat text block for additionalContext.
+
+    Format: "[L0] {id-prefix}: {content}" for locked, "[L1] ..." for
+    BM25-ranked. One belief per line, truncated to PER_LINE_CHAR_CAP.
+    """
+    lines: list[str] = []
+    for b in beliefs:
+        bid = getattr(b, "id", "") or ""
+        content = getattr(b, "content", "") or ""
+        if not bid or not content:
+            continue
+        tier = "L0" if bid in locked_ids else "L1"
+        prefix = bid[:16]
+        line = f"[{tier}] {prefix}: {content}".replace("\n", " ")
+        if len(line) > PER_LINE_CHAR_CAP:
+            line = line[: PER_LINE_CHAR_CAP - 3] + "..."
+        lines.append(line)
+    if not lines:
+        return (
+            f'<aelfrice-search query="{query}">'
+            f"no matching beliefs in store; the tool result will fill the gap"
+            f"</aelfrice-search>"
+        )
+    body = "\n".join(lines)
+    return (
+        f'<aelfrice-search query="{query}">aelf search ran on this query before '
+        f"the tool fires; results:\n{body}\n"
+        f"If this answers the question, you may skip the tool call. Otherwise "
+        f"use the tool to fill gaps.</aelfrice-search>"
+    )
+
+
+def _emit(stdout: IO[str], context: str) -> None:
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "additionalContext": context,
+        }
+    }
+    stdout.write(json.dumps(payload))
+
+
+def _do_search(
+    payload: dict[str, object], stdout: IO[str]
+) -> None:
+    """Core hook body. Returns silently on any non-budget failure.
+
+    Lazy imports keep the cold-start path light: the hook does not pay
+    for `aelfrice.store` / `aelfrice.retrieval` import cost on tool
+    calls that aren't `Grep` / `Glob`, or on patterns that have no
+    extractable tokens.
+    """
+    if not _is_search_tool_call(payload):
+        return
+    query = _extract_query(payload)
+    if query is None:
+        return
+
+    cwd_obj = payload.get("cwd")
+    cwd = cwd_obj if isinstance(cwd_obj, str) else None
+
+    # Lazy imports: cold-start cost is paid only when we actually search.
+    from aelfrice.cli import db_path  # noqa: PLC0415  # pyright: ignore[reportPrivateUsage]
+    from aelfrice.retrieval import retrieve  # noqa: PLC0415
+    from aelfrice.store import MemoryStore  # noqa: PLC0415
+
+    p = db_path(cwd=cwd) if _db_path_accepts_cwd(db_path) else db_path()
+    if str(p) != ":memory:" and not p.exists():
+        # Empty / not-yet-onboarded store — explicit sentinel so the agent
+        # learns the check ran.
+        _emit(stdout, _format_results(query, [], set()))
+        return
+
+    store = MemoryStore(str(p))
+    try:
+        locked = store.list_locked_beliefs()
+        locked_ids = {b.id for b in locked}
+        beliefs = retrieve(
+            store,
+            query,
+            token_budget=INJECTED_TOKEN_BUDGET,
+            l1_limit=INJECTED_L1_LIMIT,
+        )
+    finally:
+        store.close()
+
+    _emit(stdout, _format_results(query, beliefs, locked_ids))
+
+
+def _db_path_accepts_cwd(db_path_fn: object) -> bool:
+    """Best-effort detection: does aelfrice.cli.db_path() accept a cwd kw?
+
+    v1.1.0 db_path() reads cwd from os.getcwd(); a later patch may add a
+    cwd parameter for callers that need to scope to a specific worktree.
+    The hook detects either signature without a hard dependency on the
+    later API.
+    """
+    import inspect  # noqa: PLC0415
+
+    try:
+        sig = inspect.signature(db_path_fn)  # pyright: ignore[reportArgumentType]
+    except (TypeError, ValueError):
+        return False
+    return "cwd" in sig.parameters
+
+
+def main(
+    *,
+    stdin: IO[str] | None = None,
+    stdout: IO[str] | None = None,
+    stderr: IO[str] | None = None,
+) -> int:
+    """Hook entry point. Always returns 0 (non-blocking contract)."""
+    sin = stdin if stdin is not None else sys.stdin
+    sout = stdout if stdout is not None else sys.stdout
+    serr = stderr if stderr is not None else sys.stderr
+    try:
+        payload = _read_payload(sin)
+        if payload is None:
+            return 0
+        _do_search(payload, sout)
+    except Exception:  # non-blocking: surface but never raise
+        traceback.print_exc(file=serr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/aelfrice/setup.py
+++ b/src/aelfrice/setup.py
@@ -639,6 +639,95 @@ def uninstall_commit_ingest_hook(
     return UninstallResult(path=settings_path, removed=removed)
 
 
+# --- Search-tool wiring -----------------------------------------------
+
+
+SEARCH_TOOL_EVENT: Final[str] = "PreToolUse"
+SEARCH_TOOL_MATCHER: Final[str] = "Grep|Glob"
+SEARCH_TOOL_SCRIPT_NAME: Final[str] = "aelf-search-tool-hook"
+
+
+def resolve_search_tool_command(scope: SettingsScope) -> str:
+    """Pick the absolute aelf-search-tool-hook path for `scope`.
+
+    Same routing primitive as resolve_commit_ingest_command: project
+    scope pins to the venv next to sys.executable; user scope prefers
+    $PATH (typically a pipx install).
+    """
+    venv_bin = _venv_bin_dir()
+    venv_hook = _executable_in_dir(venv_bin, SEARCH_TOOL_SCRIPT_NAME)
+    path_hook_str = shutil.which(SEARCH_TOOL_SCRIPT_NAME)
+    path_hook = Path(path_hook_str) if path_hook_str else None
+    if scope == "project":
+        chosen = venv_hook or path_hook
+    else:
+        chosen = path_hook or venv_hook
+    if chosen is None:
+        return SEARCH_TOOL_SCRIPT_NAME
+    return str(chosen)
+
+
+def install_search_tool_hook(
+    settings_path: Path, *, command: str, timeout: int | None = None,
+) -> InstallResult:
+    """Add a PreToolUse:matcher=Grep|Glob hook entry running `command`.
+
+    Idempotent against the same `command`. Coexists with other PreToolUse
+    entries — appending only after confirming no matching entry already
+    exists for the same command.
+    """
+    if not command:
+        raise ValueError("command must be a non-empty string")
+    data = _load_settings(settings_path)
+    entries = _get_event_list(data, SEARCH_TOOL_EVENT, create=True)
+    if _find_entry_index(entries, command) is not None:
+        return InstallResult(
+            path=settings_path, installed=False, already_present=True,
+        )
+    entries.append(_build_entry(
+        command=command, timeout=timeout, status_message=None,
+        matcher=SEARCH_TOOL_MATCHER,
+    ))
+    _atomic_write(settings_path, data)
+    return InstallResult(
+        path=settings_path, installed=True, already_present=False,
+    )
+
+
+def uninstall_search_tool_hook(
+    settings_path: Path, *,
+    command: str | None = None,
+    command_basename: str | None = None,
+) -> UninstallResult:
+    """Strip PreToolUse entries matching `command` or `command_basename`.
+
+    Pass exactly one of the two. Other PreToolUse entries (other matchers,
+    other tools) are left alone.
+    """
+    if command is None and command_basename is None:
+        raise ValueError("provide command or command_basename")
+    if command is not None and command_basename is not None:
+        raise ValueError("command and command_basename are mutually exclusive")
+    if not settings_path.exists():
+        return UninstallResult(path=settings_path, removed=0)
+    data = _load_settings(settings_path)
+    entries = _get_event_list(data, SEARCH_TOOL_EVENT, create=False)
+    if entries is None:
+        return UninstallResult(path=settings_path, removed=0)
+    before = len(entries)
+    if command is not None:
+        kept = [e for e in entries if not _entry_matches(e, command)]
+    else:
+        assert command_basename is not None
+        kept = [e for e in entries if not _entry_matches_basename(e, command_basename)]
+    removed = before - len(kept)
+    if removed == 0:
+        return UninstallResult(path=settings_path, removed=0)
+    entries[:] = kept
+    _atomic_write(settings_path, data)
+    return UninstallResult(path=settings_path, removed=removed)
+
+
 # --- SessionStart wiring -----------------------------------------------
 
 

--- a/tests/test_search_tool_hook.py
+++ b/tests/test_search_tool_hook.py
@@ -1,0 +1,264 @@
+"""search-tool hook: dispatch, query extraction, retrieval injection, failure modes.
+
+Mirrors test_commit_ingest_hook.py structure. Acceptance criteria from
+docs/search_tool_hook.md numbered in test docstrings.
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice import hook_search_tool as hk
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.store import MemoryStore
+
+
+# --- Fixtures ------------------------------------------------------------
+
+
+@pytest.fixture
+def per_repo_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Force the hook's `db_path()` resolution to a tmp file."""
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    return db
+
+
+def _payload(
+    *,
+    pattern: str,
+    tool_name: str = "Grep",
+    cwd: str | None = None,
+) -> dict[str, object]:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool_name,
+        "tool_input": {"pattern": pattern},
+        "cwd": cwd or "/tmp",
+        "session_id": "smoke",
+    }
+
+
+def _run(payload: dict[str, object]) -> tuple[int, str, str]:
+    sin = io.StringIO(json.dumps(payload))
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = hk.main(stdin=sin, stdout=sout, stderr=serr)
+    return rc, sout.getvalue(), serr.getvalue()
+
+
+_BELIEF_COUNTER = [0]
+
+
+def _seed_belief(db_path: Path, content: str, *, locked: bool = False) -> str:
+    """Insert a belief; return its id."""
+    _BELIEF_COUNTER[0] += 1
+    bid = f"B{_BELIEF_COUNTER[0]:08x}"
+    b = Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_USER if locked else LOCK_NONE,
+        locked_at="2026-04-27T00:00:00Z" if locked else None,
+        demotion_pressure=0,
+        created_at="2026-04-27T00:00:00Z",
+        last_retrieved_at=None,
+    )
+    store = MemoryStore(str(db_path))
+    try:
+        store.insert_belief(b)
+    finally:
+        store.close()
+    return bid
+
+
+# --- Acceptance criterion 1: matcher discrimination ----------------------
+
+
+def test_grep_tool_call_fires_hook(per_repo_db: Path) -> None:
+    """AC1: Grep tool calls fire the hook."""
+    _seed_belief(per_repo_db, "directive-gate hook is misbehaving")
+    rc, out, _ = _run(_payload(pattern="directive-gate", tool_name="Grep"))
+    assert rc == 0
+    assert "<aelfrice-search" in out
+    assert "directive-gate" in out
+
+
+def test_glob_tool_call_fires_hook(per_repo_db: Path) -> None:
+    """AC1: Glob tool calls fire the hook."""
+    _seed_belief(per_repo_db, "settings.json was modified by aelf setup")
+    rc, out, _ = _run(_payload(pattern="settings.json", tool_name="Glob"))
+    assert rc == 0
+    assert "<aelfrice-search" in out
+
+
+def test_other_tool_calls_do_not_fire(per_repo_db: Path) -> None:
+    """AC1: Read / Bash / Edit tool calls are ignored."""
+    _seed_belief(per_repo_db, "x")
+    for tool in ("Read", "Bash", "Edit", "Write", "WebFetch"):
+        _, out, _ = _run(_payload(pattern="x", tool_name=tool))
+        assert out == "", f"{tool} should not produce output"
+
+
+# --- Acceptance criterion 2: results emitted on match --------------------
+
+
+def test_pattern_with_tokens_produces_results(per_repo_db: Path) -> None:
+    """AC2: Extractable pattern + matching belief → additionalContext block."""
+    bid = _seed_belief(per_repo_db, "alpha decision: use FTS5 for retrieval")
+    _, out, _ = _run(_payload(pattern="alpha"))
+    payload = json.loads(out)
+    body = payload["hookSpecificOutput"]["additionalContext"]
+    assert 'query="alpha"' in body
+    assert bid[:16] in body or "alpha decision" in body
+
+
+def test_locked_belief_appears_with_l0_marker(per_repo_db: Path) -> None:
+    """AC2: Locked beliefs are tagged [L0]; unlocked are [L1]."""
+    _seed_belief(per_repo_db, "locked rule about beta", locked=True)
+    _seed_belief(per_repo_db, "regular fact about beta")
+    _, out, _ = _run(_payload(pattern="beta"))
+    body = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "[L0]" in body
+    assert "[L1]" in body
+
+
+# --- Acceptance criterion 3: empty token sets are no-ops -----------------
+
+
+def test_pure_glob_pattern_is_noop(per_repo_db: Path) -> None:
+    """AC3: Glob patterns with no extractable word tokens skip the hook."""
+    _seed_belief(per_repo_db, "x")
+    _, out, _ = _run(_payload(pattern="**/*.rs", tool_name="Glob"))
+    assert out == ""
+
+
+def test_short_token_only_is_noop(per_repo_db: Path) -> None:
+    """AC3: Patterns with only short tokens (<3 chars) skip."""
+    _seed_belief(per_repo_db, "x")
+    _, out, _ = _run(_payload(pattern=r"\\b\\d", tool_name="Grep"))
+    assert out == ""
+
+
+def test_empty_pattern_is_noop(per_repo_db: Path) -> None:
+    """AC3: Empty pattern skips."""
+    _, out, _ = _run(_payload(pattern=""))
+    assert out == ""
+
+
+# --- Acceptance criterion 4: idempotency --------------------------------
+
+
+def test_repeated_calls_produce_same_output(per_repo_db: Path) -> None:
+    """AC4: Same payload twice → identical additionalContext."""
+    _seed_belief(per_repo_db, "gamma is the third letter")
+    _, out1, _ = _run(_payload(pattern="gamma"))
+    _, out2, _ = _run(_payload(pattern="gamma"))
+    assert out1 == out2
+
+
+# --- Acceptance criterion 5: empty store sentinel ------------------------
+
+
+def test_empty_store_emits_no_match_sentinel(per_repo_db: Path) -> None:
+    """AC5: Empty store → 'no matching beliefs' sentinel, not empty stdout."""
+    rc, out, _ = _run(_payload(pattern="nonexistent"))
+    assert rc == 0
+    assert out  # not empty
+    body = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "no matching beliefs" in body
+
+
+def test_missing_db_file_emits_sentinel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC5: DB file does not exist → sentinel block, not silence."""
+    monkeypatch.setenv("AELFRICE_DB", str(tmp_path / "absent.db"))
+    rc, out, _ = _run(_payload(pattern="anything"))
+    assert rc == 0
+    body = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "no matching beliefs" in body
+
+
+# --- Acceptance criterion 7: failure modes are silent --------------------
+
+
+def test_malformed_json_returns_0_silently() -> None:
+    """AC7: Malformed JSON payload → exit 0, no output."""
+    sin = io.StringIO("not json {")
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = hk.main(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+def test_empty_stdin_returns_0_silently() -> None:
+    """AC7: Empty stdin → exit 0, no output."""
+    sin = io.StringIO("")
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = hk.main(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+def test_non_dict_payload_returns_0_silently() -> None:
+    """AC7: JSON array (not object) → exit 0, no output."""
+    sin = io.StringIO("[1, 2, 3]")
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = hk.main(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+# --- Token extraction unit tests ----------------------------------------
+
+
+def test_extract_query_picks_alphanumeric_tokens() -> None:
+    q = hk._extract_query({"tool_input": {"pattern": "src/**/test_*.py"}})
+    assert q is not None
+    # 'src' (3 chars), 'test' (4 chars). 'py' filtered (2 chars).
+    assert "src" in q
+    assert "test" in q
+    assert "py" not in q
+
+
+def test_extract_query_caps_at_token_limit() -> None:
+    pattern = "alpha beta gamma delta epsilon zeta eta theta"
+    q = hk._extract_query({"tool_input": {"pattern": pattern}})
+    assert q is not None
+    # First 5 tokens only.
+    assert q.count(" OR ") == hk.QUERY_TOKEN_LIMIT - 1
+
+
+def test_extract_query_returns_none_for_empty_tool_input() -> None:
+    assert hk._extract_query({"tool_input": {}}) is None
+    assert hk._extract_query({"tool_input": "not a dict"}) is None
+    assert hk._extract_query({}) is None
+
+
+def test_extract_query_returns_none_for_pure_metachars() -> None:
+    """Patterns with no token >= MIN_TOKEN_LEN are no-ops."""
+    assert hk._extract_query({"tool_input": {"pattern": ".*"}}) is None
+    assert hk._extract_query({"tool_input": {"pattern": "**/*.go"}}) is None
+    assert hk._extract_query({"tool_input": {"pattern": r"\\b\\d+"}}) is None
+
+
+# --- Per-line truncation --------------------------------------------------
+
+
+def test_long_belief_content_is_truncated(per_repo_db: Path) -> None:
+    """Each line is capped at PER_LINE_CHAR_CAP to bound injection size."""
+    long_content = "alpha " + "x" * 500
+    _seed_belief(per_repo_db, long_content)
+    _, out, _ = _run(_payload(pattern="alpha"))
+    body = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    for line in body.splitlines():
+        if line.startswith("[L0]") or line.startswith("[L1]"):
+            assert len(line) <= hk.PER_LINE_CHAR_CAP


### PR DESCRIPTION
## Summary

- New PreToolUse hook (matcher: `Grep|Glob`) that runs the same query against the per-project belief store before the tool fires and emits results as \`additionalContext\`. If memory has the answer, the agent can skip / refine the tool call; if not, the tool fills the gap.
- Pulled forward into a v1.2.x patch (per spec status line). Validates the \`PreToolUse\` retrieval surface ahead of the larger v1.3 retrieval wave.
- Inverse of the v1.2.0 commit-ingest hook: that one *writes* the graph after the agent acts; this one *reads* before. Together they close the loop on agent-initiated activity.
- Spec: \`docs/search_tool_hook.md\`. Implementation: \`src/aelfrice/hook_search_tool.py\` (stdlib only, lazy imports, never blocks the tool call). Wiring: \`aelf setup --search-tool\` / \`aelf unsetup --search-tool\`.

## Test plan

- [x] 19 unit tests in \`tests/test_search_tool_hook.py\` covering acceptance criteria 1–5 and 7 (matcher discrimination, query extraction, idempotency, empty-store sentinel, malformed-payload handling, per-line truncation).
- [x] Full suite passes locally: 1148 passed, 2 skipped, 0 failed.
- [ ] Latency regression test (AC6: median ≤ 50 ms / p95 ≤ 200 ms on a 10k-belief fixture) deferred to a follow-up commit.
- [ ] Setup/unsetup integration test (AC8) deferred to a follow-up commit.

## Default

Opt-in. Default-on candidate at v1.3.0 once a representative corpus shows the latency budget holds in the wild. See spec § Open questions.

## Out of scope at this milestone

- LLM-augmented query expansion.
- Read / WebFetch / WebSearch matchers.
- Hook-side caching.
- Confidence threshold filtering.