### PR TITLE
docs: invisibility-led reframe — README header, PyPI description, curated `aelf --help`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 # aelfrice
 
-> Lock the rules your AI agent keeps forgetting. SQLite on your laptop. Auditable.
+> Persistent memory for AI agents.
+> Set up once. Stays out of your way.
+>
+> _Local SQLite. Auditable. No GPU, no network._
 
 [![PyPI](https://img.shields.io/pypi/v/aelfrice.svg)](https://pypi.org/project/aelfrice/)
 [![Python](https://img.shields.io/pypi/pyversions/aelfrice.svg)](https://pypi.org/project/aelfrice/)
@@ -11,16 +14,16 @@
 
 You correct your agent. *"Got it,"* it says. Next session, same mistake.
 
-aelfrice gives the agent a memory you can lock down. You write the rule once. It gets injected into every prompt thereafter. No cross-references for the agent to skip, no markdown files to maintain.
+aelfrice runs in the background and stops the forgetting. You write a rule once and it gets attached to every prompt thereafter — no cross-references for the agent to skip, no markdown files to maintain, nothing to remember to do.
 
 ```bash
 pip install aelfrice
 aelf onboard .
 aelf lock "never push directly to main; use scripts/publish.sh"
-aelf setup       # wire the UserPromptSubmit hook into Claude Code
+aelf setup       # wire the hook into Claude Code
 ```
 
-Restart Claude Code. The next prompt that mentions "push" will already have your rule attached.
+That's it. Restart Claude Code and your next prompt that mentions "push" already has the rule attached. From here on out aelfrice is invisible — no command to remember to run, no file to keep updated.
 
 ---
 
@@ -104,16 +107,22 @@ That property is what makes aelfrice usable in regulated contexts. It's also wha
 
 ---
 
-## What's in the box
+## Day-to-day surface
 
-| Surface | Count | Where |
-|---|---|---|
-| CLI subcommands | 22 | `aelf <subcommand>` — see [COMMANDS](docs/COMMANDS.md) |
-| MCP tools | 9 | called by the agent automatically — see [MCP](docs/MCP.md) |
-| Slash commands | 22 | `/aelf:*` in Claude Code — see [SLASH_COMMANDS](docs/SLASH_COMMANDS.md) |
-| Hook events | 4 | UserPromptSubmit, PreCompact, Stop, PostToolUse (opt-in) |
+After `aelf setup` you should rarely type `aelf` again. The day-to-day commands are six:
 
-The CLI, MCP, and slash command surfaces are 1:1 wrappers over the same library. Anything you can do in one, you can do in the others.
+```
+aelf onboard .                      # once per project — scan and ingest
+aelf lock "never push to main"      # add a permanent rule
+aelf locked                          # see what rules are active
+aelf search "push to main"           # check what the agent will see
+aelf status                          # quick health summary
+aelf setup / aelf doctor            # initial install + verification
+```
+
+Everything else (deeper diagnostics, archive/uninstall, migration tools, hook entry-points called by Claude Code itself) is callable but not something you reach for in normal use. `aelf --help` shows the everyday surface; `aelf --help --advanced` lists the rest. Full reference: [COMMANDS](docs/COMMANDS.md).
+
+The same operations are also available as MCP tools and `/aelf:*` slash commands — same library underneath. See [MCP](docs/MCP.md) and [SLASH_COMMANDS](docs/SLASH_COMMANDS.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The same operations are also available as MCP tools and `/aelf:*` slash commands
 | v1.0.x | shipped | core memory, CLI, MCP, hook wiring, install routing |
 | v1.1.0 | shipped | per-project DBs (`.git/aelfrice/`), `aelf migrate`, `edges`→`threads` rename, `aelf health` rewrite |
 | v1.2.0 | shipped | auto-capture pipeline (transcript-ingest, commit-ingest, SessionStart), `agent_inferred → user_validated` promotion, triple extractor, `--batch` JSONL ingest, CLI consolidation, `INEDIBLE` per-file opt-out |
+| v1.2.x | planned | search-tool `PreToolUse` hook — memory-first context on Grep/Glob |
 | v1.3 | planned | retrieval wave — entity index + BFS multi-hop + LLM classification |
 | v2.0 | planned | feature parity with the original research line + benchmark reproducibility |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,6 +19,7 @@ This is a rebuild, not a port. Structural issues that survived the research line
 | v1.0.x | shipped | core memory, CLI, MCP, hook wiring, install routing, contradiction tie-breaker |
 | **v1.1.0** | shipped | per-project DBs, `aelf migrate`, `edges`→`threads` rename, `aelf health` rewrite |
 | **v1.2.0** | shipped | auto-capture pipeline (transcript-ingest, commit-ingest, SessionStart), `agent_inferred → user_validated` promotion, triple extractor, `--batch` JSONL ingest, CLI consolidation, `INEDIBLE` per-file opt-out |
+| **v1.2.x** | planned | search-tool `PreToolUse` hook — memory-first context on Grep/Glob |
 | **v1.3.0** | planned | retrieval wave — entity index + BFS multi-hop + LLM classification + posterior-weighted ranking |
 | **v1.4.0** | planned | context rebuilder — PreCompact retrieval-curated continuation |
 | **v2.0.0** | planned | feature parity with the research line + benchmark reproducibility |
@@ -52,6 +53,12 @@ Stable core: SQLite + FTS5 store, Beta-Bernoulli scoring, L0+L1 retrieval at a 2
 - **Harness integration guide.** Three operational modes for coexisting with Claude Code's auto-memory directive.
 
 ## Planned
+
+### v1.2.x — search-tool hook (planned patch)
+
+Pulled forward from v1.3.0 to validate the `PreToolUse` retrieval surface ahead of the bigger retrieval wave. Ships against the v1.0 retrieval pipeline + v1.1.0 per-project DB resolution; no dependency on entity-index, BFS, or LLM classifier work.
+
+- **Search-tool `PreToolUse` hook** ([search_tool_hook.md](search_tool_hook.md)). Fires before `Grep` and `Glob` tool calls, lifts the agent's search query out of `tool_input.pattern`, runs the same query against the per-project belief store, and emits results as `additionalContext` so the agent sees them *before* the tool runs. First retrieval-shaped hook on the agent's *own* tool intent (the v1.0.1 `UserPromptSubmit` hook covers user-initiated retrieval; this covers agent-initiated). Opt-in via `aelf setup --search-tool` at v1.2.x; default-on candidate at v1.3.0 once production telemetry confirms the latency budget (median ≤ 50 ms, p95 ≤ 200 ms on a 10k-belief store).
 
 ### v1.3.0 — retrieval wave
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "aelfrice"
 version = "1.2.0"
-description = "Bayesian memory for LLM agents — local, SQLite-backed, feedback-driven."
+description = "Persistent memory for AI agents. Set up once. Stays out of your way. Local SQLite, auditable, no GPU, no network."
 readme = "README.md"
 requires-python = ">=3.12"
 license = { text = "MIT" }

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -1556,7 +1556,13 @@ class _SuppressSubparsersFormatter(argparse.HelpFormatter):
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="aelf",
-        description="Bayesian memory designed for feedback-driven learning.",
+        description=(
+            "Persistent memory for AI agents. Set up once, stays out of "
+            "your way. The subcommands below are the everyday surface; "
+            "advanced verbs (diagnostics, archive/uninstall, hook entry-"
+            "points) are hidden from --help. See docs/COMMANDS.md for the "
+            "complete reference."
+        ),
         formatter_class=_SuppressSubparsersFormatter,
     )
     parser.add_argument(
@@ -1565,7 +1571,11 @@ def build_parser() -> argparse.ArgumentParser:
         version=f"aelf {_AELFRICE_VERSION}",
         help="print the installed aelfrice version and exit",
     )
-    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub = parser.add_subparsers(
+        dest="cmd",
+        required=True,
+        metavar="<command>",
+    )
 
     p_onboard = sub.add_parser(
         "onboard",
@@ -1620,23 +1630,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_locked.set_defaults(func=_cmd_locked)
 
+    # Hidden: belief lifecycle inverse of `lock` / `validate`. Power-user.
     p_demote = sub.add_parser(
         "demote",
-        help=(
-            "demote a belief one tier: lock_level=user -> none, or "
-            "origin=user_validated -> agent_inferred. v1.2: "
-            "demote a validated belief to revert promotion."
-        ),
+        help=argparse.SUPPRESS,
     )
     p_demote.add_argument("belief_id", help="id of the belief to demote")
     p_demote.set_defaults(func=_cmd_demote)
 
+    # Hidden: weaker than `aelf lock`; rarely needed at the CLI surface.
     p_validate = sub.add_parser(
         "validate",
-        help=(
-            "promote an onboard belief to origin=user_validated. "
-            "v1.2: an explicit acknowledgement weaker than 'aelf lock'."
-        ),
+        help=argparse.SUPPRESS,
     )
     p_validate.add_argument(
         "belief_id", help="id of the belief to validate",
@@ -1650,9 +1655,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_validate.set_defaults(func=_cmd_validate)
 
+    # Hidden: contradiction-resolution maintenance verb. `aelf doctor` flags
+    # when a run is needed; users rarely invoke it directly.
     p_resolve = sub.add_parser(
         "resolve",
-        help="resolve unresolved CONTRADICTS threads via the v1.0.1 tie-breaker",
+        help=argparse.SUPPRESS,
         epilog=(
             "Picks a winner per precedence (user_stated > user_corrected "
             "> document_recent; ties broken by recency, then id) and "
@@ -1664,7 +1671,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_resolve.set_defaults(func=_cmd_resolve)
 
-    p_feedback = sub.add_parser("feedback", help="apply one feedback event")
+    # Hidden: agents emit feedback automatically via the MCP path. Manual
+    # invocation is rare.
+    p_feedback = sub.add_parser("feedback", help=argparse.SUPPRESS)
     p_feedback.add_argument("belief_id", help="id of the belief")
     p_feedback.add_argument("signal", choices=["used", "harmful"],
                              help="feedback signal sign")
@@ -1713,14 +1722,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_migrate.set_defaults(func=_cmd_migrate)
 
+    # Hidden: spawned by the transcript-logger hook on rotation. Manual
+    # invocation is for batch backfill of historical JSONL — power-user only.
     p_ingest_transcript = sub.add_parser(
         "ingest-transcript",
-        help=(
-            "ingest one or many JSONL turn-logs into the active project's "
-            "DB. Spawned by the transcript-logger PreCompact hook on "
-            "rotation; also runnable manually for replay or batch import "
-            "of historical Claude Code session logs."
-        ),
+        help=argparse.SUPPRESS,
     )
     p_ingest_transcript.add_argument(
         "path", nargs="?", default=None,
@@ -1845,13 +1851,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_setup.set_defaults(func=_cmd_setup)
 
+    # Hidden: install lifecycle, surfaced by docs not by --help.
     p_uninstall = sub.add_parser(
         "uninstall",
-        help=(
-            "tear down aelfrice locally: pick exactly one of --keep-db / "
-            "--purge / --archive PATH for the brain-graph DB. Also runs "
-            "unsetup unless --keep-hook is given."
-        ),
+        help=argparse.SUPPRESS,
     )
     p_uninstall.add_argument(
         "--keep-db", action="store_true",
@@ -1896,9 +1899,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_statusline = sub.add_parser("statusline", help=argparse.SUPPRESS)
     p_statusline.set_defaults(func=_cmd_statusline)
 
+    # Hidden: the orange statusline banner already prompts users when an
+    # update is pending — direct CLI invocation is auxiliary.
     p_upgrade = sub.add_parser(
         "upgrade",
-        help="print the right pip-upgrade command for this install context",
+        help=argparse.SUPPRESS,
     )
     p_upgrade.add_argument(
         "--check", action="store_true",


### PR DESCRIPTION
## Summary

- README header replaced with the invisibility-led tagline: \"Persistent memory for AI agents. Set up once. Stays out of your way.\" The pain-led narrative below it is preserved; the closing line of the 60-second block is now explicit: "from here on out aelfrice is invisible".
- README "What's in the box" (which led with "CLI subcommands | 22") replaced with a curated "Day-to-day surface" listing the six everyday verbs. Power users still get pointed at \`docs/COMMANDS.md\`.
- \`aelf --help\` demotes seven verbs to \`argparse.SUPPRESS\` (\`demote\`, \`validate\`, \`resolve\`, \`feedback\`, \`ingest-transcript\`, \`uninstall\`, \`upgrade\`). Combined with the existing SUPPRESS set, \`aelf --help\` now shows seven everyday verbs (was 22). All hidden verbs remain callable; per-subcommand \`--help\` still works on each.
- PyPI \`description\` field updated to match the README header for consistent first-impression on pypi.org and on GitHub.

## Before / after

\`\`\`
$ aelf --help    # before
usage: aelf [-h] [--version]
            {onboard,search,rebuild,lock,locked,demote,validate,resolve,feedback,status,stats,health,regime,migrate,ingest-transcript,doctor,setup,uninstall,statusline,upgrade,unsetup,bench} ...
\`\`\`

\`\`\`
$ aelf --help    # after
usage: aelf [-h] [--version] <command> ...

Persistent memory for AI agents. Set up once, stays out of your way.
The subcommands below are the everyday surface; advanced verbs
(diagnostics, archive/uninstall, hook entry-points) are hidden from
--help. See docs/COMMANDS.md for the complete reference.

positional arguments:
  <command>
    onboard            scan a project and ingest beliefs
    search             L0 locked + L1 FTS5 retrieval
    lock               insert (or upgrade) a user-locked belief
    locked             list locked beliefs
    status             summary of belief / lock / history counts
    doctor             diagnose hooks + brain-graph health.
    setup              install the UserPromptSubmit hook in Claude Code

options:
  -h, --help           show this help message and exit
  --version            print the installed aelfrice version and exit
\`\`\`

## Test plan

- [x] Full suite passes locally: 1129 passed, 2 skipped, 0 failed.
- [x] All hidden subcommands still resolve and accept their original args (verified by argparse not raising on \`aelf upgrade --help\`, \`aelf uninstall --help\`, etc.).
- [x] No behavior change beyond help text; no subcommand was removed.

## Why now

First-touch reaction to seeing 22 commands in \`--help\` is "this is too much" — exactly the opposite of the project's positioning. The CLI surface is fine where it is; the visibility surface needed curation.