### PR TITLE
docs: release sweep for v1.0.3 + v1.2.0 (closes #131, closes #132)

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -63,13 +63,16 @@ Override with `--scope user|project` and `--command /abs/path/aelf-hook` when yo
 aelf doctor
 ```
 
-Walks every `command` in `settings.json` and checks the binary is reachable. Exits 1 on broken entries so CI can gate on it. It also surfaces stale `bash <missing>.sh 2>/dev/null || true` style hooks left over from older installs.
+At v1.2.0 `aelf doctor` runs two checks back-to-back: hook resolution (every `command` in `settings.json` checked against `$PATH`; surfaces stale `bash <missing>.sh 2>/dev/null || true` wrappers from older installs) and the structural graph audit (orphan threads, FTS5 sync, locked-belief contradictions, corpus volume). Exits 1 on any structural failure so CI can gate on it. Empty store on a fresh project is normal — the corpus-volume warning only fires once the project is at least 7 days old.
+
+Scope to one half:
 
 ```bash
-aelf health
+aelf doctor hooks      # hook resolution only
+aelf doctor graph      # structural auditor only
 ```
 
-Runs the structural auditor: orphan threads, FTS5 sync, locked-belief contradictions, corpus volume. Empty store on a fresh project is normal — the warning only fires once the project is at least 7 days old.
+`aelf health` and `aelf stats` continue to work as back-compat aliases through v1.2.x; they are scheduled for deletion at v1.4. The canonical replacements are `aelf doctor graph` and `aelf status`.
 
 ## 4. Onboard a project
 

--- a/docs/SLASH_COMMANDS.md
+++ b/docs/SLASH_COMMANDS.md
@@ -1,6 +1,8 @@
 # Slash Commands
 
-Twenty-two markdown files in `src/aelfrice/slash_commands/`. After `aelf setup`, they appear as `/aelf:*` in Claude Code. Each is a thin wrapper over the CLI — `/aelf:foo` invokes `aelf foo` against the active project's DB.
+Fourteen markdown files in `src/aelfrice/slash_commands/`, tracking the v1.2.0 CLI consolidation. After `aelf setup`, they appear as `/aelf:*` in Claude Code. Each is a thin wrapper over the CLI — `/aelf:foo` invokes `aelf foo` against the active project's DB.
+
+Slash files are not shipped for hidden CLI subcommands (`bench`, `health`, `migrate`, `rebuild`, `regime`, `stats`, `statusline`, `unsetup`). Those subcommands stay callable from the CLI for scripting, hook entry-points, and back-compat aliases — they're just not surfaced as slashes.
 
 Manual install:
 
@@ -21,20 +23,12 @@ cp src/aelfrice/slash_commands/*.md ~/.claude/commands/aelf/
 | `/aelf:validate` | belief id |
 | `/aelf:feedback` | `<belief_id> <used\|harmful>` |
 | `/aelf:resolve` | (none) — sweep CONTRADICTS via tie-breaker |
-| `/aelf:stats` | (none) |
-| `/aelf:health` | (none) |
-| `/aelf:status` | (none) — alias for `health` |
-| `/aelf:regime` | (none) — v1.0 regime classifier |
-| `/aelf:doctor` | optional `--user-settings`, `--project-root` |
-| `/aelf:migrate` | optional `--apply`, `--all`, `--from` |
+| `/aelf:status` | (none) — belief / lock / history counts (renamed from `stats` at v1.2.0) |
+| `/aelf:doctor` | optional `[hooks\|graph]`, `--user-settings`, `--project-root` |
 | `/aelf:ingest-transcript` | path or `--batch DIR` |
-| `/aelf:rebuild` | optional `--transcript PATH` (alpha) |
 | `/aelf:setup` | optional `--scope`, `--command`, `--transcript-ingest`, etc. |
-| `/aelf:unsetup` | same flags as `setup` |
-| `/aelf:statusline` | (none) — emit Claude Code statusline |
 | `/aelf:upgrade` | (none) — print pip-upgrade hint |
 | `/aelf:uninstall` | one of `--keep-db`, `--archive`, `--purge` |
-| `/aelf:bench` | optional `--top-k N` |
 
 Behaviour matches the CLI exactly — see [COMMANDS](COMMANDS.md). The v1.1.0 `edges` → `threads` user-facing rename does not surface here; the program name remains `aelf`.
 


### PR DESCRIPTION
## Summary

Bundled docs-only sweep for the two open release checklists (#131 v1.0.3 and #132 v1.2.0). Eleven items per checklist verified against current `main`; two real fixes landed, the rest already-accurate after the recent docs reframe (#128, #147).

Two atomic commits:
- `docs: SLASH_COMMANDS reflects v1.2.0 CLI consolidation (14 files, not 22)`
- `docs: INSTALL verify section uses v1.2.0 \`aelf doctor\` consolidation`

## v1.0.3 sweep (#131)

| # | Item | Status |
|---|---|---|
| 1 | README headline NOTE reflects v1.0.3 | already-accurate (legacy NOTE removed by #147 reframe; new tagline is version-agnostic) |
| 2 | README Install/60-seconds blocks mention v1.0.3 install-time commands or extras | already-accurate (no new extras at v1.0.3; install block intentionally minimal post-#147) |
| 3 | README roadmap table next-version theme correct | already-accurate (v1.2.x = search-tool hook, matches #134) |
| 4 | docs/ROADMAP.md `## v1.0.3` section exists and lists what shipped | already-accurate by design — #128 doc rewrite consolidated to `### v1.0.x — surface`. Per-patch narrative lives in CHANGELOG; ROADMAP is now version-themed. |
| 5 | docs/ROADMAP.md next-version section reflects v1.0.3 scope changes | already-accurate (resolve / aelf doctor were in scope, shipped at v1.0.3 per CHANGELOG; v1.2.x and v1.3.0 narratives don't claim them) |
| 6 | docs/RELEASING.md pytest count | already-accurate (`~1,150 passing at v1.2`; actual is 1149) |
| 7 | docs/COMMANDS.md command count + new commands documented | already-accurate (says "Twenty-two CLI subcommands", actual is 22; `resolve` listed in Memory operations table) |
| 8 | docs/INSTALL.md new optional extras + post-install verification | already-accurate for v1.0.3 (no new extras; verification commands present) |
| 9 | docs/BENCHMARKS.md Activation status version label | N/A (no per-adapter version label exists in BENCHMARKS.md; per-adapter status lives in `benchmarks/README.md` and was not changed by v1.0.3) |
| 10 | docs/LIMITATIONS.md items resolved by v1.0.3 moved out | already-accurate (contradiction-resolution no longer listed as a known issue post tie-breaker) |
| 11 | docs/MCP.md / docs/SLASH_COMMANDS.md surface counts and new entries reflect v1.0.3 | **fixed in this PR** (SLASH_COMMANDS.md said 22, actual is 14 after v1.2.0 deletions; MCP.md "nine memory tools" matches reality and was already accurate) |

## v1.2.0 sweep (#132)

| # | Item | Status |
|---|---|---|
| 1 | README headline NOTE reflects v1.2.0 | already-accurate (legacy NOTE removed by #147) |
| 2 | README Install/60-seconds blocks mention v1.2.0 install-time commands or extras | already-accurate (`aelf setup --commit-ingest`, `--transcript-ingest`, `--session-start`, `--rebuilder` documented in INSTALL.md § Optional hooks; README install block intentionally minimal) |
| 3 | README roadmap table next-version theme correct | already-accurate (v1.2.x = search-tool hook) |
| 4 | docs/ROADMAP.md `## v1.2.0` section exists and lists what shipped | already-accurate (`### v1.2.0 — auto-capture and triple extraction` is the longest section in ROADMAP, with full deliverable list) |
| 5 | docs/ROADMAP.md next-version section reflects v1.2.0 scope changes | already-accurate (v1.2.x search-tool hook section added by `ce95cb6`; v1.4.0 alpha-shipped-in-v1.2.0a0 cross-ref present) |
| 6 | docs/RELEASING.md pytest count | already-accurate |
| 7 | docs/COMMANDS.md command count + new commands documented | already-accurate (`validate`, `ingest-transcript`, `rebuild` all documented; count is 22) |
| 8 | docs/INSTALL.md new optional extras + post-install verification | **fixed in this PR** — verify section described `aelf doctor` and `aelf health` as separate commands; v1.2.0 consolidated `health` into `aelf doctor graph` with `aelf doctor` running both checks. Updated to reflect the consolidation, with explicit note that `aelf health` / `aelf stats` continue as back-compat aliases through v1.2.x. |
| 9 | docs/BENCHMARKS.md Activation status version label | N/A (no version label) |
| 10 | docs/LIMITATIONS.md items resolved by v1.2.0 moved out | already-accurate (harness-conflict closed by #125; demotion-pressure entry now references v1.2 commit-ingest / transcript-ingest mitigations) |
| 11 | docs/MCP.md / docs/SLASH_COMMANDS.md surface counts and new entries reflect v1.2.0 | **fixed in this PR** (same SLASH_COMMANDS.md fix as v1.0.3 — v1.2.0 was the release that deleted 8 slash files via CLI consolidation; MCP.md "nine memory tools" is correct and already lists `validate` from v1.2.0) |

## Out of scope / deferred

- README claim `aelf --help --advanced lists the rest` (line 123): the `--advanced` flag is referenced in README but not implemented in `cli.py`. This was introduced by the #147 reframe, not by v1.0.3 or v1.2.0, and is not on either checklist. Flagging here for orchestrator visibility — separate fix PR if desired.

## Test plan

- [x] `uv run pytest tests/ -x -q` (1149 passing, 2 skipped — docs-only PR, no code touched)
- [x] Manual verification of every checklist item against current `main` content before either flagging or marking already-accurate
- [x] No new claim added that's not already in CHANGELOG / shipped PRs
- [x] `tests/test_slash_commands.py` invariants still hold (file count and `EXPECTED_COMMANDS` match the SLASH_COMMANDS.md reference table)