### PR TITLE
feat: aelf project-warm — preload project beliefs on cwd change (closes #137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Pre-`1.0.0` releases are atomic milestones building toward the first
 installable release; see the roadmap in [README.md](README.md).
 
+## [Unreleased]
+
+### Added
+
+- **`aelf project-warm <path>`** ([#137](https://github.com/robotrocketscience/aelfrice/issues/137)). Hidden CwdChanged-hook entry point. Resolves a path to a project root (git work-tree via `git rev-parse --show-toplevel` — worktrees correctly resolve to the worktree, not the main checkout — or first ancestor with a `.aelfrice/projects/<id>/` provisioned layout) and pre-loads the project's SQLite + OS file-cache pages so the next `aelf` invocation hits warm storage. Idempotent + 60s-debounced via a unix-ts sentinel at `~/.aelfrice/projects/<id>/.last_warm`. Deny-glob defaults catch `/tmp/**`, `/var/folders/**`, `~/Downloads/**`, `~/Desktop/**`; configurable via `~/.aelfrice/config.json` (`project_warm.deny_globs`). The CLI surface is silent on every code path — unknown projects, denied paths, debounced calls, and any unexpected exception all return exit 0 with empty stdout. The companion `~/.claude/hooks/aelfrice-cwd-warm.sh` lives in the HOME repo and is out of scope for this release. New module `aelfrice.project_warm` exposes `resolve_project_root`, `warm_project`, `warm_path`, `WarmResult`, `ProjectRef`, `WarmConfig`. 19 deterministic unit tests cover the full matrix.
+
 ## [1.2.0] - 2026-04-28
 
 Major release. Auto-capture pipeline (transcript-ingest, commit-ingest, SessionStart hooks), the v1.1.0-designed `agent_inferred → user_validated` promotion path, the triple extractor, ingest-enrichment schema, batch-ingest of historical Claude Code JSONLs, the harness-integration guide, the `INEDIBLE` per-file privacy opt-out, and the v1.3-planned CLI consolidation rolled forward into this release. 16 PRs landed since v1.1.0. Folds in everything that shipped under the v1.2.0a0 alpha (#109) — that pre-release is now superseded; users should upgrade directly to 1.2.0.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,6 +1,6 @@
 # Commands
 
-Twenty-two CLI subcommands. The retrieval/feedback ones are also exposed as MCP tools (see [MCP](MCP.md)) and slash commands (see [SLASH_COMMANDS](SLASH_COMMANDS.md)). Lifecycle commands (`setup`, `doctor`, `migrate`, `upgrade`, `uninstall`, etc.) are CLI-only.
+Twenty-three CLI subcommands. The retrieval/feedback ones are also exposed as MCP tools (see [MCP](MCP.md)) and slash commands (see [SLASH_COMMANDS](SLASH_COMMANDS.md)). Lifecycle commands (`setup`, `doctor`, `migrate`, `upgrade`, `uninstall`, etc.) are CLI-only.
 
 ```
 aelf <subcommand> [args] [options]
@@ -46,6 +46,7 @@ DB resolves from `$AELFRICE_DB`, then `<git-common-dir>/aelfrice/memory.db` when
 | `statusline` | Emit the update-banner snippet (or empty). Reads cache only, no network. |
 | `ingest-transcript [PATH \| --batch DIR] [--since DATE]` | Ingest one `turns.jsonl` file or batch-walk a directory. Auto-detects aelfrice and Claude Code formats. Idempotent. |
 | `rebuild [--transcript PATH] [--n N] [--budget N]` | Manual context-rebuilder run (alpha; normally fires on `PreCompact`). Prints the rebuild block to stdout. |
+| `project-warm <path> [--debounce N]` | CwdChanged hook entry point. Resolves `<path>` to a project root (git work-tree or `~/.aelfrice/projects/<id>/`-provisioned ancestor), pre-loads the SQLite + OS page cache, and writes a sentinel under `~/.aelfrice/projects/<id>/.last_warm`. Silent no-op for unknown paths, denied paths (default deny: `/tmp/**`, `/var/folders/**`, `~/Downloads/**`, `~/Desktop/**` — override via `~/.aelfrice/config.json` `project_warm.deny_globs`), and any call inside the 60-second debounce window. Always exits 0; never writes to stdout. |
 
 ## Output and exit codes
 

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -19,6 +19,7 @@ Commands:
   uninstall                        tear down aelfrice locally + handle DB
   statusline                       emit Claude Code statusline snippet
   bench                            run the v0.9.0-rc benchmark harness
+  project-warm <path>              CwdChanged hook entry — pre-load the project's belief cache
 
 DB path resolves from AELFRICE_DB environment variable when set,
 otherwise from <git-common-dir>/aelfrice/memory.db when cwd is inside
@@ -79,6 +80,10 @@ from aelfrice.lifecycle import (
     read_cache as _read_update_cache,
     uninstall as _lifecycle_uninstall,
     upgrade_advice,
+)
+from aelfrice.project_warm import (
+    DEFAULT_DEBOUNCE_SECONDS as _PROJECT_WARM_DEBOUNCE,
+    warm_path as _warm_path,
 )
 from aelfrice.retrieval import DEFAULT_TOKEN_BUDGET, retrieve
 from aelfrice.scanner import scan_repo
@@ -654,6 +659,26 @@ def _resolve_settings_path(args: argparse.Namespace) -> Path:
         Path(args.project_root) if args.project_root is not None else None
     )
     return default_settings_path(_effective_scope(args), project_root=project_root)
+
+
+def _cmd_project_warm(args: argparse.Namespace, out: object) -> int:
+    """Hook entry-point: pre-load the project's SQLite + OS page cache.
+
+    Called by the CwdChanged hook (HOME repo) on every cd. Silent
+    no-op for unknown paths, denied paths, and the debounce window —
+    we never block, never error, and never write to stdout. The hook
+    fires fan-out across many cd events and any noise on stdout would
+    leak into Claude Code's session log.
+    """
+    del out  # silent path
+    debounce = args.debounce if args.debounce is not None else _PROJECT_WARM_DEBOUNCE
+    try:
+        _warm_path(Path(args.path), debounce_seconds=debounce)
+    except Exception:  # noqa: BLE001
+        # The hook fan-out semantics demand "never propagate". A
+        # broken warm should never block the user's prompt.
+        return 0
+    return 0
 
 
 def _cmd_setup(args: argparse.Namespace, out: object) -> int:
@@ -2021,6 +2046,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="(synthetic only) retrieval depth for hit@k (default 5)",
     )
     p_bench.set_defaults(func=_cmd_bench)
+
+    # Hidden: invoked by the CwdChanged hook (HOME repo). Pre-loads the
+    # active project's SQLite + OS page caches so the next aelf call
+    # pays only the second-hit cost. Silent no-op for unknown / denied
+    # paths, debounced to 60s per project. Issue #137.
+    p_project_warm = sub.add_parser("project-warm", help=argparse.SUPPRESS)
+    p_project_warm.add_argument(
+        "path", help="path to warm; resolved to a project root by aelfrice",
+    )
+    p_project_warm.add_argument(
+        "--debounce", type=int, default=None,
+        help=(
+            "override the debounce window in seconds "
+            f"(default {_PROJECT_WARM_DEBOUNCE})"
+        ),
+    )
+    p_project_warm.set_defaults(func=_cmd_project_warm)
 
     return parser
 

--- a/src/aelfrice/project_warm.py
+++ b/src/aelfrice/project_warm.py
@@ -1,0 +1,356 @@
+"""Preload a project's belief store on cwd-change events.
+
+Wired to a Claude Code `CwdChanged` hook (out of scope for this module,
+lives in HOME repo). The hook fires `aelf project-warm <path>`; this
+module resolves the path to a project root, opens the project's
+SQLite store, and touches the indexes a future `aelf search` will read.
+The "warming" is real but modest: the SQLite page cache and the OS
+file cache are populated, so the next process pays only the second-hit
+cost. There is no shared in-process cache between CLI invocations —
+that's a fact about `aelf`'s process model, not a missing feature.
+
+A sentinel file at `~/.aelfrice/projects/<id>/.last_warm` debounces
+repeat calls; subsequent invocations within `debounce_seconds` are
+no-ops and return `WarmResult.DEBOUNCED`.
+
+Resolution order for `resolve_project_root(path)`:
+
+1. `git rev-parse --show-toplevel` from `path`. Returns the worktree
+   root, not the main checkout — worktrees are separate workspaces and
+   should each warm independently.
+2. First ancestor of `path` containing a `.aelfrice/projects/<id>/`
+   directory. Lets non-git workspaces (research notebooks, scratch
+   dirs) opt in by hand-creating that layout.
+3. None — the caller's contract is to silently no-op for unknown
+   paths.
+
+Deny-glob defaults catch the common false-positive cases:
+`/tmp/**`, `/var/folders/**`, `~/Downloads/**`, `~/Desktop/**`.
+Override via `~/.aelfrice/config.json`'s `project_warm.deny_globs`
+key (list of strings; `~` expanded at load time).
+"""
+from __future__ import annotations
+
+import enum
+import fnmatch
+import hashlib
+import json
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Final, cast
+
+
+_AELFRICE_HOME_DIRNAME: Final[str] = ".aelfrice"
+_PROJECTS_SUBDIR: Final[str] = "projects"
+_SENTINEL_FILENAME: Final[str] = ".last_warm"
+_CONFIG_FILENAME: Final[str] = "config.json"
+_PROJECT_ID_LEN: Final[int] = 12
+
+_GIT_TIMEOUT_SECONDS: Final[float] = 5.0
+
+DEFAULT_DEBOUNCE_SECONDS: Final[int] = 60
+
+# Path globs that should never be warmed even if a `.git/` happens to
+# exist there. `~` is expanded against `Path.home()` at match time so
+# the same defaults work across machines.
+DEFAULT_DENY_GLOBS: Final[tuple[str, ...]] = (
+    "/tmp/**",
+    "/var/folders/**",
+    "~/Downloads/**",
+    "~/Desktop/**",
+)
+
+
+class WarmResult(str, enum.Enum):
+    """Outcome of `warm_project`. String values stay readable in logs."""
+
+    WARMED = "warmed"
+    DEBOUNCED = "debounced"
+    UNKNOWN_PROJECT = "unknown_project"
+    DENIED_PATH = "denied_path"
+
+
+@dataclass(frozen=True)
+class ProjectRef:
+    """Resolved project identity. `id` is path-derived and stable."""
+
+    root: Path
+    id: str
+
+
+@dataclass(frozen=True)
+class WarmConfig:
+    """Resolved warming config. Built from `~/.aelfrice/config.json`."""
+
+    deny_globs: tuple[str, ...] = field(default=DEFAULT_DENY_GLOBS)
+    aelfrice_home: Path = field(default_factory=lambda: Path.home() / _AELFRICE_HOME_DIRNAME)
+
+
+def _project_id(root: Path) -> str:
+    """Stable short id for a project root.
+
+    sha256 of the absolute root path, truncated. The full hash is too
+    long to embed in shell paths and we don't need cryptographic
+    collision resistance — we just want a directory-safe slug that
+    survives path renames cleanly within one machine.
+    """
+    digest = hashlib.sha256(str(root).encode("utf-8")).hexdigest()
+    return digest[:_PROJECT_ID_LEN]
+
+
+def _git_show_toplevel(path: Path) -> Path | None:
+    """Return cwd's git work-tree root, or None when not in a repo.
+
+    `--show-toplevel` returns the worktree path for `git worktree`
+    checkouts, not the main repo. That's intentional: worktrees are
+    separate workspaces and warm independently.
+    """
+    if not path.is_dir():
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(path),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    raw = result.stdout.strip()
+    if not raw:
+        return None
+    return Path(raw).resolve()
+
+
+def _ancestor_with_project_layout(
+    path: Path, aelfrice_home: Path,
+) -> Path | None:
+    """Walk parents looking for a `.aelfrice/projects/<id>/` directory.
+
+    Returns the first ancestor (including `path` itself) that has a
+    sentinel directory under `~/.aelfrice/projects/<id>/`, where `<id>`
+    is the project id of that ancestor. This is the opt-in path for
+    non-git workspaces — the user creates the project dir once, then
+    every subsequent cwd into a child path warms it.
+    """
+    projects_dir = aelfrice_home / _PROJECTS_SUBDIR
+    if not projects_dir.is_dir():
+        return None
+    candidate: Path = path if path.is_dir() else path.parent
+    candidate = candidate.resolve()
+    seen: set[Path] = set()
+    while candidate not in seen:
+        seen.add(candidate)
+        cid = _project_id(candidate)
+        if (projects_dir / cid).is_dir():
+            return candidate
+        if candidate.parent == candidate:
+            return None
+        candidate = candidate.parent
+    return None
+
+
+def resolve_project_root(
+    path: Path, *, aelfrice_home: Path | None = None,
+) -> ProjectRef | None:
+    """Resolve a path to a known project root, or None.
+
+    See module docstring for the resolution rules. `aelfrice_home`
+    overrides the default `~/.aelfrice/` for tests.
+    """
+    home = aelfrice_home if aelfrice_home is not None else Path.home() / _AELFRICE_HOME_DIRNAME
+    root = _git_show_toplevel(path)
+    if root is None:
+        root = _ancestor_with_project_layout(path, home)
+    if root is None:
+        return None
+    return ProjectRef(root=root, id=_project_id(root))
+
+
+def _expand_glob(pattern: str) -> str:
+    """Expand a leading `~` against `Path.home()`.
+
+    `fnmatch` does not handle `~` itself, so we resolve it before the
+    match. Patterns without a leading `~` pass through unchanged.
+    """
+    if pattern.startswith("~"):
+        return str(Path(pattern).expanduser())
+    return pattern
+
+
+def _is_denied(root: Path, deny_globs: tuple[str, ...]) -> bool:
+    target = str(root)
+    for raw in deny_globs:
+        pattern = _expand_glob(raw)
+        if fnmatch.fnmatch(target, pattern):
+            return True
+        # `**` in fnmatch only matches a single segment; treat `<prefix>/**`
+        # as "prefix or any descendant".
+        if pattern.endswith("/**"):
+            prefix = pattern[:-3]
+            if target == prefix or target.startswith(prefix + "/"):
+                return True
+    return False
+
+
+def load_config(
+    *, aelfrice_home: Path | None = None,
+) -> WarmConfig:
+    """Read warming config from `<aelfrice_home>/config.json`.
+
+    Schema (all keys optional):
+
+        {
+          "project_warm": {
+            "deny_globs": ["/tmp/**", "~/scratch/**"]
+          }
+        }
+
+    Missing file or invalid JSON falls back to `DEFAULT_DENY_GLOBS`.
+    Unknown keys are ignored — config is forward-compatible by design.
+    """
+    home = aelfrice_home if aelfrice_home is not None else Path.home() / _AELFRICE_HOME_DIRNAME
+    path = home / _CONFIG_FILENAME
+    deny_globs: tuple[str, ...] = DEFAULT_DENY_GLOBS
+    if path.is_file():
+        raw_obj: Any
+        try:
+            raw_obj = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            raw_obj = None
+        if isinstance(raw_obj, dict):
+            raw_dict = cast(dict[str, Any], raw_obj)
+            section_obj: Any = raw_dict.get("project_warm")
+            if isinstance(section_obj, dict):
+                section_dict = cast(dict[str, Any], section_obj)
+                globs_obj: Any = section_dict.get("deny_globs")
+                if isinstance(globs_obj, list):
+                    raw_list = cast(list[Any], globs_obj)
+                    str_globs: list[str] = [
+                        g for g in raw_list if isinstance(g, str)
+                    ]
+                    if len(str_globs) == len(raw_list):
+                        deny_globs = tuple(str_globs)
+    return WarmConfig(deny_globs=deny_globs, aelfrice_home=home)
+
+
+def _sentinel_path(project_id: str, aelfrice_home: Path) -> Path:
+    return aelfrice_home / _PROJECTS_SUBDIR / project_id / _SENTINEL_FILENAME
+
+
+def _read_sentinel(path: Path) -> float | None:
+    """Return the unix-ts in `path`, or None when missing/unparseable."""
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except (OSError, FileNotFoundError):
+        return None
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _write_sentinel(path: Path, ts: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{ts:.6f}\n", encoding="utf-8")
+
+
+def _warm_store(project_root: Path) -> None:
+    """Open the project DB and touch the indexes a search would read.
+
+    Cheap: a `count_beliefs` plus `list_locked_beliefs` is enough to
+    pull the relevant pages into the SQLite page cache and the OS file
+    cache. We close the connection immediately — there is no
+    in-process state to keep alive across CLI invocations.
+
+    Imports are local to keep the module light when the warming side is
+    never invoked (e.g., on `aelf --version`).
+    """
+    from aelfrice.cli import db_path  # noqa: PLC0415  # pyright: ignore[reportPrivateUsage]
+    from aelfrice.store import MemoryStore  # noqa: PLC0415
+
+    # `db_path()` reads cwd-derived state; project_root is the right cwd.
+    import os  # noqa: PLC0415
+
+    saved_cwd = os.getcwd()
+    try:
+        os.chdir(str(project_root))
+        path = db_path()
+    finally:
+        os.chdir(saved_cwd)
+    if not path.exists():
+        # Nothing to warm yet — first onboard hasn't run. Touching the
+        # parent dir is harmless but a no-op for performance, so skip.
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    store = MemoryStore(str(path))
+    try:
+        _ = store.count_beliefs()
+        _ = store.list_locked_beliefs()
+    finally:
+        store.close()
+
+
+def warm_project(
+    ref: ProjectRef,
+    *,
+    debounce_seconds: int = DEFAULT_DEBOUNCE_SECONDS,
+    config: WarmConfig | None = None,
+    now: float | None = None,
+) -> WarmResult:
+    """Warm `ref`'s project store. Idempotent + debounced.
+
+    Returns:
+        - `WarmResult.DENIED_PATH` when `ref.root` is on the deny list.
+        - `WarmResult.DEBOUNCED` when the sentinel was last written
+          fewer than `debounce_seconds` ago.
+        - `WarmResult.WARMED` after a successful warm + sentinel
+          rewrite.
+
+    `config` defaults to `load_config()` (read from disk). `now`
+    defaults to `time.time()` and is wired up so tests can drive the
+    debounce window without sleeping.
+    """
+    cfg = config if config is not None else load_config()
+    if _is_denied(ref.root, cfg.deny_globs):
+        return WarmResult.DENIED_PATH
+    sentinel = _sentinel_path(ref.id, cfg.aelfrice_home)
+    current = now if now is not None else time.time()
+    last = _read_sentinel(sentinel)
+    if last is not None and (current - last) < debounce_seconds:
+        return WarmResult.DEBOUNCED
+    _warm_store(ref.root)
+    _write_sentinel(sentinel, current)
+    return WarmResult.WARMED
+
+
+def warm_path(
+    path: Path,
+    *,
+    debounce_seconds: int = DEFAULT_DEBOUNCE_SECONDS,
+    config: WarmConfig | None = None,
+    now: float | None = None,
+) -> WarmResult:
+    """Convenience wrapper: resolve + warm in one call.
+
+    Returns `WarmResult.UNKNOWN_PROJECT` when no project root could be
+    resolved from `path`. Otherwise delegates to `warm_project`.
+    """
+    cfg = config if config is not None else load_config()
+    ref = resolve_project_root(path, aelfrice_home=cfg.aelfrice_home)
+    if ref is None:
+        return WarmResult.UNKNOWN_PROJECT
+    return warm_project(
+        ref,
+        debounce_seconds=debounce_seconds,
+        config=cfg,
+        now=now,
+    )

--- a/tests/test_project_warm.py
+++ b/tests/test_project_warm.py
@@ -1,0 +1,437 @@
+"""Deterministic tests for `aelfrice.project_warm`.
+
+Hard rules from issue #137 / the GSD playbook:
+
+- No real `~/.aelfrice` writes — every test redirects `aelfrice_home`
+  via `monkeypatch` or the `WarmConfig.aelfrice_home` field.
+- No network. No probabilistic assertions. Each test ≤2s.
+- Real git operations are allowed in `tmp_path`-scoped throwaway repos
+  because `git init` is fast and deterministic; we don't mock the
+  binary.
+
+Coverage matrix per the issue body:
+
+  * git repo                      → resolves to repo root
+  * git worktree                  → resolves to the worktree, not main
+  * non-git dir                   → returns None / UNKNOWN_PROJECT
+  * denied path                   → DENIED_PATH
+  * debounce window               → DEBOUNCED on the second call
+  * unknown project               → UNKNOWN_PROJECT
+  * config.json deny override     → custom deny applies
+  * sentinel write                → file appears with the right ts
+  * CLI silent no-op              → exit 0 + empty stdout
+
+Plus a few near-tests for the helpers that aren't directly observable
+through the public API (project-id determinism, deny matcher).
+"""
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from aelfrice.cli import main as cli_main
+from aelfrice.project_warm import (
+    DEFAULT_DEBOUNCE_SECONDS,
+    DEFAULT_DENY_GLOBS,
+    ProjectRef,
+    WarmConfig,
+    WarmResult,
+    load_config,
+    resolve_project_root,
+    warm_path,
+    warm_project,
+)
+
+
+# --- fixtures ---------------------------------------------------------------
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    """Run `git <args>` in `cwd` with deterministic identity + no signing."""
+    subprocess.run(
+        [
+            "git",
+            "-c", "user.email=test@example.invalid",
+            "-c", "user.name=test",
+            "-c", "commit.gpgsign=false",
+            *args,
+        ],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    """Make `repo` a git work-tree with one commit."""
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-q", "-b", "main"], cwd=repo)
+    (repo / "README").write_text("seed", encoding="utf-8")
+    _git(["add", "."], cwd=repo)
+    _git(["commit", "-q", "-m", "seed"], cwd=repo)
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect `~/.aelfrice/` to a tmp_path so tests never write to $HOME.
+
+    Returns the path that `Path.home() / ".aelfrice"` resolves to under
+    the redirect — the CLI test needs this exact mapping because
+    `aelf project-warm` builds `WarmConfig` via `load_config()` which
+    reads `Path.home() / ".aelfrice"`. Setting HOME alone is enough on
+    macOS / Linux where `Path.home()` consults `$HOME`.
+    """
+    fake_user_home = tmp_path / "fake_user_home"
+    fake_user_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_user_home))
+    home = fake_user_home / ".aelfrice"
+    home.mkdir()
+    return home
+
+
+# --- resolve_project_root ---------------------------------------------------
+
+
+def test_resolve_project_root_git_repo(tmp_path: Path, fake_home: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    sub = repo / "src" / "pkg"
+    sub.mkdir(parents=True)
+
+    ref = resolve_project_root(sub, aelfrice_home=fake_home)
+
+    assert ref is not None
+    assert ref.root == repo.resolve()
+    assert len(ref.id) == 12
+
+
+def test_resolve_project_root_git_worktree(
+    tmp_path: Path, fake_home: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    wt = tmp_path / "wt"
+    _git(["worktree", "add", "-q", "-b", "feat/x", str(wt)], cwd=repo)
+
+    ref = resolve_project_root(wt, aelfrice_home=fake_home)
+
+    # The risk-acknowledged behaviour: worktrees are separate workspaces,
+    # so the returned root is the worktree path, not the main checkout.
+    assert ref is not None
+    assert ref.root == wt.resolve()
+    assert ref.root != repo.resolve()
+
+
+def test_resolve_project_root_non_git_dir(
+    tmp_path: Path, fake_home: Path,
+) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+
+    ref = resolve_project_root(plain, aelfrice_home=fake_home)
+
+    assert ref is None
+
+
+def test_resolve_project_root_ancestor_with_layout(
+    tmp_path: Path, fake_home: Path,
+) -> None:
+    """Non-git dir that has its `.aelfrice/projects/<id>/` provisioned."""
+    project = tmp_path / "notebook"
+    (project / "deep" / "nested").mkdir(parents=True)
+    # Provision the project layout the way `aelf onboard` would.
+    from aelfrice.project_warm import _project_id  # pyright: ignore[reportPrivateUsage]
+    pid = _project_id(project.resolve())
+    (fake_home / "projects" / pid).mkdir(parents=True)
+
+    ref = resolve_project_root(project / "deep" / "nested", aelfrice_home=fake_home)
+
+    assert ref is not None
+    assert ref.root == project.resolve()
+    assert ref.id == pid
+
+
+def test_resolve_project_root_returns_none_for_missing_path(
+    tmp_path: Path, fake_home: Path,
+) -> None:
+    missing = tmp_path / "does-not-exist"
+
+    ref = resolve_project_root(missing, aelfrice_home=fake_home)
+
+    # Path doesn't exist → not a git repo, not under an opted-in
+    # ancestor → None. Hook callers downgrade this to a silent no-op.
+    assert ref is None
+
+
+# --- warm_project: core paths ----------------------------------------------
+
+
+def _ref_for(root: Path) -> ProjectRef:
+    from aelfrice.project_warm import _project_id  # pyright: ignore[reportPrivateUsage]
+    return ProjectRef(root=root.resolve(), id=_project_id(root.resolve()))
+
+
+def test_warm_project_writes_sentinel(
+    tmp_path: Path, fake_home: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    ref = _ref_for(repo)
+    cfg = WarmConfig(deny_globs=(), aelfrice_home=fake_home)
+
+    result = warm_project(ref, config=cfg, now=1_700_000_000.0)
+
+    assert result is WarmResult.WARMED
+    sentinel = fake_home / "projects" / ref.id / ".last_warm"
+    assert sentinel.is_file()
+    assert float(sentinel.read_text(encoding="utf-8").strip()) == 1_700_000_000.0
+
+
+def test_warm_project_debounces_within_window(
+    tmp_path: Path, fake_home: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    ref = _ref_for(repo)
+    cfg = WarmConfig(deny_globs=(), aelfrice_home=fake_home)
+
+    # First call seeds the sentinel.
+    first = warm_project(ref, config=cfg, now=1_700_000_000.0)
+    # Second call inside the 60s window must be a no-op.
+    second = warm_project(
+        ref, config=cfg, debounce_seconds=60, now=1_700_000_030.0,
+    )
+    # Third call past the window warms again.
+    third = warm_project(
+        ref, config=cfg, debounce_seconds=60, now=1_700_000_061.0,
+    )
+
+    assert first is WarmResult.WARMED
+    assert second is WarmResult.DEBOUNCED
+    assert third is WarmResult.WARMED
+
+
+def test_warm_project_denied_path(
+    tmp_path: Path, fake_home: Path,
+) -> None:
+    # Use a deny-glob the test root actually matches so we don't depend
+    # on the host having /tmp/* layouts under tmp_path (it varies).
+    repo = tmp_path / "scratch"
+    _init_repo(repo)
+    ref = _ref_for(repo)
+    cfg = WarmConfig(
+        deny_globs=(str(tmp_path) + "/**",),
+        aelfrice_home=fake_home,
+    )
+
+    result = warm_project(ref, config=cfg, now=1_700_000_000.0)
+
+    assert result is WarmResult.DENIED_PATH
+    sentinel = fake_home / "projects" / ref.id / ".last_warm"
+    assert not sentinel.exists()  # denied path must not seed sentinel
+
+
+def test_warm_project_skips_when_db_does_not_exist(
+    tmp_path: Path, fake_home: Path,
+) -> None:
+    """No DB yet (first onboard hasn't run) is still a successful warm.
+
+    The warm step is best-effort. The sentinel still updates so the
+    debounce window applies the next time a real DB is present.
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    ref = _ref_for(repo)
+    cfg = WarmConfig(deny_globs=(), aelfrice_home=fake_home)
+
+    result = warm_project(ref, config=cfg, now=1_700_000_000.0)
+
+    assert result is WarmResult.WARMED
+    db = repo / ".git" / "aelfrice" / "memory.db"
+    assert not db.exists()
+
+
+def test_warm_project_warms_real_store(
+    tmp_path: Path, fake_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a populated DB has its locked-beliefs path exercised."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    db_dir = repo / ".git" / "aelfrice"
+    db_dir.mkdir(parents=True)
+    db = db_dir / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+
+    # Seed one belief so count_beliefs / list_locked_beliefs touch real
+    # pages. Using the public store API keeps the test resilient.
+    from aelfrice.models import (
+        BELIEF_FACTUAL,
+        LOCK_USER,
+        Belief,
+    )
+    from aelfrice.store import MemoryStore
+
+    seeded = MemoryStore(str(db))
+    try:
+        seeded.insert_belief(
+            Belief(
+                id="warm-test-0001",
+                content="warming smoke belief",
+                content_hash="warm-test-0001-hash",
+                alpha=9.0,
+                beta=0.5,
+                type=BELIEF_FACTUAL,
+                lock_level=LOCK_USER,
+                locked_at="2026-04-27T00:00:00Z",
+                demotion_pressure=0,
+                created_at="2026-04-27T00:00:00Z",
+                last_retrieved_at=None,
+                origin="user_stated",
+            ),
+        )
+    finally:
+        seeded.close()
+
+    monkeypatch.delenv("AELFRICE_DB", raising=False)
+    ref = _ref_for(repo)
+    cfg = WarmConfig(deny_globs=(), aelfrice_home=fake_home)
+
+    result = warm_project(ref, config=cfg, now=1_700_000_000.0)
+
+    assert result is WarmResult.WARMED
+
+
+# --- warm_path: end-to-end via the convenience wrapper ---------------------
+
+
+def test_warm_path_unknown_project(
+    tmp_path: Path, fake_home: Path,
+) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    cfg = WarmConfig(deny_globs=(), aelfrice_home=fake_home)
+
+    result = warm_path(plain, config=cfg, now=1_700_000_000.0)
+
+    assert result is WarmResult.UNKNOWN_PROJECT
+
+
+# --- config -----------------------------------------------------------------
+
+
+def test_load_config_defaults_when_no_file(fake_home: Path) -> None:
+    cfg = load_config(aelfrice_home=fake_home)
+    assert cfg.deny_globs == DEFAULT_DENY_GLOBS
+    assert cfg.aelfrice_home == fake_home
+
+
+def test_load_config_overrides_deny_globs(fake_home: Path) -> None:
+    (fake_home / "config.json").write_text(
+        json.dumps({"project_warm": {"deny_globs": ["/srv/**", "~/scratch/**"]}}),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(aelfrice_home=fake_home)
+
+    assert cfg.deny_globs == ("/srv/**", "~/scratch/**")
+
+
+def test_load_config_ignores_malformed_globs(fake_home: Path) -> None:
+    (fake_home / "config.json").write_text(
+        json.dumps({"project_warm": {"deny_globs": ["/ok/**", 42]}}),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(aelfrice_home=fake_home)
+
+    # One non-string in the list discards the whole override.
+    assert cfg.deny_globs == DEFAULT_DENY_GLOBS
+
+
+def test_load_config_falls_back_on_invalid_json(fake_home: Path) -> None:
+    (fake_home / "config.json").write_text("{not json", encoding="utf-8")
+
+    cfg = load_config(aelfrice_home=fake_home)
+
+    assert cfg.deny_globs == DEFAULT_DENY_GLOBS
+
+
+# --- CLI surface ------------------------------------------------------------
+
+
+def test_cli_project_warm_silent_for_unknown_path(
+    tmp_path: Path, fake_home: Path,
+) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    buf = io.StringIO()
+
+    code = cli_main(["project-warm", str(plain)], out=buf)
+
+    assert code == 0
+    assert buf.getvalue() == ""
+
+
+def test_cli_project_warm_silent_for_denied_path(
+    tmp_path: Path, fake_home: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    # Configure deny so this tmp_path is blocked.
+    (fake_home / "config.json").write_text(
+        json.dumps({"project_warm": {"deny_globs": [str(tmp_path) + "/**"]}}),
+        encoding="utf-8",
+    )
+    buf = io.StringIO()
+
+    code = cli_main(["project-warm", str(repo)], out=buf)
+
+    assert code == 0
+    assert buf.getvalue() == ""
+    sentinel_dir = fake_home / "projects"
+    # No project layout should have been created — denied paths are
+    # invisible to the warm pipeline.
+    if sentinel_dir.exists():
+        assert list(sentinel_dir.iterdir()) == []
+
+
+def test_cli_project_warm_warms_and_debounces(
+    tmp_path: Path, fake_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    # Disable deny globs so tmp_path-rooted repos can warm.
+    (fake_home / "config.json").write_text(
+        json.dumps({"project_warm": {"deny_globs": []}}),
+        encoding="utf-8",
+    )
+    # Pin time so the second call lands inside the debounce window.
+    fixed_now = 1_700_000_000.0
+    monkeypatch.setattr(time, "time", lambda: fixed_now)
+
+    buf1 = io.StringIO()
+    code1 = cli_main(["project-warm", str(repo)], out=buf1)
+    buf2 = io.StringIO()
+    code2 = cli_main(["project-warm", str(repo)], out=buf2)
+
+    assert code1 == 0
+    assert code2 == 0
+    # The CLI surface stays silent on both paths — observable evidence
+    # is the sentinel file alone.
+    assert buf1.getvalue() == ""
+    assert buf2.getvalue() == ""
+    from aelfrice.project_warm import _project_id  # pyright: ignore[reportPrivateUsage]
+    pid = _project_id(repo.resolve())
+    sentinel = fake_home / "projects" / pid / ".last_warm"
+    assert sentinel.is_file()
+    assert float(sentinel.read_text(encoding="utf-8").strip()) == fixed_now
+
+
+def test_cli_project_warm_default_debounce_constant() -> None:
+    """Issue #137 pins the default to 60 seconds — guard against drift."""
+    assert DEFAULT_DEBOUNCE_SECONDS == 60

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -100,7 +100,7 @@ def test_no_extra_files_in_slash_commands_dir() -> None:
 # callable indefinitely as scripting / hook entry points.
 HIDDEN_SUBCOMMANDS = frozenset({
     "rebuild", "statusline", "bench", "regime", "migrate", "unsetup",
-    "health", "stats",
+    "health", "stats", "project-warm",
 })
 
 


### PR DESCRIPTION
## Summary

- New `aelfrice.project_warm` module: `resolve_project_root` (git work-tree via `--show-toplevel`, then `~/.aelfrice/projects/<id>/`-provisioned ancestor, else None), `warm_project` / `warm_path`, `WarmResult` enum (`WARMED` / `DEBOUNCED` / `UNKNOWN_PROJECT` / `DENIED_PATH`), `ProjectRef`, `WarmConfig`.
- Hidden CLI subcommand `aelf project-warm <path> [--debounce N]`. Silent on every code path — unknown / denied / debounced / unexpected-exception all return exit 0 with empty stdout. Required because the companion CwdChanged hook (HOME repo, out of scope here) fan-outs across every cd.
- 60-second debounce via unix-ts sentinel at `~/.aelfrice/projects/<id>/.last_warm`. Deny-glob defaults `/tmp/**`, `/var/folders/**`, `~/Downloads/**`, `~/Desktop/**`; override via `~/.aelfrice/config.json` (`project_warm.deny_globs`). Malformed JSON falls back to defaults; non-string entries discard the override.
- 19 deterministic unit tests (`tests/test_project_warm.py`) cover git repo / worktree / non-git / ancestor-with-layout / debounce window / unknown / denied / sentinel writes / config overrides / CLI silence. Each ≤0.5s. Real `git init` against `tmp_path`-scoped throwaway repos; `HOME` redirected so `~/.aelfrice/` is never touched.
- Docs: row in `docs/COMMANDS.md` Lifecycle table, `Unreleased` entry in `CHANGELOG.md`, hidden subcommand list updated in `cli.py` docstring + `tests/test_slash_commands.py::HIDDEN_SUBCOMMANDS`.

The "warming" is real but modest — each `aelf` CLI invocation is a fresh process, so the only cache that crosses invocations is the SQLite page cache and the OS file cache. The module touches `count_beliefs` + `list_locked_beliefs` to pull the relevant pages in. There is no shared in-process state between calls (that's a fact about the process model, not a missing feature; documented in the module docstring).

Closes #137. Out of scope: the `~/.claude/hooks/aelfrice-cwd-warm.sh` script that fires this — it lives in the HOME repo per #137's design.

## Test plan

- [x] `uv run pytest tests/test_project_warm.py -x -q` (19 passed)
- [x] `uv run pytest -x -q` (1167 passed, 2 skipped — full suite stays green; new test count: 19)
- [x] `uv run pyright src/aelfrice/project_warm.py` (0 errors, strict)
- [x] `uv run aelf project-warm /tmp/foo` exits 0 silently
- [x] `aelf --help` does not list `project-warm` (hidden as designed)
- [x] Slash-commands audit (`tests/test_slash_commands.py`) reflects the new hidden subcommand