### PR TITLE
fix: project-warm sentinel debounce keys off git-common-dir (closes #161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`project-warm`: sentinel debounce keyed off git-common-dir, not worktree path** ([#161](https://github.com/robotrocketscience/aelfrice/issues/161)). Previously `_project_id` was derived from `git rev-parse --show-toplevel`, giving each worktree of the same repo a distinct sentinel under `~/.aelfrice/projects/<id>/.last_warm`. Two worktrees of one repo share a single DB (via `git-common-dir`), so they should share one sentinel. `resolve_project_root` now calls `git rev-parse --path-format=absolute --show-toplevel --git-common-dir` in a single subprocess and keys `ProjectRef.id` off the git-common-dir while keeping `ProjectRef.root` as the worktree working directory (for `os.chdir` in `_warm_store`). New test `test_resolve_project_root_worktrees_share_id` verifies that two worktrees of one repo produce identical `ProjectRef.id` values.
+
 ### Added
 
 - **`aelf session-delta --id <session_id>`** ([#140](https://github.com/robotrocketscience/aelfrice/issues/140)). Hidden SessionEnd-hook entry point. New module `aelfrice.telemetry` exposes `compute_session_delta(store, session_id, *, telemetry_path, now) -> dict` (pure function) and `emit_session_delta(session_id, *, store, path, now) -> None` (append to file). The writer reads beliefs tagged with `session_id` to compute per-session deltas (`beliefs_created`, `corrections_detected`, `feedback_given`, `velocity_items_per_hour`, `velocity_tier`, `duration_seconds`), snapshots the current store state for the `beliefs` and `graph` blocks, and computes 7-day and 30-day rolling-window rollups by walking the existing `telemetry.jsonl` tail. Schema matches the v=1 format already produced by the HOME-repo hook. Missing or empty `--id` is a stderr-warn no-op (exit 0) so hook failures never surface as broken shell sessions. Idle sessions (zero beliefs) still emit a zero-row so `len(telemetry.jsonl)` equals session count. `window_7` / `window_30` rollups now reflect real per-session activity instead of being static. 10 new tests in `tests/test_telemetry_session_delta.py`.

--- a/src/aelfrice/project_warm.py
+++ b/src/aelfrice/project_warm.py
@@ -13,11 +13,20 @@ A sentinel file at `~/.aelfrice/projects/<id>/.last_warm` debounces
 repeat calls; subsequent invocations within `debounce_seconds` are
 no-ops and return `WarmResult.DEBOUNCED`.
 
+**Sentinel keying:** the sentinel `<id>` is derived from the repo's
+`git-common-dir` (via `git rev-parse --git-common-dir`), not from the
+worktree path. Two worktrees of the same repo share one git-common-dir
+and therefore share one sentinel, matching the v1.1.0 design principle
+that worktrees share a single belief store. `ProjectRef.root` remains
+the worktree working directory so that `_warm_store` can `os.chdir` to
+the right place for `db_path()`.
+
 Resolution order for `resolve_project_root(path)`:
 
-1. `git rev-parse --show-toplevel` from `path`. Returns the worktree
-   root, not the main checkout — worktrees are separate workspaces and
-   should each warm independently.
+1. `git rev-parse --git-common-dir` from `path`. Two worktrees of the
+   same repo share a git-common-dir, so both map to the same `id` and
+   share one debounce sentinel. `ProjectRef.root` is still the
+   worktree's working directory.
 2. First ancestor of `path` containing a `.aelfrice/projects/<id>/`
    directory. Lets non-git workspaces (research notebooks, scratch
    dirs) opt in by hand-creating that layout.
@@ -100,18 +109,26 @@ def _project_id(root: Path) -> str:
     return digest[:_PROJECT_ID_LEN]
 
 
-def _git_show_toplevel(path: Path) -> Path | None:
-    """Return cwd's git work-tree root, or None when not in a repo.
+def _git_resolve(path: Path) -> tuple[Path, Path] | None:
+    """Return (worktree_root, git_common_dir) for `path`, or None.
 
-    `--show-toplevel` returns the worktree path for `git worktree`
-    checkouts, not the main repo. That's intentional: worktrees are
-    separate workspaces and warm independently.
+    `worktree_root` is `git rev-parse --show-toplevel` — the working
+    directory for this worktree. `git_common_dir` is the shared git
+    object store root (identical across all worktrees of one repo and
+    matches what `cli._git_common_dir()` returns). Using git-common-dir
+    as the sentinel key means all worktrees of one repo share a single
+    debounce sentinel, matching the v1.1.0 design.
     """
     if not path.is_dir():
         return None
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            [
+                "git", "rev-parse",
+                "--path-format=absolute",
+                "--show-toplevel",
+                "--git-common-dir",
+            ],
             cwd=str(path),
             capture_output=True,
             text=True,
@@ -122,10 +139,12 @@ def _git_show_toplevel(path: Path) -> Path | None:
         return None
     if result.returncode != 0:
         return None
-    raw = result.stdout.strip()
-    if not raw:
+    lines = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+    if len(lines) < 2:
         return None
-    return Path(raw).resolve()
+    worktree_root = Path(lines[0]).resolve()
+    common_dir = Path(lines[1]).resolve()
+    return worktree_root, common_dir
 
 
 def _ancestor_with_project_layout(
@@ -163,11 +182,18 @@ def resolve_project_root(
 
     See module docstring for the resolution rules. `aelfrice_home`
     overrides the default `~/.aelfrice/` for tests.
+
+    For git repos/worktrees: `ProjectRef.root` is the worktree working
+    directory (used by `_warm_store` for `os.chdir`), while
+    `ProjectRef.id` is keyed off the git-common-dir so all worktrees of
+    one repo share the same sentinel.
     """
     home = aelfrice_home if aelfrice_home is not None else Path.home() / _AELFRICE_HOME_DIRNAME
-    root = _git_show_toplevel(path)
-    if root is None:
-        root = _ancestor_with_project_layout(path, home)
+    git_result = _git_resolve(path)
+    if git_result is not None:
+        worktree_root, common_dir = git_result
+        return ProjectRef(root=worktree_root, id=_project_id(common_dir))
+    root = _ancestor_with_project_layout(path, home)
     if root is None:
         return None
     return ProjectRef(root=root, id=_project_id(root))

--- a/tests/test_project_warm.py
+++ b/tests/test_project_warm.py
@@ -120,11 +120,36 @@ def test_resolve_project_root_git_worktree(
 
     ref = resolve_project_root(wt, aelfrice_home=fake_home)
 
-    # The risk-acknowledged behaviour: worktrees are separate workspaces,
-    # so the returned root is the worktree path, not the main checkout.
+    # ProjectRef.root is the worktree working directory — not the main
+    # checkout — so _warm_store can os.chdir to the right place.
     assert ref is not None
     assert ref.root == wt.resolve()
     assert ref.root != repo.resolve()
+
+
+def test_resolve_project_root_worktrees_share_id(
+    tmp_path: Path, fake_home: Path,
+) -> None:
+    """Two worktrees of the same repo share a single ProjectRef.id.
+
+    The sentinel is keyed by git-common-dir, so both worktrees hit the
+    same debounce sentinel, matching the v1.1.0 design that worktrees of
+    one repo share a single belief store.
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    wt = tmp_path / "wt"
+    _git(["worktree", "add", "-q", "-b", "feat/x", str(wt)], cwd=repo)
+
+    ref_main = resolve_project_root(repo, aelfrice_home=fake_home)
+    ref_wt = resolve_project_root(wt, aelfrice_home=fake_home)
+
+    assert ref_main is not None
+    assert ref_wt is not None
+    # Roots differ — each worktree is a separate working directory.
+    assert ref_main.root != ref_wt.root
+    # IDs must be identical — both map to the same git-common-dir.
+    assert ref_main.id == ref_wt.id
 
 
 def test_resolve_project_root_non_git_dir(
@@ -426,7 +451,9 @@ def test_cli_project_warm_warms_and_debounces(
     assert buf1.getvalue() == ""
     assert buf2.getvalue() == ""
     from aelfrice.project_warm import _project_id  # pyright: ignore[reportPrivateUsage]
-    pid = _project_id(repo.resolve())
+    # The sentinel id is keyed off git-common-dir (repo/.git for a
+    # non-worktree repo), not the repo root itself.
+    pid = _project_id((repo / ".git").resolve())
     sentinel = fake_home / "projects" / pid / ".last_warm"
     assert sentinel.is_file()
     assert float(sentinel.read_text(encoding="utf-8").strip()) == fixed_now


### PR DESCRIPTION
## Summary

- `_project_id` was keyed off `git rev-parse --show-toplevel`, giving each worktree of the same repo a separate sentinel under `~/.aelfrice/projects/<id>/.last_warm`. Two worktrees share one DB (via git-common-dir), so they should share one sentinel.
- Replace `_git_show_toplevel` with `_git_resolve` which calls `git rev-parse --path-format=absolute --show-toplevel --git-common-dir` in a single subprocess. `ProjectRef.id` is now keyed off `git-common-dir`; `ProjectRef.root` remains the worktree working directory for `_warm_store`'s `os.chdir`.
- New test `test_resolve_project_root_worktrees_share_id` creates a real `git worktree add` checkout and asserts both worktrees produce identical `ProjectRef.id` values.

## Test plan

- [x] `uv run --with pytest --with pytest-timeout pytest tests/test_project_warm.py -x -q` → 20 passed (19 original + 1 new)
- [x] `uv run --with pytest --with pytest-timeout pytest -x -q` → 1179 passed, 2 skipped
- [x] `uv run --with pyright pyright src/aelfrice/project_warm.py` → 0 errors, 0 warnings

Closes #161.