### PR TITLE
ci: reduce GitHub Actions burn (concurrency + dedup pytest + uv cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - run: uv sync --frozen --extra dev --extra archive
       - run: uv run pytest tests/ -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -9,6 +9,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   secrets-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -97,19 +97,6 @@ jobs:
           rm -f /tmp/p /tmp/h /tmp/d
           exit "$fail"
 
-  pytest:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.12', '3.13']
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: uv sync --frozen --extra dev --extra archive
-      - run: uv run pytest tests/ -q
-
   release-docs-check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Why

Last 12.5h on this repo: 46 `Staging Gate` runs + 46 `CI` runs = 92 PR-triggered runs. Public repos get unlimited free GitHub-hosted Actions minutes, so this isn't a billing problem — it's a noise + latency problem. Three structural sources of duplicate work:

1. **No concurrency cancellation.** Branches like `feat/v1.4-precompact-rebuilder` ran 3× back-to-back within 5 min on rapid pushes, all running to completion instead of the older runs being cancelled.
2. **Duplicate pytest matrix.** `CI` and `Staging Gate` both ran the identical `pytest 3.12+3.13` matrix on every PR — twice the pytest jobs, identical signal, twice the check-run rows on the PR page.
3. **No uv cache.** Every pytest job re-resolved + reinstalled the full dep tree from scratch via `uv sync --frozen`.

## What

Three atomic commits:

- `ci: cancel superseded CI and Staging Gate runs per PR` — adds `concurrency` group + `cancel-in-progress: true` to both workflows.
- `ci: drop duplicate pytest matrix from Staging Gate` — pytest stays in CI; Staging Gate now does only its unique jobs (gitleaks, pattern-scan, history-scan, release-docs-check, commit-msg-prefix, pr-body-issue-link).
- `perf(ci): cache uv downloads and venv across pytest runs` — `enable-cache: true` on `setup-uv`, keyed on `uv.lock`.

## Verified on this PR

- 8 checks total instead of 10 (the two `Staging Gate / pytest` checks are gone).
- pytest 3.12: **33s** | pytest 3.13: **23s** (was ~120s avg before — uv cache hit).
- All security/release-docs/commit-msg/pr-body jobs still firing under Staging Gate.

## Out of scope: self-hosted runners

This repo is public, so self-hosted runners on willow/archon are **off the table** as a CI-burn solution. GitHub's own guidance recommends self-hosted runners only for private repositories — a fork PR can execute arbitrary code on the runner host, which on a public repo means any GitHub user. See https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security. The right next levers if these three fixes aren't enough: GitHub-hosted larger runners (free for public repos), or ephemeral-per-job self-hosted via runner-controller — never static self-hosted on this repo.

## Note for future branch protection

When required status checks are configured, list `CI / pytest` — `Staging Gate / pytest` no longer exists.

<!-- no-issue -->