### PR TITLE
release: v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-04-28
+
 ### Added
 
 - **Conventional-commit prefix enforcement in CI + PR-body issue-link advisory** ([#169](https://github.com/robotrocketscience/aelfrice/issues/169), [#170](https://github.com/robotrocketscience/aelfrice/issues/170)). Two new jobs added to `.github/workflows/staging-gate.yml`. `commit-msg-prefix` iterates every commit in the PR range (`base..head`) and calls `scripts/check-commit-msg.py --subject <subject>` for each; the job fails if any commit has an invalid prefix — `Merge` and `Revert` auto-subjects are exempt. `scripts/check-commit-msg.py` is also wired as a local `commit-msg` hook via `.githooks/commit-msg`; run `sh scripts/setup-hooks.sh` once after cloning to install it. `pr-body-issue-link` checks whether the PR body contains a GitHub auto-close keyword (`Closes #N`, `Fixes #N`, `Resolves #N`, etc.) or an opt-out marker (`<!-- no-issue -->`); the job always exits 0 — it is advisory only, emitting a `::warning::` annotation when neither pattern is found. 29 deterministic unit tests in `tests/test_check_commit_msg.py` cover the prefix validator.
@@ -40,6 +42,14 @@ installable release; see the roadmap in [README.md](README.md).
 - **`aelf session-delta --id <session_id>`** ([#140](https://github.com/robotrocketscience/aelfrice/issues/140)). Hidden SessionEnd-hook entry point. New module `aelfrice.telemetry` exposes `compute_session_delta(store, session_id, *, telemetry_path, now) -> dict` (pure function) and `emit_session_delta(session_id, *, store, path, now) -> None` (append to file). The writer reads beliefs tagged with `session_id` to compute per-session deltas (`beliefs_created`, `corrections_detected`, `feedback_given`, `velocity_items_per_hour`, `velocity_tier`, `duration_seconds`), snapshots the current store state for the `beliefs` and `graph` blocks, and computes 7-day and 30-day rolling-window rollups by walking the existing `telemetry.jsonl` tail. Schema matches the v=1 format already produced by the HOME-repo hook. Missing or empty `--id` is a stderr-warn no-op (exit 0) so hook failures never surface as broken shell sessions. Idle sessions (zero beliefs) still emit a zero-row so `len(telemetry.jsonl)` equals session count. `window_7` / `window_30` rollups now reflect real per-session activity instead of being static. 10 new tests in `tests/test_telemetry_session_delta.py`.
 
 - **`aelf project-warm <path>`** ([#137](https://github.com/robotrocketscience/aelfrice/issues/137)). Hidden CwdChanged-hook entry point. Resolves a path to a project root (git work-tree via `git rev-parse --show-toplevel` — worktrees correctly resolve to the worktree, not the main checkout — or first ancestor with a `.aelfrice/projects/<id>/` provisioned layout) and pre-loads the project's SQLite + OS file-cache pages so the next `aelf` invocation hits warm storage. Idempotent + 60s-debounced via a unix-ts sentinel at `~/.aelfrice/projects/<id>/.last_warm`. Deny-glob defaults catch `/tmp/**`, `/var/folders/**`, `~/Downloads/**`, `~/Desktop/**`; configurable via `~/.aelfrice/config.json` (`project_warm.deny_globs`). The CLI surface is silent on every code path — unknown projects, denied paths, debounced calls, and any unexpected exception all return exit 0 with empty stdout. The companion `~/.claude/hooks/aelfrice-cwd-warm.sh` lives in the HOME repo and is out of scope for this release. New module `aelfrice.project_warm` exposes `resolve_project_root`, `warm_project`, `warm_path`, `WarmResult`, `ProjectRef`, `WarmConfig`. 19 deterministic unit tests cover the full matrix.
+
+### Performance
+
+- **`update-check`: TTL shortened from 24h to 6h** ([#172](https://github.com/robotrocketscience/aelfrice/issues/172)). Default update-check TTL drops from 24 hours to 6 hours so users on a daily cadence notice new releases sooner without overwhelming the version-manifest endpoint. Existing TTL override paths are unchanged.
+
+### CI
+
+- **GitHub Actions burn reduction — concurrency + dedup pytest + uv cache** ([#184](https://github.com/robotrocketscience/aelfrice/pull/184)). Three structural CI tweaks landed together. (1) `concurrency` group + `cancel-in-progress: true` on both `CI` and `Staging Gate` workflows so rapid-push streaks no longer run superseded jobs to completion. (2) Drop the duplicate `pytest 3.12 + 3.13` matrix from `Staging Gate` — pytest now runs only on `CI`; `Staging Gate` keeps its unique jobs (gitleaks, pattern-scan, history-scan, release-docs-check, commit-msg-prefix, pr-body-issue-link). (3) `enable-cache: true` on `setup-uv`, keyed on `uv.lock`, so pytest legs hit a warm uv cache on most pushes. Net effect: ~50% fewer pytest jobs per PR push; sharply lower wall-clock on cache hits. Branch-protection note for the post-public-flip required-checks list: use `CI / pytest`, since `Staging Gate / pytest` no longer exists.
 
 ## [1.2.0] - 2026-04-28
 
@@ -506,7 +516,8 @@ Foundation milestone — store, models, config.
 - Initial repo scaffold: pyproject, README, GitHub Actions workflows,
   scan configs (commit `67b4343`).
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/robotrocketscience/aelfrice/compare/v1.2.0...v1.4.0
 [1.2.0]: https://github.com/robotrocketscience/aelfrice/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/robotrocketscience/aelfrice/compare/v1.0.2...v1.0.3

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ The same operations are also available as MCP tools and `/aelf:*` slash commands
 | v1.1.0 | shipped | per-project DBs (`.git/aelfrice/`), `aelf migrate`, `edges`→`threads` rename, `aelf health` rewrite |
 | v1.2.0 | shipped | auto-capture pipeline (transcript-ingest, commit-ingest, SessionStart), `agent_inferred → user_validated` promotion, triple extractor, `--batch` JSONL ingest, CLI consolidation, `INEDIBLE` per-file opt-out |
 | v1.2.x | planned | search-tool `PreToolUse` hook — memory-first context on Grep/Glob |
-| v1.3 | planned | retrieval wave — entity index + BFS multi-hop + LLM classification + posterior-weighted ranking |
-| v1.4 | planned | context rebuilder — PreCompact retrieval-curated continuation |
+| v1.3 | shipped | retrieval wave — entity index (L2.5), BFS multi-hop (L3), LLM-Haiku onboard classifier (opt-in), partial Bayesian-weighted ranking |
+| v1.4 | shipped | context rebuilder — PreCompact retrieval-curated continuation (augment mode); manual + threshold trigger; continuation-fidelity scorer (exact-match) |
 | v2.0 | planned | feature parity with the original research line + benchmark reproducibility. v2.0's component issues (#148–#154) will land incrementally across v1.5+ minor versions; final v2.0 tag is the reproducibility cut. |
 
 Per-version detail: [docs/ROADMAP.md](docs/ROADMAP.md). Open issues: [docs/LIMITATIONS.md](docs/LIMITATIONS.md).

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ aelfrice replaces the chain with a mechanism. The hook injects matched beliefs *
 
 ---
 
-## Determinism is the property
+## Determinism
 
-Every retrieval is reproducible bit-for-bit from the write log and the code. No embeddings, no learned re-rankers, no LLM in the retrieval path. *"Why did this rule surface for this query?"* has a finite answer that bottoms out in named beliefs created by named user actions at named timestamps.
+Same store + same query gives the same beliefs. The retrieval path is stdlib + SQLite — no embeddings, no learned re-rankers, no LLM — so every result traces back to a specific belief and the user action that wrote it.
 
-That property is what makes aelfrice usable in regulated contexts. It's also what costs you fuzzy semantic recall — that's a deliberate trade. See [PHILOSOPHY.md](docs/PHILOSOPHY.md).
+Tradeoff: no fuzzy semantic recall. See [PHILOSOPHY.md](docs/PHILOSOPHY.md).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "1.2.0"
+version = "1.4.0"
 description = "Persistent memory for AI agents. Set up once. Stays out of your way. Local SQLite, auditable, no GPU, no network."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "1.2.0"
+version = "1.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Cuts v1.4.0 — the **context rebuilder** (PreCompact retrieval-curated continuation) plus the **v1.3 retrieval wave** (entity index, BFS multi-hop, opt-in LLM-Haiku classifier, partial Bayesian-weighted ranking). Companion fixes, CI work, and docs polish ship in the same tag.

## Headline features

- **v1.4 — context rebuilder (augment mode).** PreCompact hook + `rebuild_v14()` ([#139](https://github.com/robotrocketscience/aelfrice/issues/139)); manual + threshold trigger modes (dynamic parked v1.5) ([#141](https://github.com/robotrocketscience/aelfrice/issues/141)); continuation-fidelity scorer (`exact` method) ([#138](https://github.com/robotrocketscience/aelfrice/issues/138)); eval-harness scaffolding ([#136](https://github.com/robotrocketscience/aelfrice/issues/136)).
- **v1.3 — retrieval wave.** Entity-index L2.5 ([#143](https://github.com/robotrocketscience/aelfrice/issues/143)); BFS multi-hop L3, default-OFF ([#144](https://github.com/robotrocketscience/aelfrice/issues/144)); LLM-Haiku onboard classifier (four-gate opt-in) ([#145](https://github.com/robotrocketscience/aelfrice/issues/145)); partial Bayesian-weighted ranking, log-additive ([#146](https://github.com/robotrocketscience/aelfrice/issues/146)).
- **Companion features.** `aelf project-warm` ([#137](https://github.com/robotrocketscience/aelfrice/issues/137)); `aelf session-delta --id` ([#140](https://github.com/robotrocketscience/aelfrice/issues/140)); `aelf --advanced` / `aelf --help --advanced` ([#159](https://github.com/robotrocketscience/aelfrice/issues/159)).
- **Fixes.** `project-warm` worktree sentinel ([#161](https://github.com/robotrocketscience/aelfrice/issues/161)).
- **Performance.** Update-check TTL 24h → 6h ([#172](https://github.com/robotrocketscience/aelfrice/issues/172)).
- **CI.** Conventional-commit prefix enforcement + PR-body issue-link advisory ([#169](https://github.com/robotrocketscience/aelfrice/issues/169), [#170](https://github.com/robotrocketscience/aelfrice/issues/170)); GitHub Actions burn reduction — concurrency + dedup pytest + uv cache ([#184](https://github.com/robotrocketscience/aelfrice/pull/184)).
- **Docs.** Cross-cutting sweep ([#181](https://github.com/robotrocketscience/aelfrice/pull/181)); softened tone on the README "Determinism" section; embedded Setr/Garsecg masking image in PRIVACY.md ([#183](https://github.com/robotrocketscience/aelfrice/pull/183)).

Full detail: see [CHANGELOG.md `## [1.4.0]`](https://github.com/robotrocketscience/aelfrice/blob/release/v1.4.0/CHANGELOG.md).

## Pre-flight

- `uv run pytest tests/ -x -q` → **1443 passed, 2 skipped** locally.
- `uv build` → `dist/aelfrice-1.4.0-py3-none-any.whl` and `dist/aelfrice-1.4.0.tar.gz` clean.
- `uv run aelf --help` → CLI surface matches expectation (rebuild, search, lock, locked, status, doctor, setup, onboard).
- `uv run pyright src/` → **90 errors** — pre-existing on `main` (verified by reverting `pyproject.toml` + `uv.lock` and re-running). Not introduced by this release; tracked separately.

## What this PR does

Two atomic commits:

- `docs: soften Determinism section tone in README` — replaces "Determinism is the property" with a quieter "Determinism" section per maintainer feedback.
- `release: v1.4.0` — bumps `pyproject.toml` to `1.4.0`, regenerates `uv.lock`, rotates CHANGELOG `[Unreleased]` → `[1.4.0] - 2026-04-28`, backfills the missing #172 / #184 entries, updates the README roadmap to mark v1.3 / v1.4 as **shipped**, and adds the `[1.4.0]` link footnote.

## Tag plan

After merge: `git tag -s v1.4.0 -m "release: v1.4.0" && git push github v1.4.0`. Tag push triggers `.github/workflows/publish.yml`; publish remains gated until v1.0.0 (already passed) — workflow now wired and will fire.

<!-- no-issue -->