### PR TITLE
docs(roadmap): schedule v1.5–v1.7 split for unscheduled v2.0 components

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The same operations are also available as MCP tools and `/aelf:*` slash commands
 | v1.4 | shipped | context rebuilder — PreCompact retrieval-curated continuation (augment mode); manual + threshold trigger; continuation-fidelity scorer (exact-match) |
 | v1.5 | planned | retrieval plumbing — unified `retrieve()` composition tracker (#154), BM25F anchor text (#148), search-tool matcher extension (#155), v1.4 dynamic-trigger revisit |
 | v1.6 | planned | graph signal wave — signed Laplacian + eigenbasis (#149), heat kernel authority (#150), posterior-weighted ranking full (#151) |
-| v1.7 | planned | structural retrieval lane — HRR bind/probe (#152), Twiddler relevance-aware retest (#153) |
+| v1.7 | planned | structural retrieval lane — HRR bind/probe (#152), `uri_baki` post-rank adjuster retest (#153) |
 | v2.0 | planned | feature parity with the original research line + benchmark reproducibility. v2.0's component issues land incrementally across v1.5–v1.7; final v2.0 tag is the reproducibility cut. |
 
 Per-version detail: [docs/ROADMAP.md](docs/ROADMAP.md). Open issues: [docs/LIMITATIONS.md](docs/LIMITATIONS.md).

--- a/README.md
+++ b/README.md
@@ -136,7 +136,10 @@ The same operations are also available as MCP tools and `/aelf:*` slash commands
 | v1.2.x | planned | search-tool `PreToolUse` hook — memory-first context on Grep/Glob |
 | v1.3 | shipped | retrieval wave — entity index (L2.5), BFS multi-hop (L3), LLM-Haiku onboard classifier (opt-in), partial Bayesian-weighted ranking |
 | v1.4 | shipped | context rebuilder — PreCompact retrieval-curated continuation (augment mode); manual + threshold trigger; continuation-fidelity scorer (exact-match) |
-| v2.0 | planned | feature parity with the original research line + benchmark reproducibility. v2.0's component issues (#148–#154) will land incrementally across v1.5+ minor versions; final v2.0 tag is the reproducibility cut. |
+| v1.5 | planned | retrieval plumbing — unified `retrieve()` composition tracker (#154), BM25F anchor text (#148), search-tool matcher extension (#155), v1.4 dynamic-trigger revisit |
+| v1.6 | planned | graph signal wave — signed Laplacian + eigenbasis (#149), heat kernel authority (#150), posterior-weighted ranking full (#151) |
+| v1.7 | planned | structural retrieval lane — HRR bind/probe (#152), Twiddler relevance-aware retest (#153) |
+| v2.0 | planned | feature parity with the original research line + benchmark reproducibility. v2.0's component issues land incrementally across v1.5–v1.7; final v2.0 tag is the reproducibility cut. |
 
 Per-version detail: [docs/ROADMAP.md](docs/ROADMAP.md). Open issues: [docs/LIMITATIONS.md](docs/LIMITATIONS.md).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ This is a rebuild, not a port. Structural issues that survived the research line
 | **v1.4.0** | planned | context rebuilder — PreCompact retrieval-curated continuation |
 | **v1.5.0** | planned | retrieval plumbing — composition tracker, BM25F anchor text, search-tool matcher extension, dynamic-trigger revisit |
 | **v1.6.0** | planned | graph signal wave — signed Laplacian + eigenbasis, heat kernel authority, posterior-weighted ranking (full) |
-| **v1.7.0** | planned | structural retrieval lane — HRR bind/probe, Twiddler relevance-aware retest |
+| **v1.7.0** | planned | structural retrieval lane — HRR bind/probe, `uri_baki` post-rank adjuster retest |
 | **v2.0.0** | planned | feature parity with the research line + benchmark reproducibility |
 
 ## What shipped
@@ -105,7 +105,7 @@ Hard prerequisite: v1.5 #154 composition tracker (heat kernel and posterior-full
 ### v1.7.0 — structural retrieval lane and research retests
 
 - **HRR structural-query lane (bind/probe over outgoing edges)** ([#152](https://github.com/robotrocketscience/aelfrice/issues/152)). A separate retrieval lane, not a projection — naive HRR projection into BM25 ranking was rejected at -0.10 NDCG (R9 in the bake-off). Bind/probe over outgoing edges is the structural-query path that survives. Persists `id_vec` per belief; `enable_hrr` config flag default-off until any belief has HRR vectors written.
-- **Twiddler post-rank retest with relevance-aware locked set** ([#153](https://github.com/robotrocketscience/aelfrice/issues/153)). Random-pinned Twiddlers scored -0.05 NDCG in the bake-off due to R12 methodology bug (random pinning drowned signal). Relevance-aware retest decides whether the lane is dead or just needed a fairer eval. Research item; ships only if the retest beats the BM25F + heat-kernel + posterior baseline.
+- **`uri_baki` post-rank adjuster retest with relevance-aware locked set** ([#153](https://github.com/robotrocketscience/aelfrice/issues/153)). Named after Uri and Baki, the two Fire Aelfmaidens in Gene Wolfe's *The Wizard Knight* (2004) — bound attendants who operate after the main action to tilt outcomes for their bound knight. Locked-floor (Uri's protection), supersession demote (Baki's undermining), recency decay (the Aelfrice time-tilt). The pattern is publicly described as Google's "Twiddler" in Pandu Nayak's DOJ testimony (October 2023) and the May 2024 Content Warehouse API leak; aelfrice uses neutral naming to avoid trading on Google's term-of-art. A prior random-pinned synthetic regressed -0.05 NDCG due to a methodology bug (random pinning drowned signal). The relevance-aware retest uses `Belief.lock_state` and decides whether the lane is dead or just needed a fairer eval. Research item; ships only if the retest beats the BM25F + heat-kernel + posterior baseline.
 
 ### v2.0.0 — feature parity and reproducibility
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,6 +22,9 @@ This is a rebuild, not a port. Structural issues that survived the research line
 | **v1.2.x** | planned | search-tool `PreToolUse` hook — memory-first context on Grep/Glob |
 | **v1.3.0** | planned | retrieval wave — entity index + BFS multi-hop + LLM classification + posterior-weighted ranking |
 | **v1.4.0** | planned | context rebuilder — PreCompact retrieval-curated continuation |
+| **v1.5.0** | planned | retrieval plumbing — composition tracker, BM25F anchor text, search-tool matcher extension, dynamic-trigger revisit |
+| **v1.6.0** | planned | graph signal wave — signed Laplacian + eigenbasis, heat kernel authority, posterior-weighted ranking (full) |
+| **v1.7.0** | planned | structural retrieval lane — HRR bind/probe, Twiddler relevance-aware retest |
 | **v2.0.0** | planned | feature parity with the research line + benchmark reproducibility |
 
 ## What shipped
@@ -80,6 +83,30 @@ Long-running sessions cheaper without a visible seam.
 
 Hard prerequisites: v1.2 transcript-ingest, v1.2 `session_id` schema. Alpha shipped in v1.2.0a0.
 
+### v1.5.0 — retrieval plumbing
+
+Composition gate first, then cheap retrieval wins. No new ranking math in this minor; that's v1.6.
+
+- **Pipeline composition tracker — unified `retrieve()` with feature-flag gate** ([#154](https://github.com/robotrocketscience/aelfrice/issues/154)). One entry point, every retrieval feature behind a config flag, telemetry per lane. This is the prerequisite for the v1.6 graph wave: `retrieve()` must be the only path before heat kernel and posterior-full can ship safely behind defaults.
+- **Augmented BM25F (incoming-edge anchor text) + vectorized BM25 sparse matvec** ([#148](https://github.com/robotrocketscience/aelfrice/issues/148)). +0.06 NDCG @ +0 ms vs BM25 in the v1.6 component bake-off — adopt now since runtime cost is free.
+- **Search-tool hook — extend matcher beyond `Grep|Glob`** ([#155](https://github.com/robotrocketscience/aelfrice/issues/155)). Carryover from v1.3. Widens the `PreToolUse` matcher list once telemetry from v1.2.x confirms latency budget on the existing two.
+- **v1.4 dynamic-trigger revisit** ([#141](https://github.com/robotrocketscience/aelfrice/issues/141)). The dynamic mode parked at v1.4 ship-gate (no ≥ 5% absolute fidelity uplift over threshold on synthetic fixture) gets a second eval pass on captured-corpus calibration data. Keeps parking if the bar still isn't met.
+
+### v1.6.0 — graph signal wave
+
+The release where ranking moves beyond BM25 + L2.5 + BFS into graph-authority and full posterior-weighted territory.
+
+- **Signed normalized Laplacian + offline eigenbasis (top-K=200) builder** ([#149](https://github.com/robotrocketscience/aelfrice/issues/149)). Offline-only build step; no runtime cost. Hard prerequisite for #150.
+- **Heat kernel authority signal via precomputed eigenbasis** ([#150](https://github.com/robotrocketscience/aelfrice/issues/150)). +0.41 NDCG @ +7.8 ms p50 on a 50k-belief store — biggest single retrieval gain in the bake-off. Ships default-on; latency stays inside the v1.2.x search-tool hook's 50 ms median budget.
+- **Posterior-weighted ranking via Beta-Bernoulli prior — full** ([#151](https://github.com/robotrocketscience/aelfrice/issues/151)). Closes the v1.3 partial. Log-additive, weight 0.5, with the 10-round MRR uplift eval and ECE calibration scorer that v1.3 deferred. The central feedback-into-ranking claim becomes fully testable here; v2.0 only re-runs it for the canonical reproducibility cut.
+
+Hard prerequisite: v1.5 #154 composition tracker (heat kernel and posterior-full must ship behind the unified `retrieve()` entry point with telemetry per lane).
+
+### v1.7.0 — structural retrieval lane and research retests
+
+- **HRR structural-query lane (bind/probe over outgoing edges)** ([#152](https://github.com/robotrocketscience/aelfrice/issues/152)). A separate retrieval lane, not a projection — naive HRR projection into BM25 ranking was rejected at -0.10 NDCG (R9 in the bake-off). Bind/probe over outgoing edges is the structural-query path that survives. Persists `id_vec` per belief; `enable_hrr` config flag default-off until any belief has HRR vectors written.
+- **Twiddler post-rank retest with relevance-aware locked set** ([#153](https://github.com/robotrocketscience/aelfrice/issues/153)). Random-pinned Twiddlers scored -0.05 NDCG in the bake-off due to R12 methodology bug (random pinning drowned signal). Relevance-aware retest decides whether the lane is dead or just needed a fairer eval. Research item; ships only if the retest beats the BM25F + heat-kernel + posterior baseline.
+
 ### v2.0.0 — feature parity and reproducibility
 
 After v2.0.0, `benchmarks/` reproduces every published headline number on a fresh clone with `uv sync && aelf bench all`, within documented tolerance bands.
@@ -107,7 +134,10 @@ What the research line had, when each piece returns:
 | Entity-index retrieval | v1.3.0 |
 | BFS multi-hop graph traversal | v1.3.0 |
 | LLM-Haiku onboard classifier | v1.3.0 |
-| Posterior-weighted ranking | v1.3.0 (partial) / v2.0.0 (full) |
+| Posterior-weighted ranking | v1.3.0 (partial) / v1.6.0 (full) |
+| BM25F anchor-text + vectorized BM25 | v1.5.0 |
+| Signed Laplacian + heat-kernel authority | v1.6.0 |
+| HRR structural-query lane | v1.7.0 |
 | HRR vocabulary bridge | v2.0.0 |
 | Type-aware compression | v2.0.0 |
 | Doc / semantic linker | v2.0.0 |


### PR DESCRIPTION
## Summary

- Adds v1.5/v1.6/v1.7 rows to the README roadmap table and matching planned sections in `docs/ROADMAP.md`.
- Sequencing rationale: composition tracker (#154) lands first in v1.5 to enable feature-flagged ship for the v1.6 graph wave; heat kernel (#150) ships v1.6 default-on per +0.41 NDCG / +7.8 ms p50 budget; HRR bind/probe (#152) and Twiddler retest (#153) park to v1.7.
- Recovery inventory updated for items whose target version moved (BM25F → v1.5, signed Laplacian + heat kernel → v1.6, HRR structural lane → v1.7, posterior-full → v1.6 from v2.0).

## Issues touched

- v1.5: #154, #148, #155, #141 (revisit)
- v1.6: #149, #150, #151
- v1.7: #152, #153

## Test plan

- [ ] `docs/ROADMAP.md` renders cleanly on GitHub
- [ ] README roadmap table shows v1.0–v2.0 in version order with no gaps
- [ ] Recovery-inventory rows match the planned-section assignments