### PR TITLE
feat: signed normalized Laplacian + eigenbasis builder (#149)

### DIFF
--- a/src/aelfrice/graph_spectral.py
+++ b/src/aelfrice/graph_spectral.py
@@ -1,0 +1,225 @@
+# pyright: reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownParameterType=false, reportMissingTypeStubs=false, reportOptionalSubscript=false, reportAttributeAccessIssue=false, reportGeneralTypeIssues=false, reportConstantRedefinition=false, reportArgumentType=false
+"""Signed normalized Laplacian + offline eigenbasis builder (#149).
+
+Constructs the signed normalized Laplacian
+``L = I - D_abs^(-1/2) W_sym D_abs^(-1/2)``
+over the typed edge graph (Kunegis 2010), where ``CONTRADICTS`` /
+``SUPERSEDES`` count as negative-weight edges and the supportive edge
+families as positive. The top-K=200 eigenpairs of ``L`` are the offline
+foundation consumed by the heat-kernel authority signal (#150). This
+module ships only the builder + serialization; no integration into
+``retrieve()``.
+
+All construction is offline — no query-time cost. Rebuild is wired to
+the same store-mutation invalidation callback that ``RetrievalCache``
+subscribes to (extending the registry, not duplicating it).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+
+from aelfrice.models import (
+    EDGE_CITES,
+    EDGE_CONTRADICTS,
+    EDGE_DERIVED_FROM,
+    EDGE_RELATES_TO,
+    EDGE_SUPERSEDES,
+    EDGE_SUPPORTS,
+)
+from aelfrice.store import MemoryStore
+
+# Edge-type → signed weight mapping for Laplacian construction.
+# Distinct from `models.EDGE_TYPE_WEIGHTS` (used for valence
+# propagation; different polarity convention). Per #149 spec; exposed
+# as a constant so a follow-up sweep issue can override without
+# touching call sites.
+EDGE_LAPLACIAN_WEIGHTS: Final[dict[str, float]] = {
+    EDGE_SUPPORTS: 1.0,
+    EDGE_CITES: 1.0,
+    EDGE_RELATES_TO: 1.0,
+    EDGE_DERIVED_FROM: 1.0,
+    EDGE_CONTRADICTS: -1.0,
+    EDGE_SUPERSEDES: -0.5,
+}
+
+# Top-K eigenpairs retained from the signed Laplacian. K=200 is the
+# spec default: at bandwidth t=8 the heat-kernel filter exp(-tL)
+# suppresses K>200 modes below 1e-3 contribution.
+DEFAULT_K: Final[int] = 200
+
+# Persisted .npz layout version. Bump on incompatible field changes.
+_NPZ_VERSION: Final[int] = 1
+
+
+def build_signed_adjacency(
+    store: MemoryStore,
+    weights: dict[str, float] | None = None,
+) -> tuple[sp.csr_matrix, list[str]]:
+    """Build the symmetric signed adjacency ``W_sym = W + W.T``.
+
+    Returns ``(W_sym, belief_ids)`` where ``belief_ids`` is the
+    canonical row/column ordering used by every downstream consumer
+    in this module. Edges referencing ids absent from
+    ``list_belief_ids()`` are dropped (defensive: foreign-key
+    invariant should prevent this, but a stale graph isn't worth
+    crashing the build).
+    """
+    w_map = EDGE_LAPLACIAN_WEIGHTS if weights is None else weights
+    belief_ids = store.list_belief_ids()
+    n = len(belief_ids)
+    if n == 0:
+        return sp.csr_matrix((0, 0), dtype=np.float64), belief_ids
+
+    idx = {bid: i for i, bid in enumerate(belief_ids)}
+    rows: list[int] = []
+    cols: list[int] = []
+    vals: list[float] = []
+    for e in store.iter_all_edges():
+        if e.src not in idx or e.dst not in idx:
+            continue
+        w = w_map.get(e.type, 0.0)
+        if w == 0.0:
+            continue
+        rows.append(idx[e.src])
+        cols.append(idx[e.dst])
+        vals.append(w)
+
+    W = sp.csr_matrix(
+        (vals, (rows, cols)), shape=(n, n), dtype=np.float64
+    )
+    W_sym = (W + W.T).tocsr()
+    return W_sym, belief_ids
+
+
+def build_signed_normalized_laplacian(W: sp.csr_matrix) -> sp.csr_matrix:
+    """Construct ``L = I - D_abs^(-1/2) W D_abs^(-1/2)`` (Kunegis 2010).
+
+    ``D_abs[i,i] = sum_j |W[i,j]|`` — the absolute-degree
+    normalization is what makes negative weights propagate as
+    opposition rather than collapse into the standard normalization.
+    Isolated nodes (zero absolute degree) get a zero row/column in
+    the normalizer; their Laplacian row reduces to the identity
+    contribution, which is the conventional handling.
+    """
+    n = W.shape[0]
+    if n == 0:
+        return sp.csr_matrix((0, 0), dtype=np.float64)
+
+    abs_W = W.copy()
+    abs_W.data = np.abs(abs_W.data)
+    deg = np.asarray(abs_W.sum(axis=1)).ravel()
+    with np.errstate(divide="ignore"):
+        d_inv_sqrt = np.where(deg > 0, 1.0 / np.sqrt(deg), 0.0)
+    D = sp.diags(d_inv_sqrt)
+    L = sp.eye(n, format="csr") - (D @ W @ D)
+    # Symmetrize against floating-point asymmetry in the matvec
+    # composition. W is symmetric by construction, but D @ W @ D can
+    # accumulate ~1e-16 asymmetry that breaks `eigsh`.
+    L = ((L + L.T) * 0.5).tocsr()
+    return L
+
+
+def compute_eigenbasis(
+    L: sp.csr_matrix, k: int = DEFAULT_K
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(eigvals, eigvecs)`` — smallest-magnitude eigenpairs.
+
+    ``eigvals`` shape ``(k,)``; ``eigvecs`` shape ``(n, k)``. Sorted
+    ascending by eigenvalue. For ``k >= n`` falls back to dense
+    ``eigh`` (eigsh requires k < n).
+    """
+    n = L.shape[0]
+    if n == 0:
+        return np.zeros((0,), dtype=np.float64), np.zeros((0, 0), dtype=np.float64)
+    k_eff = min(k, n - 1) if n > 1 else 1
+    if k_eff < 1 or k_eff >= n:
+        L_dense = L.toarray() if sp.issparse(L) else np.asarray(L)
+        eigvals, eigvecs = np.linalg.eigh(L_dense)
+        return eigvals[:k], eigvecs[:, :k]
+    eigvals, eigvecs = spla.eigsh(L, k=k_eff, which="SM")
+    order = np.argsort(eigvals)
+    return eigvals[order], eigvecs[:, order]
+
+
+def save_eigenbasis(
+    path: str | Path,
+    eigvals: np.ndarray,
+    eigvecs: np.ndarray,
+    belief_ids: list[str] | None = None,
+) -> None:
+    """Round-trippable persistence to ``.npz``. Creates parent dirs."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, np.ndarray] = {
+        "version": np.array([_NPZ_VERSION], dtype=np.int32),
+        "eigvals": np.asarray(eigvals, dtype=np.float64),
+        "eigvecs": np.asarray(eigvecs, dtype=np.float64),
+    }
+    if belief_ids is not None:
+        payload["belief_ids"] = np.asarray(belief_ids, dtype=object)
+    np.savez(p, **payload)
+
+
+def load_eigenbasis(
+    path: str | Path,
+) -> tuple[np.ndarray, np.ndarray, list[str] | None]:
+    """Inverse of :func:`save_eigenbasis`. ``belief_ids`` is ``None``
+    if the archive was written without one."""
+    z = np.load(path, allow_pickle=True)
+    bids: list[str] | None = None
+    if "belief_ids" in z.files:
+        bids = [str(x) for x in z["belief_ids"].tolist()]
+    return z["eigvals"], z["eigvecs"], bids
+
+
+@dataclass
+class GraphEigenbasisCache:
+    """In-memory eigenbasis with on-disk persistence and store-mutation
+    invalidation.
+
+    Construction registers an invalidation callback on the store; any
+    belief or edge mutation invalidates the cached eigenbasis and
+    deletes the persisted ``.npz``. ``build()`` is the explicit entry
+    point — this class does not eagerly rebuild on invalidation,
+    consistent with the offline-only contract (#149 spec).
+    """
+
+    store: MemoryStore
+    path: Path
+    k: int = DEFAULT_K
+    eigvals: np.ndarray | None = field(default=None, init=False)
+    eigvecs: np.ndarray | None = field(default=None, init=False)
+    belief_ids: list[str] | None = field(default=None, init=False)
+    _stale: bool = field(default=True, init=False)
+
+    def __post_init__(self) -> None:
+        self.store.add_invalidation_callback(self._on_store_mutation)
+
+    def build(self) -> None:
+        W, ids = build_signed_adjacency(self.store)
+        L = build_signed_normalized_laplacian(W)
+        ev, vc = compute_eigenbasis(L, k=self.k)
+        self.eigvals = ev
+        self.eigvecs = vc
+        self.belief_ids = ids
+        self._stale = False
+        save_eigenbasis(self.path, ev, vc, ids)
+
+    def is_stale(self) -> bool:
+        return self._stale
+
+    def _on_store_mutation(self) -> None:
+        self.eigvals = None
+        self.eigvecs = None
+        self.belief_ids = None
+        self._stale = True
+        try:
+            self.path.unlink()
+        except FileNotFoundError:
+            pass

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import secrets
 import sqlite3
 from datetime import datetime, timezone
-from typing import Callable, Final, Iterable
+from typing import Callable, Final, Iterable, Iterator
 
 from aelfrice.models import (
     EDGE_VALENCE,
@@ -857,6 +857,14 @@ class MemoryStore:
             "SELECT * FROM edges WHERE src = ?", (src,)
         )
         return [_row_to_edge(r) for r in cur.fetchall()]
+
+    def iter_all_edges(self) -> Iterator[Edge]:
+        """Stream every edge in the store. Ordering is insertion order
+        (sqlite ROWID). Used by graph-wide builders such as the signed
+        Laplacian eigenbasis (#149)."""
+        cur = self._conn.execute("SELECT * FROM edges")
+        for r in cur:
+            yield _row_to_edge(r)
 
     def iter_incoming_anchor_text(self) -> Iterable[tuple[str, str]]:
         """Yield `(dst_belief_id, anchor_text)` for every edge whose

--- a/tests/test_graph_spectral.py
+++ b/tests/test_graph_spectral.py
@@ -1,0 +1,311 @@
+# pyright: reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownParameterType=false, reportMissingTypeStubs=false, reportConstantRedefinition=false
+"""Tests for the signed normalized Laplacian + eigenbasis builder (#149).
+
+Acceptance map (#149 §Test plan):
+- AC1: build_signed_adjacency → symmetric sparse matrix
+- AC2: edge-type weight mapping is a module-level constant
+- AC3: build_signed_normalized_laplacian → symmetric L per Kunegis 2010
+- AC4: compute_eigenbasis returns smallest-K eigenpairs
+- AC5: save/load round-trip is byte-identical (numerically lossless)
+- AC6: invalidation callback fires on store mutation
+- AC7: build is deterministic at fixed seed for the eigsolve
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from aelfrice.graph_spectral import (
+    DEFAULT_K,
+    EDGE_LAPLACIAN_WEIGHTS,
+    GraphEigenbasisCache,
+    build_signed_adjacency,
+    build_signed_normalized_laplacian,
+    compute_eigenbasis,
+    load_eigenbasis,
+    save_eigenbasis,
+)
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CITES,
+    EDGE_CONTRADICTS,
+    EDGE_RELATES_TO,
+    EDGE_SUPERSEDES,
+    EDGE_SUPPORTS,
+    LOCK_NONE,
+    Belief,
+    Edge,
+)
+from aelfrice.store import MemoryStore
+
+
+def _has_run_perf(request: pytest.FixtureRequest) -> bool:
+    try:
+        return bool(request.config.getoption("--run-perf", default=False))
+    except (AttributeError, ValueError):
+        return False
+
+
+def _mk(bid: str, content: str = "x") -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-28T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _toy_store() -> MemoryStore:
+    """Five-node toy graph mixing positive and negative edges.
+
+    Topology:
+        b1 -SUPPORTS-> b2     (+1)
+        b2 -CITES-> b3        (+1)
+        b1 -CONTRADICTS-> b3  (-1)
+        b3 -SUPERSEDES-> b4   (-0.5)
+        b4 -RELATES_TO-> b5   (+1)
+    """
+    s = MemoryStore(":memory:")
+    for i in range(1, 6):
+        s.insert_belief(_mk(f"b{i}"))
+    s.insert_edge(Edge(src="b1", dst="b2", type=EDGE_SUPPORTS, weight=1.0))
+    s.insert_edge(Edge(src="b2", dst="b3", type=EDGE_CITES, weight=1.0))
+    s.insert_edge(Edge(src="b1", dst="b3", type=EDGE_CONTRADICTS, weight=1.0))
+    s.insert_edge(Edge(src="b3", dst="b4", type=EDGE_SUPERSEDES, weight=1.0))
+    s.insert_edge(Edge(src="b4", dst="b5", type=EDGE_RELATES_TO, weight=1.0))
+    return s
+
+
+# --- AC1: adjacency symmetry & ordering ---------------------------------------
+
+
+def test_signed_adjacency_is_symmetric() -> None:
+    s = _toy_store()
+    W, ids = build_signed_adjacency(s)
+    assert ids == ["b1", "b2", "b3", "b4", "b5"]
+    Wd = W.toarray()
+    np.testing.assert_array_equal(Wd, Wd.T)
+    # b1 <-> b3 carries -1 (contradicts) plus 0 supportive => -1
+    assert Wd[0, 2] == pytest.approx(-1.0)
+    assert Wd[2, 0] == pytest.approx(-1.0)
+    # b1 <-> b2 supports => +1
+    assert Wd[0, 1] == pytest.approx(1.0)
+    # b3 <-> b4 supersedes => -0.5
+    assert Wd[2, 3] == pytest.approx(-0.5)
+
+
+def test_signed_adjacency_empty_store() -> None:
+    s = MemoryStore(":memory:")
+    W, ids = build_signed_adjacency(s)
+    assert ids == []
+    assert W.shape == (0, 0)
+
+
+# --- AC2: edge-type weight mapping is a module-level constant -----------------
+
+
+def test_edge_laplacian_weights_constant() -> None:
+    """Mapping is exposed and overridable per spec acceptance #2."""
+    assert EDGE_LAPLACIAN_WEIGHTS[EDGE_SUPPORTS] == 1.0
+    assert EDGE_LAPLACIAN_WEIGHTS[EDGE_CONTRADICTS] == -1.0
+    assert EDGE_LAPLACIAN_WEIGHTS[EDGE_SUPERSEDES] == -0.5
+    s = _toy_store()
+    # Override: drop CONTRADICTS to zero — adjacency loses that entry.
+    custom = dict(EDGE_LAPLACIAN_WEIGHTS)
+    custom[EDGE_CONTRADICTS] = 0.0
+    W, _ = build_signed_adjacency(s, weights=custom)
+    Wd = W.toarray()
+    assert Wd[0, 2] == pytest.approx(0.0)
+
+
+# --- AC3: Laplacian symmetry & shape ------------------------------------------
+
+
+def test_laplacian_symmetric_and_normalized() -> None:
+    s = _toy_store()
+    W, _ = build_signed_adjacency(s)
+    L = build_signed_normalized_laplacian(W)
+    Ld = L.toarray()
+    np.testing.assert_allclose(Ld, Ld.T, atol=1e-12)
+    # Diagonal entries are 1 for nodes with nonzero absolute degree.
+    deg_abs = np.abs(W.toarray()).sum(axis=1)
+    for i, d in enumerate(deg_abs):
+        if d > 0:
+            assert Ld[i, i] == pytest.approx(1.0, abs=1e-12)
+
+
+def test_laplacian_empty_input() -> None:
+    L = build_signed_normalized_laplacian(sp.csr_matrix((0, 0)))
+    assert L.shape == (0, 0)
+
+
+# --- AC4: eigenbasis -----------------------------------------------------------
+
+
+def test_eigenbasis_smallest_k() -> None:
+    s = _toy_store()
+    W, _ = build_signed_adjacency(s)
+    L = build_signed_normalized_laplacian(W)
+    eigvals, eigvecs = compute_eigenbasis(L, k=3)
+    # toy graph N=5, k=3 → falls back to dense eigh (k_eff = min(3,4) = 3)
+    assert eigvals.shape == (3,)
+    assert eigvecs.shape == (5, 3)
+    # Ascending order
+    assert np.all(np.diff(eigvals) >= -1e-12)
+    # Reconstruction sanity: L @ v ≈ λ v for each pair
+    Ld = L.toarray()
+    for j in range(eigvals.shape[0]):
+        lhs = Ld @ eigvecs[:, j]
+        rhs = eigvals[j] * eigvecs[:, j]
+        np.testing.assert_allclose(lhs, rhs, atol=1e-8)
+
+
+def test_eigenbasis_real_valued() -> None:
+    """Symmetric real matrices yield real eigenvalues."""
+    s = _toy_store()
+    W, _ = build_signed_adjacency(s)
+    L = build_signed_normalized_laplacian(W)
+    eigvals, _ = compute_eigenbasis(L, k=3)
+    assert eigvals.dtype.kind == "f"
+    assert np.all(np.isfinite(eigvals))
+
+
+# --- AC5: serialization round-trip --------------------------------------------
+
+
+def test_save_load_roundtrip(tmp_path: Path) -> None:
+    s = _toy_store()
+    W, ids = build_signed_adjacency(s)
+    L = build_signed_normalized_laplacian(W)
+    ev, vc = compute_eigenbasis(L, k=3)
+
+    p = tmp_path / "subdir" / "graph_eigenbasis.npz"
+    save_eigenbasis(p, ev, vc, ids)
+    assert p.exists()
+
+    ev2, vc2, ids2 = load_eigenbasis(p)
+    np.testing.assert_array_equal(ev, ev2)
+    np.testing.assert_array_equal(vc, vc2)
+    assert ids2 == ids
+
+
+def test_save_load_without_belief_ids(tmp_path: Path) -> None:
+    p = tmp_path / "no_ids.npz"
+    ev = np.array([0.1, 0.2, 0.3])
+    vc = np.eye(3)
+    save_eigenbasis(p, ev, vc, belief_ids=None)
+    ev2, vc2, ids2 = load_eigenbasis(p)
+    np.testing.assert_array_equal(ev, ev2)
+    np.testing.assert_array_equal(vc, vc2)
+    assert ids2 is None
+
+
+# --- AC6: invalidation callback wiring ----------------------------------------
+
+
+def test_eigenbasis_cache_invalidated_on_mutation(tmp_path: Path) -> None:
+    s = _toy_store()
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz", k=3)
+    assert cache.is_stale()
+    cache.build()
+    assert not cache.is_stale()
+    assert cache.eigvals is not None
+    assert (tmp_path / "eb.npz").exists()
+
+    # Insert a new belief — fires _fire_invalidation
+    s.insert_belief(_mk("b6"))
+    assert cache.is_stale()
+    assert cache.eigvals is None
+    assert cache.eigvecs is None
+    assert cache.belief_ids is None
+    # Persisted file is removed alongside the in-memory wipe so a
+    # crash-restart cannot re-load stale eigenpairs.
+    assert not (tmp_path / "eb.npz").exists()
+
+
+def test_eigenbasis_cache_invalidated_on_edge_mutation(tmp_path: Path) -> None:
+    s = _toy_store()
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz", k=3)
+    cache.build()
+    assert not cache.is_stale()
+
+    s.insert_edge(Edge(src="b1", dst="b5", type=EDGE_SUPPORTS, weight=1.0))
+    assert cache.is_stale()
+
+
+def test_rebuild_after_invalidation_diverges(tmp_path: Path) -> None:
+    """Cached eigenbasis from before the mutation is not consumed
+    after; the rebuild produces a fresh result that differs from
+    the pre-mutation snapshot when the graph changed."""
+    s = _toy_store()
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz", k=3)
+    cache.build()
+    ev_before = np.copy(cache.eigvals)  # type: ignore[arg-type]
+
+    # Add a new node + supportive edge — changes the spectrum.
+    s.insert_belief(_mk("b6"))
+    s.insert_edge(Edge(src="b1", dst="b6", type=EDGE_SUPPORTS, weight=1.0))
+    cache.build()
+    ev_after = cache.eigvals
+    assert ev_after is not None
+    # Spectrum changed (different N, different topology).
+    assert ev_before.shape != ev_after.shape or not np.allclose(
+        ev_before, ev_after, atol=1e-9
+    )
+
+
+# --- AC7: determinism ---------------------------------------------------------
+
+
+def test_build_deterministic(tmp_path: Path) -> None:
+    """Same store, two builds → identical eigenvalues (numerically).
+    Eigenvector signs may differ across eigsh runs; we test eigvals
+    plus the absolute-value subspace projection norm, which is
+    sign-invariant."""
+    s = _toy_store()
+    W, _ = build_signed_adjacency(s)
+    L = build_signed_normalized_laplacian(W)
+    ev1, vc1 = compute_eigenbasis(L, k=3)
+    ev2, vc2 = compute_eigenbasis(L, k=3)
+    np.testing.assert_allclose(ev1, ev2, atol=1e-10)
+    # Subspace agreement: |vc1.T @ vc2| diagonal close to 1
+    overlap = np.abs(vc1.T @ vc2)
+    np.testing.assert_allclose(np.diag(overlap), np.ones(3), atol=1e-8)
+
+
+# --- Perf gate ----------------------------------------------------------------
+
+
+def test_eigsolve_under_budget_n10k(request: pytest.FixtureRequest) -> None:
+    """Spec table: top-200 eigsolve at N=10k completes in ~4s. Gated
+    behind --run-perf."""
+    if not _has_run_perf(request):
+        pytest.skip("perf benchmark; pass --run-perf to enable")
+    rng = np.random.default_rng(0)
+    n = 10_000
+    # Sparse signed graph: ~5 edges/node, 20% negative.
+    nnz = 5 * n
+    rows = rng.integers(0, n, size=nnz)
+    cols = rng.integers(0, n, size=nnz)
+    signs = rng.choice([-1.0, 1.0], size=nnz, p=[0.2, 0.8])
+    W = sp.csr_matrix((signs, (rows, cols)), shape=(n, n))
+    W = (W + W.T).tocsr()
+    L = build_signed_normalized_laplacian(W)
+    t0 = time.monotonic()
+    eigvals, eigvecs = compute_eigenbasis(L, k=DEFAULT_K)
+    elapsed = time.monotonic() - t0
+    assert eigvals.shape == (DEFAULT_K,)
+    assert eigvecs.shape == (n, DEFAULT_K)
+    # Generous bound — spec says ~4s; allow 30s for noisy hosts.
+    assert elapsed < 30.0


### PR DESCRIPTION
## Summary

Closes #149. Ships the offline foundation for #150 (heat-kernel
authority signal). No integration into `retrieve()`; no query-time
cost.

- New module `aelfrice.graph_spectral` implementing Kunegis 2010's
  signed normalized Laplacian `L = I - D_abs^(-1/2) W_sym D_abs^(-1/2)`
  over the typed edge graph.
- Edge polarity per spec §Algorithm:
  `SUPPORTS|CITES|RELATES_TO|DERIVED_FROM = +1.0`,
  `CONTRADICTS = -1.0`, `SUPERSEDES = -0.5`. Mapping exposed as
  module-level `EDGE_LAPLACIAN_WEIGHTS` (separate from
  `models.EDGE_TYPE_WEIGHTS` which serves valence propagation
  under a different polarity convention).
- API: `build_signed_adjacency`, `build_signed_normalized_laplacian`,
  `compute_eigenbasis`, `save_eigenbasis`, `load_eigenbasis`, plus
  `GraphEigenbasisCache` for invalidation wiring.
- `GraphEigenbasisCache` registers on the same `add_invalidation_callback`
  registry `RetrievalCache` uses; mutation invalidates both
  in-memory eigenpairs and the persisted `.npz`.
- Adds `MemoryStore.iter_all_edges()` so graph-wide builders don't
  reach into `_conn` directly.

## Test plan

- [x] `tests/test_graph_spectral.py` — 13 tests covering all 7
      acceptance criteria; toy 5-node fixture; deterministic.
- [x] `uv run pytest` — full suite **1476 passed, 5 skipped**
      (no regressions from `iter_all_edges` addition).
- [x] `uv run pyright src/aelfrice/graph_spectral.py
      tests/test_graph_spectral.py src/aelfrice/store.py` — clean.
- [x] Perf gate (`--run-perf`): `test_eigsolve_under_budget_n10k`
      — skipped in regular runs.

## Out of scope

Heat kernel consumer (#150), block-Lanczos for N≥10⁶, online
incremental eigenbasis updates, per-corpus weight sweeps.