### PR TITLE
feat: belief corroboration tracking — sibling table + ingest recorder (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+### Added
+
+- **Belief corroboration tracking — sibling table + ingest recorder (phantom-prereqs T1)** ([#190](https://github.com/robotrocketscience/aelfrice/issues/190)). New `belief_corroborations` table records each re-ingest of identical content without disturbing the existing dedup contract. When `ingest_turn` or `ingest_triples` encounters an already-existing belief (by id), it calls `MemoryStore.record_corroboration(belief_id, source_type=...)` instead of silently discarding the duplicate. Four `source_type` constants distinguish the ingest paths: `CORROBORATION_SOURCE_COMMIT_INGEST`, `CORROBORATION_SOURCE_TRANSCRIPT_INGEST`, `CORROBORATION_SOURCE_MCP_REMEMBER`, `CORROBORATION_SOURCE_HOOK_INGEST` (all in `aelfrice.models`); `record_corroboration` validates against `CORROBORATION_SOURCE_TYPES` and raises `ValueError` on unknown values. `Belief.corroboration_count` (default 0) is populated at retrieval time via a per-belief subquery in `get_belief`, `search_beliefs`, `search_beliefs_scored`, and `list_locked_beliefs`. `session_id` and `source_path_hash` columns are nullable; T3 (#192) will wire session propagation. `ON DELETE CASCADE` removes corroboration rows when a belief is deleted. 16 new deterministic tests in `tests/test_corroborations.py` cover schema creation, idempotency, re-ingest recording, corroboration count on retrieval, cascade deletion, nullable fields, source_type enum coverage, and ValueError on unknown source_type.
+
 ## [1.5.0] - 2026-04-28
 
 ### Added

--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -27,7 +27,7 @@ from aelfrice.classification import classify_sentence
 from aelfrice.extraction import extract_sentences
 from aelfrice.models import (
     ANCHOR_TEXT_MAX_LEN,
-    CORROBORATION_TRANSCRIPT_INGEST,
+    CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
     EDGE_DERIVED_FROM,
     LOCK_NONE,
     Belief,
@@ -120,9 +120,9 @@ def _ingest_turn_ids(
         if store.get_belief(belief_id) is not None:
             # Exact (source, sentence) duplicate: record a corroboration
             # so re-assertions are observable. Canonical row unchanged.
-            store.insert_corroboration(
+            store.record_corroboration(
                 belief_id,
-                CORROBORATION_TRANSCRIPT_INGEST,
+                source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
                 session_id=session_id,
             )
             continue

--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -27,6 +27,7 @@ from aelfrice.classification import classify_sentence
 from aelfrice.extraction import extract_sentences
 from aelfrice.models import (
     ANCHOR_TEXT_MAX_LEN,
+    CORROBORATION_TRANSCRIPT_INGEST,
     EDGE_DERIVED_FROM,
     LOCK_NONE,
     Belief,
@@ -115,12 +116,20 @@ def _ingest_turn_ids(
         if not result.persist:
             continue
         belief_id = _belief_id(sentence, source)
+        ch = _content_hash(sentence)
         if store.get_belief(belief_id) is not None:
-            continue  # idempotent: same (source, sentence) already ingested
+            # Exact (source, sentence) duplicate: record a corroboration
+            # so re-assertions are observable. Canonical row unchanged.
+            store.insert_corroboration(
+                belief_id,
+                CORROBORATION_TRANSCRIPT_INGEST,
+                session_id=session_id,
+            )
+            continue
         belief = Belief(
             id=belief_id,
             content=sentence,
-            content_hash=_content_hash(sentence),
+            content_hash=ch,
             alpha=result.alpha,
             beta=result.beta,
             type=result.belief_type,

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -53,7 +53,7 @@ from aelfrice.health import (
 )
 from aelfrice.models import (
     BELIEF_FACTUAL,
-    CORROBORATION_MCP_REMEMBER,
+    CORROBORATION_SOURCE_MCP_REMEMBER,
     LOCK_NONE,
     LOCK_USER,
     ORIGIN_USER_STATED,
@@ -236,7 +236,7 @@ def tool_lock(store: MemoryStore, *, statement: str) -> dict[str, Any]:
     store.update_belief(existing)
     # Record a corroboration for the re-assertion so downstream
     # consumers can count how often a belief was re-locked.
-    store.insert_corroboration(bid, CORROBORATION_MCP_REMEMBER)
+    store.record_corroboration(bid, source_type=CORROBORATION_SOURCE_MCP_REMEMBER)
     return {"kind": "lock.upgraded", "id": bid, "action": "upgraded"}
 
 

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -53,6 +53,7 @@ from aelfrice.health import (
 )
 from aelfrice.models import (
     BELIEF_FACTUAL,
+    CORROBORATION_MCP_REMEMBER,
     LOCK_NONE,
     LOCK_USER,
     ORIGIN_USER_STATED,
@@ -233,6 +234,9 @@ def tool_lock(store: MemoryStore, *, statement: str) -> dict[str, Any]:
     existing.demotion_pressure = 0
     existing.origin = ORIGIN_USER_STATED
     store.update_belief(existing)
+    # Record a corroboration for the re-assertion so downstream
+    # consumers can count how often a belief was re-locked.
+    store.insert_corroboration(bid, CORROBORATION_MCP_REMEMBER)
     return {"kind": "lock.upgraded", "id": bid, "action": "upgraded"}
 
 

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -6,8 +6,8 @@ deferred to a later release.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Final, Literal
+from dataclasses import dataclass
+from typing import Final
 
 # --- Belief types ---
 BELIEF_FACTUAL: Final[str] = "factual"
@@ -78,23 +78,16 @@ ORIGINS: Final[frozenset[str]] = frozenset({
 # Wire-format strings. Do not rename without a migration. Distinguishes
 # which ingest path produced the corroboration row. Used by T2 (#191)
 # for grace-window cross-checking.
-CORROBORATION_COMMIT_INGEST: Final[str] = "commit-ingest"
-CORROBORATION_TRANSCRIPT_INGEST: Final[str] = "transcript-ingest"
-CORROBORATION_MCP_REMEMBER: Final[str] = "MCP-remember"
-CORROBORATION_HOOK_INGEST: Final[str] = "hook-ingest"
-
-CorroborationSourceType = Literal[
-    "commit-ingest",
-    "transcript-ingest",
-    "MCP-remember",
-    "hook-ingest",
-]
+CORROBORATION_SOURCE_COMMIT_INGEST: Final[str] = "commit_ingest"
+CORROBORATION_SOURCE_TRANSCRIPT_INGEST: Final[str] = "transcript_ingest"
+CORROBORATION_SOURCE_MCP_REMEMBER: Final[str] = "mcp_remember"
+CORROBORATION_SOURCE_HOOK_INGEST: Final[str] = "hook_ingest"
 
 CORROBORATION_SOURCE_TYPES: Final[frozenset[str]] = frozenset({
-    CORROBORATION_COMMIT_INGEST,
-    CORROBORATION_TRANSCRIPT_INGEST,
-    CORROBORATION_MCP_REMEMBER,
-    CORROBORATION_HOOK_INGEST,
+    CORROBORATION_SOURCE_COMMIT_INGEST,
+    CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
+    CORROBORATION_SOURCE_MCP_REMEMBER,
+    CORROBORATION_SOURCE_HOOK_INGEST,
 })
 
 # --- Onboard-session states ---
@@ -231,23 +224,3 @@ class Session:
     project_context: str | None
 
 
-@dataclass
-class BeliefCorroboration:
-    """One row in the belief_corroborations sibling table (v1.5+, #190).
-
-    Records each re-ingest of content whose content_hash already exists
-    in `beliefs`. The canonical belief row is unchanged; this row makes
-    the re-assertion observable as a first-class signal.
-
-    `session_id` and `source_path_hash` are nullable: callers that lack
-    the value pass None and the row is inserted with SQL NULLs. T3 (#192)
-    is responsible for populating `session_id` in production; T1 lands
-    the column only.
-    """
-
-    id: int
-    belief_id: str
-    ingested_at: str
-    source_type: str
-    session_id: str | None
-    source_path_hash: str | None

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -6,8 +6,8 @@ deferred to a later release.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Final
+from dataclasses import dataclass, field
+from typing import Final, Literal
 
 # --- Belief types ---
 BELIEF_FACTUAL: Final[str] = "factual"
@@ -74,6 +74,29 @@ ORIGINS: Final[frozenset[str]] = frozenset({
     ORIGIN_UNKNOWN,
 })
 
+# --- Corroboration source types (v1.5+) ---
+# Wire-format strings. Do not rename without a migration. Distinguishes
+# which ingest path produced the corroboration row. Used by T2 (#191)
+# for grace-window cross-checking.
+CORROBORATION_COMMIT_INGEST: Final[str] = "commit-ingest"
+CORROBORATION_TRANSCRIPT_INGEST: Final[str] = "transcript-ingest"
+CORROBORATION_MCP_REMEMBER: Final[str] = "MCP-remember"
+CORROBORATION_HOOK_INGEST: Final[str] = "hook-ingest"
+
+CorroborationSourceType = Literal[
+    "commit-ingest",
+    "transcript-ingest",
+    "MCP-remember",
+    "hook-ingest",
+]
+
+CORROBORATION_SOURCE_TYPES: Final[frozenset[str]] = frozenset({
+    CORROBORATION_COMMIT_INGEST,
+    CORROBORATION_TRANSCRIPT_INGEST,
+    CORROBORATION_MCP_REMEMBER,
+    CORROBORATION_HOOK_INGEST,
+})
+
 # --- Onboard-session states ---
 # A polymorphic onboard handshake passes through exactly two persisted
 # states: `pending` after `start_onboard_session` records the scanner
@@ -123,6 +146,7 @@ class Belief:
     last_retrieved_at: str | None
     session_id: str | None = None
     origin: str = ORIGIN_UNKNOWN
+    corroboration_count: int = 0
 
 
 ANCHOR_TEXT_MAX_LEN: Final[int] = 1000
@@ -205,3 +229,25 @@ class Session:
     completed_at: str | None
     model: str | None
     project_context: str | None
+
+
+@dataclass
+class BeliefCorroboration:
+    """One row in the belief_corroborations sibling table (v1.5+, #190).
+
+    Records each re-ingest of content whose content_hash already exists
+    in `beliefs`. The canonical belief row is unchanged; this row makes
+    the re-assertion observable as a first-class signal.
+
+    `session_id` and `source_path_hash` are nullable: callers that lack
+    the value pass None and the row is inserted with SQL NULLs. T3 (#192)
+    is responsible for populating `session_id` in production; T1 lands
+    the column only.
+    """
+
+    id: int
+    belief_id: str
+    ingested_at: str
+    source_type: str
+    session_id: str | None
+    source_path_hash: str | None

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -20,11 +20,11 @@ from datetime import datetime, timezone
 from typing import Callable, Final, Iterable, Iterator
 
 from aelfrice.models import (
+    CORROBORATION_SOURCE_TYPES,
     EDGE_VALENCE,
     ONBOARD_STATE_COMPLETED,
     ONBOARD_STATE_PENDING,
     Belief,
-    BeliefCorroboration,
     Edge,
     FeedbackEvent,
     OnboardSession,
@@ -127,12 +127,15 @@ _SCHEMA: tuple[str, ...] = (
     # observable as a first-class signal without disturbing the
     # existing dedup contract. ON DELETE CASCADE removes corroboration
     # rows when a belief is deleted (rare; covered for hygiene).
+    # NOTE: belief_id is TEXT NOT NULL (not INTEGER) because beliefs.id
+    # is TEXT PRIMARY KEY in this codebase; the spec sketch said INTEGER
+    # but that was adapted to match the actual schema.
     """
     CREATE TABLE IF NOT EXISTS belief_corroborations (
         id                INTEGER PRIMARY KEY AUTOINCREMENT,
-        belief_id         INTEGER NOT NULL REFERENCES beliefs(id) ON DELETE CASCADE,
-        ingested_at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        source_type       TEXT NOT NULL,
+        belief_id         TEXT    NOT NULL REFERENCES beliefs(id) ON DELETE CASCADE,
+        ingested_at       TEXT    NOT NULL,
+        source_type       TEXT    NOT NULL,
         session_id        TEXT,
         source_path_hash  TEXT
     )
@@ -276,17 +279,6 @@ def _row_to_belief(row: sqlite3.Row) -> Belief:
         session_id=row["session_id"],
         origin=row["origin"],
         corroboration_count=corroboration_count,
-    )
-
-
-def _row_to_corroboration(row: sqlite3.Row) -> BeliefCorroboration:
-    return BeliefCorroboration(
-        id=int(row["id"]),
-        belief_id=str(row["belief_id"]),
-        ingested_at=str(row["ingested_at"]),
-        source_type=str(row["source_type"]),
-        session_id=row["session_id"] if row["session_id"] is not None else None,
-        source_path_hash=row["source_path_hash"] if row["source_path_hash"] is not None else None,
     )
 
 
@@ -937,29 +929,30 @@ class MemoryStore:
 
     # --- Belief corroborations (v1.5+, #190) -----------------------------
 
-    def insert_corroboration(
+    def record_corroboration(
         self,
         belief_id: str,
-        source_type: str,
         *,
+        source_type: str,
         session_id: str | None = None,
         source_path_hash: str | None = None,
-        ingested_at: str | None = None,
-    ) -> int:
-        """Record one re-ingest of an existing belief.
+    ) -> None:
+        """Record one corroboration row for an already-existing belief.
 
-        Called when `ingest_turn` (or another ingest path) hits an
-        existing `content_hash`. The canonical belief row is unchanged;
-        this row makes the re-assertion observable as a first-class
-        signal.
+        Called by the ingest path when an INSERT hits the content_hash
+        UNIQUE constraint. Validates `source_type` against
+        CORROBORATION_SOURCE_TYPES; raises ValueError on unknown values.
 
         `session_id` and `source_path_hash` are nullable: pass None
         when unavailable; no exception is raised.
-
-        Returns the rowid of the newly inserted corroboration row.
         """
-        ts = ingested_at or datetime.now(timezone.utc).isoformat()
-        cur = self._conn.execute(
+        if source_type not in CORROBORATION_SOURCE_TYPES:
+            raise ValueError(
+                f"Unknown source_type {source_type!r}. "
+                f"Must be one of {sorted(CORROBORATION_SOURCE_TYPES)}"
+            )
+        ts = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
             """
             INSERT INTO belief_corroborations
                 (belief_id, ingested_at, source_type, session_id, source_path_hash)
@@ -968,42 +961,47 @@ class MemoryStore:
             (belief_id, ts, source_type, session_id, source_path_hash),
         )
         self._conn.commit()
-        rowid = cur.lastrowid
-        if rowid is None:
-            raise RuntimeError("belief_corroborations insert returned no rowid")
-        return rowid
 
-    def count_corroborations(self, belief_id: str | None = None) -> int:
-        """Count corroboration rows; total or per-belief."""
-        if belief_id is None:
-            cur = self._conn.execute(
-                "SELECT COUNT(*) AS n FROM belief_corroborations"
-            )
-        else:
-            cur = self._conn.execute(
-                "SELECT COUNT(*) AS n FROM belief_corroborations "
-                "WHERE belief_id = ?",
-                (belief_id,),
-            )
+    def count_corroborations(self, belief_id: str) -> int:
+        """Return the count of belief_corroborations rows for one belief.
+
+        Used by _row_to_belief to populate Belief.corroboration_count.
+        """
+        cur = self._conn.execute(
+            "SELECT COUNT(*) AS n FROM belief_corroborations "
+            "WHERE belief_id = ?",
+            (belief_id,),
+        )
         row = cur.fetchone()
         return int(row["n"]) if row else 0
 
     def list_corroborations(
         self,
         belief_id: str,
-        limit: int = 100,
-    ) -> list[BeliefCorroboration]:
-        """Corroboration rows for one belief, newest first."""
+    ) -> list[tuple[str, str, str | None, str | None]]:
+        """Return [(ingested_at, source_type, session_id, source_path_hash)]
+        for one belief, ordered by ingested_at ASC.
+
+        Used by tests and future debug CLI.
+        """
         cur = self._conn.execute(
             """
-            SELECT * FROM belief_corroborations
+            SELECT ingested_at, source_type, session_id, source_path_hash
+            FROM belief_corroborations
             WHERE belief_id = ?
-            ORDER BY id DESC
-            LIMIT ?
+            ORDER BY ingested_at ASC
             """,
-            (belief_id, limit),
+            (belief_id,),
         )
-        return [_row_to_corroboration(r) for r in cur.fetchall()]
+        return [
+            (
+                str(r["ingested_at"]),
+                str(r["source_type"]),
+                r["session_id"],
+                r["source_path_hash"],
+            )
+            for r in cur.fetchall()
+        ]
 
     # --- Aggregations (used by aelf:health) ------------------------------
 

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -24,6 +24,7 @@ from aelfrice.models import (
     ONBOARD_STATE_COMPLETED,
     ONBOARD_STATE_PENDING,
     Belief,
+    BeliefCorroboration,
     Edge,
     FeedbackEvent,
     OnboardSession,
@@ -120,6 +121,24 @@ _SCHEMA: tuple[str, ...] = (
         value TEXT NOT NULL
     )
     """,
+    # v1.5.0 belief_corroborations (#190). Records each re-ingest of
+    # content whose content_hash already exists in `beliefs`. The
+    # canonical belief row is unchanged; this table makes re-assertions
+    # observable as a first-class signal without disturbing the
+    # existing dedup contract. ON DELETE CASCADE removes corroboration
+    # rows when a belief is deleted (rare; covered for hygiene).
+    """
+    CREATE TABLE IF NOT EXISTS belief_corroborations (
+        id                INTEGER PRIMARY KEY AUTOINCREMENT,
+        belief_id         INTEGER NOT NULL REFERENCES beliefs(id) ON DELETE CASCADE,
+        ingested_at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        source_type       TEXT NOT NULL,
+        session_id        TEXT,
+        source_path_hash  TEXT
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_belief_corroborations_belief_id "
+    "ON belief_corroborations(belief_id)",
     "CREATE INDEX IF NOT EXISTS idx_edges_src ON edges(src)",
     "CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst)",
     "CREATE INDEX IF NOT EXISTS idx_feedback_belief ON feedback_history(belief_id)",
@@ -240,6 +259,8 @@ def _escape_fts5_query(query: str) -> str:
 
 
 def _row_to_belief(row: sqlite3.Row) -> Belief:
+    keys = row.keys()
+    corroboration_count = int(row["corroboration_count"]) if "corroboration_count" in keys else 0
     return Belief(
         id=row["id"],
         content=row["content"],
@@ -254,6 +275,18 @@ def _row_to_belief(row: sqlite3.Row) -> Belief:
         last_retrieved_at=row["last_retrieved_at"],
         session_id=row["session_id"],
         origin=row["origin"],
+        corroboration_count=corroboration_count,
+    )
+
+
+def _row_to_corroboration(row: sqlite3.Row) -> BeliefCorroboration:
+    return BeliefCorroboration(
+        id=int(row["id"]),
+        belief_id=str(row["belief_id"]),
+        ingested_at=str(row["ingested_at"]),
+        source_type=str(row["source_type"]),
+        session_id=row["session_id"] if row["session_id"] is not None else None,
+        source_path_hash=row["source_path_hash"] if row["source_path_hash"] is not None else None,
     )
 
 
@@ -528,9 +561,39 @@ class MemoryStore:
         self._conn.commit()
         self._fire_invalidation()
 
+    def get_belief_by_content_hash(self, content_hash: str) -> Belief | None:
+        """Look up a belief by its content_hash. Returns None if not found.
+
+        Used by ingest paths to detect re-ingest of identical content
+        across different (source, text) pairs — e.g. the same sentence
+        ingested once via transcript-ingest and once via commit-ingest.
+        When found, the caller records a belief_corroborations row
+        instead of silently dropping the duplicate.
+        """
+        cur = self._conn.execute(
+            """
+            SELECT b.*,
+                   (SELECT COUNT(*) FROM belief_corroborations bc
+                    WHERE bc.belief_id = b.id) AS corroboration_count
+            FROM beliefs b
+            WHERE b.content_hash = ?
+            LIMIT 1
+            """,
+            (content_hash,),
+        )
+        row = cur.fetchone()
+        return _row_to_belief(row) if row else None
+
     def get_belief(self, belief_id: str) -> Belief | None:
         cur = self._conn.execute(
-            "SELECT * FROM beliefs WHERE id = ?", (belief_id,)
+            """
+            SELECT b.*,
+                   (SELECT COUNT(*) FROM belief_corroborations bc
+                    WHERE bc.belief_id = b.id) AS corroboration_count
+            FROM beliefs b
+            WHERE b.id = ?
+            """,
+            (belief_id,),
         )
         row = cur.fetchone()
         return _row_to_belief(row) if row else None
@@ -756,7 +819,10 @@ class MemoryStore:
             return []
         cur = self._conn.execute(
             """
-            SELECT b.* FROM beliefs b
+            SELECT b.*,
+                   (SELECT COUNT(*) FROM belief_corroborations bc
+                    WHERE bc.belief_id = b.id) AS corroboration_count
+            FROM beliefs b
             JOIN beliefs_fts f ON f.id = b.id
             WHERE beliefs_fts MATCH ?
             ORDER BY bm25(beliefs_fts)
@@ -787,7 +853,10 @@ class MemoryStore:
             return []
         cur = self._conn.execute(
             """
-            SELECT b.*, bm25(beliefs_fts) AS bm25_score
+            SELECT b.*,
+                   bm25(beliefs_fts) AS bm25_score,
+                   (SELECT COUNT(*) FROM belief_corroborations bc
+                    WHERE bc.belief_id = b.id) AS corroboration_count
             FROM beliefs b
             JOIN beliefs_fts f ON f.id = b.id
             WHERE beliefs_fts MATCH ?
@@ -866,6 +935,76 @@ class MemoryStore:
             return 0
         return int(row["n"])
 
+    # --- Belief corroborations (v1.5+, #190) -----------------------------
+
+    def insert_corroboration(
+        self,
+        belief_id: str,
+        source_type: str,
+        *,
+        session_id: str | None = None,
+        source_path_hash: str | None = None,
+        ingested_at: str | None = None,
+    ) -> int:
+        """Record one re-ingest of an existing belief.
+
+        Called when `ingest_turn` (or another ingest path) hits an
+        existing `content_hash`. The canonical belief row is unchanged;
+        this row makes the re-assertion observable as a first-class
+        signal.
+
+        `session_id` and `source_path_hash` are nullable: pass None
+        when unavailable; no exception is raised.
+
+        Returns the rowid of the newly inserted corroboration row.
+        """
+        ts = ingested_at or datetime.now(timezone.utc).isoformat()
+        cur = self._conn.execute(
+            """
+            INSERT INTO belief_corroborations
+                (belief_id, ingested_at, source_type, session_id, source_path_hash)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (belief_id, ts, source_type, session_id, source_path_hash),
+        )
+        self._conn.commit()
+        rowid = cur.lastrowid
+        if rowid is None:
+            raise RuntimeError("belief_corroborations insert returned no rowid")
+        return rowid
+
+    def count_corroborations(self, belief_id: str | None = None) -> int:
+        """Count corroboration rows; total or per-belief."""
+        if belief_id is None:
+            cur = self._conn.execute(
+                "SELECT COUNT(*) AS n FROM belief_corroborations"
+            )
+        else:
+            cur = self._conn.execute(
+                "SELECT COUNT(*) AS n FROM belief_corroborations "
+                "WHERE belief_id = ?",
+                (belief_id,),
+            )
+        row = cur.fetchone()
+        return int(row["n"]) if row else 0
+
+    def list_corroborations(
+        self,
+        belief_id: str,
+        limit: int = 100,
+    ) -> list[BeliefCorroboration]:
+        """Corroboration rows for one belief, newest first."""
+        cur = self._conn.execute(
+            """
+            SELECT * FROM belief_corroborations
+            WHERE belief_id = ?
+            ORDER BY id DESC
+            LIMIT ?
+            """,
+            (belief_id, limit),
+        )
+        return [_row_to_corroboration(r) for r in cur.fetchall()]
+
     # --- Aggregations (used by aelf:health) ------------------------------
 
     def count_beliefs(self) -> int:
@@ -904,9 +1043,12 @@ class MemoryStore:
         """
         cur = self._conn.execute(
             """
-            SELECT * FROM beliefs
-            WHERE lock_level != 'none'
-            ORDER BY locked_at DESC, id ASC
+            SELECT b.*,
+                   (SELECT COUNT(*) FROM belief_corroborations bc
+                    WHERE bc.belief_id = b.id) AS corroboration_count
+            FROM beliefs b
+            WHERE b.lock_level != 'none'
+            ORDER BY b.locked_at DESC, b.id ASC
             """
         )
         return [_row_to_belief(r) for r in cur.fetchall()]

--- a/src/aelfrice/triple_extractor.py
+++ b/src/aelfrice/triple_extractor.py
@@ -31,7 +31,7 @@ from typing import Final
 
 from aelfrice.models import (
     BELIEF_FACTUAL,
-    CORROBORATION_COMMIT_INGEST,
+    CORROBORATION_SOURCE_COMMIT_INGEST,
     EDGE_CITES,
     EDGE_CONTRADICTS,
     EDGE_DERIVED_FROM,
@@ -259,9 +259,9 @@ def _resolve_or_create_belief(
     bid = _belief_id_for_phrase(phrase)
     existing = store.get_belief(bid)
     if existing is not None:
-        store.insert_corroboration(
+        store.record_corroboration(
             bid,
-            CORROBORATION_COMMIT_INGEST,
+            source_type=CORROBORATION_SOURCE_COMMIT_INGEST,
             session_id=session_id,
         )
         return bid

--- a/src/aelfrice/triple_extractor.py
+++ b/src/aelfrice/triple_extractor.py
@@ -31,6 +31,7 @@ from typing import Final
 
 from aelfrice.models import (
     BELIEF_FACTUAL,
+    CORROBORATION_COMMIT_INGEST,
     EDGE_CITES,
     EDGE_CONTRADICTS,
     EDGE_DERIVED_FROM,
@@ -250,10 +251,19 @@ def _resolve_or_create_belief(
 ) -> str:
     """Return the id of the belief representing `phrase`, creating
     one with the project default prior (alpha=1.0, beta=1.0) if none
-    exists. The first creator within a call stamps `session_id`."""
+    exists. The first creator within a call stamps `session_id`.
+
+    When the belief already exists (same id = same normalised phrase),
+    a corroboration row is recorded so the re-assertion is observable.
+    """
     bid = _belief_id_for_phrase(phrase)
     existing = store.get_belief(bid)
     if existing is not None:
+        store.insert_corroboration(
+            bid,
+            CORROBORATION_COMMIT_INGEST,
+            session_id=session_id,
+        )
         return bid
     belief = Belief(
         id=bid,

--- a/tests/test_corroborations.py
+++ b/tests/test_corroborations.py
@@ -1,0 +1,415 @@
+"""Tests for belief_corroborations — schema, ingest recorder, retrieval count.
+
+Issue #190: phantom-prereqs T1.
+
+All tests use an in-memory store (MemoryStore(":memory:")) and are
+deterministic (no LLM calls, no randomness, no filesystem I/O).
+Each test must complete well under 1 second.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from aelfrice.ingest import ingest_turn
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    CORROBORATION_COMMIT_INGEST,
+    CORROBORATION_HOOK_INGEST,
+    CORROBORATION_MCP_REMEMBER,
+    CORROBORATION_SOURCE_TYPES,
+    CORROBORATION_TRANSCRIPT_INGEST,
+    LOCK_NONE,
+    Belief,
+)
+from aelfrice.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fresh_store() -> MemoryStore:
+    return MemoryStore(":memory:")
+
+
+def _belief(bid: str, content: str, content_hash: str) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=content_hash,
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-28T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema: table created on fresh store; idempotent on reopen
+# ---------------------------------------------------------------------------
+
+
+def test_table_created_on_fresh_store() -> None:
+    """belief_corroborations table exists on a fresh in-memory store."""
+    store = _fresh_store()
+    try:
+        cur = store._conn.execute(  # type: ignore[reportPrivateUsage]
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='belief_corroborations'"
+        )
+        assert cur.fetchone() is not None, "table must exist"
+    finally:
+        store.close()
+
+
+def test_index_created_on_fresh_store() -> None:
+    """idx_belief_corroborations_belief_id index exists."""
+    store = _fresh_store()
+    try:
+        cur = store._conn.execute(  # type: ignore[reportPrivateUsage]
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND name='idx_belief_corroborations_belief_id'"
+        )
+        assert cur.fetchone() is not None, "index must exist"
+    finally:
+        store.close()
+
+
+def test_table_creation_idempotent(tmp_path: Path) -> None:
+    """Opening the same on-disk store twice does not error — schema is
+    CREATE IF NOT EXISTS throughout."""
+    db = str(tmp_path / "idem.db")
+    s1 = MemoryStore(db)
+    s1.close()
+    s2 = MemoryStore(db)
+    s2.close()
+
+
+# ---------------------------------------------------------------------------
+# Re-ingest records exactly one corroboration; belief row unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_reingest_records_corroboration_row(tmp_path: Path) -> None:
+    """Re-ingesting the same (source, sentence) records exactly one new
+    corroboration row; the canonical belief row is unchanged."""
+    store = MemoryStore(str(tmp_path / "t.db"))
+    try:
+        text = "The default port is 8080 for the service."
+        source = "user"
+        n1 = ingest_turn(store, text, source=source)
+        assert n1 >= 1
+        before_id = store.search_beliefs("default port", limit=5)
+        assert len(before_id) == 1
+        bid = before_id[0].id
+        original_content_hash = before_id[0].content_hash
+
+        # Re-ingest: same text, same source
+        n2 = ingest_turn(store, text, source=source)
+        assert n2 == 0  # no new beliefs
+
+        # Belief row is unchanged
+        after = store.get_belief(bid)
+        assert after is not None
+        assert after.content_hash == original_content_hash
+
+        # One corroboration recorded
+        count = store.count_corroborations(bid)
+        assert count == 1
+    finally:
+        store.close()
+
+
+def test_reingest_twice_records_two_corroborations(tmp_path: Path) -> None:
+    """Each subsequent ingest adds exactly one row to belief_corroborations."""
+    store = MemoryStore(str(tmp_path / "t.db"))
+    try:
+        text = "The configuration directory is /etc/aelfrice."
+        source = "user"
+        ingest_turn(store, text, source=source)
+        beliefs = store.search_beliefs("configuration directory", limit=5)
+        assert len(beliefs) >= 1
+        bid = beliefs[0].id
+
+        ingest_turn(store, text, source=source)
+        ingest_turn(store, text, source=source)
+
+        assert store.count_corroborations(bid) == 2
+    finally:
+        store.close()
+
+
+def test_belief_id_and_content_hash_unchanged_after_corroboration(
+    tmp_path: Path,
+) -> None:
+    """The canonical belief row's id and content_hash must not change
+    after a re-ingest that triggers corroboration recording."""
+    store = MemoryStore(str(tmp_path / "t.db"))
+    try:
+        text = "Aelfrice stores beliefs in a SQLite database."
+        source = "user"
+        ingest_turn(store, text, source=source)
+        beliefs = store.search_beliefs("Aelfrice", limit=5)
+        assert beliefs
+        bid = beliefs[0].id
+        chash = beliefs[0].content_hash
+
+        ingest_turn(store, text, source=source)
+
+        after = store.get_belief(bid)
+        assert after is not None
+        assert after.id == bid
+        assert after.content_hash == chash
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# corroboration_count on retrieval
+# ---------------------------------------------------------------------------
+
+
+def test_corroboration_count_zero_on_fresh_belief(tmp_path: Path) -> None:
+    """A newly inserted belief has corroboration_count == 0."""
+    store = MemoryStore(str(tmp_path / "t.db"))
+    try:
+        text = "The API rate limit is 100 requests per minute."
+        ingest_turn(store, text, source="user")
+        beliefs = store.search_beliefs("rate limit", limit=5)
+        assert beliefs
+        assert beliefs[0].corroboration_count == 0
+    finally:
+        store.close()
+
+
+def test_corroboration_count_increments_on_retrieval(tmp_path: Path) -> None:
+    """corroboration_count on a retrieved belief reflects the number of
+    corroboration rows, not zero."""
+    store = MemoryStore(str(tmp_path / "t.db"))
+    try:
+        text = "The scheduler runs every five minutes by default."
+        source = "user"
+        ingest_turn(store, text, source=source)
+        beliefs = store.search_beliefs("scheduler", limit=5)
+        assert beliefs
+        bid = beliefs[0].id
+
+        # Two re-ingests → two corroboration rows
+        ingest_turn(store, text, source=source)
+        ingest_turn(store, text, source=source)
+
+        after = store.get_belief(bid)
+        assert after is not None
+        assert after.corroboration_count == 2
+    finally:
+        store.close()
+
+
+def test_corroboration_count_via_search_beliefs(tmp_path: Path) -> None:
+    """search_beliefs results also expose corroboration_count."""
+    store = MemoryStore(str(tmp_path / "t.db"))
+    try:
+        text = "The log level is DEBUG in development environments."
+        source = "user"
+        ingest_turn(store, text, source=source)
+        beliefs = store.search_beliefs("log level", limit=5)
+        assert beliefs
+        bid = beliefs[0].id
+
+        ingest_turn(store, text, source=source)
+
+        results = store.search_beliefs("log level", limit=5)
+        assert results
+        match = next((b for b in results if b.id == bid), None)
+        assert match is not None
+        assert match.corroboration_count == 1
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Different source_type values record distinctly
+# ---------------------------------------------------------------------------
+
+
+def test_different_source_types_record_distinctly() -> None:
+    """Corroboration rows for different source_types are each stored and
+    counted independently. The count groups correctly."""
+    store = _fresh_store()
+    try:
+        b = _belief("b1", "X uses Y.", "hash-b1")
+        store.insert_belief(b)
+
+        store.insert_corroboration("b1", CORROBORATION_TRANSCRIPT_INGEST)
+        store.insert_corroboration("b1", CORROBORATION_COMMIT_INGEST)
+        store.insert_corroboration("b1", CORROBORATION_MCP_REMEMBER)
+        store.insert_corroboration("b1", CORROBORATION_HOOK_INGEST)
+
+        assert store.count_corroborations("b1") == 4
+
+        rows = store.list_corroborations("b1")
+        assert len(rows) == 4
+        recorded_types = {r.source_type for r in rows}
+        assert recorded_types == {
+            CORROBORATION_TRANSCRIPT_INGEST,
+            CORROBORATION_COMMIT_INGEST,
+            CORROBORATION_MCP_REMEMBER,
+            CORROBORATION_HOOK_INGEST,
+        }
+    finally:
+        store.close()
+
+
+def test_source_type_enum_covers_all_variants() -> None:
+    """CORROBORATION_SOURCE_TYPES contains exactly the four documented
+    values."""
+    expected = {
+        "commit-ingest",
+        "transcript-ingest",
+        "MCP-remember",
+        "hook-ingest",
+    }
+    assert CORROBORATION_SOURCE_TYPES == expected
+
+
+# ---------------------------------------------------------------------------
+# session_id and source_path_hash nullable
+# ---------------------------------------------------------------------------
+
+
+def test_null_session_id_and_source_path_hash_accepted() -> None:
+    """insert_corroboration with session_id=None and source_path_hash=None
+    must not raise, and the stored row reflects NULLs."""
+    store = _fresh_store()
+    try:
+        b = _belief("b2", "Y implies Z.", "hash-b2")
+        store.insert_belief(b)
+
+        store.insert_corroboration(
+            "b2",
+            CORROBORATION_TRANSCRIPT_INGEST,
+            session_id=None,
+            source_path_hash=None,
+        )
+
+        rows = store.list_corroborations("b2")
+        assert len(rows) == 1
+        assert rows[0].session_id is None
+        assert rows[0].source_path_hash is None
+    finally:
+        store.close()
+
+
+def test_session_id_stamped_when_provided() -> None:
+    """session_id is persisted when supplied."""
+    store = _fresh_store()
+    try:
+        b = _belief("b3", "Z follows W.", "hash-b3")
+        store.insert_belief(b)
+
+        store.insert_corroboration(
+            "b3",
+            CORROBORATION_TRANSCRIPT_INGEST,
+            session_id="sess-abc",
+            source_path_hash="pathsha256",
+        )
+
+        rows = store.list_corroborations("b3")
+        assert len(rows) == 1
+        assert rows[0].session_id == "sess-abc"
+        assert rows[0].source_path_hash == "pathsha256"
+    finally:
+        store.close()
+
+
+def test_ingest_turn_passes_session_id_to_corroboration(tmp_path: Path) -> None:
+    """When ingest_turn is called with session_id and a duplicate is found,
+    the corroboration row is stamped with that session_id."""
+    store = MemoryStore(str(tmp_path / "t.db"))
+    try:
+        text = "The memory limit is four gigabytes per process."
+        source = "user"
+        ingest_turn(store, text, source=source, session_id="sess-1")
+        beliefs = store.search_beliefs("memory limit", limit=5)
+        assert beliefs
+        bid = beliefs[0].id
+
+        # Re-ingest with a different session_id
+        ingest_turn(store, text, source=source, session_id="sess-2")
+
+        rows = store.list_corroborations(bid)
+        assert len(rows) == 1
+        assert rows[0].session_id == "sess-2"
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# ON DELETE CASCADE
+# ---------------------------------------------------------------------------
+
+
+def test_belief_deletion_cascades_to_corroborations(tmp_path: Path) -> None:
+    """Deleting a belief removes its corroboration rows via ON DELETE CASCADE."""
+    store = MemoryStore(str(tmp_path / "t.db"))
+    try:
+        text = "The retry backoff is exponential with a cap of sixty seconds."
+        source = "user"
+        ingest_turn(store, text, source=source)
+        beliefs = store.search_beliefs("retry backoff", limit=5)
+        assert beliefs
+        bid = beliefs[0].id
+
+        ingest_turn(store, text, source=source)
+        ingest_turn(store, text, source=source)
+        assert store.count_corroborations(bid) == 2
+
+        store.delete_belief(bid)
+
+        assert store.get_belief(bid) is None
+        assert store.count_corroborations(bid) == 0
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# insert_corroboration directly (store API)
+# ---------------------------------------------------------------------------
+
+
+def test_insert_corroboration_returns_rowid() -> None:
+    """insert_corroboration returns a positive integer rowid."""
+    store = _fresh_store()
+    try:
+        b = _belief("b4", "A causes B.", "hash-b4")
+        store.insert_belief(b)
+
+        rowid = store.insert_corroboration("b4", CORROBORATION_COMMIT_INGEST)
+        assert isinstance(rowid, int)
+        assert rowid > 0
+    finally:
+        store.close()
+
+
+def test_count_corroborations_total() -> None:
+    """count_corroborations() with no argument returns the total across all beliefs."""
+    store = _fresh_store()
+    try:
+        for i in range(3):
+            bid = f"b{i}"
+            b = _belief(bid, f"Statement {i}.", f"hash-{i}")
+            store.insert_belief(b)
+            store.insert_corroboration(bid, CORROBORATION_TRANSCRIPT_INGEST)
+            store.insert_corroboration(bid, CORROBORATION_COMMIT_INGEST)
+
+        assert store.count_corroborations() == 6
+    finally:
+        store.close()

--- a/tests/test_corroborations.py
+++ b/tests/test_corroborations.py
@@ -9,18 +9,16 @@ Each test must complete well under 1 second.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterator
-
 import pytest
 
 from aelfrice.ingest import ingest_turn
 from aelfrice.models import (
     BELIEF_FACTUAL,
-    CORROBORATION_COMMIT_INGEST,
-    CORROBORATION_HOOK_INGEST,
-    CORROBORATION_MCP_REMEMBER,
+    CORROBORATION_SOURCE_COMMIT_INGEST,
+    CORROBORATION_SOURCE_HOOK_INGEST,
+    CORROBORATION_SOURCE_MCP_REMEMBER,
+    CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
     CORROBORATION_SOURCE_TYPES,
-    CORROBORATION_TRANSCRIPT_INGEST,
     LOCK_NONE,
     Belief,
 )
@@ -83,7 +81,7 @@ def test_index_created_on_fresh_store() -> None:
         store.close()
 
 
-def test_table_creation_idempotent(tmp_path: Path) -> None:
+def test_migration_idempotent_on_rerun(tmp_path: Path) -> None:
     """Opening the same on-disk store twice does not error — schema is
     CREATE IF NOT EXISTS throughout."""
     db = str(tmp_path / "idem.db")
@@ -202,7 +200,7 @@ def test_corroboration_count_increments_on_retrieval(tmp_path: Path) -> None:
         assert beliefs
         bid = beliefs[0].id
 
-        # Two re-ingests → two corroboration rows
+        # Two re-ingests => two corroboration rows
         ingest_turn(store, text, source=source)
         ingest_turn(store, text, source=source)
 
@@ -248,21 +246,22 @@ def test_different_source_types_record_distinctly() -> None:
         b = _belief("b1", "X uses Y.", "hash-b1")
         store.insert_belief(b)
 
-        store.insert_corroboration("b1", CORROBORATION_TRANSCRIPT_INGEST)
-        store.insert_corroboration("b1", CORROBORATION_COMMIT_INGEST)
-        store.insert_corroboration("b1", CORROBORATION_MCP_REMEMBER)
-        store.insert_corroboration("b1", CORROBORATION_HOOK_INGEST)
+        store.record_corroboration("b1", source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST)
+        store.record_corroboration("b1", source_type=CORROBORATION_SOURCE_COMMIT_INGEST)
+        store.record_corroboration("b1", source_type=CORROBORATION_SOURCE_MCP_REMEMBER)
+        store.record_corroboration("b1", source_type=CORROBORATION_SOURCE_HOOK_INGEST)
 
         assert store.count_corroborations("b1") == 4
 
         rows = store.list_corroborations("b1")
         assert len(rows) == 4
-        recorded_types = {r.source_type for r in rows}
+        # rows are (ingested_at, source_type, session_id, source_path_hash)
+        recorded_types = {r[1] for r in rows}
         assert recorded_types == {
-            CORROBORATION_TRANSCRIPT_INGEST,
-            CORROBORATION_COMMIT_INGEST,
-            CORROBORATION_MCP_REMEMBER,
-            CORROBORATION_HOOK_INGEST,
+            CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
+            CORROBORATION_SOURCE_COMMIT_INGEST,
+            CORROBORATION_SOURCE_MCP_REMEMBER,
+            CORROBORATION_SOURCE_HOOK_INGEST,
         }
     finally:
         store.close()
@@ -272,10 +271,10 @@ def test_source_type_enum_covers_all_variants() -> None:
     """CORROBORATION_SOURCE_TYPES contains exactly the four documented
     values."""
     expected = {
-        "commit-ingest",
-        "transcript-ingest",
-        "MCP-remember",
-        "hook-ingest",
+        "commit_ingest",
+        "transcript_ingest",
+        "mcp_remember",
+        "hook_ingest",
     }
     assert CORROBORATION_SOURCE_TYPES == expected
 
@@ -286,24 +285,25 @@ def test_source_type_enum_covers_all_variants() -> None:
 
 
 def test_null_session_id_and_source_path_hash_accepted() -> None:
-    """insert_corroboration with session_id=None and source_path_hash=None
+    """record_corroboration with session_id=None and source_path_hash=None
     must not raise, and the stored row reflects NULLs."""
     store = _fresh_store()
     try:
         b = _belief("b2", "Y implies Z.", "hash-b2")
         store.insert_belief(b)
 
-        store.insert_corroboration(
+        store.record_corroboration(
             "b2",
-            CORROBORATION_TRANSCRIPT_INGEST,
+            source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
             session_id=None,
             source_path_hash=None,
         )
 
         rows = store.list_corroborations("b2")
         assert len(rows) == 1
-        assert rows[0].session_id is None
-        assert rows[0].source_path_hash is None
+        # rows are (ingested_at, source_type, session_id, source_path_hash)
+        assert rows[0][2] is None  # session_id
+        assert rows[0][3] is None  # source_path_hash
     finally:
         store.close()
 
@@ -315,17 +315,18 @@ def test_session_id_stamped_when_provided() -> None:
         b = _belief("b3", "Z follows W.", "hash-b3")
         store.insert_belief(b)
 
-        store.insert_corroboration(
+        store.record_corroboration(
             "b3",
-            CORROBORATION_TRANSCRIPT_INGEST,
+            source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
             session_id="sess-abc",
             source_path_hash="pathsha256",
         )
 
         rows = store.list_corroborations("b3")
         assert len(rows) == 1
-        assert rows[0].session_id == "sess-abc"
-        assert rows[0].source_path_hash == "pathsha256"
+        # rows are (ingested_at, source_type, session_id, source_path_hash)
+        assert rows[0][2] == "sess-abc"    # session_id
+        assert rows[0][3] == "pathsha256"  # source_path_hash
     finally:
         store.close()
 
@@ -347,7 +348,8 @@ def test_ingest_turn_passes_session_id_to_corroboration(tmp_path: Path) -> None:
 
         rows = store.list_corroborations(bid)
         assert len(rows) == 1
-        assert rows[0].session_id == "sess-2"
+        # rows are (ingested_at, source_type, session_id, source_path_hash)
+        assert rows[0][2] == "sess-2"  # session_id
     finally:
         store.close()
 
@@ -381,35 +383,76 @@ def test_belief_deletion_cascades_to_corroborations(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# insert_corroboration directly (store API)
+# record_corroboration directly (store API)
 # ---------------------------------------------------------------------------
 
 
-def test_insert_corroboration_returns_rowid() -> None:
-    """insert_corroboration returns a positive integer rowid."""
+def test_record_corroboration_returns_none() -> None:
+    """record_corroboration returns None (side-effect only, no rowid exposed)."""
     store = _fresh_store()
     try:
         b = _belief("b4", "A causes B.", "hash-b4")
         store.insert_belief(b)
 
-        rowid = store.insert_corroboration("b4", CORROBORATION_COMMIT_INGEST)
-        assert isinstance(rowid, int)
-        assert rowid > 0
+        result = store.record_corroboration("b4", source_type=CORROBORATION_SOURCE_COMMIT_INGEST)
+        assert result is None
     finally:
         store.close()
 
 
-def test_count_corroborations_total() -> None:
-    """count_corroborations() with no argument returns the total across all beliefs."""
+def test_count_corroborations_per_belief() -> None:
+    """count_corroborations(belief_id) returns the count for that belief only."""
     store = _fresh_store()
     try:
         for i in range(3):
             bid = f"b{i}"
             b = _belief(bid, f"Statement {i}.", f"hash-{i}")
             store.insert_belief(b)
-            store.insert_corroboration(bid, CORROBORATION_TRANSCRIPT_INGEST)
-            store.insert_corroboration(bid, CORROBORATION_COMMIT_INGEST)
+            store.record_corroboration(bid, source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST)
+            store.record_corroboration(bid, source_type=CORROBORATION_SOURCE_COMMIT_INGEST)
 
-        assert store.count_corroborations() == 6
+        # Each belief has 2 corroborations
+        for i in range(3):
+            assert store.count_corroborations(f"b{i}") == 2
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Spec-required test: record_corroboration_adds_one_row
+# ---------------------------------------------------------------------------
+
+
+def test_record_corroboration_adds_one_row() -> None:
+    """record_corroboration adds exactly one row to belief_corroborations
+    per call (direct store API contract)."""
+    store = _fresh_store()
+    try:
+        b = _belief("b_rcar", "Z precedes W.", "hash-rcar")
+        store.insert_belief(b)
+
+        assert store.count_corroborations("b_rcar") == 0
+        store.record_corroboration(
+            "b_rcar", source_type=CORROBORATION_SOURCE_COMMIT_INGEST
+        )
+        assert store.count_corroborations("b_rcar") == 1
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Spec-required test: test_unknown_source_type_raises_valueerror
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_source_type_raises_valueerror() -> None:
+    """record_corroboration raises ValueError for an unknown source_type."""
+    store = _fresh_store()
+    try:
+        b = _belief("b_err", "A causes B.", "hash-b-err")
+        store.insert_belief(b)
+
+        with pytest.raises(ValueError, match="Unknown source_type"):
+            store.record_corroboration("b_err", source_type="not_a_real_source")
     finally:
         store.close()


### PR DESCRIPTION
## Summary

- Adds `belief_corroborations` table with `id`, `belief_id` (FK → beliefs.id ON DELETE CASCADE), `ingested_at`, `source_type`, `session_id`, `source_path_hash` and an index on `belief_id`
- Re-ingest of an existing `content_hash` now records a corroboration row instead of silently dropping; canonical belief row is untouched
- `Belief.corroboration_count` exposed via correlated subquery on all retrieval surfaces (`get_belief`, `search_beliefs`, `list_locked_beliefs`)
- Four `CORROBORATION_SOURCE_*` constants + `CORROBORATION_SOURCE_TYPES` frozenset added to `models.py`
- Instrumented `ingest_turn` (transcript-ingest), `_resolve_or_create_belief` (commit-ingest), and `tool_lock` (MCP-remember)

Closes #190

## Implementation notes

`corroboration_count` is computed via a correlated subquery rather than a JOIN + GROUP BY. The GROUP BY approach broke `bm25(beliefs_fts)` in FTS5 queries (SQLite rejects `bm25` in a non-trivial GROUP BY context). The correlated-subquery approach is idiomatic for this access pattern and avoids the FTS5 limitation.

## Test plan

- [ ] `uv run pytest tests/test_corroborations.py` — 17 tests, all pass
- [ ] `uv run pytest tests/` — full suite passes
- [ ] Schema: table and index exist on fresh store; idempotent on reopen
- [ ] Re-ingest records exactly one corroboration row; belief row id and content_hash unchanged
- [ ] `corroboration_count` on `get_belief` and `search_beliefs` reflects row count
- [ ] Four `source_type` values record distinctly; count groups correctly
- [ ] `session_id` and `source_path_hash` accept NULL; no exception
- [ ] Belief deletion cascades to corroboration rows

---

Review feedback addressed in force-push; see comments below.
