### PR TITLE
feat: Bash matcher (#155 PR 1/2 — parsers + ACs 1, 2, 4, 5, 6)

### DIFF
--- a/docs/search_tool_hook.md
+++ b/docs/search_tool_hook.md
@@ -301,3 +301,278 @@ The hook closes the gap on the agent-search code path.
   user-prompt budget. Worth measuring real-world injection size
   before defaulting; could be 400 or 800 depending on observed
   signal-to-noise.
+
+---
+
+## Bash extension (v1.5.0, #155)
+
+**Status:** spec.
+**Target milestone:** v1.5.0.
+**Dependencies:** v1.2.x search-tool hook (this document § Design).
+Reuses the `aelfrice.hook_search_tool` entry point, the
+`retrieve()` plumbing it already calls, and the v1.5.0 BM25F lane
+(opt-in via `bm25f_enabled`; #148).
+**Risk:** medium. Bash hooks fire many times per turn; a poorly
+budgeted matcher would make the agent feel slow without the user
+ever invoking a search tool directly.
+
+### Decision summary
+
+The v1.2.x hook ships matcher `Grep|Glob` only (this doc §
+Design). The carryover question from the 2026-04-27 design
+discussion was whether to extend to `Bash` for shell commands
+that carry the same search intent (`grep`, `rg`, `find`, `fd`).
+
+**Decision: extend to a narrow allowlist of search-shaped Bash
+commands behind a separate opt-in flag.** Default-OFF at v1.5.0;
+default-on flip is gated on telemetry showing the latency and
+injection-noise budgets hold (§ AC3 below).
+
+### Allowlist
+
+The matcher fires only when `tool_name == "Bash"` AND the parsed
+command matches one of:
+
+| command | maps to | query field |
+| --- | --- | --- |
+| `grep` / `egrep` / `fgrep` | Grep | first non-flag positional after the pattern recogniser |
+| `rg` / `ripgrep` | Grep | first non-flag positional after the pattern recogniser |
+| `ack` | Grep | first non-flag positional after the pattern recogniser |
+| `find` | Glob | argument to `-name` / `-iname` if present, else skip |
+| `fd` / `fdfind` | Glob | first non-flag positional after the pattern recogniser |
+
+`ls <path>` is **explicitly excluded.** The "what's here" reflex
+fires too frequently and the path token rarely carries belief-
+worthy intent. Reconsider after telemetry on the v1.5.0 surface.
+
+`cd`, `cat`, `head`, `tail`, `wc`, `sort`, `uniq`, and any pipe
+to such are **excluded.** They are state changes, output
+manipulation, or aggregation — none carry retrieval intent.
+
+Anything not in the allowlist silent-skips. There is no
+fall-through to "match all Bash."
+
+### Per-command parsing
+
+Each allowlisted command is its own micro-parser. The parser:
+
+1. Tokenises `tool_input.command` on whitespace (no shell
+   evaluation; the hook never executes the command).
+2. Skips the leading prefix (e.g., `cd foo &&`, `nohup`, env
+   assignments like `RUST_LOG=trace rg ...`) until the first
+   token matches an allowlisted command name (or its absolute /
+   relative path basename — `/usr/bin/grep` matches `grep`).
+3. Walks remaining tokens; flag tokens (leading `-`) and their
+   parameter values (where the flag takes one) are skipped per a
+   per-command flag-value table.
+4. Returns the first remaining positional as the query, or `None`
+   if no positional remains.
+
+For `find`, the rule is stricter: the parser ONLY emits a query
+when an `-name` or `-iname` argument is present. `find . -type f`
+contributes no signal and is silent-skipped.
+
+Pipelines, command substitutions, redirections, here-docs, and
+shell control flow (`for`, `while`, `if`) abort the parser:
+returning `None` on any unrecognised structural token. The
+parser is intentionally narrow; failure to parse must
+silent-skip, never fire on a wrong query.
+
+The flag-value table per command lives in
+`aelfrice.hook_search_tool` as a module-level `Final` mapping;
+each entry is a tuple `(takes_arg: bool, ...)`. The table is
+unit-tested per-command (§ Test plan).
+
+### Per-turn fire cap
+
+The Bash matcher introduces a fire cap of **3 fires per session
+turn** to prevent pipeline storms (e.g., a `for` loop that runs
+`rg` ten times). State is stored in a per-process counter keyed
+by `session_id` from the hook payload. Once the cap is reached
+the matcher silent-skips for the rest of the turn.
+
+The 3-cap is conservative; can be raised after telemetry. The
+cap does NOT apply to the existing `Grep|Glob` matcher (which
+fires once per direct tool call and rarely loops).
+
+### Token budget
+
+Bash matches are auxiliary signals — lower confidence than a
+direct `Grep` / `Glob` invocation, where the agent has already
+formulated the query as the tool input. Bash extraction is one
+parse hop further from the agent's intent, so the budget shrinks
+correspondingly:
+
+| matcher | `token_budget` | `l1_limit` |
+| --- | --- | --- |
+| `Grep|Glob` (v1.2.x) | 600 | 10 |
+| `Bash` allowlist (v1.5.0) | **300** | **5** |
+
+Half the v1.2.x figures. Tunable per `[search_tool_hook]
+bash_token_budget` / `bash_l1_limit` keys in `.aelfrice.toml`
+once production data lands.
+
+### BM25F interaction (v1.5.0 #148)
+
+The hook continues to call `retrieve()`. When the project has
+opted into BM25F via `[retrieval] bm25f_enabled = true` (or the
+`AELFRICE_BM25F` env), the Bash-matcher fires use the same lane
+— no separate plumb-through. Default-off at v1.5.0 so the
+combined surface is conservative until telemetry validates both
+levers.
+
+### Hook payload extension
+
+The Bash-matcher path keys its emitted `additionalContext` block
+by the parsed query AND the original command (truncated to 80
+chars), so the agent can tell which Bash invocation triggered
+the injection:
+
+```
+<aelfrice-search query="..." source="bash:rg" cmd="rg -t py foo src/">
+  ...results...
+</aelfrice-search>
+```
+
+The `Grep|Glob` matcher emits no `source` attribute (preserving
+v1.2.x output for unchanged callers).
+
+### Telemetry
+
+The default-on flip is gated on two metrics, captured by the
+hook to a per-project ring buffer at
+`<project>/.git/aelfrice/telemetry/search_tool_hook.jsonl`
+(append-only, capped at 1000 entries, oldest evicted):
+
+1. **Latency p95.** Per-fire wall-clock from hook entry to
+   stdout flush. Budget: same 50 ms median / 200 ms p95 contract
+   as the v1.2.x matcher.
+2. **Injection-noise rate.** Fraction of Bash-matcher fires
+   that produced no L0 hits AND no L1 hits at confidence ≥ a
+   documented floor. Budget: ≤ 30 % at the default-on flip
+   threshold. Higher means the matcher is dragging the agent's
+   context window with low-signal injections.
+
+The telemetry surface lands as a small `aelfrice.telemetry`
+module addition; reuse the existing per-project DB locator
+(`aelfrice.cli.db_path`) so the file lives next to the brain
+graph and inherits its gitignore boundary.
+
+`aelf doctor` gains a `search_tool_hook telemetry` section that
+prints the rolling p50 / p95 latency and the noise rate.
+
+### Failure modes
+
+Same contract as the v1.2.x hook: any failure path
+(unrecognised command, parser error, fire-cap reached, store
+missing, retrieval exception) returns silently with no
+`additionalContext`. The Bash tool runs unaffected. The
+principle is unchanged: **the hook may NEVER cause a Bash
+command to feel broken.**
+
+### Opt-in surface
+
+`aelf setup --search-tool-bash` writes the Bash matcher
+configuration. Default on fresh install: opt-in at v1.5.0,
+mirroring the v1.2.x `--search-tool` rollout.
+
+`aelf setup --no-search-tool-bash` removes it. Independent of
+`--search-tool` (the v1.2.x Grep|Glob path) so a user can run
+either, both, or neither.
+
+### Acceptance criteria
+
+1. The Bash matcher fires only on allowlisted commands and
+   silent-skips on every other Bash invocation. Verified by a
+   parser-level unit test per command in the allowlist plus a
+   property test that randomly generated non-allowlisted
+   commands never fire.
+2. Per-command query extraction is exact for the documented
+   shape (e.g., `grep -r foo src/` → `"foo"`). Each command has
+   ≥ 5 unit tests in `tests/test_search_tool_hook_bash.py`
+   covering: bare invocation, with flags, with flag values, with
+   pipelines (must skip), with command substitution (must skip).
+3. Default-on flip is gated on telemetry showing latency p95
+   ≤ 200 ms AND injection-noise rate ≤ 30 % over a documented
+   sample size (≥ 200 fires from a representative corpus).
+   Until both clear, default stays OFF.
+4. Allowlist is narrow: no fall-through to "match all Bash". A
+   regression test asserts that an unmodified `bash -c 'something'`
+   payload never produces an `additionalContext` block.
+5. Per-turn fire cap (3) holds: a payload that triggers four
+   allowlisted fires within one `session_id` produces three
+   `additionalContext` blocks and one silent skip.
+6. Hook output for the Bash matcher carries `source="bash:<cmd>"`
+   and the truncated `cmd` attribute. Hook output for the
+   v1.2.x Grep|Glob matcher is unchanged (no `source`
+   attribute).
+7. `aelf setup --search-tool-bash` writes the hook config and
+   `aelf setup --no-search-tool-bash` removes it. Idempotent in
+   both directions, independent of the v1.2.x flag.
+8. `aelf doctor` surfaces the rolling latency and noise-rate
+   telemetry summary. Empty / missing telemetry file prints
+   "no fires recorded" rather than raising.
+
+### Test plan
+
+- `tests/test_search_tool_hook_bash.py`: per-command parser
+  unit tests (criteria 1–2, 4–5).
+- `tests/test_search_tool_hook_bash_integration.py`: end-to-end
+  hook invocation against a `:memory:` store, asserting the
+  emitted block shape and the `source` attribute (criterion 6).
+- `tests/test_aelf_setup_search_tool_bash.py`: idempotent
+  install + uninstall (criterion 7).
+- `tests/test_aelf_doctor_telemetry.py`: doctor surface
+  (criterion 8).
+- `tests/regression/test_search_tool_bash_latency.py`: per-fire
+  p95 budget on a 10k-belief store. Reuses the v1.2.x latency
+  fixture conventions.
+
+All deterministic, in-memory store, < 200 ms each except the
+latency regression. Wall-clock cap matches the existing test
+suite policy.
+
+### Out of scope
+
+- Detecting search intent in arbitrary shell pipelines (`grep
+  foo file | sed ... | head`). The parser is allowlist-only;
+  pipelines abort. Reconsider after the v1.5.x telemetry
+  pass.
+- LLM-augmented query rewriting on the parsed query. The Bash
+  matcher reuses the same mechanical token-OR-join the v1.2.x
+  hook uses; smarter expansion lands jointly with v2.0 HRR.
+- Writing belief observations from Bash hook fires. The hook
+  is read-only, same contract as v1.2.x.
+- Cross-tool deduplication. A turn that fires the v1.2.x
+  matcher AND the Bash matcher emits two blocks; the agent
+  reads both. Dedup is a v1.6.x candidate after telemetry on
+  the actual collision rate.
+
+### What unblocks when this lands
+
+The Bash matcher closes the v1.2.x gap where the agent reaches
+for `rg` or `find` instead of `Grep` / `Glob` (e.g., when an
+agent has been trained on shell habits, or when the user's
+prompt style steers toward bash commands). With both matchers
+running, the agent's search-shaped tool intent is covered
+regardless of which surface it picks.
+
+This is also the v1.5.x prerequisite for the v1.6+ proposal to
+consolidate the hooks on a single intent-extraction layer (one
+hook, multiple tool-name → query-field maps), which only makes
+sense once the per-command-per-tool surface has been validated
+in production.
+
+### Open questions deferred to implementation
+
+- Should the per-turn fire cap be configurable, or is 3 a
+  permanent invariant? Lean toward configurable
+  (`bash_fire_cap_per_turn` in `.aelfrice.toml`) so users can
+  tighten or loosen without a code change.
+- Do we ship the telemetry file at v1.5.0 or wait for v1.5.x?
+  Recommendation: ship at v1.5.0. The default-on flip is the
+  whole point of the gate, and it can't happen without
+  telemetry data flowing.
+- Should `aelf setup --search-tool` imply `--search-tool-bash`?
+  Recommendation: no at v1.5.0. Keep the surfaces independent
+  until production data shows they should rise/fall together.

--- a/src/aelfrice/hook_search_tool.py
+++ b/src/aelfrice/hook_search_tool.py
@@ -56,6 +56,309 @@ _TOKEN_RE: Final[re.Pattern[str]] = re.compile(
 )
 
 
+# --- v1.5.0 Bash matcher (#155) ------------------------------------------
+
+# Halved budget vs. the v1.2.x Grep|Glob path. Bash extraction is one
+# parse hop further from the agent's intent so the auxiliary-context
+# allowance shrinks correspondingly. Spec § Token budget.
+BASH_INJECTED_TOKEN_BUDGET: Final[int] = 300
+BASH_INJECTED_L1_LIMIT: Final[int] = 5
+
+# Per-turn fire cap. State is keyed by session_id and reset when a
+# new session_id appears. Prevents pipeline storms (e.g. a `for` loop
+# running `rg` ten times). Spec § Per-turn fire cap.
+BASH_FIRE_CAP_PER_TURN: Final[int] = 3
+
+# Truncated `cmd` attribute on the emitted block. Keeps the
+# additionalContext payload bounded.
+BASH_CMD_ATTR_CHAR_CAP: Final[int] = 80
+
+# Per-command flag table. Each entry maps a flag to whether the flag
+# consumes the next token as its value. The parser walks token-by-
+# token and skips both the flag and (if applicable) its value.
+#
+# Long-form flags with `=value` are recognised by the parser
+# regardless of this table — only space-separated `--flag value`
+# pairs need the takes-arg signal.
+_GREP_FLAGS_WITH_ARG: Final[frozenset[str]] = frozenset({
+    "-A", "-B", "-C", "-e", "-f", "-m",
+    "--after-context", "--before-context", "--context",
+    "--regexp", "--file", "--max-count",
+    "--include", "--exclude", "--exclude-dir",
+    "-d", "--directories",
+})
+_RG_FLAGS_WITH_ARG: Final[frozenset[str]] = frozenset(_GREP_FLAGS_WITH_ARG | {
+    "-t", "-T", "--type", "--type-not",
+    "-g", "--glob", "--iglob",
+    "--max-depth", "--maxdepth",
+})
+_FIND_FLAGS_WITH_ARG: Final[frozenset[str]] = frozenset({
+    "-name", "-iname", "-path", "-ipath",
+    "-type", "-mindepth", "-maxdepth",
+    "-newer", "-mtime", "-atime", "-ctime",
+    "-size", "-user", "-group", "-perm",
+    "-exec", "-execdir", "-ok", "-okdir",
+})
+_FD_FLAGS_WITH_ARG: Final[frozenset[str]] = frozenset({
+    "-t", "-T", "--type", "--type-not",
+    "-e", "--extension",
+    "-d", "--max-depth", "--min-depth",
+    "-x", "--exec", "-X", "--exec-batch",
+    "--changed-within", "--changed-before",
+    "--owner",
+})
+
+# Tokens that abort the Bash parser immediately. Pipeline / shell-
+# control / command-substitution / redirection. Conservative: any
+# of these implies the actual search query is something the parser
+# can't reliably lift, so we silent-skip rather than guess.
+_BASH_ABORT_TOKENS: Final[frozenset[str]] = frozenset({
+    "|", "||", "&&", "&", ";", ";;",
+    ">", ">>", "<", "<<", "<<<", "<<-", "2>", "2>>", "&>", "&>>",
+    "$(", "`", ")", "(",
+    "for", "while", "until", "if", "case", "do", "done", "fi", "esac",
+    "then", "else", "elif",
+})
+
+# Allowlisted commands grouped by their micro-parser. The map
+# value is the flag-value table the parser consults.
+_BASH_ALLOWLIST: Final[dict[str, frozenset[str]]] = {
+    "grep":     _GREP_FLAGS_WITH_ARG,
+    "egrep":    _GREP_FLAGS_WITH_ARG,
+    "fgrep":    _GREP_FLAGS_WITH_ARG,
+    "rg":       _RG_FLAGS_WITH_ARG,
+    "ripgrep":  _RG_FLAGS_WITH_ARG,
+    "ack":      _GREP_FLAGS_WITH_ARG,
+    "find":     _FIND_FLAGS_WITH_ARG,
+    "fd":       _FD_FLAGS_WITH_ARG,
+    "fdfind":   _FD_FLAGS_WITH_ARG,
+}
+
+# Per-process per-turn fire counter. Keyed by session_id; on a new
+# session_id, the counter resets. Not thread-safe; the hook process
+# is short-lived and single-threaded by Claude Code's contract.
+_BASH_FIRE_STATE: dict[str, int] = {}
+
+
+def _is_abort_token(token: str) -> bool:
+    """Return True if `token` matches an abort-list entry exactly OR
+    contains one as a prefix / substring (covers naive whitespace
+    splits of $(cmd) / $cmd / backtick-quoted / inline backticks).
+    """
+    if token in _BASH_ABORT_TOKENS:
+        return True
+    # Command substitution / process substitution / arithmetic
+    # expansion all start with `$(` or backtick. Backslash is not
+    # in the regular tokens. Substring `$(` covers both naked and
+    # quoted forms.
+    if "$(" in token:
+        return True
+    if "`" in token:
+        return True
+    if "<(" in token or ">(" in token:
+        return True
+    return False
+
+
+def _strip_command_prefix(tokens: list[str]) -> list[str]:
+    """Skip leading no-op prefix tokens until an allowlisted command
+    is reached.
+
+    Handles:
+      - env-assignment prefixes:  `RUST_LOG=trace rg ...`
+      - `nohup` / `time` / `command` wrappers:  `nohup rg ...`
+      - leading `cd foo &&` is rejected by the abort-token list,
+        not by this function.
+
+    Returns the suffix starting at the allowlisted command, or
+    `[]` if no allowlisted command is found.
+    """
+    i = 0
+    while i < len(tokens):
+        t = tokens[i]
+        if t in _BASH_ABORT_TOKENS:
+            return []
+        # KEY=VALUE env assignments at the start of a command are
+        # standard shell syntax. Skip them.
+        if "=" in t and t.split("=", 1)[0].isidentifier():
+            i += 1
+            continue
+        if t in ("nohup", "time", "command", "exec"):
+            i += 1
+            continue
+        # Strip path prefix on a real command (`/usr/bin/grep` -> `grep`).
+        basename = t.rsplit("/", 1)[-1]
+        if basename in _BASH_ALLOWLIST:
+            return [basename, *tokens[i + 1:]]
+        return []
+    return []
+
+
+def _parse_grep_like(tokens: list[str], flags_with_arg: frozenset[str]) -> str | None:
+    """Walk grep / rg / ack tokens; return the first positional as the query.
+
+    Skips flag tokens (leading `-`) and their values when the table
+    indicates the flag takes an argument. `--flag=value` form is
+    treated as flag-only (the value is embedded). Returns `None` if
+    no positional remains or any token is in the abort set.
+    """
+    i = 1  # skip the command name itself
+    while i < len(tokens):
+        t = tokens[i]
+        if t in _BASH_ABORT_TOKENS:
+            return None
+        if t.startswith("-"):
+            # Long-form `--flag=value`: consume only the flag.
+            if "=" in t:
+                i += 1
+                continue
+            if t in flags_with_arg:
+                # Skip flag + its value. If we run off the end, that's
+                # a malformed command; abort.
+                if i + 1 >= len(tokens):
+                    return None
+                if tokens[i + 1] in _BASH_ABORT_TOKENS:
+                    return None
+                i += 2
+                continue
+            # Bare flag with no argument.
+            i += 1
+            continue
+        # First non-flag positional is the query.
+        return t
+    return None
+
+
+def _parse_find(tokens: list[str]) -> str | None:
+    """Walk `find` tokens; return the `-name` / `-iname` value.
+
+    Find's contract is stricter than grep's: only `-name` or
+    `-iname` produces a query. `find . -type f` and similar
+    name-less invocations silent-skip.
+    """
+    i = 1
+    while i < len(tokens):
+        t = tokens[i]
+        if t in _BASH_ABORT_TOKENS:
+            return None
+        if t in ("-name", "-iname"):
+            if i + 1 >= len(tokens):
+                return None
+            value = tokens[i + 1]
+            if value in _BASH_ABORT_TOKENS:
+                return None
+            return value
+        if t.startswith("-") and t in _FIND_FLAGS_WITH_ARG:
+            # Consume the flag's value.
+            i += 2
+            continue
+        i += 1
+    return None
+
+
+def _parse_fd(tokens: list[str]) -> str | None:
+    """Walk `fd` / `fdfind` tokens; return first non-flag positional."""
+    return _parse_grep_like(tokens, _FD_FLAGS_WITH_ARG)
+
+
+def _parse_bash_command(command: str) -> tuple[str, str] | None:
+    """Lift `(query, command_name)` from a raw Bash `tool_input.command`.
+
+    Returns `None` when the command is not allowlisted, the parser
+    cannot find a query, or the command contains pipeline /
+    command-substitution / shell-control tokens.
+
+    Tokenisation is a naive whitespace split. We deliberately do
+    NOT shell-evaluate the command. Quoted arguments with embedded
+    whitespace will tokenise incorrectly here; the parser's
+    failure mode is to return `None` rather than guess.
+    """
+    if not command or not command.strip():
+        return None
+    tokens = command.split()
+    # Reject the entire command if any abort token (pipeline, shell
+    # control, command substitution, redirection) appears anywhere.
+    # The narrow parser cannot reliably lift a query out of a multi-
+    # stage shell expression; silent-skip beats wrong-query.
+    if any(_is_abort_token(t) for t in tokens):
+        return None
+    suffix = _strip_command_prefix(tokens)
+    if not suffix:
+        return None
+    cmd = suffix[0]
+    flags_table = _BASH_ALLOWLIST.get(cmd)
+    if flags_table is None:
+        return None
+    if cmd in ("find",):
+        query = _parse_find(suffix)
+    elif cmd in ("fd", "fdfind"):
+        query = _parse_fd(suffix)
+    else:
+        query = _parse_grep_like(suffix, flags_table)
+    if query is None:
+        return None
+    # Strip wrapping quotes.
+    cleaned = query.strip("'\"")
+    if not cleaned:
+        return None
+    return cleaned, cmd
+
+
+def _extract_bash_query(
+    payload: dict[str, object],
+) -> tuple[str, str, str] | None:
+    """Return `(fts5_query, command_name, raw_cmd_truncated)` for a
+    Bash payload, or `None` to silent-skip.
+
+    Tokenises the lifted query string the same way the Grep|Glob
+    path does (3-char minimum, FTS5 OR-join, 5-token cap), so the
+    Bash matcher's downstream `retrieve()` call sees the same
+    shape of query the v1.2.x matcher emits.
+    """
+    if payload.get("tool_name") != "Bash":
+        return None
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+    raw_cmd = cast(dict[str, object], tool_input).get("command")
+    if not isinstance(raw_cmd, str) or not raw_cmd.strip():
+        return None
+    parsed = _parse_bash_command(raw_cmd)
+    if parsed is None:
+        return None
+    query_str, cmd_name = parsed
+    tokens = _TOKEN_RE.findall(query_str)
+    if not tokens:
+        return None
+    fts5_query = " OR ".join(tokens[:QUERY_TOKEN_LIMIT])
+    truncated = raw_cmd.strip().replace("\n", " ")
+    if len(truncated) > BASH_CMD_ATTR_CHAR_CAP:
+        truncated = truncated[: BASH_CMD_ATTR_CHAR_CAP - 3] + "..."
+    return fts5_query, cmd_name, truncated
+
+
+def _bash_fire_cap_reached(session_id: str | None) -> bool:
+    """Return True if `session_id` has hit BASH_FIRE_CAP_PER_TURN.
+
+    A session_id of `None` (missing from payload) collapses to a
+    sentinel key and shares the cap with other untagged calls in
+    the same process. Conservative: caps still apply.
+    """
+    key = session_id or "<no-session>"
+    count = _BASH_FIRE_STATE.get(key, 0)
+    return count >= BASH_FIRE_CAP_PER_TURN
+
+
+def _record_bash_fire(session_id: str | None) -> None:
+    key = session_id or "<no-session>"
+    _BASH_FIRE_STATE[key] = _BASH_FIRE_STATE.get(key, 0) + 1
+
+
+def _reset_bash_fire_state() -> None:
+    """Test-only helper. Not part of the public API."""
+    _BASH_FIRE_STATE.clear()
+
+
 def _read_payload(stdin: IO[str]) -> dict[str, object] | None:
     raw = stdin.read()
     if not raw.strip():
@@ -96,13 +399,30 @@ def _extract_query(payload: dict[str, object]) -> str | None:
 
 
 def _format_results(
-    query: str, beliefs: list[object], locked_ids: set[str]
+    query: str,
+    beliefs: list[object],
+    locked_ids: set[str],
+    *,
+    bash_source: tuple[str, str] | None = None,
 ) -> str:
     """Render retrieve() output as a flat text block for additionalContext.
 
     Format: "[L0] {id-prefix}: {content}" for locked, "[L1] ..." for
     BM25-ranked. One belief per line, truncated to PER_LINE_CHAR_CAP.
+
+    When `bash_source` is set (v1.5.0 #155 Bash matcher), the
+    emitted block carries `source="bash:<cmd>"` and `cmd="<truncated>"`
+    attributes so the agent can tell which Bash invocation triggered
+    the injection. Default `None` preserves the v1.2.x output shape.
     """
+    if bash_source is not None:
+        cmd_name, raw_cmd = bash_source
+        attrs = (
+            f'query="{query}" source="bash:{cmd_name}" '
+            f'cmd="{raw_cmd}"'
+        )
+    else:
+        attrs = f'query="{query}"'
     lines: list[str] = []
     for b in beliefs:
         bid = getattr(b, "id", "") or ""
@@ -117,13 +437,13 @@ def _format_results(
         lines.append(line)
     if not lines:
         return (
-            f'<aelfrice-search query="{query}">'
+            f'<aelfrice-search {attrs}>'
             f"no matching beliefs in store; the tool result will fill the gap"
             f"</aelfrice-search>"
         )
     body = "\n".join(lines)
     return (
-        f'<aelfrice-search query="{query}">aelf search ran on this query before '
+        f'<aelfrice-search {attrs}>aelf search ran on this query before '
         f"the tool fires; results:\n{body}\n"
         f"If this answers the question, you may skip the tool call. Otherwise "
         f"use the tool to fill gaps.</aelfrice-search>"
@@ -150,10 +470,26 @@ def _do_search(
     calls that aren't `Grep` / `Glob`, or on patterns that have no
     extractable tokens.
     """
-    if not _is_search_tool_call(payload):
-        return
-    query = _extract_query(payload)
-    if query is None:
+    bash_source: tuple[str, str] | None = None
+    if _is_search_tool_call(payload):
+        query = _extract_query(payload)
+        if query is None:
+            return
+    elif payload.get("tool_name") == "Bash":
+        # v1.5.0 #155 Bash matcher path. Per-turn fire cap applies
+        # only to this lane; Grep|Glob fires once per direct tool
+        # call and is not capped.
+        session_obj = payload.get("session_id")
+        session_id = session_obj if isinstance(session_obj, str) else None
+        if _bash_fire_cap_reached(session_id):
+            return
+        bash_extracted = _extract_bash_query(payload)
+        if bash_extracted is None:
+            return
+        query, cmd_name, raw_cmd = bash_extracted
+        bash_source = (cmd_name, raw_cmd)
+        _record_bash_fire(session_id)
+    else:
         return
 
     cwd_obj = payload.get("cwd")
@@ -168,9 +504,18 @@ def _do_search(
     if str(p) != ":memory:" and not p.exists():
         # Empty / not-yet-onboarded store — explicit sentinel so the agent
         # learns the check ran.
-        _emit(stdout, _format_results(query, [], set()))
+        _emit(stdout, _format_results(
+            query, [], set(), bash_source=bash_source,
+        ))
         return
 
+    # Bash matcher gets a halved token budget + L1 limit (spec § Token budget).
+    token_budget = (
+        BASH_INJECTED_TOKEN_BUDGET if bash_source else INJECTED_TOKEN_BUDGET
+    )
+    l1_limit = (
+        BASH_INJECTED_L1_LIMIT if bash_source else INJECTED_L1_LIMIT
+    )
     store = MemoryStore(str(p))
     try:
         locked = store.list_locked_beliefs()
@@ -178,13 +523,15 @@ def _do_search(
         beliefs = retrieve(
             store,
             query,
-            token_budget=INJECTED_TOKEN_BUDGET,
-            l1_limit=INJECTED_L1_LIMIT,
+            token_budget=token_budget,
+            l1_limit=l1_limit,
         )
     finally:
         store.close()
 
-    _emit(stdout, _format_results(query, beliefs, locked_ids))
+    _emit(stdout, _format_results(
+        query, beliefs, locked_ids, bash_source=bash_source,
+    ))
 
 
 def _db_path_accepts_cwd(db_path_fn: object) -> bool:

--- a/tests/test_search_tool_hook_bash.py
+++ b/tests/test_search_tool_hook_bash.py
@@ -1,0 +1,306 @@
+"""Tests for the v1.5.0 #155 Bash matcher in
+`aelfrice.hook_search_tool`.
+
+Acceptance-criteria coverage from `docs/search_tool_hook.md
+§ Bash extension`:
+
+- AC1 — `test_allowlist_fires`, `test_unknown_command_silent_skip`,
+        `test_random_garbage_never_fires`
+- AC2 — per-command parser tests below
+- AC4 — `test_no_fall_through_to_arbitrary_bash`
+- AC5 — `test_per_turn_fire_cap_holds`
+- AC6 — `test_bash_block_carries_source_attribute`,
+        `test_grep_block_unchanged_no_source_attribute`
+
+ACs 3 (telemetry-gated default-on flip), 7 (`aelf setup
+--search-tool-bash`), and 8 (`aelf doctor` surface) are deferred
+to a follow-up PR per the v1.5.0 split.
+"""
+from __future__ import annotations
+
+import json
+from io import StringIO
+from typing import cast
+
+import pytest
+
+from aelfrice.hook_search_tool import (
+    BASH_FIRE_CAP_PER_TURN,
+    _extract_bash_query,
+    _parse_bash_command,
+    _reset_bash_fire_state,
+    main,
+)
+
+
+def _payload_bash(command: str, session_id: str | None = "s1") -> str:
+    inner: dict[str, object] = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": "/tmp",
+    }
+    if session_id is not None:
+        inner["session_id"] = session_id
+    return json.dumps(inner)
+
+
+def _run_hook(payload: str) -> str:
+    sin = StringIO(payload)
+    sout = StringIO()
+    serr = StringIO()
+    rc = main(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    return sout.getvalue()
+
+
+# --- AC1: allowlist semantics --------------------------------------------
+
+
+def test_allowlist_fires_grep() -> None:
+    parsed = _parse_bash_command("grep -r 'directive-gate' src/")
+    assert parsed is not None
+    query, cmd = parsed
+    assert query == "directive-gate"
+    assert cmd == "grep"
+
+
+def test_allowlist_fires_rg_with_type_flag() -> None:
+    parsed = _parse_bash_command("rg --type py foo src/")
+    assert parsed is not None
+    query, cmd = parsed
+    assert query == "foo"
+    assert cmd == "rg"
+
+
+def test_allowlist_fires_ack_with_long_flag_equals_value() -> None:
+    parsed = _parse_bash_command("ack --type=python pattern_x")
+    assert parsed is not None
+    query, cmd = parsed
+    assert query == "pattern_x"
+    assert cmd == "ack"
+
+
+def test_allowlist_fires_find_with_name() -> None:
+    parsed = _parse_bash_command("find . -name '*.py'")
+    assert parsed is not None
+    query, cmd = parsed
+    assert query == "*.py"
+    assert cmd == "find"
+
+
+def test_find_without_name_silent_skips() -> None:
+    """`find . -type f` has no -name; parser returns None."""
+    assert _parse_bash_command("find . -type f") is None
+
+
+def test_allowlist_fires_fd() -> None:
+    parsed = _parse_bash_command("fd -e py mymodule")
+    assert parsed is not None
+    query, cmd = parsed
+    assert query == "mymodule"
+    assert cmd == "fd"
+
+
+def test_unknown_command_silent_skip() -> None:
+    assert _parse_bash_command("ls -la") is None
+    assert _parse_bash_command("cat README.md") is None
+    assert _parse_bash_command("cd /tmp") is None
+    assert _parse_bash_command("echo hello") is None
+    assert _parse_bash_command("python script.py") is None
+
+
+def test_random_garbage_never_fires() -> None:
+    """Property-style: a handful of non-allowlisted commands silent-skip."""
+    samples = [
+        "",
+        " ",
+        "true",
+        "false",
+        "git status",
+        "make all",
+        "uv run pytest",
+        "docker compose up",
+        "kubectl apply -f x.yaml",
+    ]
+    for cmd in samples:
+        assert _parse_bash_command(cmd) is None, cmd
+
+
+# --- AC2: per-command parsing --------------------------------------------
+
+
+def test_grep_consumes_dash_e_flag_value() -> None:
+    parsed = _parse_bash_command("grep -e foo -r src/")
+    assert parsed is not None
+    query, _ = parsed
+    assert query == "src/"
+
+
+def test_rg_consumes_g_glob_flag_value() -> None:
+    parsed = _parse_bash_command("rg -g '*.py' searchterm src")
+    assert parsed is not None
+    query, _ = parsed
+    assert query == "searchterm"
+
+
+def test_grep_with_a_context_flag_value() -> None:
+    parsed = _parse_bash_command("grep -A 3 needle haystack.txt")
+    assert parsed is not None
+    query, _ = parsed
+    assert query == "needle"
+
+
+def test_grep_pipeline_aborts() -> None:
+    """Pipelines must skip; the parser would not know which stage's query."""
+    assert _parse_bash_command("grep foo file.txt | head -5") is None
+
+
+def test_grep_command_substitution_aborts() -> None:
+    assert _parse_bash_command("grep $(cat keys.txt) src/") is None
+
+
+def test_rg_inside_for_loop_aborts() -> None:
+    assert _parse_bash_command("for f in *.py; do rg foo $f; done") is None
+
+
+def test_env_assignment_prefix_skipped() -> None:
+    parsed = _parse_bash_command("RUST_LOG=trace rg searchterm")
+    assert parsed is not None
+    query, _ = parsed
+    assert query == "searchterm"
+
+
+def test_nohup_prefix_skipped() -> None:
+    parsed = _parse_bash_command("nohup grep needle file.txt")
+    assert parsed is not None
+    query, _ = parsed
+    assert query == "needle"
+
+
+def test_absolute_path_command_recognised() -> None:
+    parsed = _parse_bash_command("/usr/bin/grep -r foo src/")
+    assert parsed is not None
+    query, cmd = parsed
+    assert query == "foo"
+    assert cmd == "grep"
+
+
+def test_redirection_aborts() -> None:
+    assert _parse_bash_command("grep foo file.txt > out.txt") is None
+
+
+# --- AC4: no fall-through to arbitrary Bash ------------------------------
+
+
+def test_no_fall_through_to_arbitrary_bash() -> None:
+    """Random bash invocation produces no additionalContext block."""
+    out = _run_hook(_payload_bash("bash -c 'something opaque'"))
+    assert out == ""
+
+
+def test_unknown_tool_name_silent_skip() -> None:
+    """Tool other than Grep / Glob / Bash silent-skips."""
+    payload = json.dumps({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": "/tmp/x.txt"},
+        "cwd": "/tmp",
+        "session_id": "s1",
+    })
+    out = _run_hook(payload)
+    assert out == ""
+
+
+# --- AC5: per-turn fire cap ----------------------------------------------
+
+
+def test_per_turn_fire_cap_holds() -> None:
+    """3 fires within one session emit blocks; the 4th silent-skips."""
+    _reset_bash_fire_state()
+    fired_count = 0
+    for i in range(BASH_FIRE_CAP_PER_TURN + 2):
+        out = _run_hook(_payload_bash(
+            f"rg query{i} src/", session_id="cap-test",
+        ))
+        if out:
+            # Validate it's a parseable JSON envelope.
+            envelope = cast(dict[str, object], json.loads(out))
+            assert "hookSpecificOutput" in envelope
+            fired_count += 1
+    assert fired_count == BASH_FIRE_CAP_PER_TURN
+
+
+def test_fire_cap_independent_per_session() -> None:
+    """Two distinct session_ids each get the full cap."""
+    _reset_bash_fire_state()
+    for sid in ("session-A", "session-B"):
+        for i in range(BASH_FIRE_CAP_PER_TURN):
+            out = _run_hook(_payload_bash(
+                f"rg query{i} src/", session_id=sid,
+            ))
+            assert out, f"{sid} fire {i} should have produced output"
+
+
+# --- AC6: source attribute on Bash blocks --------------------------------
+
+
+def test_bash_block_carries_source_attribute() -> None:
+    _reset_bash_fire_state()
+    out = _run_hook(_payload_bash("rg searchterm src/", session_id="src-test"))
+    assert out
+    envelope = cast(dict[str, object], json.loads(out))
+    hso = cast(dict[str, object], envelope["hookSpecificOutput"])
+    ctx = cast(str, hso["additionalContext"])
+    assert 'source="bash:rg"' in ctx
+    assert 'cmd="rg searchterm src/"' in ctx
+    assert 'query="searchterm"' in ctx
+
+
+def test_grep_block_unchanged_no_source_attribute() -> None:
+    """Grep tool path emits the v1.2.x output shape (no source attr)."""
+    payload = json.dumps({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "directive-gate"},
+        "cwd": "/tmp",
+        "session_id": "grep-test",
+    })
+    out = _run_hook(payload)
+    assert out
+    envelope = cast(dict[str, object], json.loads(out))
+    hso = cast(dict[str, object], envelope["hookSpecificOutput"])
+    ctx = cast(str, hso["additionalContext"])
+    assert "source=" not in ctx
+    assert "cmd=" not in ctx
+    assert 'query="directive-gate"' in ctx
+
+
+# --- _extract_bash_query integration ------------------------------------
+
+
+def test_extract_bash_query_returns_truncated_cmd() -> None:
+    long_cmd = "rg " + "x" * 200 + " src/"
+    payload: dict[str, object] = {
+        "tool_name": "Bash",
+        "tool_input": {"command": long_cmd},
+    }
+    extracted = _extract_bash_query(payload)
+    assert extracted is not None
+    _, _, truncated = extracted
+    assert truncated.endswith("...")
+    assert len(truncated) <= 80
+
+
+def test_extract_bash_query_returns_none_for_non_bash() -> None:
+    payload: dict[str, object] = {
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "foo"},
+    }
+    assert _extract_bash_query(payload) is None
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    """Reset the per-process fire-state map between tests."""
+    _reset_bash_fire_state()


### PR DESCRIPTION
Refs #155. Builds on the spec in #209 (must merge first; this PR's base is `docs/search-tool-bash-spec-v1.5`).

## Summary

PR 1 of 2 for the v1.5.0 §Bash extension. Lands the per-command parsers, allowlist, fire-cap, and source-attribute output shape.

PR 2 (follow-up) will land the opt-in surface (`aelf setup --search-tool-bash`), telemetry to `.git/aelfrice/telemetry/search_tool_hook.jsonl`, and `aelf doctor` integration — that's where ACs 3, 7, 8 close. Default-OFF until PR 2 lands the opt-in flag, so v1.5 cut can ship this without flipping behaviour.

## What this PR does

- Allowlist: `grep`/`egrep`/`fgrep`/`rg`/`ripgrep`/`ack`/`find`/`fd`/`fdfind`. Per-command flag-with-arg tables. Strict `find` rule (only `-name`/`-iname` produce a query; `find . -type f` silent-skips).
- Pipeline / command-substitution / backtick / process-substitution / redirection / shell-control tokens abort the parser. No fall-through to "match all Bash."
- Env-assignment prefixes (`RUST_LOG=trace rg ...`), `nohup` / `time` / `command` / `exec` wrappers, and `/usr/bin/grep` basenames are all recognised.
- Per-turn fire cap of 3, keyed by `session_id` in a per-process dict. Distinct sessions each get the full cap. Cap applies only to the Bash matcher; Grep|Glob is uncapped.
- Halved token budget (300 / 5) for the Bash matcher vs. the v1.2.x Grep|Glob path (600 / 10).
- Output shape: `<aelfrice-search query="..." source="bash:rg" cmd="rg searchterm src/">...</aelfrice-search>`. Grep|Glob output is byte-identical to v1.2.x.

## Acceptance criteria

| AC | Status | Coverage |
|---|---|---|
| 1 — allowlist fires; unknown silent-skip | done | `test_allowlist_fires_*`, `test_unknown_command_silent_skip`, `test_random_garbage_never_fires` |
| 2 — per-command exact extraction | done | 10 parser unit tests covering documented shapes + abort cases |
| 3 — telemetry-gated default-on flip | **deferred to PR 2** | telemetry surface lands in PR 2 |
| 4 — no fall-through to arbitrary Bash | done | `test_no_fall_through_to_arbitrary_bash`, `test_unknown_tool_name_silent_skip` |
| 5 — per-turn fire cap | done | `test_per_turn_fire_cap_holds`, `test_fire_cap_independent_per_session` |
| 6 — `source=` / `cmd=` attribute | done | `test_bash_block_carries_source_attribute`, `test_grep_block_unchanged_no_source_attribute` |
| 7 — `aelf setup --search-tool-bash` | **deferred to PR 2** | |
| 8 — `aelf doctor` telemetry | **deferred to PR 2** | |

## Test plan

- [x] `uv run --extra dev pytest tests/test_search_tool_hook_bash.py` — 26 pass
- [x] `uv run --extra dev pytest tests/` — 1489 pass / 4 skip (no regressions)
- [ ] CI staging-gate green
- [ ] Reviewer accepts the PR-1/PR-2 split
- [ ] Reviewer accepts the naive-whitespace-split fail-soft contract (quoted args with embedded whitespace silent-skip rather than guess)