### PR TITLE
fix: suppress stale upgrade banner when installed version has caught up

### DIFF
--- a/src/aelfrice/statusline.py
+++ b/src/aelfrice/statusline.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import os
 from typing import Final
 
-from aelfrice.lifecycle import UpdateStatus, read_cache
+from aelfrice.lifecycle import UpdateStatus, installed_version, is_newer, read_cache
 
 # CSS orange #FFA500 in truecolor, 256-color 208 (#FF8700), basic 33.
 ANSI_RESET: Final[str] = "\x1b[0m"
@@ -65,6 +65,7 @@ def format_snippet(
     status: UpdateStatus,
     *,
     env: dict[str, str] | None = None,
+    installed: str | None = None,
 ) -> str:
     """Return the statusline snippet for the given cache status.
 
@@ -72,8 +73,20 @@ def format_snippet(
     returns 'COLOR_ON⬆ aelfrice X.Y.Z available, run: aelf upgrade
     COLOR_OFF │ '. The trailing ' │ ' is the GSD-style separator
     so the snippet composes naturally as a leading badge.
+
+    Self-correcting: even when the cache says update_available=True,
+    the banner is suppressed if the running interpreter is already at
+    or ahead of status.latest.  This prevents the banner from
+    persisting after an out-of-band upgrade that has not yet triggered
+    a fresh PyPI check.  The ``installed`` parameter overrides the
+    running version for testing; when omitted, installed_version() is
+    called.  If installed_version() returns "" (lookup failure) the
+    banner is shown, preserving the default-visible safe fallback.
     """
     if not status.update_available or not status.latest:
+        return ""
+    running = installed if installed is not None else installed_version()
+    if running and not is_newer(status.latest, running):
         return ""
     color_on = _pick_color(env)
     color_off = ANSI_RESET if color_on else ""

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -71,6 +71,30 @@ def test_snippet_includes_upgrade_command() -> None:
     assert statusline.ICON in out
 
 
+def test_suppressed_when_running_version_caught_up() -> None:
+    s = _fresh(latest="1.4.0")
+    assert statusline.format_snippet(s, env={}, installed="1.4.0") == ""
+
+
+def test_suppressed_when_running_version_ahead_of_cache() -> None:
+    s = _fresh(latest="1.4.0")
+    assert statusline.format_snippet(s, env={}, installed="1.5.0") == ""
+
+
+def test_visible_when_running_version_behind_cache() -> None:
+    s = _fresh(latest="1.4.0")
+    out = statusline.format_snippet(s, env={}, installed="1.3.0")
+    assert "1.4.0" in out
+    assert out.endswith(statusline.SEPARATOR)
+
+
+def test_visible_when_installed_unknown() -> None:
+    s = _fresh(latest="1.4.0")
+    out = statusline.format_snippet(s, env={}, installed="")
+    assert "1.4.0" in out
+    assert out.endswith(statusline.SEPARATOR)
+
+
 def test_render_reads_cache(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     p = tmp_path / "cache.json"
     lifecycle._write_cache(_fresh("1.5.0"), p)


### PR DESCRIPTION
## Summary

- Adds `installed: str | None = None` parameter to `format_snippet` for testability.
- After the existing `update_available` check, compares `status.latest` against the running version via `installed_version()` / `is_newer`; returns `""` when installed >= latest.
- Degrades safely: if `installed_version()` returns `""`, banner remains visible (preserves default behavior).

Closes #214

## Test plan

- [ ] `test_suppressed_when_running_version_caught_up` — installed="1.4.0", latest="1.4.0", expect ""
- [ ] `test_suppressed_when_running_version_ahead_of_cache` — installed="1.5.0", latest="1.4.0", expect ""
- [ ] `test_visible_when_running_version_behind_cache` — installed="1.3.0", latest="1.4.0", expect banner shown
- [ ] `test_visible_when_installed_unknown` — installed="", expect banner shown (safe fallback)
- [ ] All pre-existing `tests/test_statusline.py` tests pass
- [ ] Full suite (1456 tests) passes