### PR TITLE
feat: port Plate FFT HRR primitives to public repo (#216)

### DIFF
--- a/src/aelfrice/hrr.py
+++ b/src/aelfrice/hrr.py
@@ -1,0 +1,148 @@
+"""Holographic Reduced Representations primitives (Plate 1995).
+
+Circular-convolution binding, FFT-correlation unbinding, vector
+superposition, and a cleanup-memory utility for nearest-neighbor
+recovery via cosine similarity.
+
+This module ships the algebra only. No integration into the
+retrieval surface; consumers (e.g. #152's HRR structural-query
+lane) build their indices on top of these primitives.
+
+Pure-numpy. Numpy is already a runtime dep at v1.5.0 (BM25F
+sparse-matvec work, #148); no dep-policy break.
+
+Reference: Plate, T.A. (1995), *Holographic Reduced
+Representations*, IEEE Transactions on Neural Networks 6(3).
+"""
+from __future__ import annotations
+
+from typing import Final
+
+import numpy as np
+import numpy.typing as npt
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+Vector = npt.NDArray[np.float64]
+
+# Default dimensionality. Capacity per Plate's analysis is roughly
+# dim/9 retrievable bound pairs at signal-to-noise threshold; 2048
+# accommodates ~227 distinct bindings, well above aelfrice's typical
+# ~5 outgoing edges per belief.
+DEFAULT_DIM: Final[int] = 2048
+
+
+# ---------------------------------------------------------------------------
+# Core HRR operations
+# ---------------------------------------------------------------------------
+
+
+def random_vector(dim: int, rng: np.random.Generator) -> Vector:
+    """Sample a unit vector from N(0, 1/sqrt(n)) and normalise.
+
+    Random vectors drawn this way are approximately orthogonal in
+    high dimension — the property HRR algebra relies on. The caller
+    supplies the ``Generator`` so determinism is the consumer's
+    responsibility (e.g. seed from ``hash(store_path) ^ index``)."""
+    v: Vector = rng.normal(0, 1.0 / np.sqrt(dim), size=dim).astype(np.float64)
+    norm: float = float(np.linalg.norm(v))
+    if norm > 0:
+        v = (v / norm).astype(np.float64)
+    return v
+
+
+def bind(a: Vector, b: Vector) -> Vector:
+    """Circular convolution of ``a`` and ``b`` (the HRR bind operation).
+
+    Computed via FFT: ``ifft(fft(a) * fft(b))``. Commutative and
+    associative; distributive over superposition. Real-valued by
+    construction (the imaginary part is FFT round-off; we drop it)."""
+    result: Vector = np.real(
+        np.fft.ifft(np.fft.fft(a) * np.fft.fft(b))
+    ).astype(np.float64)
+    return result
+
+
+def unbind(key: Vector, composite: Vector) -> Vector:
+    """Circular correlation: approximate inverse of ``bind(key, .)``.
+
+    ``unbind(k, bind(k, v))`` recovers ``v`` exactly in the noise-free
+    single-pair case. In a superposition ``s = sum_i bind(k_i, v_i)``,
+    ``unbind(k_j, s)`` recovers ``v_j`` plus orthogonal noise of
+    magnitude ``~1/sqrt(dim)`` per bound term."""
+    result: Vector = np.real(
+        np.fft.ifft(np.conj(np.fft.fft(key)) * np.fft.fft(composite))
+    ).astype(np.float64)
+    return result
+
+
+def superpose(vectors: list[Vector]) -> Vector:
+    """Vector-sum bundle. Accepts an empty list (returns zero-vector
+    of dimension 0; callers must avoid this corner if their pipeline
+    cannot tolerate a 0-d array)."""
+    if not vectors:
+        return np.zeros(0, dtype=np.float64)
+    result: Vector = np.sum(np.array(vectors), axis=0).astype(np.float64)
+    return result
+
+
+def cosine_similarity(a: Vector, b: Vector) -> float:
+    """Cosine similarity ``a . b / (|a||b|)``. Returns 0.0 for either
+    vector having zero norm (Plate 1995 §3 conventions)."""
+    na: float = float(np.linalg.norm(a))
+    nb: float = float(np.linalg.norm(b))
+    if na == 0 or nb == 0:
+        return 0.0
+    return float(np.dot(a, b) / (na * nb))
+
+
+# ---------------------------------------------------------------------------
+# Cleanup memory: nearest-neighbour recovery
+# ---------------------------------------------------------------------------
+
+
+class CleanupMemory:
+    """Labeled-vector store with batched cosine-similarity recovery.
+
+    Standard HRR cleanup pattern: after ``unbind`` the recovered
+    vector is approximate — find the nearest stored *clean* vector
+    and return its label. Recall is monotone in dimension and in the
+    superposition's bound-pair count.
+
+    The vector matrix is materialised lazily and invalidated on every
+    ``add`` to keep insertion O(1)."""
+
+    def __init__(self) -> None:
+        self._labels: list[str] = []
+        self._vectors: list[Vector] = []
+        self._matrix: Vector | None = None
+
+    def add(self, label: str, vector: Vector) -> None:
+        self._labels.append(label)
+        self._vectors.append(vector)
+        self._matrix = None
+
+    def query(self, probe: Vector, top_k: int = 10) -> list[tuple[str, float]]:
+        """Top-K nearest labels by cosine similarity, descending."""
+        if not self._labels:
+            return []
+        if self._matrix is None:
+            self._matrix = np.array(self._vectors, dtype=np.float64)
+        norms: Vector = np.linalg.norm(self._matrix, axis=1).astype(np.float64)
+        norms = np.where(norms > 0, norms, 1.0).astype(np.float64)
+        normalized: Vector = (self._matrix / norms[:, np.newaxis]).astype(np.float64)
+        probe_norm: float = float(np.linalg.norm(probe))
+        if probe_norm == 0:
+            return []
+        probe_normalized: Vector = (probe / probe_norm).astype(np.float64)
+        sims: Vector = (normalized @ probe_normalized).astype(np.float64)
+        k: int = min(top_k, len(self._labels))
+        # `argpartition` is O(N); `argsort` only the K winners after.
+        top_indices: npt.NDArray[np.intp] = np.argpartition(sims, -k)[-k:]
+        top_indices = top_indices[np.argsort(sims[top_indices])[::-1]]
+        return [(self._labels[int(i)], float(sims[int(i)])) for i in top_indices]
+
+    def size(self) -> int:
+        return len(self._labels)

--- a/tests/test_hrr.py
+++ b/tests/test_hrr.py
@@ -1,0 +1,165 @@
+# pyright: reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportMissingTypeStubs=false
+"""Acceptance tests for the Plate FFT HRR primitives (#216).
+
+One test per acceptance criterion in the issue body. All
+deterministic at fixed seed; per-test wall-clock under 200ms.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from aelfrice.hrr import (
+    DEFAULT_DIM,
+    CleanupMemory,
+    bind,
+    cosine_similarity,
+    random_vector,
+    superpose,
+    unbind,
+)
+
+
+def _rng(seed: int = 0) -> np.random.Generator:
+    return np.random.default_rng(seed)
+
+
+# --- AC1: bind/unbind round-trip --------------------------------------------
+
+
+def test_unbind_inverts_bind_high_similarity() -> None:
+    """Plate 1995 with random unit keys: ``unbind(k, bind(k, v))``
+    is ``v`` filtered per-frequency by ``|fft(k)|²``. With random
+    Gaussian keys (non-unitary) the empirical cosine similarity sits
+    at ~0.71 (range ~0.69–0.72 across seeds 0–9 at dim=2048), not
+    the ~1.0 you'd get with unitary keys. Cleanup memory recovers
+    the true filler from the degraded vector — that is the standard
+    HRR recovery pipeline."""
+    rng = _rng()
+    k = random_vector(DEFAULT_DIM, rng)
+    v = random_vector(DEFAULT_DIM, rng)
+    recovered = unbind(k, bind(k, v))
+    sim = cosine_similarity(recovered, v)
+    assert sim >= 0.65
+
+
+# --- AC2: random_vector determinism -----------------------------------------
+
+
+def test_random_vector_deterministic_at_fixed_seed() -> None:
+    a = random_vector(DEFAULT_DIM, _rng(0))
+    b = random_vector(DEFAULT_DIM, _rng(0))
+    np.testing.assert_array_equal(a, b)
+    # Different seeds produce different vectors.
+    c = random_vector(DEFAULT_DIM, _rng(1))
+    assert not np.allclose(a, c)
+    # Unit norm.
+    assert float(np.linalg.norm(a)) == pytest.approx(1.0, abs=1e-12)
+
+
+# --- AC3: bind commutativity ------------------------------------------------
+
+
+def test_bind_is_commutative() -> None:
+    rng = _rng()
+    a = random_vector(DEFAULT_DIM, rng)
+    b = random_vector(DEFAULT_DIM, rng)
+    np.testing.assert_allclose(bind(a, b), bind(b, a), atol=1e-12)
+
+
+# --- AC4: noise-free single-pair recovery -----------------------------------
+
+
+def test_unbind_single_pair_recovery_above_threshold() -> None:
+    """Single-pair recovery cosine well above the dim=2048 noise floor."""
+    rng = _rng()
+    k = random_vector(DEFAULT_DIM, rng)
+    v = random_vector(DEFAULT_DIM, rng)
+    composite = bind(k, v)
+    recovered = unbind(k, composite)
+    sim = cosine_similarity(recovered, v)
+    assert sim >= 0.65
+
+
+# --- AC5: superposed-pair recovery ------------------------------------------
+
+
+def test_superposed_recovery_above_capacity_threshold() -> None:
+    """Two bound pairs in superposition: unbinding either key
+    should recover the corresponding filler at cosine similarity
+    well above the noise floor (1/sqrt(dim) ~ 0.022 at dim=2048)."""
+    rng = _rng()
+    k1, v1 = random_vector(DEFAULT_DIM, rng), random_vector(DEFAULT_DIM, rng)
+    k2, v2 = random_vector(DEFAULT_DIM, rng), random_vector(DEFAULT_DIM, rng)
+    s = superpose([bind(k1, v1), bind(k2, v2)])
+    sim_v1 = cosine_similarity(unbind(k1, s), v1)
+    sim_v2 = cosine_similarity(unbind(k2, s), v2)
+    assert sim_v1 >= 0.5
+    assert sim_v2 >= 0.5
+    # Cross-talk should be close to noise floor (well below the
+    # right-key recovery).
+    sim_cross = cosine_similarity(unbind(k1, s), v2)
+    assert abs(sim_cross) < sim_v1 / 2
+
+
+# --- AC6: cleanup-memory ordering -------------------------------------------
+
+
+def test_cleanup_memory_returns_descending_similarity() -> None:
+    rng = _rng()
+    cm = CleanupMemory()
+    targets = [random_vector(DEFAULT_DIM, rng) for _ in range(5)]
+    for i, t in enumerate(targets):
+        cm.add(f"v{i}", t)
+    # Probe = exact match of v2 → v2 should be #1.
+    out = cm.query(targets[2], top_k=5)
+    assert out[0][0] == "v2"
+    assert out[0][1] == pytest.approx(1.0, abs=1e-9)
+    # Descending order across the full result.
+    sims = [s for _, s in out]
+    assert sims == sorted(sims, reverse=True)
+
+
+# --- AC7: cleanup-memory exact-match recall ---------------------------------
+
+
+def test_cleanup_memory_exact_recall_of_stored_vector() -> None:
+    rng = _rng()
+    cm = CleanupMemory()
+    v = random_vector(DEFAULT_DIM, rng)
+    cm.add("only", v)
+    out = cm.query(v, top_k=1)
+    assert out == [("only", pytest.approx(1.0, abs=1e-9))]
+
+
+# --- AC8: determinism + corner cases ----------------------------------------
+
+
+def test_superpose_empty_list_returns_zero_vector() -> None:
+    out = superpose([])
+    assert out.shape == (0,)
+
+
+def test_cosine_similarity_zero_norm_returns_zero() -> None:
+    rng = _rng()
+    v = random_vector(DEFAULT_DIM, rng)
+    z = np.zeros(DEFAULT_DIM, dtype=np.float64)
+    assert cosine_similarity(z, v) == 0.0
+    assert cosine_similarity(v, z) == 0.0
+    assert cosine_similarity(z, z) == 0.0
+
+
+def test_cleanup_memory_empty_returns_empty() -> None:
+    cm = CleanupMemory()
+    rng = _rng()
+    probe = random_vector(DEFAULT_DIM, rng)
+    assert cm.query(probe, top_k=10) == []
+    assert cm.size() == 0
+
+
+def test_cleanup_memory_zero_probe_returns_empty() -> None:
+    cm = CleanupMemory()
+    rng = _rng()
+    cm.add("a", random_vector(DEFAULT_DIM, rng))
+    z = np.zeros(DEFAULT_DIM, dtype=np.float64)
+    assert cm.query(z, top_k=1) == []


### PR DESCRIPTION
## Summary

Closes #216. Prereq for #152 (HRR structural-query lane), whose spec assumes `aelfrice.hrr` already exists in the public repo.

- New module `aelfrice.hrr` with the 5 Plate (1995) primitives (`random_vector`, `bind`, `unbind`, `superpose`, `cosine_similarity`) plus `CleanupMemory` for nearest-neighbor recovery.
- Lifted from the lab-side reference at `aelfrice-lab/.../src/aelfrice/hrr.py` lines 1-112. The `HRRGraph` partitioned-encoder class is intentionally **not** ported — its responsibilities overlap with the structural index #152 will build, so duplicating now would make #152's PR harder to review.
- Numpy is already runtime as of v1.5.0 (BM25F sparse-matvec, #148); no `pyproject.toml` dep change.
- 12 tests, all deterministic.

## Spec correction

Issue body's AC1 / AC4 stated `unbind(k, bind(k, v))` recovers `v` "to within 1e-10 FFT noise." That is wrong for random Gaussian keys: the recovery is `v` scaled per-frequency by `|fft(k)|²`, giving empirical cosine similarity ~0.71 (range 0.69-0.72 across seeds 0-9 at dim=2048), not ~1.0. Cleanup memory disambiguates the degraded vector — that's the standard HRR pipeline. Tests use a >=0.65 threshold which sits comfortably above both the noise floor and the two-pair cross-talk. Issue should be amended to reflect the realistic threshold; flagging here so the spec gets corrected before #152 lands.

## Test plan

- [x] `uv run pytest tests/test_hrr.py -q` — 11 pass.
- [x] `uv run pytest` — full suite **1474 passed, 4 skipped** (no regressions).
- [x] `uv run pyright src/aelfrice/hrr.py tests/test_hrr.py` — clean.

## Out of scope

`HRRGraph`, sentence encoder, HRR-vs-FTS5 eval (lab-side scripts) — separate issues.