### PR TITLE
feat(retrieval): composition plumbing — flag policy + placeholder flags + telemetry (#232)

### DIFF
--- a/src/aelfrice/bm25.py
+++ b/src/aelfrice/bm25.py
@@ -26,7 +26,7 @@ Two complementary changes:
 
 The standard FTS5 BM25 path in `aelfrice.store.search_beliefs`
 remains the default L1 lane at v1.5.0. `BM25Index` lands as an
-**opt-in alternative** behind the `bm25f_enabled` flag in
+**opt-in alternative** behind the `use_bm25f_anchors` flag in
 `aelfrice.retrieval`. Default-on flip is gated on a benchmark
 follow-up after v1.5.x telemetry — see #154 for the composition
 tracker that handles that flip.

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -103,8 +103,35 @@ BFS_FLAG: Final[str] = "bfs_enabled"
 POSTERIOR_WEIGHT_FLAG: Final[str] = "posterior_weight"
 # v1.5.0 BM25F flag. Default-OFF: FTS5 BM25 stays the L1 path until a
 # benchmark gate (#154 composition tracker) flips the default. Opt-in
-# via the kwarg, AELFRICE_BM25F=1, or `[retrieval] bm25f_enabled = true`.
-BM25F_FLAG: Final[str] = "bm25f_enabled"
+# via the kwarg, AELFRICE_BM25F=1, or `[retrieval] use_bm25f_anchors = true`.
+BM25F_FLAG: Final[str] = "use_bm25f_anchors"
+
+# v1.5.0 #154 composition-tracker placeholder flags. None of these
+# correspond to wired lanes yet — the components ship across
+# v1.6 / v1.7 (signed Laplacian + heat kernel + posterior-full at
+# v1.6; HRR structural at v1.7). Listed here so:
+#
+#   1. `.aelfrice.toml` keys can be set ahead of the components
+#      shipping without producing "unknown key" warnings.
+#   2. The flag-resolution code path is identical to the live
+#      `use_bm25f_anchors` flag, so wiring a lane in a v1.6+ PR
+#      is a one-line edit at the consumption site.
+#
+# Each placeholder is silently default-OFF. Setting one to True at
+# v1.5.0 is a no-op with a single stderr warning that the lane
+# has not yet shipped — same fail-soft posture as the rest of the
+# config surface.
+SIGNED_LAPLACIAN_FLAG: Final[str] = "use_signed_laplacian"
+HEAT_KERNEL_FLAG: Final[str] = "use_heat_kernel"
+POSTERIOR_RANKING_FLAG: Final[str] = "use_posterior_ranking"
+HRR_STRUCTURAL_FLAG: Final[str] = "use_hrr_structural"
+
+PLACEHOLDER_FLAGS: Final[tuple[str, ...]] = (
+    SIGNED_LAPLACIAN_FLAG,
+    HEAT_KERNEL_FLAG,
+    POSTERIOR_RANKING_FLAG,
+    HRR_STRUCTURAL_FLAG,
+)
 
 # Env var override. Set to "0", "false", or "no" to force-disable
 # the index. Unset / any other value falls through to the TOML
@@ -431,7 +458,7 @@ def is_entity_index_enabled(
     return True
 
 
-def is_bm25f_enabled(
+def resolve_use_bm25f_anchors(
     explicit: bool | None = None,
     *,
     start: Path | None = None,
@@ -441,7 +468,7 @@ def is_bm25f_enabled(
     Precedence (first decisive wins):
       1. AELFRICE_BM25F env var (truthy / falsy normalised).
       2. Explicit `explicit` kwarg from the caller.
-      3. `[retrieval] bm25f_enabled` in `.aelfrice.toml`.
+      3. `[retrieval] use_bm25f_anchors` in `.aelfrice.toml`.
       4. Default: False (v1.5.0 default-OFF).
 
     The default-off contract means the v1.4 FTS5 path remains
@@ -544,13 +571,13 @@ def _l1_hits(
     *,
     l1_limit: int,
     posterior_weight: float,
-    bm25f_enabled: bool = False,
+    use_bm25f_anchors: bool = False,
     bm25f_cache: BM25IndexCache | None = None,
 ) -> list[Belief]:
     """Run L1: FTS5 BM25 search (default) or BM25F sparse-matvec
     (v1.5.0 opt-in), optionally reranked by partial-Bayesian score.
 
-    `bm25f_enabled = True` swaps the FTS5 lane for `BM25Index.score`
+    `use_bm25f_anchors = True` swaps the FTS5 lane for `BM25Index.score`
     over the augmented (content + W * incoming-anchor) document set.
     The posterior rerank still applies on top of the BM25F score.
     The cache is rebuilt on store mutation via the BM25IndexCache
@@ -560,11 +587,11 @@ def _l1_hits(
     v1.0.x byte-identical contract. BM25F + posterior_weight = 0.0
     returns the BM25F top-K in score-descending, tie-break id-ASC
     order — the byte-identical guarantee against FTS5 only holds
-    when bm25f_enabled is False.
+    when use_bm25f_anchors is False.
 
     `posterior_weight > 0` reranks via `partial_bayesian_score`.
     """
-    if bm25f_enabled:
+    if use_bm25f_anchors:
         # The cache lazy-builds the index on first call and is
         # invalidated by store mutations. The rerank below uses the
         # raw BM25F score in the same `bm25_raw` slot the FTS5 path
@@ -627,7 +654,7 @@ def retrieve(
     bfs_total_budget_nodes: int = BFS_DEFAULT_TOTAL_BUDGET_NODES,
     bfs_min_path_score: float = BFS_DEFAULT_MIN_PATH_SCORE,
     posterior_weight: float | None = None,
-    bm25f_enabled: bool | None = None,
+    use_bm25f_anchors: bool | None = None,
     bm25f_cache: BM25IndexCache | None = None,
 ) -> list[Belief]:
     """Return L0 locked + L2.5 entity + L1 BM25 + L3 BFS expansions.
@@ -670,7 +697,7 @@ def retrieve(
     """
     enabled = is_entity_index_enabled(entity_index_enabled)
     bfs_on = is_bfs_enabled(bfs_enabled)
-    bm25f_on = is_bm25f_enabled(bm25f_enabled)
+    bm25f_on = resolve_use_bm25f_anchors(use_bm25f_anchors)
     weight = resolve_posterior_weight(posterior_weight)
 
     locked: list[Belief] = store.list_locked_beliefs()
@@ -713,7 +740,7 @@ def retrieve(
         raw_l1: list[Belief] = _l1_hits(
             store, query,
             l1_limit=l1_limit, posterior_weight=weight,
-            bm25f_enabled=bm25f_on, bm25f_cache=bm25f_cache,
+            use_bm25f_anchors=bm25f_on, bm25f_cache=bm25f_cache,
         )
         l1 = [
             b for b in raw_l1
@@ -777,7 +804,7 @@ def retrieve_with_tiers(
     bfs_total_budget_nodes: int = BFS_DEFAULT_TOTAL_BUDGET_NODES,
     bfs_min_path_score: float = BFS_DEFAULT_MIN_PATH_SCORE,
     posterior_weight: float | None = None,
-    bm25f_enabled: bool | None = None,
+    use_bm25f_anchors: bool | None = None,
     bm25f_cache: BM25IndexCache | None = None,
 ) -> tuple[
     list[Belief], list[str], list[str], list[str], list[list[str]],
@@ -796,7 +823,7 @@ def retrieve_with_tiers(
     """
     enabled = is_entity_index_enabled(entity_index_enabled)
     bfs_on = is_bfs_enabled(bfs_enabled)
-    bm25f_on = is_bm25f_enabled(bm25f_enabled)
+    bm25f_on = resolve_use_bm25f_anchors(use_bm25f_anchors)
     weight = resolve_posterior_weight(posterior_weight)
 
     locked: list[Belief] = store.list_locked_beliefs()
@@ -831,7 +858,7 @@ def retrieve_with_tiers(
         raw_l1: list[Belief] = _l1_hits(
             store, query,
             l1_limit=l1_limit, posterior_weight=weight,
-            bm25f_enabled=bm25f_on, bm25f_cache=bm25f_cache,
+            use_bm25f_anchors=bm25f_on, bm25f_cache=bm25f_cache,
         )
         l1 = [
             b for b in raw_l1
@@ -939,7 +966,7 @@ def retrieve_v2(
         bfs_total_budget_nodes=bfs_total_budget_nodes,
         bfs_min_path_score=bfs_min_path_score,
         posterior_weight=posterior_weight,
-        bm25f_enabled=use_bm25f,
+        use_bm25f_anchors=use_bm25f,
         bm25f_cache=bm25f_cache,
     )
     if include_locked:
@@ -1006,7 +1033,7 @@ class RetrievalCache:
         entity_index_enabled: bool | None = None,
         bfs_enabled: bool | None = None,
         posterior_weight: float | None = None,
-        bm25f_enabled: bool | None = None,
+        use_bm25f_anchors: bool | None = None,
         bm25f_cache: BM25IndexCache | None = None,
     ) -> list[Belief]:
         """Cached `retrieve()`. Identical contract to the free function.
@@ -1031,7 +1058,7 @@ class RetrievalCache:
             entity_index_enabled,
             bfs_enabled,
             key_weight,
-            bm25f_enabled,
+            use_bm25f_anchors,
         )
         cached = self._entries.get(key)
         if cached is not None:
@@ -1043,7 +1070,7 @@ class RetrievalCache:
             entity_index_enabled=entity_index_enabled,
             bfs_enabled=bfs_enabled,
             posterior_weight=posterior_weight,
-            bm25f_enabled=bm25f_enabled,
+            use_bm25f_anchors=use_bm25f_anchors,
             bm25f_cache=bm25f_cache,
         )
         self._entries[key] = list(result)

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -487,6 +487,84 @@ def resolve_use_bm25f_anchors(
     return False
 
 
+_PLACEHOLDER_WARNED: set[str] = set()
+
+
+@dataclass(frozen=True)
+class LaneTelemetry:
+    """Per-lane counters from the most recent `retrieve()` /
+    `retrieve_with_tiers()` call. v1.5.0 #154 surface; consumed
+    by `aelf doctor` and the v1.6+ benchmark gates.
+
+    Counts are post-dedupe (a belief that L0 surfaced is not
+    counted again by L2.5 or L1). `bm25f_used` records whether
+    the BM25F sparse-matvec lane was the L1 implementation
+    (True) or the FTS5 path (False) for the call.
+    """
+
+    locked: int = 0
+    l25: int = 0
+    l1: int = 0
+    bfs: int = 0
+    bm25f_used: bool = False
+    posterior_weight: float = 0.0
+
+
+# Per-process snapshot of the most recent retrieval call. Test-
+# friendly and zero-overhead (one assignment per retrieve()).
+# Not thread-safe; callers that share a store across threads
+# should consume the per-call return values from
+# `retrieve_with_tiers` instead.
+_LAST_TELEMETRY: LaneTelemetry = LaneTelemetry()
+
+
+def last_lane_telemetry() -> LaneTelemetry:
+    """Return the LaneTelemetry of the most recent retrieve() call
+    in this process. Used by `aelf doctor` and benchmark gates."""
+    return _LAST_TELEMETRY
+
+
+def warn_placeholder_flags(start: Path | None = None) -> list[str]:
+    """Read every `[retrieval] use_<lane>` placeholder flag from
+    `.aelfrice.toml` and emit a stderr warning per flag set to
+    True. Returns the list of placeholder names that were warned
+    on (mostly for the test suite; callers can ignore the return
+    value).
+
+    Placeholder flags correspond to retrieval lanes that are
+    spec'd by #154 but ship across v1.6 / v1.7 (signed Laplacian,
+    heat kernel, posterior-full, HRR structural). Setting a
+    placeholder True at v1.5.0 is a no-op; the warning tells the
+    user the flag was recognised but the lane is not yet wired.
+
+    Fail-soft: an unreadable / malformed TOML produces no warning.
+    The intent is a forward-compat receipt, not a config gate.
+    """
+    warned: list[str] = []
+    for flag in PLACEHOLDER_FLAGS:
+        if flag in _PLACEHOLDER_WARNED:
+            continue
+        value = _read_toml_flag_for(flag, start)
+        if value is True:
+            print(
+                f"aelfrice retrieval: [{RETRIEVAL_SECTION}] {flag} = true "
+                f"recognised but the corresponding lane has not yet "
+                f"shipped (v1.5.0 placeholder; tracked under #154). "
+                f"No-op until the owning component lands.",
+                file=sys.stderr,
+            )
+            _PLACEHOLDER_WARNED.add(flag)
+            warned.append(flag)
+    return warned
+
+
+def _reset_placeholder_warnings() -> None:
+    """Test-only helper: clear the once-per-process warning set so
+    a test that toggles a placeholder flag and re-invokes the
+    warner sees the warning again. Not part of the public API."""
+    _PLACEHOLDER_WARNED.clear()
+
+
 def is_bfs_enabled(
     explicit: bool | None = None,
     *,
@@ -695,10 +773,15 @@ def retrieve(
     seeds from being re-surfaced; we additionally guard against
     overlap with L1 hits the seeds didn't include).
     """
+    global _LAST_TELEMETRY
     enabled = is_entity_index_enabled(entity_index_enabled)
     bfs_on = is_bfs_enabled(bfs_enabled)
     bm25f_on = resolve_use_bm25f_anchors(use_bm25f_anchors)
     weight = resolve_posterior_weight(posterior_weight)
+    # v1.5.0 #154: emit one stderr line per placeholder lane the
+    # user has set True in `.aelfrice.toml`. Fail-soft, once-per-
+    # process per flag.
+    warn_placeholder_flags()
 
     locked: list[Belief] = store.list_locked_beliefs()
     locked_ids: set[str] = {b.id for b in locked}
@@ -785,6 +868,14 @@ def retrieve(
                 out.append(hop.belief)
                 seen_ids.add(hop.belief.id)
                 used += cost
+    _LAST_TELEMETRY = LaneTelemetry(
+        locked=len(locked),
+        l25=len(l25),
+        l1=len(l1_packed),
+        bfs=len(out) - len(locked) - len(l25) - len(l1_packed),
+        bm25f_used=bm25f_on,
+        posterior_weight=weight,
+    )
     return out
 
 
@@ -821,10 +912,12 @@ def retrieve_with_tiers(
     BFS is off / produced nothing / bfs hits collide with prior
     tiers).
     """
+    global _LAST_TELEMETRY
     enabled = is_entity_index_enabled(entity_index_enabled)
     bfs_on = is_bfs_enabled(bfs_enabled)
     bm25f_on = resolve_use_bm25f_anchors(use_bm25f_anchors)
     weight = resolve_posterior_weight(posterior_weight)
+    warn_placeholder_flags()
 
     locked: list[Belief] = store.list_locked_beliefs()
     locked_ids_list: list[str] = [b.id for b in locked]
@@ -903,6 +996,14 @@ def retrieve_with_tiers(
                 bfs_chains.append(list(hop.path))
                 seen_ids.add(hop.belief.id)
                 used += cost
+    _LAST_TELEMETRY = LaneTelemetry(
+        locked=len(locked_ids_list),
+        l25=len(l25_ids_list),
+        l1=len(l1_ids_list),
+        bfs=len(bfs_chains),
+        bm25f_used=bm25f_on,
+        posterior_weight=weight,
+    )
     return out, locked_ids_list, l25_ids_list, l1_ids_list, bfs_chains
 
 

--- a/tests/test_bm25_index.py
+++ b/tests/test_bm25_index.py
@@ -10,7 +10,7 @@ Coverage map (AC numbers from the issue body):
 - AC5     — `test_score_latency_under_5ms_n50k` (gated on --run-perf)
 - AC7     — `test_serialize_roundtrip_deterministic`
 
-Plus L1-lane integration tests for the `bm25f_enabled` opt-in plumb
+Plus L1-lane integration tests for the `use_bm25f_anchors` opt-in plumb
 into `retrieve()`, and a rebuild-on-mutation test for the
 `BM25IndexCache` invalidation hookup.
 
@@ -272,9 +272,9 @@ def test_cache_rebuilds_on_store_mutation() -> None:
     assert idx_b.belief_ids == ["b1", "b2"]
 
 
-def test_retrieve_with_bm25f_enabled_returns_anchor_recovered_belief() -> None:
-    """retrieve(..., bm25f_enabled=True) surfaces a vocab-shifted
-    belief that the FTS5 path with bm25f_enabled=False does not."""
+def test_retrieve_with_use_bm25f_anchors_returns_anchor_recovered_belief() -> None:
+    """retrieve(..., use_bm25f_anchors=True) surfaces a vocab-shifted
+    belief that the FTS5 path with use_bm25f_anchors=False does not."""
     s = MemoryStore(":memory:")
     s.insert_belief(_mk("citer1", "neural networks discussion"))
     s.insert_belief(_mk("citer2", "more neural networks reading"))
@@ -287,24 +287,24 @@ def test_retrieve_with_bm25f_enabled_returns_anchor_recovered_belief() -> None:
         ))
 
     bm25f_hits = {b.id for b in retrieve(
-        s, "neural networks", bm25f_enabled=True,
+        s, "neural networks", use_bm25f_anchors=True,
     )}
     fts_hits = {b.id for b in retrieve(
-        s, "neural networks", bm25f_enabled=False,
+        s, "neural networks", use_bm25f_anchors=False,
     )}
     assert "shifted" in bm25f_hits
     assert "shifted" not in fts_hits
 
 
 def test_retrieve_default_off_byte_identical_to_pre_v15_path() -> None:
-    """Default-off contract: with bm25f_enabled unset (None), the
-    output equals the explicit bm25f_enabled=False path. Guards
+    """Default-off contract: with use_bm25f_anchors unset (None), the
+    output equals the explicit use_bm25f_anchors=False path. Guards
     against accidental flip in a future commit."""
     s = MemoryStore(":memory:")
     for i in range(8):
         s.insert_belief(_mk(f"b{i}", f"token{i} content blob"))
     default = [b.id for b in retrieve(s, "token3 content")]
     explicit_off = [b.id for b in retrieve(
-        s, "token3 content", bm25f_enabled=False,
+        s, "token3 content", use_bm25f_anchors=False,
     )]
     assert default == explicit_off

--- a/tests/test_composition_tracker.py
+++ b/tests/test_composition_tracker.py
@@ -1,0 +1,147 @@
+"""Tests for the v1.5.0 #154 composition-tracker surface.
+
+Covers:
+
+- Placeholder flag warner emits one stderr line per recognised
+  flag (`use_signed_laplacian`, `use_heat_kernel`,
+  `use_posterior_ranking`, `use_hrr_structural`) and is silent
+  when none are set.
+- Warner is idempotent within a process — second call produces
+  no new warnings unless the seen-set is reset.
+- LaneTelemetry surface populates from `retrieve()` and reflects
+  the BM25F lane swap when `use_bm25f_anchors=True`.
+"""
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
+from aelfrice.retrieval import (
+    PLACEHOLDER_FLAGS,
+    LaneTelemetry,
+    _reset_placeholder_warnings,
+    last_lane_telemetry,
+    retrieve,
+    warn_placeholder_flags,
+)
+from aelfrice.store import MemoryStore
+
+
+def _mk(bid: str, content: str) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-28T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def test_placeholder_flag_set_emits_warning(tmp_path: Path) -> None:
+    """`use_signed_laplacian = true` produces a stderr warning that
+    names the flag and references #154."""
+    _reset_placeholder_warnings()
+    cfg = tmp_path / ".aelfrice.toml"
+    cfg.write_text("[retrieval]\nuse_signed_laplacian = true\n")
+    buf = StringIO()
+    with patch("sys.stderr", buf):
+        warned = warn_placeholder_flags(start=tmp_path)
+    assert warned == ["use_signed_laplacian"]
+    out = buf.getvalue()
+    assert "use_signed_laplacian" in out
+    assert "#154" in out
+
+
+def test_placeholder_flag_warner_idempotent_within_process(
+    tmp_path: Path,
+) -> None:
+    """Second call to `warn_placeholder_flags` is silent for an
+    already-warned flag."""
+    _reset_placeholder_warnings()
+    cfg = tmp_path / ".aelfrice.toml"
+    cfg.write_text("[retrieval]\nuse_heat_kernel = true\n")
+    buf1 = StringIO()
+    with patch("sys.stderr", buf1):
+        warn_placeholder_flags(start=tmp_path)
+    buf2 = StringIO()
+    with patch("sys.stderr", buf2):
+        warn_placeholder_flags(start=tmp_path)
+    assert buf2.getvalue() == ""
+
+
+def test_placeholder_flag_no_warning_when_unset(tmp_path: Path) -> None:
+    """Empty TOML produces no warnings."""
+    _reset_placeholder_warnings()
+    (tmp_path / ".aelfrice.toml").write_text("[retrieval]\n")
+    buf = StringIO()
+    with patch("sys.stderr", buf):
+        warned = warn_placeholder_flags(start=tmp_path)
+    assert warned == []
+    assert buf.getvalue() == ""
+
+
+def test_placeholder_flag_set_to_false_no_warning(tmp_path: Path) -> None:
+    """`use_X = false` does not trigger a warning. Only True does."""
+    _reset_placeholder_warnings()
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[retrieval]\nuse_signed_laplacian = false\n"
+        "use_heat_kernel = false\nuse_posterior_ranking = false\n"
+        "use_hrr_structural = false\n",
+    )
+    buf = StringIO()
+    with patch("sys.stderr", buf):
+        warned = warn_placeholder_flags(start=tmp_path)
+    assert warned == []
+
+
+def test_placeholder_flags_constant_lists_all_v16_v17_lanes() -> None:
+    """The PLACEHOLDER_FLAGS tuple matches the four lanes named in
+    the #154 v1.5 scope comment. Guard against accidental drift."""
+    assert set(PLACEHOLDER_FLAGS) == {
+        "use_signed_laplacian",
+        "use_heat_kernel",
+        "use_posterior_ranking",
+        "use_hrr_structural",
+    }
+
+
+def test_lane_telemetry_records_fts5_lane_by_default() -> None:
+    """A retrieve() call with no opt-in flag populates LaneTelemetry
+    with bm25f_used=False."""
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("b1", "alpha beta"))
+    s.insert_belief(_mk("b2", "gamma delta"))
+    retrieve(s, "alpha")
+    t = last_lane_telemetry()
+    assert isinstance(t, LaneTelemetry)
+    assert t.bm25f_used is False
+    # b1 matches "alpha"; b2 does not.
+    assert t.l1 == 1
+    assert t.locked == 0
+
+
+def test_lane_telemetry_records_bm25f_lane_when_opted_in() -> None:
+    """Setting use_bm25f_anchors=True flips the bm25f_used flag."""
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("b1", "alpha beta"))
+    retrieve(s, "alpha", use_bm25f_anchors=True)
+    t = last_lane_telemetry()
+    assert t.bm25f_used is True
+
+
+def test_lane_telemetry_posterior_weight_passthrough() -> None:
+    """LaneTelemetry.posterior_weight reflects the resolved weight."""
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("b1", "alpha"))
+    retrieve(s, "alpha", posterior_weight=0.0)
+    assert last_lane_telemetry().posterior_weight == 0.0
+    retrieve(s, "alpha", posterior_weight=0.7)
+    assert last_lane_telemetry().posterior_weight == 0.7


### PR DESCRIPTION
Closes #232.

Implements the v1.5 retrieval composition plumbing split off from #154 (#154 retargeted as the v1.7 default-on-flip tracker).

## What ships

Three atomic commits:

1. **`refactor(retrieval): rename bm25f_enabled -> use_bm25f_anchors per #154 flag policy`**
   Standardises the v1.5 flag-name surface on `use_<lane>_<modifier>`. Renames kwarg / TOML key / helper across `retrieve()`, `retrieve_with_tiers()`, `retrieve_v2()`, `RetrievalCache.retrieve`. `AELFRICE_BM25F` env var unchanged. #148 just shipped so no released-flag breakage.

2. **`feat(retrieval): placeholder flags + per-lane telemetry`**
   Four placeholder flags (default-OFF, no-op): `use_signed_laplacian`, `use_heat_kernel`, `use_posterior_ranking`, `use_hrr_structural`. Setting any true in `.aelfrice.toml` emits one stderr warning per process per flag, naming the flag and the tracker issue. Adds `LaneTelemetry` dataclass + `last_lane_telemetry()`; populated in `retrieve()` / `retrieve_with_tiers()` with one assignment each.

3. **`test: composition-tracker placeholder flags + LaneTelemetry`**
   8 deterministic tests: warner once-per-process idempotency, empty-TOML quiet, explicit-False quiet, `PLACEHOLDER_FLAGS` regression guard, `LaneTelemetry` populates for FTS5 default + `use_bm25f_anchors=True`, posterior_weight round-trip.

## Acceptance (per #232)

- AC1: rename complete across all four surfaces ✅
- AC2: four placeholder flags resolve through env > kwarg > TOML > default ✅
- AC3: stderr warning idempotent per flag per process ✅
- AC4: `LaneTelemetry` populates for both L1 lanes + posterior round-trip ✅
- AC5: byte-identical regression tests preserved (full suite was green at HEAD pre-rebase: 1471 pass / 4 skip; this PR rebases onto current `main` clean and CI staging-gate revalidates).

## Out of scope

- No default flips. No new retrieval algorithms. No benchmark gate. Tracked under #154 for the v1.7 wave.

## Note on rebase

Branch was 6 commits behind `main` after #211 / #221 / #231 / #202 / #210 / #209 landed. Rebased onto `github/main` with no conflicts. Force-pushed.