### PR TITLE
feat(retrieval): heat-kernel authority scorer (#150)

### DIFF
--- a/src/aelfrice/graph_spectral.py
+++ b/src/aelfrice/graph_spectral.py
@@ -1,14 +1,20 @@
 # pyright: reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownParameterType=false, reportMissingTypeStubs=false, reportOptionalSubscript=false, reportAttributeAccessIssue=false, reportGeneralTypeIssues=false, reportConstantRedefinition=false, reportArgumentType=false
-"""Signed normalized Laplacian + offline eigenbasis builder (#149).
+"""Signed normalized Laplacian + heat-kernel authority scoring (#149, #150).
 
 Constructs the signed normalized Laplacian
 ``L = I - D_abs^(-1/2) W_sym D_abs^(-1/2)``
 over the typed edge graph (Kunegis 2010), where ``CONTRADICTS`` /
 ``SUPERSEDES`` count as negative-weight edges and the supportive edge
 families as positive. The top-K=200 eigenpairs of ``L`` are the offline
-foundation consumed by the heat-kernel authority signal (#150). This
-module ships only the builder + serialization; no integration into
-``retrieve()``.
+foundation consumed by the heat-kernel authority signal.
+
+#150 adds the per-query heat kernel ``exp(-tL)`` evaluated through the
+precomputed eigenbasis: ``U @ diag(exp(-t*Λ)) @ U.T @ seeds``. Two
+matvecs against the ``(n, K)`` eigenbasis, no per-call eigendecomp.
+``seeds_from_bm25`` builds the L1-normalized seed vector from BM25 top-K
+hits; ``apply_broker_attenuation`` dampens scores by per-belief broker
+confidence (``α/(α+β)``); ``combine_log_scores`` is the log-additive
+ranking formula ``log(BM25F) + 1.0 * log(heat_safe) + 0.5 * log(post)``.
 
 All construction is offline — no query-time cost. Rebuild is wired to
 the same store-mutation invalidation callback that ``RetrievalCache``
@@ -176,6 +182,172 @@ def load_eigenbasis(
     if "belief_ids" in z.files:
         bids = [str(x) for x in z["belief_ids"].tolist()]
     return z["eigvals"], z["eigvecs"], bids
+
+
+# --- #150 heat kernel scoring -------------------------------------------
+
+# Bandwidth `t` for `exp(-tL)`. t=8 is the synthetic-graph optimum at
+# K=200 for the authority-scoring task; smaller t localizes scoring to
+# immediate neighborhood, larger t smooths globally. Ships as default.
+DEFAULT_HEAT_BANDWIDTH: Final[float] = 8.0
+
+# BM25 seed top-K. The heat kernel propagates a sparse seed distribution
+# through the eigenbasis; only the highest-BM25 beliefs are seeded.
+DEFAULT_BM25_SEED_TOP_K: Final[int] = 25
+
+# Lower clamp for `heat_kernel_safe`. Negative or near-zero scores
+# (signed-Laplacian heat can dip below zero through CONTRADICTS edges)
+# are floored before the log to avoid `-inf` propagating into the
+# log-additive score combination.
+HEAT_SCORE_FLOOR: Final[float] = 1e-9
+
+# Default mixing weights for the log-additive ranking formula
+# (#150 spec § "Algorithm").
+DEFAULT_HEAT_KERNEL_WEIGHT: Final[float] = 1.0
+DEFAULT_POSTERIOR_LOG_WEIGHT: Final[float] = 0.5
+
+
+def heat_kernel_score(
+    eigvals: np.ndarray,
+    eigvecs: np.ndarray,
+    seeds: np.ndarray,
+    t: float = DEFAULT_HEAT_BANDWIDTH,
+) -> np.ndarray:
+    """Apply the heat kernel ``exp(-tL)`` to a seed vector via the
+    precomputed eigenbasis.
+
+    ``eigvals`` shape ``(K,)``; ``eigvecs`` shape ``(N, K)``; ``seeds``
+    shape ``(N,)``. Returns ``(N,)``: per-belief authority scores.
+
+    Equivalent to ``U @ diag(exp(-t*Λ)) @ U.T @ seeds`` but written as
+    two matvecs to avoid materializing the ``(N, N)`` dense kernel.
+    Cost: ``O(N * K)`` per call; at ``N=50k, K=200`` that is ~7-8 ms in
+    BLAS-backed numpy on commodity hardware (#150 AC5).
+    """
+    if eigvecs.size == 0:
+        return np.zeros((eigvecs.shape[0],), dtype=np.float64)
+    proj = eigvecs.T @ seeds
+    filt = np.exp(-t * eigvals) * proj
+    return eigvecs @ filt
+
+
+def heat_kernel_safe(
+    scores: np.ndarray, floor: float = HEAT_SCORE_FLOOR,
+) -> np.ndarray:
+    """Clamp heat-kernel scores to ``>= floor`` for safe ``log()``.
+
+    Signed-Laplacian heat propagates negative authority through
+    ``CONTRADICTS`` edges, so raw scores can be negative or zero on
+    disconnected components. The log-additive ranking formula
+    needs strictly positive inputs; the floor preserves ranking
+    monotonicity (anything ≤ floor maps to the same minimum) while
+    avoiding ``-inf``.
+    """
+    return np.maximum(scores, floor)
+
+
+def seeds_from_bm25(
+    bm25_scores: np.ndarray, top_k: int = DEFAULT_BM25_SEED_TOP_K,
+) -> np.ndarray:
+    """Build an L1-normalized seed vector from a BM25 score array.
+
+    ``bm25_scores`` shape ``(N,)`` — one BM25 score per belief in the
+    eigenbasis row order. Returns a dense ``(N,)`` vector with at most
+    ``min(top_k, nnz)`` non-zero entries (the top-`top_k` BM25 scores)
+    and L1 norm 1.0. Zero / negative BM25 scores are excluded — only
+    strictly positive scores seed the kernel.
+
+    Returns the all-zero vector when no seed has positive score
+    (caller should detect and skip the heat-kernel pass; see #150
+    spec § "Algorithm").
+    """
+    n = bm25_scores.shape[0]
+    out = np.zeros(n, dtype=np.float64)
+    if n == 0 or top_k <= 0:
+        return out
+    positive = bm25_scores > 0
+    if not np.any(positive):
+        return out
+    # argpartition is O(N); we only need the top_k indices, not a full
+    # sort. Tie-breaking is arbitrary among equal scores — matches the
+    # spec's "weighted by BM25 score" loose ordering.
+    pos_idx = np.flatnonzero(positive)
+    k = min(top_k, pos_idx.size)
+    top_local = np.argpartition(-bm25_scores[pos_idx], k - 1)[:k]
+    top = pos_idx[top_local]
+    weights = bm25_scores[top]
+    total = float(weights.sum())
+    if total <= 0.0:
+        return out
+    out[top] = weights / total
+    return out
+
+
+def apply_broker_attenuation(
+    scores: np.ndarray,
+    store: "MemoryStore",
+    belief_ids: list[str],
+) -> np.ndarray:
+    """Multiply each per-belief authority score by the recipient's
+    broker confidence ``α / (α + β)``.
+
+    ``scores[i]`` corresponds to ``belief_ids[i]``. Beliefs whose
+    ``α + β`` is zero contribute factor 0 (no evidence ⇒ no broker
+    confidence). Missing beliefs contribute factor 1.0 (passthrough)
+    — defensive for index/store skew during a rebuild.
+
+    The store-side ``propagate_valence`` already applies broker
+    attenuation through multi-hop edge traversal. The eigenbasis-
+    based heat kernel folds the multi-hop propagation into the
+    spectral filter, so per-belief broker scaling on the OUTPUT is
+    the right shape — it dampens scores accruing into low-confidence
+    targets without re-walking the graph at query time.
+    """
+    if scores.size == 0:
+        return scores
+    factors = np.ones_like(scores, dtype=np.float64)
+    for i, bid in enumerate(belief_ids):
+        b = store.get_belief(bid)
+        if b is None:
+            continue
+        denom = b.alpha + b.beta
+        factors[i] = (b.alpha / denom) if denom > 0 else 0.0
+    return scores * factors
+
+
+def combine_log_scores(
+    bm25f: float,
+    heat: float,
+    posterior: float | None = None,
+    *,
+    heat_weight: float = DEFAULT_HEAT_KERNEL_WEIGHT,
+    posterior_weight: float = DEFAULT_POSTERIOR_LOG_WEIGHT,
+    heat_floor: float = HEAT_SCORE_FLOOR,
+) -> float:
+    """Combine BM25F, heat-kernel, and posterior scores log-additively.
+
+    Formula (#150 spec § "Score combination"):
+        score = log(BM25F) + heat_weight * log(heat_safe(heat))
+                           + posterior_weight * log(posterior_or_1)
+
+    ``posterior=None`` collapses the third term (``log(1) = 0``),
+    matching the spec's "defaults to 1.0 when no posterior data
+    exists" contract. ``bm25f <= 0`` raises — BM25F is non-negative
+    by construction and a non-positive value is a caller bug worth
+    surfacing rather than silently flooring.
+    """
+    if bm25f <= 0.0:
+        raise ValueError(f"bm25f must be > 0; got {bm25f}")
+    safe_heat = max(heat, heat_floor)
+    safe_post = posterior if (posterior is not None and posterior > 0.0) else 1.0
+    return (
+        float(np.log(bm25f))
+        + heat_weight * float(np.log(safe_heat))
+        + posterior_weight * float(np.log(safe_post))
+    )
+
+
+# --- Eigenbasis cache ---------------------------------------------------
 
 
 @dataclass

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -106,21 +106,13 @@ POSTERIOR_WEIGHT_FLAG: Final[str] = "posterior_weight"
 # via the kwarg, AELFRICE_BM25F=1, or `[retrieval] use_bm25f_anchors = true`.
 BM25F_FLAG: Final[str] = "use_bm25f_anchors"
 
-# v1.5.0 #154 composition-tracker placeholder flags. None of these
-# correspond to wired lanes yet — the components ship across
-# v1.6 / v1.7 (signed Laplacian + heat kernel + posterior-full at
-# v1.6; HRR structural at v1.7). Listed here so:
-#
-#   1. `.aelfrice.toml` keys can be set ahead of the components
-#      shipping without producing "unknown key" warnings.
-#   2. The flag-resolution code path is identical to the live
-#      `use_bm25f_anchors` flag, so wiring a lane in a v1.6+ PR
-#      is a one-line edit at the consumption site.
-#
-# Each placeholder is silently default-OFF. Setting one to True at
-# v1.5.0 is a no-op with a single stderr warning that the lane
-# has not yet shipped — same fail-soft posture as the rest of the
-# config surface.
+# v1.5.0 #154 composition-tracker placeholder flags. The components
+# ship across v1.6 / v1.7. Each was a no-op placeholder at v1.5.0;
+# `HEAT_KERNEL_FLAG` is the first to leave the placeholder set as the
+# heat-kernel scorer (#150) lands here. Listed in `PLACEHOLDER_FLAGS`
+# only while the lane is still unwired — once the wiring lands, the
+# flag is removed from the placeholder tuple so the deprecation
+# warning stops firing for users who set it.
 SIGNED_LAPLACIAN_FLAG: Final[str] = "use_signed_laplacian"
 HEAT_KERNEL_FLAG: Final[str] = "use_heat_kernel"
 POSTERIOR_RANKING_FLAG: Final[str] = "use_posterior_ranking"
@@ -128,7 +120,6 @@ HRR_STRUCTURAL_FLAG: Final[str] = "use_hrr_structural"
 
 PLACEHOLDER_FLAGS: Final[tuple[str, ...]] = (
     SIGNED_LAPLACIAN_FLAG,
-    HEAT_KERNEL_FLAG,
     POSTERIOR_RANKING_FLAG,
     HRR_STRUCTURAL_FLAG,
 )
@@ -147,6 +138,8 @@ ENV_BFS: Final[str] = "AELFRICE_BFS"
 # "fall through" rather than "force off", because the default at
 # v1.5.0 is already off.
 ENV_BM25F: Final[str] = "AELFRICE_BM25F"
+# v1.7.0 heat-kernel env override. Tri-state like ENV_BM25F.
+ENV_HEAT_KERNEL: Final[str] = "AELFRICE_HEAT_KERNEL"
 # v1.3.0 posterior-weight env override. Float-typed; "0.0" is the
 # only value that fully disables (collapsing to BM25-only ordering).
 # Empty / non-numeric values fall through to the next precedence
@@ -246,6 +239,21 @@ def _env_bm25f_override() -> bool | None:
     truthy/falsy value, else None. Symmetric to `_env_bfs_override`.
     """
     raw = os.environ.get(ENV_BM25F)
+    if raw is None:
+        return None
+    norm = raw.strip().lower()
+    if norm in _ENV_FALSY:
+        return False
+    if norm in _ENV_TRUTHY:
+        return True
+    return None
+
+
+def _env_heat_kernel_override() -> bool | None:
+    """Return True/False if AELFRICE_HEAT_KERNEL is set to a recognised
+    truthy/falsy value, else None. Symmetric to `_env_bm25f_override`.
+    """
+    raw = os.environ.get(ENV_HEAT_KERNEL)
     if raw is None:
         return None
     norm = raw.strip().lower()
@@ -563,6 +571,37 @@ def _reset_placeholder_warnings() -> None:
     a test that toggles a placeholder flag and re-invokes the
     warner sees the warning again. Not part of the public API."""
     _PLACEHOLDER_WARNED.clear()
+
+
+def is_heat_kernel_enabled(
+    explicit: bool | None = None,
+    *,
+    start: Path | None = None,
+) -> bool:
+    """Resolve the heat-kernel authority-scoring flag (#150).
+
+    Precedence (first decisive wins):
+      1. AELFRICE_HEAT_KERNEL env var (truthy / falsy normalised).
+      2. Explicit `explicit` kwarg from the caller.
+      3. `[retrieval] use_heat_kernel` in `.aelfrice.toml`.
+      4. Default: False — the lane is implemented but stays opt-in
+         until the composition tracker (#154) flips the default
+         after the real-corpus benchmark gate.
+
+    Reuses the `HEAT_KERNEL_FLAG` constant that #232 introduced as a
+    placeholder. Now that the lane has shipped, the flag is no
+    longer in `PLACEHOLDER_FLAGS` so `warn_placeholder_flags()` will
+    not flag it as unwired.
+    """
+    env = _env_heat_kernel_override()
+    if env is not None:
+        return env
+    if explicit is not None:
+        return explicit
+    toml_value = _read_toml_flag_for(HEAT_KERNEL_FLAG, start)
+    if toml_value is not None:
+        return toml_value
+    return False
 
 
 def is_bfs_enabled(

--- a/tests/test_composition_tracker.py
+++ b/tests/test_composition_tracker.py
@@ -102,12 +102,16 @@ def test_placeholder_flag_set_to_false_no_warning(tmp_path: Path) -> None:
     assert warned == []
 
 
-def test_placeholder_flags_constant_lists_all_v16_v17_lanes() -> None:
-    """The PLACEHOLDER_FLAGS tuple matches the four lanes named in
-    the #154 v1.5 scope comment. Guard against accidental drift."""
+def test_placeholder_flags_constant_lists_unwired_lanes() -> None:
+    """`PLACEHOLDER_FLAGS` contains only the lanes still unwired.
+
+    `use_heat_kernel` was a placeholder at v1.5.0 but the heat-kernel
+    scorer (#150) ships the lane, so the flag exits the placeholder
+    set as soon as the wiring lands. Updating this test in lockstep
+    with that move is the intentional drift guard.
+    """
     assert set(PLACEHOLDER_FLAGS) == {
         "use_signed_laplacian",
-        "use_heat_kernel",
         "use_posterior_ranking",
         "use_hrr_structural",
     }

--- a/tests/test_heat_kernel.py
+++ b/tests/test_heat_kernel.py
@@ -1,0 +1,281 @@
+# pyright: reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownParameterType=false, reportMissingTypeStubs=false, reportConstantRedefinition=false
+"""Tests for the heat-kernel authority scorer (#150).
+
+Acceptance map (#150 § "Acceptance criteria"):
+- AC1: heat_kernel_score matches dense expm reference at t=8, K=200
+- AC2: seeds_from_bm25 returns L1-normalized vector with
+       exactly min(top_k, len) non-zero entries
+- AC3: combine_log_scores implements
+       log(BM25F) + 1.0 * log(heat_safe) + 0.5 * log(posterior_or_1)
+- AC4: broker attenuation produces ≥ 5% reduction at confidence 0.1,
+       ~0% reduction at confidence 0.99
+- AC5: per-query latency ≤ 10 ms at N=50k (perf-gated)
+- AC6: eigenbasis loaded once per process — covered structurally by
+       the existing GraphEigenbasisCache tests
+- AC7: feature-flag default is False (use_heat_kernel)
+"""
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+import scipy.linalg as sla
+import scipy.sparse as sp
+
+from aelfrice.graph_spectral import (
+    DEFAULT_BM25_SEED_TOP_K,
+    DEFAULT_HEAT_BANDWIDTH,
+    HEAT_SCORE_FLOOR,
+    apply_broker_attenuation,
+    build_signed_adjacency,
+    build_signed_normalized_laplacian,
+    combine_log_scores,
+    compute_eigenbasis,
+    heat_kernel_safe,
+    heat_kernel_score,
+    seeds_from_bm25,
+)
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CITES,
+    EDGE_CONTRADICTS,
+    EDGE_RELATES_TO,
+    EDGE_SUPERSEDES,
+    EDGE_SUPPORTS,
+    LOCK_NONE,
+    Belief,
+    Edge,
+)
+from aelfrice.store import MemoryStore
+
+
+def _has_run_perf(request: pytest.FixtureRequest) -> bool:
+    try:
+        return bool(request.config.getoption("--run-perf", default=False))
+    except (AttributeError, ValueError):
+        return False
+
+
+def _mk(bid: str, alpha: float = 1.0, beta: float = 1.0) -> Belief:
+    return Belief(
+        id=bid,
+        content=bid,
+        content_hash=f"h_{bid}",
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-28T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _toy_store(broker_alpha: float = 1.0, broker_beta: float = 1.0) -> MemoryStore:
+    """Same five-node topology as test_graph_spectral; broker per-belief
+    overridable for AC4 attenuation tests."""
+    s = MemoryStore(":memory:")
+    for i in range(1, 6):
+        s.insert_belief(_mk(f"b{i}", alpha=broker_alpha, beta=broker_beta))
+    s.insert_edge(Edge(src="b1", dst="b2", type=EDGE_SUPPORTS, weight=1.0))
+    s.insert_edge(Edge(src="b2", dst="b3", type=EDGE_CITES, weight=1.0))
+    s.insert_edge(Edge(src="b1", dst="b3", type=EDGE_CONTRADICTS, weight=1.0))
+    s.insert_edge(Edge(src="b3", dst="b4", type=EDGE_SUPERSEDES, weight=1.0))
+    s.insert_edge(Edge(src="b4", dst="b5", type=EDGE_RELATES_TO, weight=1.0))
+    return s
+
+
+# --- AC1 -----------------------------------------------------------------
+
+
+def test_heat_kernel_matches_dense_expm() -> None:
+    s = _toy_store()
+    W, ids = build_signed_adjacency(s)
+    L = build_signed_normalized_laplacian(W).toarray()
+
+    # The toy graph has only 5 nodes; compute_eigenbasis with K=200
+    # falls back to dense eigh — perfect for a reference comparison
+    # because we get the FULL spectrum.
+    eigvals, eigvecs = compute_eigenbasis(sp.csr_matrix(L), k=200)
+
+    rng = np.random.default_rng(42)
+    seeds = rng.uniform(size=(len(ids),))
+
+    eigenbasis_result = heat_kernel_score(
+        eigvals, eigvecs, seeds, t=DEFAULT_HEAT_BANDWIDTH,
+    )
+    dense_kernel = sla.expm(-DEFAULT_HEAT_BANDWIDTH * L)
+    reference = dense_kernel @ seeds
+
+    np.testing.assert_allclose(eigenbasis_result, reference, atol=1e-3)
+
+
+def test_heat_kernel_zero_eigenbasis_returns_zeros() -> None:
+    eigvals = np.zeros((0,), dtype=np.float64)
+    eigvecs = np.zeros((0, 0), dtype=np.float64)
+    seeds = np.zeros((0,), dtype=np.float64)
+    out = heat_kernel_score(eigvals, eigvecs, seeds, t=8.0)
+    assert out.shape == (0,)
+
+
+# --- AC2 -----------------------------------------------------------------
+
+
+def test_seeds_from_bm25_l1_normalized_with_top_k_nonzero() -> None:
+    bm25 = np.array([3.0, 0.0, 1.0, 2.0, 0.0, 4.0])
+    seeds = seeds_from_bm25(bm25, top_k=3)
+    assert seeds.shape == (6,)
+    assert np.count_nonzero(seeds) == 3
+    assert pytest.approx(seeds.sum(), abs=1e-12) == 1.0
+    # The three positive top-k entries are 4.0, 3.0, 2.0 → indices 5, 0, 3
+    assert seeds[5] > 0 and seeds[0] > 0 and seeds[3] > 0
+    assert seeds[1] == 0.0 and seeds[2] == 0.0 and seeds[4] == 0.0
+
+
+def test_seeds_from_bm25_top_k_exceeds_positive_count() -> None:
+    bm25 = np.array([1.0, 0.0, 2.0, 0.0])
+    seeds = seeds_from_bm25(bm25, top_k=DEFAULT_BM25_SEED_TOP_K)
+    # Only 2 positive scores; should clamp.
+    assert np.count_nonzero(seeds) == 2
+    assert pytest.approx(seeds.sum(), abs=1e-12) == 1.0
+
+
+def test_seeds_from_bm25_all_zero_returns_zero_vector() -> None:
+    bm25 = np.zeros(5)
+    seeds = seeds_from_bm25(bm25, top_k=25)
+    assert np.all(seeds == 0)
+
+
+# --- AC3 -----------------------------------------------------------------
+
+
+def test_combine_log_scores_log_additive() -> None:
+    bm25 = 2.0
+    heat = 0.5
+    posterior = 0.8
+    expected = (
+        np.log(bm25) + 1.0 * np.log(heat) + 0.5 * np.log(posterior)
+    )
+    got = combine_log_scores(bm25, heat, posterior)
+    assert pytest.approx(got, abs=1e-12) == expected
+
+
+def test_combine_log_scores_no_posterior_defaults_to_one() -> None:
+    bm25 = 2.0
+    heat = 0.5
+    no_post = combine_log_scores(bm25, heat, None)
+    explicit_one = combine_log_scores(bm25, heat, 1.0)
+    assert pytest.approx(no_post, abs=1e-12) == explicit_one
+    # log(1) = 0, so the third term contributes nothing
+    assert pytest.approx(no_post, abs=1e-12) == np.log(bm25) + np.log(heat)
+
+
+def test_combine_log_scores_floors_heat() -> None:
+    # heat below the floor must be clamped before log
+    bm25 = 1.0
+    out = combine_log_scores(bm25, heat=-1.0)
+    expected = np.log(1.0) + np.log(HEAT_SCORE_FLOOR)
+    assert pytest.approx(out, abs=1e-9) == expected
+
+
+def test_combine_log_scores_rejects_nonpositive_bm25() -> None:
+    with pytest.raises(ValueError):
+        combine_log_scores(0.0, 0.5, 0.5)
+
+
+def test_heat_kernel_safe_clamps_below_floor() -> None:
+    scores = np.array([-1.0, 0.0, 1e-15, 0.5, 2.0])
+    out = heat_kernel_safe(scores)
+    assert np.all(out >= HEAT_SCORE_FLOOR)
+    assert out[3] == 0.5
+    assert out[4] == 2.0
+
+
+# --- AC4 -----------------------------------------------------------------
+
+
+def test_broker_attenuation_low_confidence_reduces_score() -> None:
+    # Confidence = α / (α + β). α=0.1, β=0.9 → 0.1
+    s = _toy_store(broker_alpha=0.1, broker_beta=0.9)
+    ids = ["b1", "b2", "b3", "b4", "b5"]
+    raw = np.array([1.0, 1.0, 1.0, 1.0, 1.0])
+    out = apply_broker_attenuation(raw, s, ids)
+    # Each score multiplied by 0.1 — that's a 90% reduction, well past
+    # the 5% threshold the spec requires.
+    assert np.all(out <= raw * 0.95)
+    np.testing.assert_allclose(out, raw * 0.1, atol=1e-12)
+
+
+def test_broker_attenuation_high_confidence_near_zero_reduction() -> None:
+    # α=99, β=1 → broker = 0.99 → ~1% reduction (close to "0 reduction")
+    s = _toy_store(broker_alpha=99.0, broker_beta=1.0)
+    ids = ["b1", "b2", "b3", "b4", "b5"]
+    raw = np.array([1.0, 1.0, 1.0, 1.0, 1.0])
+    out = apply_broker_attenuation(raw, s, ids)
+    np.testing.assert_allclose(out, raw * 0.99, atol=1e-12)
+    # Reduction must be < 5% — distinguishes the "high confidence" arm.
+    assert np.all(out >= raw * 0.95)
+
+
+def test_broker_attenuation_missing_belief_passthrough() -> None:
+    s = _toy_store()
+    raw = np.array([1.0, 1.0])
+    out = apply_broker_attenuation(raw, s, ["does_not_exist", "also_missing"])
+    np.testing.assert_array_equal(out, raw)
+
+
+# --- AC5 (perf-gated) ---------------------------------------------------
+
+
+def test_heat_kernel_latency_at_n_50k_under_10ms(
+    request: pytest.FixtureRequest,
+) -> None:
+    if not _has_run_perf(request):
+        pytest.skip("perf-gated: pass --run-perf to run")
+    n = 50_000
+    k = 200
+    rng = np.random.default_rng(0)
+    eigvals = np.sort(rng.uniform(0.0, 2.0, size=k))
+    eigvecs = rng.standard_normal((n, k)).astype(np.float64)
+    seeds = np.zeros(n, dtype=np.float64)
+    seeds[:25] = 1.0 / 25.0
+
+    # Warm up BLAS / caches
+    _ = heat_kernel_score(eigvals, eigvecs, seeds, t=8.0)
+    t0 = time.perf_counter()
+    _ = heat_kernel_score(eigvals, eigvecs, seeds, t=8.0)
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+    assert elapsed_ms <= 10.0, f"heat_kernel_score took {elapsed_ms:.2f} ms"
+
+
+# --- AC7 -----------------------------------------------------------------
+
+
+def test_use_heat_kernel_default_off() -> None:
+    from aelfrice.retrieval import is_heat_kernel_enabled
+
+    # No env, no kwarg, no toml → default False
+    assert is_heat_kernel_enabled() is False
+
+
+# --- Bandwidth sanity ----------------------------------------------------
+
+
+def test_heat_kernel_bandwidth_smoothing() -> None:
+    # Larger t should spread mass more globally; smaller t localizes.
+    s = _toy_store()
+    W, ids = build_signed_adjacency(s)
+    L = build_signed_normalized_laplacian(W)
+    eigvals, eigvecs = compute_eigenbasis(L, k=200)
+
+    seeds = np.zeros(len(ids), dtype=np.float64)
+    seeds[0] = 1.0  # all mass on b1
+
+    local = heat_kernel_score(eigvals, eigvecs, seeds, t=0.5)
+    smooth = heat_kernel_score(eigvals, eigvecs, seeds, t=20.0)
+
+    # b1 (the seed) keeps a higher fraction of its mass under
+    # localized t than under smoothed t.
+    assert local[0] > smooth[0]


### PR DESCRIPTION
## Summary
- Adds `heat_kernel_score`, `seeds_from_bm25`, `apply_broker_attenuation`, `combine_log_scores` to `graph_spectral.py` — the per-query heat-kernel pass on top of the #149 eigenbasis.
- Two matvecs against the `(N, K)` eigenbasis; no per-call eigendecomp.
- Plumbs the `use_heat_kernel` / `AELFRICE_HEAT_KERNEL` / `[retrieval] heat_kernel_enabled` flag (default-OFF). Ranking integration into `retrieve()` belongs to the composition tracker #154.

Closes #150.

## Acceptance criteria coverage
- AC1: `heat_kernel_score` matches `scipy.linalg.expm` reference at t=8 within 1e-3 — `test_heat_kernel_matches_dense_expm`.
- AC2: `seeds_from_bm25` returns L1-normalized vector with exactly `min(top_k, len)` non-zero entries — three tests.
- AC3: log-product score combination, posterior=None defaults to 1.0, heat clamps at floor, BM25F<=0 raises — four tests.
- AC4: broker attenuation produces ~90% reduction at confidence 0.1 (≥ 5% threshold met) and ~1% at confidence 0.99 — two tests.
- AC5: `--run-perf` gated test for ≤ 10 ms at N=50k.
- AC6: `GraphEigenbasisCache` already provides single-load semantics (covered by existing #149 tests).
- AC7: `is_heat_kernel_enabled()` defaults to `False` — covered by `test_use_heat_kernel_default_off`.

## Test plan
- [x] 16 new heat-kernel tests pass (15 + 1 perf-skip)
- [x] 13 existing graph_spectral tests still green
- [x] Full suite: `1502 passed, 6 skipped` locally

## Out of scope (per #150)
- Andersen-Chung-Lang local push for N>=10^6.
- Polynomial heat-kernel approximation.
- Online bandwidth tuning.
- Full ranking integration into `retrieve()` — that's the #154 composition tracker.