### PR TITLE
fix: extend correction-anchor regex for missed correction/requirement utterances (#225)

### DIFF
--- a/src/aelfrice/correction.py
+++ b/src/aelfrice/correction.py
@@ -1,10 +1,12 @@
 """No-LLM correction detector.
 
 Heuristic detector that identifies user corrections / directives by
-counting signal-class hits across seven categories: imperative-verb
+counting signal-class hits across nine categories: imperative-verb
 start, always/never absolutist language, negation, emphasis, prior
-reference, declarative override, and strong directive. A text counts
-as a correction when at least two distinct signals fire (precision
+reference, declarative override, strong directive, correction anchor
+(supersedes/replaces/the previous/instead/actually), and requirement
+anchor (must not/cannot/fails if/do not/never). A text counts as a
+correction when at least two distinct signals fire (precision
 trade-off: single-signal matches have ~60% precision; the explicit
 two-signal threshold trades recall for precision so the explicit
 correct-this-belief path covers the gap).
@@ -79,6 +81,20 @@ _DIRECTIVE_TERMS: tuple[str, ...] = (
     "hard rule",
 )
 
+# Correction-class anchor: phrases that signal a prior belief is being
+# replaced or overridden.  Anchored at word boundaries, case-insensitive.
+_CORRECTION_ANCHOR_RE: re.Pattern[str] = re.compile(
+    r"\b(?:supersedes?|no longer|the previous|instead|actually)\b",
+    re.IGNORECASE,
+)
+
+# Requirement-class anchor: prohibitive / precondition language that signals
+# a hard rule or constraint being stated.  Case-insensitive, word-boundary safe.
+_REQUIREMENT_ANCHOR_RE: re.Pattern[str] = re.compile(
+    r"\b(?:must not|cannot|fails? if|do not|never)\b",
+    re.IGNORECASE,
+)
+
 CORRECTION_SIGNAL_THRESHOLD: int = 2
 _CONFIDENCE_PER_SIGNAL: float = 0.3
 
@@ -101,11 +117,11 @@ class CorrectionResult:
 
 
 def detect_correction(text: str) -> CorrectionResult:
-    """Score `text` against the seven correction-signal categories.
+    """Score `text` against the nine correction-signal categories.
 
     Categories (in evaluation order, which is also the output order):
         imperative, always_never, negation, emphasis, prior_ref,
-        declarative, directive
+        declarative, directive, correction_anchor, requirement_anchor
 
     Pure function: no I/O, no side effects, deterministic for any input.
     """
@@ -132,6 +148,12 @@ def detect_correction(text: str) -> CorrectionResult:
 
     if any(term in text_lower for term in _DIRECTIVE_TERMS):
         signals.append("directive")
+
+    if _CORRECTION_ANCHOR_RE.search(text_lower):
+        signals.append("correction_anchor")
+
+    if _REQUIREMENT_ANCHOR_RE.search(text_lower):
+        signals.append("requirement_anchor")
 
     is_correction: bool = len(signals) >= CORRECTION_SIGNAL_THRESHOLD
     confidence: float = min(1.0, len(signals) * _CONFIDENCE_PER_SIGNAL)

--- a/tests/test_correction_detector.py
+++ b/tests/test_correction_detector.py
@@ -185,3 +185,144 @@ def test_uppercase_text_fires_same_signals_as_lowercase() -> None:
     upper = detect_correction("ALWAYS RUN TESTS BEFORE PUSHING")
     lower = detect_correction("always run tests before pushing")
     assert upper.signals == lower.signals
+
+
+# --- correction_anchor signal --------------------------------------------
+
+
+def test_correction_anchor_fires_on_supersedes() -> None:
+    r = detect_correction("the previous instruction supersedes the README")
+    assert "correction_anchor" in r.signals
+
+
+def test_correction_anchor_fires_on_no_longer() -> None:
+    r = detect_correction("the old approach is no longer valid")
+    assert "correction_anchor" in r.signals
+
+
+def test_correction_anchor_fires_on_the_previous() -> None:
+    r = detect_correction("the previous decision was incorrect")
+    assert "correction_anchor" in r.signals
+
+
+def test_correction_anchor_fires_on_instead() -> None:
+    r = detect_correction("use pytest instead of unittest")
+    assert "correction_anchor" in r.signals
+
+
+def test_correction_anchor_fires_on_actually() -> None:
+    r = detect_correction("actually the API returns a list not a dict")
+    assert "correction_anchor" in r.signals
+
+
+def test_correction_anchor_fires_case_insensitive() -> None:
+    r = detect_correction("This SUPERSEDES the earlier spec")
+    assert "correction_anchor" in r.signals
+
+
+def test_correction_anchor_does_not_fire_on_unrelated_text() -> None:
+    r = detect_correction("the cat sat on the mat quietly")
+    assert "correction_anchor" not in r.signals
+
+
+def test_correction_anchor_counted_as_distinct_signal_from_imperative() -> None:
+    # "instead" fires correction_anchor; "use" at start fires imperative — distinct.
+    r = detect_correction("use pytest instead of unittest")
+    assert "imperative" in r.signals
+    assert "correction_anchor" in r.signals
+    assert r.signals.count("correction_anchor") == 1
+    assert r.signals.count("imperative") == 1
+
+
+# --- requirement_anchor signal -------------------------------------------
+
+
+def test_requirement_anchor_fires_on_do_not() -> None:
+    r = detect_correction("do not commit secrets")
+    assert "requirement_anchor" in r.signals
+
+
+def test_requirement_anchor_fires_on_never() -> None:
+    r = detect_correction("never push to main without a review")
+    assert "requirement_anchor" in r.signals
+
+
+def test_requirement_anchor_fires_on_must_not() -> None:
+    r = detect_correction("you must not merge without CI passing")
+    assert "requirement_anchor" in r.signals
+
+
+def test_requirement_anchor_fires_on_cannot() -> None:
+    r = detect_correction("the agent cannot modify files outside src/")
+    assert "requirement_anchor" in r.signals
+
+
+def test_requirement_anchor_fires_on_fails_if() -> None:
+    r = detect_correction("the build fails if pyright reports errors")
+    assert "requirement_anchor" in r.signals
+
+
+def test_requirement_anchor_fires_case_insensitive() -> None:
+    r = detect_correction("NEVER push to main")
+    assert "requirement_anchor" in r.signals
+
+
+def test_requirement_anchor_does_not_fire_on_unrelated_text() -> None:
+    r = detect_correction("the cat sat on the mat quietly")
+    assert "requirement_anchor" not in r.signals
+
+
+def test_requirement_anchor_counted_as_distinct_signal_from_always_never() -> None:
+    # "never" fires both always_never (term list) and requirement_anchor (regex) —
+    # they are separate categories and both must appear.
+    r = detect_correction("never push to main")
+    assert "always_never" in r.signals
+    assert "requirement_anchor" in r.signals
+    assert len(set(r.signals)) == len(r.signals)  # no duplicates within a category
+
+
+def test_requirement_anchor_counted_as_distinct_signal_from_negation() -> None:
+    # "do not" fires both negation (term list) and requirement_anchor (regex).
+    r = detect_correction("do not commit secrets")
+    assert "negation" in r.signals
+    assert "requirement_anchor" in r.signals
+
+
+# --- Three categories are distinct signal names --------------------------
+
+
+def test_three_anchor_categories_are_distinct() -> None:
+    # A sentence that fires all three anchor categories plus others must
+    # list each category at most once and never collapse them.
+    r = detect_correction(
+        "the previous rule supersedes the README: do not push to main"
+    )
+    assert "correction_anchor" in r.signals
+    assert "requirement_anchor" in r.signals
+    assert len(r.signals) == len(set(r.signals))
+    assert r.is_correction is True
+
+
+def test_correction_utterance_from_issue_fires_anchor_signal() -> None:
+    # Canonical example from issue #225: correction_anchor fires.
+    r = detect_correction("the previous instruction supersedes the README")
+    assert "correction_anchor" in r.signals
+
+
+def test_correction_utterance_two_signals_is_correction() -> None:
+    # With an additional signal the threshold is crossed.
+    r = detect_correction("the previous rule must supersede the README")
+    assert "correction_anchor" in r.signals
+    assert r.is_correction is True
+
+
+def test_requirement_utterance_do_not_is_detected() -> None:
+    # "do not" triggers negation + requirement_anchor -> 2 signals -> correction.
+    r = detect_correction("do not commit secrets")
+    assert r.is_correction is True
+
+
+def test_requirement_utterance_never_push_is_detected() -> None:
+    # "never" triggers always_never + requirement_anchor -> 2 signals -> correction.
+    r = detect_correction("never push to main")
+    assert r.is_correction is True


### PR DESCRIPTION
## Summary

- Adds `_CORRECTION_ANCHOR_RE` matching `supersedes|no longer|the previous|instead|actually` (word-boundary, case-insensitive) as a new `correction_anchor` signal in `detect_correction`.
- Adds `_REQUIREMENT_ANCHOR_RE` matching `must not|cannot|fails if|do not|never` as a new `requirement_anchor` signal.
- Both are distinct signal categories — they don't collapse into `negation`, `always_never`, or each other. Sentences like "never push to main" now fire three signals (`always_never`, `negation`, `requirement_anchor`), all independently counted toward `CORRECTION_SIGNAL_THRESHOLD`.
- `_IMPERATIVE_RE` is unchanged.

Closes #225.

## Test plan

- [ ] CI staging-gate green.
- [ ] Sentences from the issue (`"the previous instruction supersedes the README"`, `"do not commit secrets"`, `"never push to main"`) now reach the correction/requirement label instead of falling out as `factual`.
- [ ] No precision regression on the existing positive/negative fixtures in `tests/test_correction_detector.py`.

Local: 1606 passed, 5 skipped.