### PR TITLE
feat: install /aelf:* slash commands as part of aelf setup (#208)

### DIFF
--- a/docs/SLASH_COMMANDS.md
+++ b/docs/SLASH_COMMANDS.md
@@ -4,12 +4,7 @@ Fifteen markdown files in `src/aelfrice/slash_commands/`, tracking the v1.2.0 CL
 
 Slash files are not shipped for hidden CLI subcommands (`bench`, `feedback`, `health`, `migrate`, `project-warm`, `regime`, `session-delta`, `stats`, `statusline`, `unsetup`). Those subcommands stay callable from the CLI for scripting, hook entry-points, and back-compat aliases — they're just not surfaced as slashes.
 
-Manual install:
-
-```bash
-mkdir -p ~/.claude/commands/aelf
-cp src/aelfrice/slash_commands/*.md ~/.claude/commands/aelf/
-```
+`aelf setup` installs all slash-command files automatically into `~/.claude/commands/aelf/` and prunes any stale files left behind by renames (e.g. `stats.md` after the v1.2.0 rename to `status.md`). Re-running `aelf setup` after an upgrade is sufficient to keep the set current.
 
 ## Reference
 

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -114,6 +114,7 @@ from aelfrice.setup import (
     SEARCH_TOOL_BASH_SCRIPT_NAME,
     SEARCH_TOOL_SCRIPT_NAME,
     SESSION_START_HOOK_SCRIPT_NAME,
+    SLASH_COMMANDS_DIR_DEFAULT,
     SettingsScope,
     TRANSCRIPT_LOGGER_SCRIPT_NAME,
     clean_dangling_shims,
@@ -124,6 +125,7 @@ from aelfrice.setup import (
     install_search_tool_hook,
     install_pre_compact_hook,
     install_session_start_hook,
+    install_slash_commands,
     install_statusline,
     install_transcript_ingest_hooks,
     install_user_prompt_submit_hook,
@@ -139,6 +141,7 @@ from aelfrice.setup import (
     uninstall_search_tool_hook,
     uninstall_pre_compact_hook,
     uninstall_session_start_hook,
+    uninstall_slash_commands,
     uninstall_statusline,
     uninstall_transcript_ingest_hooks,
     uninstall_user_prompt_submit_hook,
@@ -1294,6 +1297,26 @@ def _cmd_setup(args: argparse.Namespace, out: object) -> int:
                 f"{'y' if stb_rm.removed == 1 else 'ies'} from {stb_rm.path}",
                 file=out,  # type: ignore[arg-type]
             )
+    slash_dest = getattr(args, "slash_commands_dir", None)
+    slash_dest_path = Path(slash_dest) if slash_dest else None
+    sc_result = install_slash_commands(slash_dest_path)
+    if sc_result.written:
+        print(
+            f"installed {len(sc_result.written)} slash command(s) in "
+            f"{sc_result.dest_dir}: {', '.join(sc_result.written)}",
+            file=out,  # type: ignore[arg-type]
+        )
+    if sc_result.pruned:
+        print(
+            f"removed {len(sc_result.pruned)} stale slash command(s) from "
+            f"{sc_result.dest_dir}: {', '.join(sc_result.pruned)}",
+            file=out,  # type: ignore[arg-type]
+        )
+    if not sc_result.written and not sc_result.pruned:
+        print(
+            f"slash commands already up to date in {sc_result.dest_dir}",
+            file=out,  # type: ignore[arg-type]
+        )
     _print_setup_next_step(out)
     _print_setup_jsonl_history_hint(out)
     return 0
@@ -1489,6 +1512,15 @@ def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
                 f"{'y' if stb_result.removed == 1 else 'ies'} from {stb_result.path}",
                 file=out,  # type: ignore[arg-type]
             )
+    slash_dest = getattr(args, "slash_commands_dir", None)
+    slash_dest_path = Path(slash_dest) if slash_dest else None
+    usc_result = uninstall_slash_commands(slash_dest_path)
+    if usc_result.pruned:
+        print(
+            f"removed {len(usc_result.pruned)} slash command(s) from "
+            f"{usc_result.dest_dir}: {', '.join(usc_result.pruned)}",
+            file=out,  # type: ignore[arg-type]
+        )
     return 0
 
 

--- a/src/aelfrice/setup.py
+++ b/src/aelfrice/setup.py
@@ -43,12 +43,13 @@ write to a sibling tempfile and `os.replace` it into place.
 """
 from __future__ import annotations
 
+import importlib.resources
 import json
 import os
 import shutil
 import sys
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final, Literal, cast, overload
 
@@ -56,6 +57,11 @@ SettingsScope = Literal["user", "project"]
 
 USER_SETTINGS_PATH: Final[Path] = Path.home() / ".claude" / "settings.json"
 PROJECT_SETTINGS_RELPATH: Final[Path] = Path(".claude") / "settings.json"
+SLASH_COMMANDS_DIR_DEFAULT: Final[Path] = (
+    Path.home() / ".claude" / "commands" / "aelf"
+)
+_SLASH_COMMANDS_PACKAGE: Final[str] = "aelfrice"
+_SLASH_COMMANDS_SUBDIR: Final[str] = "slash_commands"
 _HOOK_SCRIPT_NAME: Final[str] = "aelf-hook"
 _PRE_COMPACT_HOOK_SCRIPT_NAME: Final[str] = "aelf-pre-compact-hook"
 # Legacy / pre-pipx shim locations we will silently clean up if they
@@ -1058,6 +1064,149 @@ def uninstall_statusline(
         _atomic_write(settings_path, data)
         return StatuslineUninstallResult(path=settings_path, mode="unwrapped")
     return StatuslineUninstallResult(path=settings_path, mode="absent")
+
+
+# --- Slash-commands installer -------------------------------------------
+
+
+def _bundled_slash_files() -> dict[str, str]:
+    """Return a mapping of filename -> text for every bundled slash command.
+
+    Uses importlib.resources so the files are readable whether the package
+    is installed as a wheel (zip), an editable install, or a plain source
+    tree.  The source of truth is the filesystem under
+    `src/aelfrice/slash_commands/`; hatchling ships those files verbatim
+    in the wheel.
+    """
+    pkg = importlib.resources.files(_SLASH_COMMANDS_PACKAGE).joinpath(
+        _SLASH_COMMANDS_SUBDIR
+    )
+    result: dict[str, str] = {}
+    for entry in pkg.iterdir():
+        name = entry.name
+        if not name.endswith(".md"):
+            continue
+        text = entry.read_text(encoding="utf-8")
+        result[name] = text
+    return result
+
+
+@dataclass(frozen=True)
+class SlashCommandsResult:
+    """Outcome of `install_slash_commands` or `uninstall_slash_commands`.
+
+    `dest_dir` is the directory that was inspected/written.
+    `written` lists files that were created or overwritten.
+    `already` lists files that were already present and identical (no-op).
+    `pruned` lists files that were removed because they are not in the
+    canonical bundle (orphan cleanup).
+    """
+    dest_dir: Path
+    written: tuple[str, ...]
+    already: tuple[str, ...]
+    pruned: tuple[str, ...]
+
+
+def install_slash_commands(
+    dest_dir: Path | None = None,
+) -> SlashCommandsResult:
+    """Write all bundled /aelf:* slash-command files into `dest_dir`.
+
+    Default `dest_dir` is `~/.claude/commands/aelf/`.
+
+    Idempotency: if a file on disk already matches the bundled content
+    byte-for-byte, it is left alone and reported under `already`.  Any
+    `.md` file in `dest_dir` that is NOT in the canonical bundle is
+    removed (orphan pruning — handles renames such as `stats.md` ->
+    `status.md`).
+
+    Atomicity: each file is written to a sibling `.tmp` file and then
+    `os.replace`d into place, matching the settings-json write pattern.
+    """
+    target = dest_dir if dest_dir is not None else SLASH_COMMANDS_DIR_DEFAULT
+    bundle = _bundled_slash_files()
+
+    written: list[str] = []
+    already: list[str] = []
+    pruned: list[str] = []
+
+    target.mkdir(parents=True, exist_ok=True)
+
+    # Write (or skip) bundled files.
+    for name, text in sorted(bundle.items()):
+        dest_file = target / name
+        if dest_file.exists():
+            existing = dest_file.read_text(encoding="utf-8")
+            if existing == text:
+                already.append(name)
+                continue
+        # Atomic write: temp + replace.
+        encoded = text.encode("utf-8")
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=name + ".", suffix=".tmp", dir=str(target)
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(encoded)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, dest_file)
+        except Exception:
+            if tmp_path.exists():
+                tmp_path.unlink()
+            raise
+        written.append(name)
+
+    # Prune orphans: .md files present in dest_dir but not in the bundle.
+    for md in sorted(target.glob("*.md")):
+        if md.name not in bundle:
+            try:
+                md.unlink()
+            except OSError:
+                pass
+            else:
+                pruned.append(md.name)
+
+    return SlashCommandsResult(
+        dest_dir=target,
+        written=tuple(written),
+        already=tuple(already),
+        pruned=tuple(pruned),
+    )
+
+
+def uninstall_slash_commands(
+    dest_dir: Path | None = None,
+) -> SlashCommandsResult:
+    """Remove all bundled /aelf:* slash-command files from `dest_dir`.
+
+    Only removes files whose names match the canonical bundle; user files
+    with other names are left alone.  Returns `pruned` listing every file
+    that was deleted.  `written` and `already` are always empty.
+    """
+    target = dest_dir if dest_dir is not None else SLASH_COMMANDS_DIR_DEFAULT
+    bundle = _bundled_slash_files()
+
+    pruned: list[str] = []
+
+    if target.is_dir():
+        for name in sorted(bundle):
+            f = target / name
+            if f.exists():
+                try:
+                    f.unlink()
+                except OSError:
+                    pass
+                else:
+                    pruned.append(name)
+
+    return SlashCommandsResult(
+        dest_dir=target,
+        written=(),
+        already=(),
+        pruned=tuple(pruned),
+    )
 
 
 # --- internal helpers ---------------------------------------------------

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -3,6 +3,10 @@
 Tests drive `cli.main(argv=...)` end-to-end against a tmp settings.json
 chosen via `--scope project --project-root <tmp_path>` so no real
 ~/.claude/settings.json is ever touched.
+
+Also covers install_slash_commands / uninstall_slash_commands (unit) and
+the end-to-end path where `aelf setup` populates a tmp slash dir and
+`aelf doctor` reports no orphan slash commands.
 """
 from __future__ import annotations
 
@@ -14,7 +18,14 @@ from typing import cast
 import pytest
 
 from aelfrice.cli import DEFAULT_HOOK_COMMAND, main
-from aelfrice.setup import resolve_hook_command
+from aelfrice.doctor import SLASH_COMMANDS_DIR_DEFAULT as DOCTOR_SLASH_DIR
+from aelfrice.setup import (
+    install_slash_commands,
+    uninstall_slash_commands,
+    resolve_hook_command,
+    SLASH_COMMANDS_DIR_DEFAULT,
+)
+from test_slash_commands import EXPECTED_COMMANDS
 
 
 @pytest.fixture(autouse=True)
@@ -170,3 +181,173 @@ def test_user_scope_writes_into_monkeypatched_user_path(
     assert fake_user_settings.exists()
     expected = resolve_hook_command("user")
     assert _hook_commands(fake_user_settings) == [expected]
+
+
+# ---------------------------------------------------------------------------
+# install_slash_commands / uninstall_slash_commands unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_install_slash_commands_writes_all_bundled_files(
+    tmp_path: Path,
+) -> None:
+    """All bundled slash files end up in dest_dir."""
+    dest = tmp_path / "slash"
+    result = install_slash_commands(dest)
+    assert result.dest_dir == dest
+    assert dest.is_dir()
+    written_names = set(result.written)
+    expected_names = {f"{cmd}.md" for cmd in EXPECTED_COMMANDS}
+    assert expected_names == written_names, (
+        f"written={sorted(written_names)} expected={sorted(expected_names)}"
+    )
+    assert result.already == ()
+    assert result.pruned == ()
+    # Files are on disk.
+    for name in expected_names:
+        assert (dest / name).exists()
+
+
+def test_install_slash_commands_idempotent(tmp_path: Path) -> None:
+    """Second install with identical content produces no writes."""
+    dest = tmp_path / "slash"
+    install_slash_commands(dest)
+    result2 = install_slash_commands(dest)
+    assert result2.written == ()
+    assert result2.pruned == ()
+    assert set(result2.already) == {f"{cmd}.md" for cmd in EXPECTED_COMMANDS}
+
+
+def test_install_slash_commands_prunes_orphans(tmp_path: Path) -> None:
+    """Stale .md files not in the bundle are removed."""
+    dest = tmp_path / "slash"
+    dest.mkdir(parents=True)
+    stale = dest / "stats.md"
+    stale.write_text("old content", encoding="utf-8")
+    result = install_slash_commands(dest)
+    assert "stats.md" in result.pruned
+    assert not stale.exists()
+
+
+def test_install_slash_commands_updates_changed_file(tmp_path: Path) -> None:
+    """A file whose content differs from the bundle is overwritten."""
+    dest = tmp_path / "slash"
+    dest.mkdir(parents=True)
+    target = dest / "setup.md"
+    target.write_text("stale content", encoding="utf-8")
+    result = install_slash_commands(dest)
+    assert "setup.md" in result.written
+    # Content now matches bundle.
+    from aelfrice.setup import _bundled_slash_files
+    bundle = _bundled_slash_files()
+    assert target.read_text(encoding="utf-8") == bundle["setup.md"]
+
+
+def test_uninstall_slash_commands_removes_bundle(tmp_path: Path) -> None:
+    """uninstall_slash_commands removes all installed files."""
+    dest = tmp_path / "slash"
+    install_slash_commands(dest)
+    result = uninstall_slash_commands(dest)
+    expected_names = {f"{cmd}.md" for cmd in EXPECTED_COMMANDS}
+    assert set(result.pruned) == expected_names
+    for name in expected_names:
+        assert not (dest / name).exists()
+    assert result.written == ()
+    assert result.already == ()
+
+
+def test_uninstall_slash_commands_noop_when_missing(tmp_path: Path) -> None:
+    """uninstall_slash_commands is a no-op when the dir does not exist."""
+    dest = tmp_path / "nonexistent"
+    result = uninstall_slash_commands(dest)
+    assert result.pruned == ()
+
+
+def test_uninstall_slash_commands_only_removes_bundle_files(
+    tmp_path: Path,
+) -> None:
+    """uninstall_slash_commands removes only bundle files, not arbitrary .md files."""
+    dest = tmp_path / "slash"
+    dest.mkdir(parents=True)
+    # Plant a non-bundle file directly (bypass install so it isn't pruned).
+    user_file = dest / "my-custom.md"
+    user_file.write_text("user content", encoding="utf-8")
+    # Manually write one bundle file to confirm only that gets removed.
+    bundle_file = dest / "setup.md"
+    bundle_file.write_text("some content", encoding="utf-8")
+    result = uninstall_slash_commands(dest)
+    assert "setup.md" in result.pruned
+    assert not bundle_file.exists()
+    # The non-bundle file is untouched.
+    assert user_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: aelf setup populates slash dir; doctor orphan check is green
+# ---------------------------------------------------------------------------
+
+
+def test_setup_cli_installs_slash_commands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """aelf setup writes slash files and outputs a confirmation line."""
+    slash_dir = tmp_path / "slash"
+    import aelfrice.setup as setup_mod
+    import aelfrice.cli as cli_mod
+
+    monkeypatch.setattr(setup_mod, "SLASH_COMMANDS_DIR_DEFAULT", slash_dir)
+    monkeypatch.setattr(cli_mod, "SLASH_COMMANDS_DIR_DEFAULT", slash_dir)
+    code, output = _run(
+        "setup", "--scope", "project", "--project-root", str(tmp_path)
+    )
+    assert code == 0
+    assert slash_dir.is_dir()
+    expected_names = {f"{cmd}.md" for cmd in EXPECTED_COMMANDS}
+    on_disk = {p.name for p in slash_dir.glob("*.md")}
+    assert expected_names == on_disk
+    assert "slash command" in output
+
+
+def test_setup_cli_idempotent_slash_commands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Running aelf setup twice reports commands as already up to date."""
+    slash_dir = tmp_path / "slash"
+    import aelfrice.setup as setup_mod
+    import aelfrice.cli as cli_mod
+
+    monkeypatch.setattr(setup_mod, "SLASH_COMMANDS_DIR_DEFAULT", slash_dir)
+    monkeypatch.setattr(cli_mod, "SLASH_COMMANDS_DIR_DEFAULT", slash_dir)
+    _run("setup", "--scope", "project", "--project-root", str(tmp_path))
+    code, output = _run(
+        "setup", "--scope", "project", "--project-root", str(tmp_path)
+    )
+    assert code == 0
+    assert "already up to date" in output
+
+
+def test_doctor_orphan_check_green_after_setup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After aelf setup the doctor orphan_slash_commands check is empty."""
+    slash_dir = tmp_path / "slash"
+    import aelfrice.setup as setup_mod
+    import aelfrice.cli as cli_mod
+    import aelfrice.doctor as doctor_mod
+
+    monkeypatch.setattr(setup_mod, "SLASH_COMMANDS_DIR_DEFAULT", slash_dir)
+    monkeypatch.setattr(cli_mod, "SLASH_COMMANDS_DIR_DEFAULT", slash_dir)
+    monkeypatch.setattr(doctor_mod, "SLASH_COMMANDS_DIR_DEFAULT", slash_dir)
+
+    _run("setup", "--scope", "project", "--project-root", str(tmp_path))
+
+    from aelfrice.cli import _known_cli_subcommands
+    from aelfrice.doctor import diagnose
+
+    report = diagnose(
+        slash_commands_dir=slash_dir,
+        known_cli_subcommands=_known_cli_subcommands(),
+    )
+    assert report.orphan_slash_commands == [], (
+        f"unexpected orphans: {report.orphan_slash_commands}"
+    )


### PR DESCRIPTION
## Summary

- `aelf setup` now calls `install_slash_commands` automatically: writes all 15 bundled `.md` files to `~/.claude/commands/aelf/` and prunes any `.md` there that isn't in the canonical bundle. Handles upgrade renames (e.g. `stats.md` → `status.md`) without a separate manual step.
- Re-running `aelf setup` is idempotent: byte-identical files are skipped, changed files are overwritten atomically (temp file + `os.replace`).
- `aelf unsetup` removes the bundle files via the new `uninstall_slash_commands` counterpart.
- Bundled files are accessed via `importlib.resources` — hatchling already ships them in the wheel, no `pyproject.toml` changes required.
- `docs/SLASH_COMMANDS.md` updated to drop the manual `cp` step.

Closes #208.

## Test plan

- [ ] CI staging-gate green.
- [ ] Fresh `pip install aelfrice && aelf setup` → working `/aelf:*` commands with no manual cp.
- [ ] Re-run `aelf setup` after a slash-rename release → orphans pruned, new files added.
- [ ] `aelf doctor` `orphan_slash_commands` check stays green after `aelf setup`.

Local: 1512 passed, 5 skipped (10 new tests).