### PR TITLE
fix(classification): drop USER_SOURCE gate on requirement / correction (#226)

### DIFF
--- a/src/aelfrice/classification.py
+++ b/src/aelfrice/classification.py
@@ -210,11 +210,17 @@ def classify_sentence(text: str, source: str) -> ClassificationResult:
             pending_classification=True,
         )
 
-    # 3. User-sourced requirement (must, mandatory, hard rule, ...)
-    #    Document text uses the same keywords descriptively; restrict
-    #    requirement classification to user sources to reduce false
-    #    positives during onboarding scans.
-    if source == USER_SOURCE and _has_any(text_lower, _REQUIREMENT_KEYWORDS):
+    # 3. Requirement keywords (must, mandatory, hard rule, ...)
+    #    Originally gated on `source == USER_SOURCE` to suppress
+    #    document-text false positives. Per #226: that gate caused
+    #    every onboard-extracted requirement (source = `doc:…`,
+    #    `ast:…`, `git:…`) to mis-classify, producing zero
+    #    requirement counts on the labeled corpus. The
+    #    source-prior-deflation in `get_source_adjusted_prior`
+    #    already lowers alpha for non-user sources, so the
+    #    false-positive risk is handled at the scoring layer
+    #    rather than by gating classification.
+    if _has_any(text_lower, _REQUIREMENT_KEYWORDS):
         alpha, beta = get_source_adjusted_prior(BELIEF_REQUIREMENT, source)
         return ClassificationResult(
             belief_type=BELIEF_REQUIREMENT,
@@ -224,18 +230,20 @@ def classify_sentence(text: str, source: str) -> ClassificationResult:
             pending_classification=True,
         )
 
-    # 4. User-sourced correction (per the no-LLM detector).
-    if source == USER_SOURCE:
-        cresult = detect_correction(text)
-        if cresult.is_correction:
-            alpha, beta = get_source_adjusted_prior(BELIEF_CORRECTION, source)
-            return ClassificationResult(
-                belief_type=BELIEF_CORRECTION,
-                alpha=alpha,
-                beta=beta,
-                persist=True,
-                pending_classification=True,
-            )
+    # 4. Correction (per the no-LLM detector). Same #226 reasoning
+    #    — the user-only gate suppressed onboard-extracted
+    #    corrections; deflated alpha at non-user sources handles
+    #    the false-positive concern.
+    cresult = detect_correction(text)
+    if cresult.is_correction:
+        alpha, beta = get_source_adjusted_prior(BELIEF_CORRECTION, source)
+        return ClassificationResult(
+            belief_type=BELIEF_CORRECTION,
+            alpha=alpha,
+            beta=beta,
+            persist=True,
+            pending_classification=True,
+        )
 
     # 5. Preference keywords (any source).
     if _has_any(text_lower, _PREFERENCE_KEYWORDS):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -124,7 +124,7 @@ def test_what_in_middle_of_sentence_is_not_a_question() -> None:
     assert r.persist is True
 
 
-# --- Requirement classification (user source only) -----------------------
+# --- Requirement classification (any source; deflated for non-user) -----
 
 
 def test_user_must_keyword_classifies_requirement() -> None:
@@ -137,11 +137,18 @@ def test_user_mandatory_classifies_requirement() -> None:
     assert r.belief_type == BELIEF_REQUIREMENT
 
 
-def test_non_user_must_does_not_classify_requirement() -> None:
-    """Document text uses 'must' descriptively. Restrict requirement
-    classification to user-sourced content."""
+def test_non_user_must_classifies_requirement_with_deflated_prior() -> None:
+    """#226 fix: doc/ast/git-sourced requirement keywords classify as
+    BELIEF_REQUIREMENT (not factual). False-positive risk is handled by
+    the source-prior deflation lowering alpha, not by suppressing
+    classification entirely. Pre-fix the scanner produced zero
+    requirement counts because every onboard candidate carried a
+    non-user source."""
     r = classify_sentence("you must restart the daemon", "doc")
-    assert r.belief_type != BELIEF_REQUIREMENT
+    assert r.belief_type == BELIEF_REQUIREMENT
+    # Deflation kicks in: alpha < user-source alpha
+    user_r = classify_sentence("you must restart the daemon", "user")
+    assert r.alpha < user_r.alpha
 
 
 def test_requirement_uses_high_alpha_prior_for_user() -> None:
@@ -149,7 +156,7 @@ def test_requirement_uses_high_alpha_prior_for_user() -> None:
     assert r.alpha == TYPE_PRIORS[BELIEF_REQUIREMENT][0]
 
 
-# --- Correction classification (user source only) ------------------------
+# --- Correction classification (any source; deflated for non-user) ------
 
 
 def test_user_correction_phrasing_classifies_correction() -> None:
@@ -157,11 +164,15 @@ def test_user_correction_phrasing_classifies_correction() -> None:
     assert r.belief_type == BELIEF_CORRECTION
 
 
-def test_non_user_correction_phrasing_does_not_classify_correction() -> None:
-    """Document scans contain correction-shaped phrasings without being
-    actual user corrections; the detector is restricted to user sources."""
+def test_non_user_correction_phrasing_classifies_correction_with_deflated_prior() -> None:
+    """#226 fix: doc-sourced correction phrasings classify as
+    BELIEF_CORRECTION. The deflated prior at non-user sources handles
+    the false-positive risk that the previous user-only gate was trying
+    to address."""
     r = classify_sentence("we discussed this; do not amend commits", "doc")
-    assert r.belief_type != BELIEF_CORRECTION
+    assert r.belief_type == BELIEF_CORRECTION
+    user_r = classify_sentence("we discussed this; do not amend commits", "user")
+    assert r.alpha < user_r.alpha
 
 
 # --- Preference classification (any source) ------------------------------


### PR DESCRIPTION
## Summary
The v1.2 onboard pipeline never emitted `BELIEF_REQUIREMENT` or `BELIEF_CORRECTION` because `classify_sentence` gated both branches on `source == USER_SOURCE`. Scanner extraction emits sources like `git:commit:<sha>`, `ast:<file>:func:<name>`, `doc:<file>:p<idx>` — none of them `"user"`, so every onboard-extracted requirement/correction candidate fell through to the factual default.

This is the code-path miss called out in the issue's "Acceptance" section.

## Fix
Lift the gate. The false-positive risk it was meant to suppress is already handled by `get_source_adjusted_prior` deflating alpha for non-user sources — same pattern preference classification has used since v1.0.

Closes #226.

## Test plan
- [x] `tests/test_classification.py` — 32 tests, including two updated assertions that now pin the corrected behaviour plus the alpha-deflation invariant.
- [x] Full suite: `1569 passed, 5 skipped`.