### PR TITLE
fix: upgrade UX — banner SSoT, importlib.metadata version, install-method routing

### DIFF
--- a/src/aelfrice/__init__.py
+++ b/src/aelfrice/__init__.py
@@ -1,2 +1,6 @@
 """aelfrice: Bayesian memory designed for feedback-driven learning."""
-__version__ = "1.2.0"
+try:
+    from importlib.metadata import version as _meta_version, PackageNotFoundError
+    __version__ = _meta_version("aelfrice")
+except Exception:
+    __version__ = "0.0.0"

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -96,6 +96,7 @@ from aelfrice.lifecycle import (
     UpdateStatus,
     check_for_update,
     clear_cache as _clear_update_cache,
+    format_update_banner as _format_update_banner,
     is_disabled as _update_check_disabled,
     is_newer,
     maybe_check_for_update_async,
@@ -1702,6 +1703,14 @@ def _cmd_statusline(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+_UPGRADE_CONTEXT_NOTE: dict[str, str] = {
+    "uv_tool": "installed via uv tool — use uv to upgrade",
+    "pipx": "installed via pipx — use pipx to upgrade",
+    "venv": "running inside a virtual environment — use pip to upgrade",
+    "system": "system / user install — use pip to upgrade",
+}
+
+
 def _cmd_upgrade(args: argparse.Namespace, out: object) -> int:
     """Print the right upgrade command for this install context.
 
@@ -1740,6 +1749,12 @@ def _cmd_upgrade(args: argparse.Namespace, out: object) -> int:
                 file=out,  # type: ignore[arg-type]
             )
         if not args.check:
+            note = _UPGRADE_CONTEXT_NOTE.get(advice.context, "")
+            if note:
+                print(
+                    f"({note})",
+                    file=out,  # type: ignore[arg-type]
+                )
             print(
                 f"run: {advice.command}",
                 file=out,  # type: ignore[arg-type]
@@ -2795,8 +2810,7 @@ def _maybe_emit_update_banner(cmd: str | None) -> None:
     if not status.update_available:
         return
     print(
-        f"\x1b[38;5;208m⬆ aelfrice {status.latest} available, "
-        f"run: aelf upgrade\x1b[0m",
+        f"\x1b[38;5;208m{_format_update_banner(status.latest)}\x1b[0m",
         file=sys.stderr,
     )
 

--- a/src/aelfrice/lifecycle.py
+++ b/src/aelfrice/lifecycle.py
@@ -88,15 +88,17 @@ def is_newer(a: str, b: str) -> bool:
 
 
 def installed_version() -> str:
-    """Resolve the installed aelfrice version.
+    """Resolve the installed aelfrice version from package metadata.
 
-    Reads aelfrice.__version__ which is the source of truth. Falls back
-    to '0.0.0' if the import is unexpectedly broken (defensive only).
+    Uses importlib.metadata so the returned version always matches the
+    installed wheel, even after an in-place upgrade that leaves the
+    source tree's __version__ constant stale. Falls back to '0.0.0'
+    when the package is not found (e.g. during unit tests run against
+    an editable install that hasn't been built yet).
     """
     try:
-        from aelfrice import __version__
-
-        return str(__version__)
+        from importlib.metadata import version, PackageNotFoundError
+        return version(PACKAGE_NAME)
     except Exception:
         return "0.0.0"
 
@@ -284,6 +286,21 @@ def maybe_check_for_update_async(
         return False
 
 
+# --- Banner helper -------------------------------------------------------
+
+
+def format_update_banner(latest: str) -> str:
+    """Return the plain (no ANSI) body text for an update-available banner.
+
+    Single source of truth for the banner format. Both the statusline
+    snippet and the CLI stderr notice derive their text from this
+    function so the wording never drifts between the two surfaces.
+
+    Example: '⬆ /aelf:upgrade to v1.5.0'
+    """
+    return f"⬆ /aelf:upgrade to v{latest}"
+
+
 # --- Upgrade advice -----------------------------------------------------
 
 
@@ -292,22 +309,55 @@ class UpgradeAdvice:
     """How to upgrade aelfrice in the user's specific install context."""
 
     command: str
-    context: str  # 'venv' | 'pipx' | 'system' | 'unknown'
+    context: str  # 'uv_tool' | 'pipx' | 'venv' | 'system'
+
+
+def _is_uv_tool_install() -> bool:
+    """Detect a uv-tool-managed install.
+
+    uv tool installs each package under ~/.local/share/uv/tools/<pkg>/.
+    We check for the package directory directly rather than shelling
+    out to `uv` (which may not be on PATH inside the managed env).
+    As a secondary signal, if sys.executable or sys.prefix resolves
+    under the uv tools directory we also consider it a uv-tool install.
+    """
+    uv_tools_dir = Path.home() / ".local" / "share" / "uv" / "tools" / PACKAGE_NAME
+    if uv_tools_dir.exists():
+        return True
+    # Secondary: check if sys.prefix or sys.executable path contains the
+    # uv tools tree. Covers cases where the package dir name differs.
+    import sys
+    prefix_norm = sys.prefix.replace("\\", "/")
+    # ~/.local/share/uv/tools/ is the canonical uv tools root on
+    # Linux/macOS. On Windows it is %APPDATA%\uv\tools\ but we only
+    # support the POSIX layout for now.
+    uv_tools_root = str(Path.home() / ".local" / "share" / "uv" / "tools")
+    return prefix_norm.startswith(uv_tools_root.replace("\\", "/"))
 
 
 def _is_pipx_install() -> bool:
-    """Detect a pipx-managed install by checking sys.prefix path.
+    """Detect a pipx-managed install.
 
-    pipx installs each package into ~/.local/pipx/venvs/<pkg>/ -- the
-    presence of '/pipx/venvs/' in sys.prefix is the canonical signal.
+    pipx installs each package into ~/.local/pipx/venvs/<pkg>/ and
+    sys.prefix will be rooted there. We check both sys.prefix (fast,
+    no FS access) and the venv directory directly (handles edge cases
+    where sys.prefix normalisation differs on some platforms).
+
+    We do NOT shell out to `pipx list` -- it's slow and may not be
+    installed in the running environment.
     """
     import sys
 
-    return "/pipx/venvs/" in sys.prefix.replace("\\", "/")
+    prefix_norm = sys.prefix.replace("\\", "/")
+    if "/pipx/venvs/" in prefix_norm:
+        return True
+    # Filesystem check: covers users whose sys.prefix is symlinked.
+    pipx_venv_dir = Path.home() / ".local" / "pipx" / "venvs" / PACKAGE_NAME
+    return pipx_venv_dir.exists()
 
 
 def _is_venv() -> bool:
-    """Detect a generic venv (PEP 405 / virtualenv).
+    """Detect a generic venv (PEP 405 / virtualenv / uv venv).
 
     sys.prefix != sys.base_prefix is the standard idiom; works for
     venv, virtualenv, uv venv, and conda envs.
@@ -318,11 +368,22 @@ def _is_venv() -> bool:
 
 
 def upgrade_advice() -> UpgradeAdvice:
-    """Return the right pip-upgrade incantation for the running env.
+    """Return the correct upgrade command for the running install context.
 
-    pipx checked before generic venv because a pipx install IS a venv,
-    but its upgrade path is different (pipx upgrade, not pip install).
+    Detection order matters: uv-tool and pipx are both virtualenvs, so
+    they must be identified before the generic venv check.
+
+    Contexts and their upgrade commands:
+      uv_tool  — uv tool upgrade aelfrice
+      pipx     — pipx upgrade aelfrice
+      venv     — pip install --upgrade aelfrice  (active venv's pip)
+      system   — pip install --user --upgrade aelfrice
     """
+    if _is_uv_tool_install():
+        return UpgradeAdvice(
+            command=f"uv tool upgrade {PACKAGE_NAME}",
+            context="uv_tool",
+        )
     if _is_pipx_install():
         return UpgradeAdvice(
             command=f"pipx upgrade {PACKAGE_NAME}",

--- a/src/aelfrice/slash_commands/upgrade.md
+++ b/src/aelfrice/slash_commands/upgrade.md
@@ -1,18 +1,18 @@
 ---
 name: aelf:upgrade
-description: Print the right pip-upgrade command for this aelfrice install context.
+description: Print the right upgrade command for this aelfrice install context.
 allowed-tools:
   - Bash
 ---
 <objective>
-Tell the user how to upgrade aelfrice. Detects venv vs pipx vs system
-install and prints the matching command. Does NOT execute the upgrade
-itself: replacing the running package mid-process is unreliable on
-Windows and can leave a broken interpreter. The user runs the line.
+Tell the user how to upgrade aelfrice. Detects the install method
+(uv tool / pipx / venv / system pip) and prints the matching command.
+Does NOT execute the upgrade itself: replacing the running package
+mid-process is unreliable on Windows and can leave a broken interpreter.
+The user runs the printed line.
 
 If an update is available, also surfaces the published wheel SHA-256
-and PyPI release URL so the user can hash-pin the install if they
-want.
+and PyPI release URL so the user can hash-pin the install if they want.
 </objective>
 
 <process>

--- a/src/aelfrice/statusline.py
+++ b/src/aelfrice/statusline.py
@@ -19,7 +19,13 @@ from __future__ import annotations
 import os
 from typing import Final
 
-from aelfrice.lifecycle import UpdateStatus, installed_version, is_newer, read_cache
+from aelfrice.lifecycle import (
+    UpdateStatus,
+    format_update_banner,
+    installed_version,
+    is_newer,
+    read_cache,
+)
 
 # CSS orange #FFA500 in truecolor, 256-color 208 (#FF8700), basic 33.
 ANSI_RESET: Final[str] = "\x1b[0m"
@@ -81,10 +87,7 @@ def format_snippet(
         return ""
     color_on = _pick_color(env)
     color_off = ANSI_RESET if color_on else ""
-    body = (
-        f"{ICON} aelfrice {status.latest} available, "
-        f"run: aelf upgrade"
-    )
+    body = format_update_banner(status.latest)
     return f"{color_on}{body}{color_off}{SEPARATOR}"
 
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -203,10 +203,9 @@ def test_wheel_sha256_returns_none_when_empty() -> None:
 
 
 def test_upgrade_advice_in_venv() -> None:
-    # The test runner itself is in a venv, so this should always be 'venv'
-    # unless we're somehow running in pipx (uncommon in CI).
+    # The test runner is in some kind of managed environment.
     advice = lifecycle.upgrade_advice()
-    assert advice.context in {"venv", "pipx", "system"}
+    assert advice.context in {"uv_tool", "venv", "pipx", "system"}
     assert "aelfrice" in advice.command
 
 

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -52,7 +52,7 @@ def test_no_color_strips_ansi() -> None:
         _fresh(), env={"NO_COLOR": "", "COLORTERM": "truecolor"}
     )
     assert "\x1b[" not in out
-    assert "aelfrice 1.2.3 available" in out
+    assert "/aelf:upgrade to v1.2.3" in out
 
 
 def test_no_color_set_to_anything_strips_ansi() -> None:
@@ -67,7 +67,7 @@ def test_snippet_includes_upgrade_command() -> None:
     out = statusline.format_snippet(
         _fresh(), env={"COLORTERM": "truecolor"}
     )
-    assert "run: aelf upgrade" in out
+    assert "/aelf:upgrade to v" in out
     assert statusline.ICON in out
 
 

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -8,6 +8,16 @@ import pytest
 from aelfrice import lifecycle, statusline
 
 
+@pytest.fixture(autouse=True)
+def _pin_installed_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin installed_version() to a low value so format_snippet's
+    self-suppression (added by the stale-banner fix) does not gate
+    every snippet test on the running package version."""
+    monkeypatch.setattr(
+        statusline, "installed_version", lambda: "0.0.0"
+    )
+
+
 def _fresh(latest: str = "1.2.3", available: bool = True) -> lifecycle.UpdateStatus:
     return lifecycle.UpdateStatus(
         update_available=available,

--- a/tests/test_upgrade_ux.py
+++ b/tests/test_upgrade_ux.py
@@ -65,7 +65,9 @@ def test_statusline_snippet_uses_banner_helper() -> None:
         checked=0.0,
         sha256=None,
     )
-    snippet = statusline.format_snippet(status, env={})
+    # Pass installed="" so the snippet is not suppressed by the running
+    # package version (which is >= status.latest in this worktree).
+    snippet = statusline.format_snippet(status, env={}, installed="")
     expected_body = lifecycle.format_update_banner("1.5.0")
     assert expected_body in snippet
 
@@ -87,8 +89,9 @@ def test_banner_shared_substring_in_statusline_and_cli(
         checked=0.0,
         sha256=None,
     )
-    # Statusline path.
-    snippet = statusline.format_snippet(status, env={})
+    # Statusline path. Pass installed="" so the running package version
+    # does not auto-suppress the snippet.
+    snippet = statusline.format_snippet(status, env={}, installed="")
     assert "/aelf:upgrade to v" in snippet
 
     # CLI stderr banner path — monkeypatch the cache reader.

--- a/tests/test_upgrade_ux.py
+++ b/tests/test_upgrade_ux.py
@@ -1,0 +1,233 @@
+"""Tests for issue #242: upgrade UX — banner format, version source-of-truth,
+install-method detection.
+
+All tests are hermetic: filesystem, sys.prefix, and importlib.metadata are
+monkeypatched so no real install state bleeds in.
+"""
+from __future__ import annotations
+
+import sys
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+
+import pytest
+
+from aelfrice import lifecycle, statusline
+
+
+# ---------------------------------------------------------------------------
+# installed_version — importlib.metadata path
+# ---------------------------------------------------------------------------
+
+
+def test_installed_version_reads_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """installed_version() returns the value from importlib.metadata."""
+    import importlib.metadata as _meta
+
+    monkeypatch.setattr(_meta, "version", lambda pkg: "9.8.7")
+    assert lifecycle.installed_version() == "9.8.7"
+
+
+def test_installed_version_fallback_on_package_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """installed_version() returns '0.0.0' when the package isn't found."""
+    import importlib.metadata as _meta
+
+    def _raise(pkg: str) -> str:
+        raise PackageNotFoundError(pkg)
+
+    monkeypatch.setattr(_meta, "version", _raise)
+    assert lifecycle.installed_version() == "0.0.0"
+
+
+# ---------------------------------------------------------------------------
+# format_update_banner — single source of truth
+# ---------------------------------------------------------------------------
+
+
+def test_format_update_banner_text() -> None:
+    """Banner text matches the canonical shortened format."""
+    banner = lifecycle.format_update_banner("1.5.0")
+    assert banner == "⬆ /aelf:upgrade to v1.5.0"
+
+
+def test_format_update_banner_contains_slash_command() -> None:
+    assert "/aelf:upgrade" in lifecycle.format_update_banner("2.0.0")
+
+
+def test_statusline_snippet_uses_banner_helper() -> None:
+    """statusline.format_snippet embeds the output of format_update_banner."""
+    status = lifecycle.UpdateStatus(
+        update_available=True,
+        installed="1.0.0",
+        latest="1.5.0",
+        checked=0.0,
+        sha256=None,
+    )
+    snippet = statusline.format_snippet(status, env={})
+    expected_body = lifecycle.format_update_banner("1.5.0")
+    assert expected_body in snippet
+
+
+def test_banner_shared_substring_in_statusline_and_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both call sites derive text from format_update_banner.
+
+    This test verifies they share the '/aelf:upgrade to v' substring,
+    ensuring the two surfaces can never drift from each other.
+    """
+    import io
+
+    status = lifecycle.UpdateStatus(
+        update_available=True,
+        installed="1.0.0",
+        latest="1.5.0",
+        checked=0.0,
+        sha256=None,
+    )
+    # Statusline path.
+    snippet = statusline.format_snippet(status, env={})
+    assert "/aelf:upgrade to v" in snippet
+
+    # CLI stderr banner path — monkeypatch the cache reader.
+    import aelfrice.cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_read_update_cache", lambda: status)
+    monkeypatch.setattr(
+        cli_mod, "_update_check_disabled", lambda: False
+    )
+
+    buf = io.StringIO()
+    # _maybe_emit_update_banner writes to sys.stderr; capture it.
+    monkeypatch.setattr(sys, "stderr", buf)
+    cli_mod._maybe_emit_update_banner("search")
+    stderr_out = buf.getvalue()
+    assert "/aelf:upgrade to v" in stderr_out
+
+
+# ---------------------------------------------------------------------------
+# install-method detection — each branch
+# ---------------------------------------------------------------------------
+
+
+def test_is_uv_tool_install_via_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """uv-tool install detected when package dir exists under uv tools root."""
+    fake_uv_tools = tmp_path / ".local" / "share" / "uv" / "tools"
+    (fake_uv_tools / "aelfrice").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    assert lifecycle._is_uv_tool_install() is True
+
+
+def test_is_uv_tool_install_via_prefix(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """uv-tool install detected when sys.prefix is under the uv tools root."""
+    uv_tools_root = tmp_path / ".local" / "share" / "uv" / "tools"
+    uv_tools_root.mkdir(parents=True)
+    fake_prefix = str(uv_tools_root / "aelfrice" / "env")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(sys, "prefix", fake_prefix)
+    assert lifecycle._is_uv_tool_install() is True
+
+
+def test_is_uv_tool_install_false_when_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No uv-tool install detected when neither directory nor prefix matches."""
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    # sys.prefix points into a plain venv that has nothing to do with uv tools.
+    monkeypatch.setattr(sys, "prefix", str(tmp_path / "my_venv"))
+    monkeypatch.setattr(
+        sys, "base_prefix", str(tmp_path / "base_python")
+    )
+    assert lifecycle._is_uv_tool_install() is False
+
+
+def test_is_pipx_install_via_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pipx install detected when sys.prefix contains /pipx/venvs/."""
+    monkeypatch.setattr(
+        sys, "prefix", "/home/user/.local/pipx/venvs/aelfrice"
+    )
+    assert lifecycle._is_pipx_install() is True
+
+
+def test_is_pipx_install_via_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """pipx install detected when the pipx venv directory exists."""
+    fake_home = tmp_path
+    pipx_venv = fake_home / ".local" / "pipx" / "venvs" / "aelfrice"
+    pipx_venv.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(sys, "prefix", str(tmp_path / "unrelated"))
+    assert lifecycle._is_pipx_install() is True
+
+
+def test_is_pipx_install_false_when_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(sys, "prefix", str(tmp_path / "my_venv"))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    assert lifecycle._is_pipx_install() is False
+
+
+def test_is_venv_true_when_prefix_differs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "prefix", "/some/venv")
+    monkeypatch.setattr(sys, "base_prefix", "/usr")
+    assert lifecycle._is_venv() is True
+
+
+def test_is_venv_false_when_prefix_equals_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "prefix", "/usr")
+    monkeypatch.setattr(sys, "base_prefix", "/usr")
+    assert lifecycle._is_venv() is False
+
+
+# ---------------------------------------------------------------------------
+# upgrade_advice — full routing table
+# ---------------------------------------------------------------------------
+
+
+def _patch_detection(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    uv_tool: bool = False,
+    pipx: bool = False,
+    venv: bool = False,
+) -> None:
+    monkeypatch.setattr(lifecycle, "_is_uv_tool_install", lambda: uv_tool)
+    monkeypatch.setattr(lifecycle, "_is_pipx_install", lambda: pipx)
+    monkeypatch.setattr(lifecycle, "_is_venv", lambda: venv)
+
+
+@pytest.mark.parametrize(
+    "uv_tool,pipx,venv,expected_context,expected_cmd_fragment",
+    [
+        (True, False, False, "uv_tool", "uv tool upgrade aelfrice"),
+        (False, True, False, "pipx", "pipx upgrade aelfrice"),
+        (False, False, True, "venv", "pip install --upgrade aelfrice"),
+        (False, False, False, "system", "pip install --user --upgrade aelfrice"),
+        # uv_tool wins even if venv is also true (order check).
+        (True, False, True, "uv_tool", "uv tool upgrade aelfrice"),
+        # pipx wins over plain venv.
+        (False, True, True, "pipx", "pipx upgrade aelfrice"),
+    ],
+)
+def test_upgrade_advice_routing(
+    monkeypatch: pytest.MonkeyPatch,
+    uv_tool: bool,
+    pipx: bool,
+    venv: bool,
+    expected_context: str,
+    expected_cmd_fragment: str,
+) -> None:
+    _patch_detection(monkeypatch, uv_tool=uv_tool, pipx=pipx, venv=venv)
+    advice = lifecycle.upgrade_advice()
+    assert advice.context == expected_context
+    assert advice.command == expected_cmd_fragment


### PR DESCRIPTION
## Summary
- **Banner SSoT:** new `lifecycle.format_update_banner(latest)` returns the canonical `⬆ /aelf:upgrade to vX.Y.Z` string. Both `statusline.format_snippet` and `cli._maybe_emit_update_banner` consume it; no more drift between the two surfaces.
- **Version source-of-truth:** `installed_version()` now reads from `importlib.metadata` (with `0.0.0` fallback on `PackageNotFoundError`) instead of trusting an in-tree `__version__`. After a real upgrade the banner self-clears immediately.
- **Install-method-aware upgrade advice:** `upgrade_advice()` detects whether the install came from `uv tool`, `pipx`, or a venv (sys.prefix + sys.executable heuristics) and routes the printed command accordingly. The `/aelf:upgrade` slash command doc is updated to match.

## Changes
- `src/aelfrice/lifecycle.py` — `format_update_banner`, `installed_version`, install-method detection, `upgrade_advice` routing.
- `src/aelfrice/statusline.py` — consume `format_update_banner`; keep the existing self-suppression path.
- `src/aelfrice/cli.py` — consume `format_update_banner`.
- `commands/aelf:upgrade.md` — doc reflects uv-tool detection.

## Tests
- New `tests/test_upgrade_ux.py` (233 LOC): banner SSoT, `installed_version` metadata + fallback, install-method detection across uv-tool/pipx/venv branches with precedence cases, banner-substring drift guard between statusline and CLI surfaces.
- `tests/test_statusline.py` — banner-text strings updated; new autouse fixture pins `installed_version` to `0.0.0` so snippet tests aren't gated on the running package version (the self-suppression check, when latest <= installed, returns empty).
- `tests/test_lifecycle.py` — banner-text strings updated.
- Full suite: 1621 passed, 4 skipped.

## Acceptance criteria (from #242)
- [x] Banner text matches the new short form in both surfaces
- [x] Single source of truth for the banner string
- [x] `tests/test_statusline.py` updated
- [x] CLI banner test coverage updated (`test_upgrade_ux.py` covers the substring-drift guard)
- [x] No behavior change to color handling / NO_COLOR / empty-snippet path

Closes #242