### PR TITLE
feat(hook): UserPromptSubmit telemetry + collapse-duplicates flag (#218)

### DIFF
--- a/src/aelfrice/doctor.py
+++ b/src/aelfrice/doctor.py
@@ -103,6 +103,67 @@ def diagnose_search_tool_telemetry(
     )
 
 
+# ---------------------------------------------------------------------------
+# UserPromptSubmit telemetry section (#218 AC4)
+# ---------------------------------------------------------------------------
+
+USER_PROMPT_SUBMIT_TELEMETRY_SUBPATH: Final[str] = (
+    "aelfrice/telemetry/user_prompt_submit.jsonl"
+)
+
+
+@dataclass(frozen=True)
+class UserPromptSubmitTelemetryStats:
+    """Rolling statistics derived from the UserPromptSubmit telemetry file.
+
+    `fire_count` is the total number of records in the ring buffer.
+    `p50_chars` and `p95_chars` are the 50th- and 95th-percentile
+    injection size in characters. `median_collapse_rate` is the median
+    ratio of n_returned / n_unique_content_hashes across all records
+    (1.0 means no duplicates seen).
+    """
+
+    fire_count: int
+    p50_chars: float
+    p95_chars: float
+    median_collapse_rate: float
+
+
+def diagnose_user_prompt_submit_telemetry(
+    telemetry_path: Path,
+) -> UserPromptSubmitTelemetryStats | None:
+    """Read the UserPromptSubmit telemetry ring buffer and return rolling stats.
+
+    Returns `None` when the file does not exist or is empty. Raises
+    `ValueError` when the file exists but contains malformed JSON.
+    """
+    from aelfrice.hook import read_user_prompt_submit_telemetry  # noqa: PLC0415
+
+    records = read_user_prompt_submit_telemetry(telemetry_path)
+    if not records:
+        return None
+
+    chars: list[float] = sorted(
+        float(r.get("total_chars", 0)) for r in records
+    )
+    collapse_rates: list[float] = []
+    for r in records:
+        n_ret = int(r.get("n_returned", 0))
+        n_uniq = int(r.get("n_unique_content_hashes", 0))
+        if n_uniq > 0:
+            collapse_rates.append(n_ret / n_uniq)
+        else:
+            collapse_rates.append(1.0)
+    collapse_rates.sort()
+
+    return UserPromptSubmitTelemetryStats(
+        fire_count=len(records),
+        p50_chars=_percentile(chars, 50),
+        p95_chars=_percentile(chars, 95),
+        median_collapse_rate=_percentile(collapse_rates, 50),
+    )
+
+
 def _load_settings_json(path: Path) -> dict[str, object]:
     """Read settings.json. Empty / nonexistent files are treated as {}."""
     if not path.exists():
@@ -206,6 +267,10 @@ class DoctorReport:
     search_tool_telemetry_path: Path | None = None
     # True when the file existed but was malformed (ValueError from read).
     search_tool_telemetry_corrupt: bool = False
+    # #218 AC4: user_prompt_submit_hook telemetry stats.
+    user_prompt_submit_telemetry: UserPromptSubmitTelemetryStats | None = None
+    user_prompt_submit_telemetry_path: Path | None = None
+    user_prompt_submit_telemetry_corrupt: bool = False
     # Runtime deps declared in pyproject.toml that are not importable
     # in the current environment (issue #236: stale uv tool env).
     missing_runtime_deps: list[str] = field(
@@ -242,6 +307,7 @@ def diagnose(
     slash_commands_dir: Path | None = None,
     known_cli_subcommands: frozenset[str] | None = None,
     search_tool_telemetry_path: Path | None = None,
+    user_prompt_submit_telemetry_path: Path | None = None,
 ) -> DoctorReport:
     """Walk user and project settings.json, return a DoctorReport.
 
@@ -255,7 +321,8 @@ def diagnose(
     for files naming subcommands the running CLI does not implement
     (issue #115). When `search_tool_telemetry_path` is provided (or
     derivable from the project root's git-common-dir), the
-    search_tool_hook telemetry section is populated.
+    search_tool_hook telemetry section is populated. Similarly for
+    `user_prompt_submit_telemetry_path` (#218 AC4).
     """
     user_path = user_settings if user_settings is not None else USER_SETTINGS_PATH
     project_path = (
@@ -285,24 +352,43 @@ def diagnose(
     # v1.5.0 #155 AC8: populate search_tool_hook telemetry section.
     tel_path = search_tool_telemetry_path
     if tel_path is None:
-        # Derive from the project root if available.
         resolved_root = project_root if project_root is not None else Path.cwd()
-        tel_path = _derive_telemetry_path(resolved_root)
+        tel_path = _derive_telemetry_path(
+            resolved_root, SEARCH_TOOL_TELEMETRY_SUBPATH,
+        )
     if tel_path is not None:
         report.search_tool_telemetry_path = tel_path
         try:
             report.search_tool_telemetry = diagnose_search_tool_telemetry(tel_path)
         except ValueError:
             report.search_tool_telemetry_corrupt = True
+    # #218 AC4: populate user_prompt_submit_hook telemetry section.
+    ups_tel_path = user_prompt_submit_telemetry_path
+    if ups_tel_path is None:
+        resolved_root = project_root if project_root is not None else Path.cwd()
+        ups_tel_path = _derive_telemetry_path(
+            resolved_root, USER_PROMPT_SUBMIT_TELEMETRY_SUBPATH,
+        )
+    if ups_tel_path is not None:
+        report.user_prompt_submit_telemetry_path = ups_tel_path
+        try:
+            report.user_prompt_submit_telemetry = (
+                diagnose_user_prompt_submit_telemetry(ups_tel_path)
+            )
+        except ValueError:
+            report.user_prompt_submit_telemetry_corrupt = True
     return report
 
 
-def _derive_telemetry_path(project_root: Path) -> Path | None:
-    """Best-effort: locate the telemetry file next to the project's DB.
+def _derive_telemetry_path(
+    project_root: Path,
+    subpath: str = SEARCH_TOOL_TELEMETRY_SUBPATH,
+) -> Path | None:
+    """Best-effort: locate a telemetry file under the project's git-common-dir.
 
-    Uses `aelfrice.cli.db_path` when available to mirror the hook's own
-    path resolution. Falls back to None (skips the section) if the
-    import fails or the function raises.
+    `subpath` is appended to the git-common-dir (e.g.
+    `aelfrice/telemetry/search_tool_hook.jsonl`). Falls back to None if
+    the git invocation fails or the project is not in a git repo.
     """
     try:
         import subprocess  # noqa: PLC0415
@@ -314,7 +400,7 @@ def _derive_telemetry_path(project_root: Path) -> Path | None:
         if result.returncode != 0 or not result.stdout.strip():
             return None
         git_common = Path(result.stdout.strip()).resolve()
-        return git_common / SEARCH_TOOL_TELEMETRY_SUBPATH
+        return git_common / subpath
     except Exception:
         return None
 
@@ -577,8 +663,9 @@ def format_report(report: DoctorReport) -> str:
         lines.append(
             "no settings.json found at user or project scope -- nothing to check"
         )
-        # Still render the telemetry section if a path is available.
+        # Still render the telemetry sections if paths are available.
         _format_telemetry_section(report, lines)
+        _format_user_prompt_submit_telemetry_section(report, lines)
         # #236: render the missing-dep block too — the install-broken
         # case is exactly when settings.json may be absent.
         _format_missing_runtime_deps_section(report, lines)
@@ -641,6 +728,7 @@ def format_report(report: DoctorReport) -> str:
             "feature is available, or remove the stale slash file."
         )
     _format_telemetry_section(report, lines)
+    _format_user_prompt_submit_telemetry_section(report, lines)
     _format_missing_runtime_deps_section(report, lines)
     return "\n".join(lines)
 
@@ -682,4 +770,31 @@ def _format_telemetry_section(report: DoctorReport, lines: list[str]) -> None:
         lines.append(
             f"  noise rate:  {st.noise_rate:.1%} "
             f"(fires with zero L0+L1 hits)"
+        )
+
+
+def _format_user_prompt_submit_telemetry_section(
+    report: DoctorReport, lines: list[str],
+) -> None:
+    """Append the user_prompt_submit_hook telemetry block to `lines` (#218 AC4)."""
+    if report.user_prompt_submit_telemetry_path is None:
+        return
+    lines.append("")
+    lines.append("user_prompt_submit_hook telemetry:")
+    lines.append(f"  file: {report.user_prompt_submit_telemetry_path}")
+    if report.user_prompt_submit_telemetry_corrupt:
+        lines.append(
+            "  status: CORRUPT — file exists but contains malformed JSON; "
+            "delete it to reset the ring buffer."
+        )
+    elif report.user_prompt_submit_telemetry is None:
+        lines.append("  no fires recorded")
+    else:
+        st = report.user_prompt_submit_telemetry
+        lines.append(f"  fires: {st.fire_count}")
+        lines.append(f"  injection size p50: {st.p50_chars:.0f} chars")
+        lines.append(f"  injection size p95: {st.p95_chars:.0f} chars")
+        lines.append(
+            f"  dedup collapse rate (median): {st.median_collapse_rate:.2f}x "
+            f"(n_returned / n_unique_hashes; 1.0 = no duplicates)"
         )

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -26,10 +26,12 @@ import json
 import os
 import sys
 import tempfile
+import tomllib
 import traceback
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import IO, Final, cast
+from typing import IO, Any, Final, cast
 
 try:
     from aelfrice.cli import db_path
@@ -81,6 +83,97 @@ SESSION_START_CLOSE_TAG: Final[str] = "</aelfrice-baseline>"
 _PROMPT_KEY: Final[str] = "prompt"
 _TRANSCRIPT_PATH_KEY: Final[str] = "transcript_path"
 _CWD_KEY: Final[str] = "cwd"
+
+# ---------------------------------------------------------------------------
+# Per-hook configuration (#218 AC6)
+# ---------------------------------------------------------------------------
+
+_UPS_SECTION: Final[str] = "user_prompt_submit_hook"
+_COLLAPSE_KEY: Final[str] = "collapse_duplicate_hashes"
+_CONFIG_FILENAME: Final[str] = ".aelfrice.toml"
+
+
+@dataclass(frozen=True)
+class UserPromptSubmitConfig:
+    """Configuration for the UserPromptSubmit hook.
+
+    All fields default to their OFF/safe value so missing config degrades
+    gracefully. Loaded from `.aelfrice.toml [user_prompt_submit_hook]`
+    by `load_user_prompt_submit_config()`.
+    """
+
+    collapse_duplicate_hashes: bool = False
+
+
+def load_user_prompt_submit_config(
+    start: Path | None = None,
+    *,
+    stderr: IO[str] | None = None,
+) -> UserPromptSubmitConfig:
+    """Walk up from `start` looking for `.aelfrice.toml`.
+
+    Returns the resolved `[user_prompt_submit_hook]` config. Missing
+    file / missing section / malformed TOML / wrong-typed values all
+    degrade to defaults with a stderr trace; never raises.
+    """
+    serr: IO[str] = stderr if stderr is not None else sys.stderr
+    current = (start if start is not None else Path.cwd()).resolve()
+    seen: set[Path] = set()
+    while current not in seen:
+        seen.add(current)
+        candidate = current / _CONFIG_FILENAME
+        if candidate.is_file():
+            try:
+                raw = candidate.read_bytes()
+            except OSError as exc:
+                print(
+                    f"aelfrice hook: cannot read {candidate}: {exc}",
+                    file=serr,
+                )
+                return UserPromptSubmitConfig()
+            try:
+                parsed: dict[str, Any] = tomllib.loads(
+                    raw.decode("utf-8", errors="replace"),
+                )
+            except tomllib.TOMLDecodeError as exc:
+                print(
+                    f"aelfrice hook: malformed TOML in {candidate}: {exc}",
+                    file=serr,
+                )
+                return UserPromptSubmitConfig()
+            section_obj: Any = parsed.get(_UPS_SECTION, {})
+            if not isinstance(section_obj, dict):
+                return UserPromptSubmitConfig()
+            section = cast(dict[str, Any], section_obj)
+            collapse_obj: Any = section.get(_COLLAPSE_KEY, False)
+            if not isinstance(collapse_obj, bool):
+                print(
+                    f"aelfrice hook: ignoring [{_UPS_SECTION}] "
+                    f"{_COLLAPSE_KEY} in {candidate} (expected bool)",
+                    file=serr,
+                )
+                collapse_obj = False
+            return UserPromptSubmitConfig(
+                collapse_duplicate_hashes=collapse_obj,
+            )
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return UserPromptSubmitConfig()
+
+
+def _dedup_by_content_hash(hits: list[Belief]) -> list[Belief]:
+    """Return hits with duplicate content hashes removed (first occurrence wins)."""
+    seen_hashes: set[str] = set()
+    result: list[Belief] = []
+    for h in hits:
+        digest = hashlib.sha1(h.content.encode()).hexdigest()
+        if digest not in seen_hashes:
+            seen_hashes.add(digest)
+            result.append(h)
+    return result
+
 
 # ---------------------------------------------------------------------------
 # Telemetry ring buffer (#218 AC1-3)
@@ -228,8 +321,10 @@ def user_prompt_submit(
             if token_budget is not None
             else DEFAULT_HOOK_TOKEN_BUDGET
         )
+        config = load_user_prompt_submit_config(stderr=serr)
         hits = _retrieve(prompt, budget)
         if hits:
+            # AC1 telemetry: record pre-collapse counts.
             n_returned = len(hits)
             unique_hashes = {
                 hashlib.sha1(h.content.encode()).hexdigest()
@@ -238,6 +333,10 @@ def user_prompt_submit(
             n_unique = len(unique_hashes)
             n_l0 = sum(1 for h in hits if h.lock_level == LOCK_USER)
             n_l1 = n_returned - n_l0
+            # AC6: optional dedup before formatting.
+            if config.collapse_duplicate_hashes:
+                hits = _dedup_by_content_hash(hits)
+            # total_chars measured post-collapse (what is actually injected).
             total_chars = sum(len(h.content) for h in hits)
             body = _format_hits(hits)
             sout.write(body)

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -121,8 +121,9 @@ def user_prompt_submit(
             if token_budget is not None
             else DEFAULT_HOOK_TOKEN_BUDGET
         )
-        body = _retrieve_and_format(prompt, budget)
-        if body:
+        hits = _retrieve(prompt, budget)
+        if hits:
+            body = _format_hits(hits)
             sout.write(body)
     except Exception:  # non-blocking: surface but do not fail
         traceback.print_exc(file=serr)
@@ -147,15 +148,19 @@ def _extract_prompt(raw: str) -> str | None:
     return prompt
 
 
-def _retrieve_and_format(prompt: str, token_budget: int) -> str:
+def _retrieve(prompt: str, token_budget: int) -> list[Belief]:
+    """Run retrieval for the given prompt and return the raw hit list.
+
+    Separating retrieval from formatting lets callers inspect the hits
+    (for telemetry, optional dedup, etc.) before the string is built.
+    Returns an empty list when the store is absent or retrieval yields
+    nothing.
+    """
     store = _open_store()
     try:
-        hits = search_for_prompt(store, prompt, token_budget=token_budget)
+        return search_for_prompt(store, prompt, token_budget=token_budget)
     finally:
         store.close()
-    if not hits:
-        return ""
-    return _format_hits(hits)
 
 
 def _format_hits(hits: list[Belief]) -> str:

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -21,9 +21,13 @@ flows here automatically.
 """
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import sys
+import tempfile
 import traceback
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO, Final, cast
 
@@ -78,6 +82,109 @@ _PROMPT_KEY: Final[str] = "prompt"
 _TRANSCRIPT_PATH_KEY: Final[str] = "transcript_path"
 _CWD_KEY: Final[str] = "cwd"
 
+# ---------------------------------------------------------------------------
+# Telemetry ring buffer (#218 AC1-3)
+# ---------------------------------------------------------------------------
+
+TELEMETRY_RING_CAP: Final[int] = 1000
+"""Maximum entries retained in the UserPromptSubmit telemetry JSONL."""
+
+TELEMETRY_SUBPATH: Final[str] = (
+    "aelfrice/telemetry/user_prompt_submit.jsonl"
+)
+"""Path fragment appended to the git-common-dir to form the telemetry path."""
+
+_QUERY_TELEMETRY_CAP: Final[int] = 500
+"""Maximum characters of the prompt stored in the telemetry record."""
+
+
+def _telemetry_path_for_db(db_path_val: Path) -> Path:
+    """Derive the UserPromptSubmit telemetry path from the DB path.
+
+    The DB lives at `<git-common-dir>/aelfrice/memory.db`. The telemetry
+    file lives at `<git-common-dir>/aelfrice/telemetry/user_prompt_submit.jsonl`.
+    """
+    return db_path_val.parent / "telemetry" / "user_prompt_submit.jsonl"
+
+
+def _append_telemetry(
+    telemetry_path: Path,
+    record: dict[str, object],
+    *,
+    stderr: IO[str] | None = None,
+) -> None:
+    """Append one telemetry record to the JSONL ring buffer. Fail-soft.
+
+    Uses read-all → trim → rewrite-atomically (tempfile + os.replace).
+    If the write fails for any reason (read-only, disk-full, missing
+    parent), traces one line to stderr and continues.
+    """
+    try:
+        telemetry_path.parent.mkdir(parents=True, exist_ok=True)
+        if telemetry_path.exists():
+            lines = [
+                ln
+                for ln in telemetry_path.read_text(encoding="utf-8").splitlines()
+                if ln.strip()
+            ]
+        else:
+            lines = []
+        lines.append(json.dumps(record))
+        if len(lines) > TELEMETRY_RING_CAP:
+            lines = lines[-TELEMETRY_RING_CAP:]
+        payload = "\n".join(lines) + "\n"
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=telemetry_path.name + ".",
+            suffix=".tmp",
+            dir=str(telemetry_path.parent),
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(payload)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, telemetry_path)
+        except Exception:
+            if tmp_path.exists():
+                tmp_path.unlink(missing_ok=True)
+            raise
+    except Exception as exc:
+        serr = stderr if stderr is not None else sys.stderr
+        print(
+            f"aelfrice: telemetry write failed (non-fatal): {exc}",
+            file=serr,
+        )
+
+
+def read_user_prompt_submit_telemetry(
+    path: Path,
+) -> list[dict[str, object]]:
+    """Read the UserPromptSubmit JSONL ring buffer at `path`.
+
+    Returns [] when the file is missing or empty. Raises `ValueError`
+    when the file exists but a line is not valid JSON (corruption).
+    Lines that are valid JSON but not objects are silently skipped.
+    """
+    if not path.exists():
+        return []
+    records: list[dict[str, object]] = []
+    text = path.read_text(encoding="utf-8")
+    for i, line in enumerate(text.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"telemetry file {path} line {i + 1} is not valid JSON: {exc}"
+            ) from exc
+        if not isinstance(parsed, dict):
+            continue
+        records.append(cast(dict[str, object], parsed))
+    return records
+
 
 def user_prompt_submit(
     *,
@@ -123,11 +230,58 @@ def user_prompt_submit(
         )
         hits = _retrieve(prompt, budget)
         if hits:
+            n_returned = len(hits)
+            unique_hashes = {
+                hashlib.sha1(h.content.encode()).hexdigest()
+                for h in hits
+            }
+            n_unique = len(unique_hashes)
+            n_l0 = sum(1 for h in hits if h.lock_level == LOCK_USER)
+            n_l1 = n_returned - n_l0
+            total_chars = sum(len(h.content) for h in hits)
             body = _format_hits(hits)
             sout.write(body)
+            # AC1: append telemetry record for fires that produce a block.
+            _write_telemetry(
+                prompt=prompt,
+                n_returned=n_returned,
+                n_unique_content_hashes=n_unique,
+                n_l0=n_l0,
+                n_l1=n_l1,
+                total_chars=total_chars,
+                stderr=serr,
+            )
     except Exception:  # non-blocking: surface but do not fail
         traceback.print_exc(file=serr)
     return 0
+
+
+def _write_telemetry(
+    *,
+    prompt: str,
+    n_returned: int,
+    n_unique_content_hashes: int,
+    n_l0: int,
+    n_l1: int,
+    total_chars: int,
+    stderr: IO[str] | None = None,
+) -> None:
+    """Build and append a telemetry record. Fail-soft."""
+    try:
+        p = db_path()
+        tel_path = _telemetry_path_for_db(p)
+    except Exception:
+        return
+    record: dict[str, object] = {
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "query": prompt[:_QUERY_TELEMETRY_CAP],
+        "n_returned": n_returned,
+        "n_unique_content_hashes": n_unique_content_hashes,
+        "n_l0": n_l0,
+        "n_l1": n_l1,
+        "total_chars": total_chars,
+    }
+    _append_telemetry(tel_path, record, stderr=stderr)
 
 
 def _extract_prompt(raw: str) -> str | None:

--- a/tests/test_aelf_doctor_user_prompt_submit_telemetry.py
+++ b/tests/test_aelf_doctor_user_prompt_submit_telemetry.py
@@ -1,0 +1,251 @@
+"""Tests for `aelf doctor` user_prompt_submit_hook telemetry section (#218 AC4).
+
+Coverage:
+- diagnose_user_prompt_submit_telemetry returns None when file missing/empty.
+- diagnose_user_prompt_submit_telemetry raises ValueError on corrupt JSON.
+- p50_chars and p95_chars computed correctly over total_chars values.
+- median_collapse_rate computed from n_returned / n_unique_content_hashes.
+- Zero n_unique_content_hashes treated as rate 1.0 (no division by zero).
+- diagnose() populates user_prompt_submit_telemetry_path and stats.
+- format_report() prints the section header and stats.
+- Missing telemetry file → "no fires recorded" sentinel, no raise.
+- Corrupt file → CORRUPT sentinel in report text.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.doctor import (
+    UserPromptSubmitTelemetryStats,
+    diagnose,
+    diagnose_user_prompt_submit_telemetry,
+    format_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_tel(path: Path, records: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _record(
+    total_chars: int = 200,
+    n_returned: int = 3,
+    n_unique: int = 3,
+    n_l0: int = 1,
+    n_l1: int = 2,
+) -> dict[str, object]:
+    return {
+        "timestamp": "2026-01-01T00:00:00Z",
+        "query": "test prompt",
+        "n_returned": n_returned,
+        "n_unique_content_hashes": n_unique,
+        "n_l0": n_l0,
+        "n_l1": n_l1,
+        "total_chars": total_chars,
+    }
+
+
+# ---------------------------------------------------------------------------
+# diagnose_user_prompt_submit_telemetry
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_returns_none_when_file_missing(tmp_path: Path) -> None:
+    result = diagnose_user_prompt_submit_telemetry(tmp_path / "no-such.jsonl")
+    assert result is None
+
+
+def test_diagnose_returns_none_for_empty_file(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    tel.write_text("", encoding="utf-8")
+    assert diagnose_user_prompt_submit_telemetry(tel) is None
+
+
+def test_diagnose_raises_on_corrupt_json(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    tel.write_text('{"ok": 1}\nnot json\n', encoding="utf-8")
+    with pytest.raises(ValueError):
+        diagnose_user_prompt_submit_telemetry(tel)
+
+
+def test_diagnose_computes_fire_count(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    _write_tel(tel, [_record() for _ in range(7)])
+    stats = diagnose_user_prompt_submit_telemetry(tel)
+    assert stats is not None
+    assert stats.fire_count == 7
+
+
+def test_diagnose_computes_injection_size_percentiles(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    # 10 records with total_chars 100, 200, ..., 1000
+    _write_tel(tel, [_record(total_chars=i * 100) for i in range(1, 11)])
+    stats = diagnose_user_prompt_submit_telemetry(tel)
+    assert stats is not None
+    # p50 nearest-rank: index = max(0, int(10*50/100) - 1) = 4 → value 500
+    assert stats.p50_chars == 500.0
+    # p95: index = max(0, int(10*95/100) - 1) = 8 → value 900
+    assert stats.p95_chars == 900.0
+
+
+def test_diagnose_collapse_rate_no_duplicates(tmp_path: Path) -> None:
+    """When n_returned == n_unique for every record, median rate should be 1.0."""
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    _write_tel(tel, [_record(n_returned=3, n_unique=3) for _ in range(5)])
+    stats = diagnose_user_prompt_submit_telemetry(tel)
+    assert stats is not None
+    assert stats.median_collapse_rate == pytest.approx(1.0)
+
+
+def test_diagnose_collapse_rate_all_duplicates(tmp_path: Path) -> None:
+    """When n_returned is double n_unique, rate should be 2.0."""
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    _write_tel(tel, [_record(n_returned=6, n_unique=3) for _ in range(4)])
+    stats = diagnose_user_prompt_submit_telemetry(tel)
+    assert stats is not None
+    assert stats.median_collapse_rate == pytest.approx(2.0)
+
+
+def test_diagnose_collapse_rate_zero_unique_treated_as_one(tmp_path: Path) -> None:
+    """n_unique_content_hashes == 0 should not raise (guard against zero-div)."""
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    _write_tel(tel, [_record(n_returned=0, n_unique=0)])
+    stats = diagnose_user_prompt_submit_telemetry(tel)
+    assert stats is not None
+    assert stats.median_collapse_rate == pytest.approx(1.0)
+
+
+def test_diagnose_mixed_collapse_rates(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    # 5 records: 3 with rate 1.0, 2 with rate 2.0 → median 1.0
+    records = (
+        [_record(n_returned=3, n_unique=3)] * 3
+        + [_record(n_returned=6, n_unique=3)] * 2
+    )
+    _write_tel(tel, records)
+    stats = diagnose_user_prompt_submit_telemetry(tel)
+    assert stats is not None
+    # sorted rates: [1.0, 1.0, 1.0, 2.0, 2.0]; p50 index = 1 → 1.0
+    assert stats.median_collapse_rate == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# diagnose() integration
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_with_explicit_ups_tel_path_populates_report(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    _write_tel(tel, [_record() for _ in range(3)])
+    report = diagnose(
+        user_settings=tmp_path / "no-user.json",
+        project_root=tmp_path / "no-proj",
+        user_prompt_submit_telemetry_path=tel,
+    )
+    assert report.user_prompt_submit_telemetry_path == tel
+    assert report.user_prompt_submit_telemetry is not None
+    assert report.user_prompt_submit_telemetry.fire_count == 3
+    assert not report.user_prompt_submit_telemetry_corrupt
+
+
+def test_diagnose_missing_ups_tel_file_sets_none_stats(tmp_path: Path) -> None:
+    tel = tmp_path / "no-such.jsonl"
+    report = diagnose(
+        user_settings=tmp_path / "no-user.json",
+        project_root=tmp_path / "no-proj",
+        user_prompt_submit_telemetry_path=tel,
+    )
+    assert report.user_prompt_submit_telemetry_path == tel
+    assert report.user_prompt_submit_telemetry is None
+    assert not report.user_prompt_submit_telemetry_corrupt
+
+
+def test_diagnose_corrupt_ups_tel_sets_flag(tmp_path: Path) -> None:
+    tel = tmp_path / "corrupt.jsonl"
+    tel.write_text('{"ok": 1}\nnot valid\n', encoding="utf-8")
+    report = diagnose(
+        user_settings=tmp_path / "no-user.json",
+        project_root=tmp_path / "no-proj",
+        user_prompt_submit_telemetry_path=tel,
+    )
+    assert report.user_prompt_submit_telemetry_corrupt is True
+    assert report.user_prompt_submit_telemetry is None
+
+
+# ---------------------------------------------------------------------------
+# format_report()
+# ---------------------------------------------------------------------------
+
+
+def test_format_report_no_fires_sentinel(tmp_path: Path) -> None:
+    tel = tmp_path / "no-such.jsonl"
+    report = diagnose(
+        user_settings=tmp_path / "no-user.json",
+        project_root=tmp_path / "no-proj",
+        user_prompt_submit_telemetry_path=tel,
+    )
+    text = format_report(report)
+    assert "no fires recorded" in text
+
+
+def test_format_report_prints_stats(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    _write_tel(tel, [_record(total_chars=500, n_returned=3, n_unique=3) for _ in range(10)])
+    report = diagnose(
+        user_settings=tmp_path / "no-user.json",
+        project_root=tmp_path / "no-proj",
+        user_prompt_submit_telemetry_path=tel,
+    )
+    text = format_report(report)
+    assert "user_prompt_submit_hook telemetry" in text
+    assert "fires: 10" in text
+    assert "injection size p50" in text
+    assert "injection size p95" in text
+    assert "dedup collapse rate" in text
+
+
+def test_format_report_corrupt_flag_surfaces(tmp_path: Path) -> None:
+    tel = tmp_path / "corrupt.jsonl"
+    tel.write_text("not json\n", encoding="utf-8")
+    report = diagnose(
+        user_settings=tmp_path / "no-user.json",
+        project_root=tmp_path / "no-proj",
+        user_prompt_submit_telemetry_path=tel,
+    )
+    text = format_report(report)
+    assert "CORRUPT" in text
+
+
+def test_format_report_includes_telemetry_file_path(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    report = diagnose(
+        user_settings=tmp_path / "no-user.json",
+        project_root=tmp_path / "no-proj",
+        user_prompt_submit_telemetry_path=tel,
+    )
+    text = format_report(report)
+    assert str(tel) in text
+
+
+def test_format_report_no_ups_tel_path_no_section(tmp_path: Path) -> None:
+    """When user_prompt_submit_telemetry_path is None and no git root,
+    the section is absent from the report (no crash)."""
+    report = diagnose(
+        user_settings=tmp_path / "no-user.json",
+        project_root=tmp_path / "no-proj",
+        user_prompt_submit_telemetry_path=None,
+    )
+    text = format_report(report)
+    assert isinstance(text, str)

--- a/tests/test_user_prompt_submit_collapse.py
+++ b/tests/test_user_prompt_submit_collapse.py
@@ -1,0 +1,274 @@
+"""Tests for the #218 AC6 collapse_duplicate_hashes flag.
+
+Coverage:
+- Default config has collapse OFF.
+- When OFF, duplicate content hashes are NOT deduped.
+- When ON, duplicate content hashes are deduped (first occurrence wins).
+- Order of unique hits preserved after collapse.
+- Telemetry n_returned records pre-collapse count.
+- Telemetry total_chars records post-collapse size.
+- n_unique_content_hashes equals number of distinct hashes pre-collapse.
+- load_user_prompt_submit_config returns defaults when no .aelfrice.toml.
+- load_user_prompt_submit_config reads collapse_duplicate_hashes from toml.
+- Malformed TOML degrades to defaults.
+- Wrong type for collapse_duplicate_hashes (non-bool) degrades to False.
+"""
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from aelfrice.hook import (
+    UserPromptSubmitConfig,
+    _dedup_by_content_hash,
+    load_user_prompt_submit_config,
+    read_user_prompt_submit_telemetry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_belief(content: str, lock_level: int = 0, belief_id: str | None = None) -> object:
+    b = MagicMock()
+    b.content = content
+    b.lock_level = lock_level
+    b.id = belief_id or ("b" + content[:4].encode().hex())
+    return b
+
+
+def _write_toml(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# UserPromptSubmitConfig defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_config_collapse_is_false() -> None:
+    cfg = UserPromptSubmitConfig()
+    assert cfg.collapse_duplicate_hashes is False
+
+
+# ---------------------------------------------------------------------------
+# _dedup_by_content_hash
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_empty_list() -> None:
+    assert _dedup_by_content_hash([]) == []
+
+
+def test_dedup_no_duplicates_preserves_all() -> None:
+    hits = [_make_belief("alpha"), _make_belief("beta"), _make_belief("gamma")]
+    result = _dedup_by_content_hash(hits)
+    assert len(result) == 3
+
+
+def test_dedup_removes_exact_content_duplicates() -> None:
+    hits = [
+        _make_belief("same content"),
+        _make_belief("unique"),
+        _make_belief("same content"),  # duplicate
+    ]
+    result = _dedup_by_content_hash(hits)
+    assert len(result) == 2
+    assert result[0].content == "same content"
+    assert result[1].content == "unique"
+
+
+def test_dedup_preserves_first_occurrence_order() -> None:
+    hits = [
+        _make_belief("c"),
+        _make_belief("a"),
+        _make_belief("b"),
+        _make_belief("a"),  # duplicate of index 1
+        _make_belief("c"),  # duplicate of index 0
+    ]
+    result = _dedup_by_content_hash(hits)
+    assert [h.content for h in result] == ["c", "a", "b"]
+
+
+def test_dedup_all_same_content_returns_one() -> None:
+    hits = [_make_belief("identical") for _ in range(5)]
+    result = _dedup_by_content_hash(hits)
+    assert len(result) == 1
+    assert result[0].content == "identical"
+
+
+# ---------------------------------------------------------------------------
+# load_user_prompt_submit_config
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_no_file_returns_defaults(tmp_path: Path) -> None:
+    cfg = load_user_prompt_submit_config(tmp_path / "nonexistent")
+    assert cfg.collapse_duplicate_hashes is False
+
+
+def test_load_config_reads_collapse_true(tmp_path: Path) -> None:
+    _write_toml(
+        tmp_path / ".aelfrice.toml",
+        "[user_prompt_submit_hook]\ncollapse_duplicate_hashes = true\n",
+    )
+    cfg = load_user_prompt_submit_config(tmp_path)
+    assert cfg.collapse_duplicate_hashes is True
+
+
+def test_load_config_reads_collapse_false(tmp_path: Path) -> None:
+    _write_toml(
+        tmp_path / ".aelfrice.toml",
+        "[user_prompt_submit_hook]\ncollapse_duplicate_hashes = false\n",
+    )
+    cfg = load_user_prompt_submit_config(tmp_path)
+    assert cfg.collapse_duplicate_hashes is False
+
+
+def test_load_config_missing_section_returns_defaults(tmp_path: Path) -> None:
+    _write_toml(tmp_path / ".aelfrice.toml", "[rebuilder]\nturn_window_n = 5\n")
+    cfg = load_user_prompt_submit_config(tmp_path)
+    assert cfg.collapse_duplicate_hashes is False
+
+
+def test_load_config_malformed_toml_returns_defaults(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text("not: [valid toml", encoding="utf-8")
+    serr = StringIO()
+    cfg = load_user_prompt_submit_config(tmp_path, stderr=serr)
+    assert cfg.collapse_duplicate_hashes is False
+    assert "malformed TOML" in serr.getvalue()
+
+
+def test_load_config_wrong_type_for_collapse_key(tmp_path: Path) -> None:
+    _write_toml(
+        tmp_path / ".aelfrice.toml",
+        "[user_prompt_submit_hook]\ncollapse_duplicate_hashes = 1\n",
+    )
+    serr = StringIO()
+    cfg = load_user_prompt_submit_config(tmp_path, stderr=serr)
+    assert cfg.collapse_duplicate_hashes is False
+    assert "expected bool" in serr.getvalue()
+
+
+def test_load_config_walks_up_to_parent(tmp_path: Path) -> None:
+    """Config file in parent dir is found when child has none."""
+    child = tmp_path / "sub" / "project"
+    child.mkdir(parents=True)
+    _write_toml(
+        tmp_path / ".aelfrice.toml",
+        "[user_prompt_submit_hook]\ncollapse_duplicate_hashes = true\n",
+    )
+    cfg = load_user_prompt_submit_config(child)
+    assert cfg.collapse_duplicate_hashes is True
+
+
+# ---------------------------------------------------------------------------
+# Integration: end-to-end collapse + telemetry accounting
+# ---------------------------------------------------------------------------
+
+
+def test_collapse_off_keeps_duplicates_in_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With collapse OFF, duplicates pass through to formatted output."""
+    from aelfrice.hook import user_prompt_submit
+    from aelfrice.models import LOCK_USER
+
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    hits = [
+        _make_belief("duplicate text"),
+        _make_belief("unique text"),
+        _make_belief("duplicate text"),  # same as first
+    ]
+
+    monkeypatch.setattr("aelfrice.hook._retrieve", lambda p, b: hits)
+    monkeypatch.setattr("aelfrice.hook._telemetry_path_for_db", lambda p: tel)
+    monkeypatch.setattr("aelfrice.hook.db_path", lambda: tmp_path / "memory.db")
+    monkeypatch.setattr(
+        "aelfrice.hook.load_user_prompt_submit_config",
+        lambda **_kw: UserPromptSubmitConfig(collapse_duplicate_hashes=False),
+    )
+
+    sin = StringIO(json.dumps({"prompt": "test"}))
+    sout = StringIO()
+    user_prompt_submit(stdin=sin, stdout=sout, stderr=StringIO())
+
+    output = sout.getvalue()
+    # All 3 should appear in the output (duplicates NOT removed).
+    assert output.count("duplicate text") == 2
+
+    records = read_user_prompt_submit_telemetry(tel)
+    assert records[0]["n_returned"] == 3
+    assert records[0]["n_unique_content_hashes"] == 2
+
+
+def test_collapse_on_deduplicates_before_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With collapse ON, duplicates are removed before formatting."""
+    from aelfrice.hook import user_prompt_submit
+
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    hits = [
+        _make_belief("duplicate text"),
+        _make_belief("unique text"),
+        _make_belief("duplicate text"),  # same as first
+    ]
+
+    monkeypatch.setattr("aelfrice.hook._retrieve", lambda p, b: hits)
+    monkeypatch.setattr("aelfrice.hook._telemetry_path_for_db", lambda p: tel)
+    monkeypatch.setattr("aelfrice.hook.db_path", lambda: tmp_path / "memory.db")
+    monkeypatch.setattr(
+        "aelfrice.hook.load_user_prompt_submit_config",
+        lambda **_kw: UserPromptSubmitConfig(collapse_duplicate_hashes=True),
+    )
+
+    sin = StringIO(json.dumps({"prompt": "test"}))
+    sout = StringIO()
+    user_prompt_submit(stdin=sin, stdout=sout, stderr=StringIO())
+
+    output = sout.getvalue()
+    # Only 1 instance of the duplicate content in output.
+    assert output.count("duplicate text") == 1
+    assert "unique text" in output
+
+
+def test_telemetry_n_returned_is_pre_collapse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """n_returned always reflects the raw retrieval count, not post-collapse."""
+    from aelfrice.hook import user_prompt_submit
+
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    # 4 hits but only 2 unique content hashes
+    hits = [
+        _make_belief("a"),
+        _make_belief("a"),
+        _make_belief("b"),
+        _make_belief("b"),
+    ]
+
+    monkeypatch.setattr("aelfrice.hook._retrieve", lambda p, b: hits)
+    monkeypatch.setattr("aelfrice.hook._telemetry_path_for_db", lambda p: tel)
+    monkeypatch.setattr("aelfrice.hook.db_path", lambda: tmp_path / "memory.db")
+    monkeypatch.setattr(
+        "aelfrice.hook.load_user_prompt_submit_config",
+        lambda **_kw: UserPromptSubmitConfig(collapse_duplicate_hashes=True),
+    )
+
+    sin = StringIO(json.dumps({"prompt": "test collapse accounting"}))
+    user_prompt_submit(stdin=sin, stdout=StringIO(), stderr=StringIO())
+
+    records = read_user_prompt_submit_telemetry(tel)
+    r = records[0]
+    # Pre-collapse count preserved.
+    assert r["n_returned"] == 4
+    assert r["n_unique_content_hashes"] == 2
+    # total_chars is post-collapse: 2 unique beliefs × 1 char each.
+    assert r["total_chars"] == 2  # len("a") + len("b")

--- a/tests/test_user_prompt_submit_telemetry.py
+++ b/tests/test_user_prompt_submit_telemetry.py
@@ -1,0 +1,270 @@
+"""Tests for the #218 UserPromptSubmit telemetry ring buffer (AC1-3, AC5).
+
+Coverage:
+- Telemetry record is written after a fire that produces a block.
+- Ring-buffer cap: oldest entries evicted when > 1000.
+- Fail-soft: unwritable path prints one stderr line and does not raise.
+- read_user_prompt_submit_telemetry returns [] for missing file.
+- read_user_prompt_submit_telemetry raises ValueError on corrupt JSON.
+- Blank lines in the file are silently skipped.
+- End-to-end: user_prompt_submit() writes a record when hits are non-empty.
+- No record written when hits is empty.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aelfrice.hook import (
+    TELEMETRY_RING_CAP,
+    UserPromptSubmitConfig,
+    _append_telemetry,
+    read_user_prompt_submit_telemetry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_record(**kwargs: object) -> dict[str, object]:
+    defaults: dict[str, object] = {
+        "timestamp": "2026-01-01T00:00:00Z",
+        "query": "test prompt",
+        "n_returned": 3,
+        "n_unique_content_hashes": 3,
+        "n_l0": 1,
+        "n_l1": 2,
+        "total_chars": 300,
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _write_prompt_payload(prompt: str = "hello world") -> str:
+    return json.dumps({"prompt": prompt})
+
+
+# ---------------------------------------------------------------------------
+# _append_telemetry
+# ---------------------------------------------------------------------------
+
+
+def test_append_telemetry_creates_file(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    _append_telemetry(tel, _make_record())
+    assert tel.exists()
+    records = read_user_prompt_submit_telemetry(tel)
+    assert len(records) == 1
+    assert records[0]["n_returned"] == 3
+    assert records[0]["n_l0"] == 1
+    assert records[0]["total_chars"] == 300
+
+
+def test_append_telemetry_accumulates(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    for i in range(5):
+        _append_telemetry(tel, _make_record(query=f"prompt_{i}"))
+    records = read_user_prompt_submit_telemetry(tel)
+    assert len(records) == 5
+    assert [r["query"] for r in records] == [f"prompt_{i}" for i in range(5)]
+
+
+def test_append_telemetry_ring_cap_evicts_oldest(tmp_path: Path) -> None:
+    tel = tmp_path / "ring.jsonl"
+    total = TELEMETRY_RING_CAP + 10
+    for i in range(total):
+        _append_telemetry(tel, _make_record(query=f"q{i}"))
+    records = read_user_prompt_submit_telemetry(tel)
+    assert len(records) == TELEMETRY_RING_CAP
+    # Oldest 10 evicted; surviving records start at index 10.
+    assert records[0]["query"] == "q10"
+    assert records[-1]["query"] == f"q{total - 1}"
+
+
+def test_append_telemetry_failsoft_on_unwritable_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unwritable dir → one stderr trace; no exception."""
+    if sys.platform == "win32":
+        pytest.skip("permission model differs on Windows")
+    locked_dir = tmp_path / "locked"
+    locked_dir.mkdir()
+    os.chmod(locked_dir, stat.S_IRUSR | stat.S_IXUSR)  # r-x, no write
+    tel = locked_dir / "sub" / "user_prompt_submit.jsonl"
+    serr = StringIO()
+    # Should not raise.
+    _append_telemetry(tel, _make_record(), stderr=serr)
+    assert "non-fatal" in serr.getvalue()
+
+
+def test_append_telemetry_creates_parent_dirs(tmp_path: Path) -> None:
+    tel = tmp_path / "a" / "b" / "c" / "user_prompt_submit.jsonl"
+    _append_telemetry(tel, _make_record())
+    assert tel.exists()
+
+
+def test_append_telemetry_record_has_timestamp(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    _append_telemetry(tel, _make_record())
+    records = read_user_prompt_submit_telemetry(tel)
+    ts = records[0].get("timestamp")
+    assert isinstance(ts, str) and len(ts) > 0
+
+
+# ---------------------------------------------------------------------------
+# read_user_prompt_submit_telemetry
+# ---------------------------------------------------------------------------
+
+
+def test_read_telemetry_missing_file_returns_empty(tmp_path: Path) -> None:
+    result = read_user_prompt_submit_telemetry(tmp_path / "no-such-file.jsonl")
+    assert result == []
+
+
+def test_read_telemetry_empty_file_returns_empty(tmp_path: Path) -> None:
+    tel = tmp_path / "empty.jsonl"
+    tel.write_text("", encoding="utf-8")
+    assert read_user_prompt_submit_telemetry(tel) == []
+
+
+def test_read_telemetry_corrupt_json_raises(tmp_path: Path) -> None:
+    tel = tmp_path / "corrupt.jsonl"
+    tel.write_text('{"ok": true}\nnot valid json\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        read_user_prompt_submit_telemetry(tel)
+
+
+def test_read_telemetry_skips_blank_lines(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    tel.write_text(
+        '\n{"n_returned": 1}\n\n{"n_returned": 2}\n',
+        encoding="utf-8",
+    )
+    records = read_user_prompt_submit_telemetry(tel)
+    assert len(records) == 2
+    assert records[0]["n_returned"] == 1
+    assert records[1]["n_returned"] == 2
+
+
+def test_read_telemetry_skips_non_dict_json(tmp_path: Path) -> None:
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    tel.write_text(
+        '["not", "a", "dict"]\n{"n_returned": 5}\n',
+        encoding="utf-8",
+    )
+    records = read_user_prompt_submit_telemetry(tel)
+    assert len(records) == 1
+    assert records[0]["n_returned"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Integration: user_prompt_submit() writes telemetry
+# ---------------------------------------------------------------------------
+
+
+def _make_belief(content: str, lock_level: int = 0) -> object:
+    """Return a minimal Belief-like mock."""
+    b = MagicMock()
+    b.content = content
+    b.lock_level = lock_level
+    b.id = "beef" + content[:4].encode().hex()
+    return b
+
+
+def test_user_prompt_submit_writes_telemetry_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """user_prompt_submit() writes a telemetry record when hits are non-empty."""
+    from aelfrice.hook import user_prompt_submit
+    from aelfrice.models import LOCK_USER
+
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    hits = [_make_belief("alpha content"), _make_belief("beta content", LOCK_USER)]
+
+    monkeypatch.setattr("aelfrice.hook._retrieve", lambda prompt, budget: hits)
+    monkeypatch.setattr(
+        "aelfrice.hook._telemetry_path_for_db", lambda p: tel
+    )
+    monkeypatch.setattr("aelfrice.hook.db_path", lambda: tmp_path / "memory.db")
+    monkeypatch.setattr(
+        "aelfrice.hook.load_user_prompt_submit_config",
+        lambda **_kw: UserPromptSubmitConfig(),
+    )
+
+    sin = StringIO(_write_prompt_payload("explain telemetry"))
+    sout = StringIO()
+    serr = StringIO()
+    rc = user_prompt_submit(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+
+    records = read_user_prompt_submit_telemetry(tel)
+    assert len(records) == 1
+    r = records[0]
+    assert r["n_returned"] == 2
+    assert r["n_l0"] == 1
+    assert r["n_l1"] == 1
+    assert r["total_chars"] == len("alpha content") + len("beta content")
+    assert r["n_unique_content_hashes"] == 2
+    assert isinstance(r["timestamp"], str)
+
+
+def test_user_prompt_submit_no_telemetry_when_empty_hits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No telemetry record written when retrieval returns no hits."""
+    from aelfrice.hook import user_prompt_submit
+
+    tel = tmp_path / "user_prompt_submit.jsonl"
+
+    monkeypatch.setattr("aelfrice.hook._retrieve", lambda prompt, budget: [])
+    monkeypatch.setattr(
+        "aelfrice.hook._telemetry_path_for_db", lambda p: tel
+    )
+    monkeypatch.setattr("aelfrice.hook.db_path", lambda: tmp_path / "memory.db")
+    monkeypatch.setattr(
+        "aelfrice.hook.load_user_prompt_submit_config",
+        lambda **_kw: UserPromptSubmitConfig(),
+    )
+
+    sin = StringIO(_write_prompt_payload("no results prompt"))
+    sout = StringIO()
+    serr = StringIO()
+    rc = user_prompt_submit(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    assert not tel.exists()
+
+
+def test_telemetry_query_capped_at_500_chars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prompt longer than 500 chars is truncated in the telemetry record."""
+    from aelfrice.hook import user_prompt_submit
+
+    tel = tmp_path / "user_prompt_submit.jsonl"
+    long_prompt = "x" * 1000
+    hits = [_make_belief("some content")]
+
+    monkeypatch.setattr("aelfrice.hook._retrieve", lambda prompt, budget: hits)
+    monkeypatch.setattr("aelfrice.hook._telemetry_path_for_db", lambda p: tel)
+    monkeypatch.setattr("aelfrice.hook.db_path", lambda: tmp_path / "memory.db")
+    monkeypatch.setattr(
+        "aelfrice.hook.load_user_prompt_submit_config",
+        lambda **_kw: UserPromptSubmitConfig(),
+    )
+
+    sin = StringIO(json.dumps({"prompt": long_prompt}))
+    sout = StringIO()
+    serr = StringIO()
+    user_prompt_submit(stdin=sin, stdout=sout, stderr=serr)
+
+    records = read_user_prompt_submit_telemetry(tel)
+    assert len(records[0]["query"]) == 500  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #218.

## Summary

Adds an observability surface to the `UserPromptSubmit` hook so dedup / relevance regressions become visible without a human eyeballing context. Mirrors the `search_tool_hook` telemetry pattern shipped in #217.

- **AC1-3, AC5 — Telemetry ring buffer.** Per-fire JSONL append at `<git-common-dir>/aelfrice/telemetry/user_prompt_submit.jsonl`. Schema: `{timestamp, query, n_returned, n_unique_content_hashes, n_l0, n_l1, total_chars}`. `query` capped at 500 chars. Ring cap 1000; atomic tempfile + `os.replace`. Fail-soft on any write error (single stderr line, hook continues). Public `read_user_prompt_submit_telemetry(path)` for the doctor surface.
- **AC4 — `aelf doctor` surface.** New `diagnose_user_prompt_submit_telemetry()` reports rolling p50/p95 of `total_chars` and median dedup-collapse-rate (`n_returned / n_unique_content_hashes`). Missing/empty → \"no fires recorded\". Corrupt JSONL → CORRUPT sentinel.
- **AC6 — `collapse_duplicate_hashes` flag.** New `[user_prompt_submit_hook] collapse_duplicate_hashes` key in `.aelfrice.toml`, default OFF. When ON, hits are deduped by content hash (first-occurrence wins) before formatting. Telemetry records the *pre-collapse* `n_returned` so the dedup-rate metric stays meaningful; `total_chars` reflects what was actually injected.

Telemetry only fires when the hook produces an `<aelfrice-memory>` block (empty hits → no record).

This is the observability + workaround track. Algorithmic dedup remains #197; topic-relevance work remains #154.

## Test plan

- [x] `tests/test_user_prompt_submit_telemetry.py` — 14 tests: write, accumulation, ring-cap eviction, fail-soft on unwritable parent, missing file, corrupt JSON, blank-line skip, end-to-end via `user_prompt_submit()`
- [x] `tests/test_user_prompt_submit_collapse.py` — 16 tests: config load (default-off, on, malformed TOML, wrong type, missing file, missing section), dedup ordering, telemetry pre/post-collapse semantics
- [x] `tests/test_aelf_doctor_user_prompt_submit_telemetry.py` — 17 tests: missing → sentinel, populated → p50/p95 + collapse-rate, corrupt → CORRUPT, formatter rendering
- [x] Full suite: 1692 passed, 8 skipped (pre-existing platform skips)