### PR TITLE
feat(doctor): --classify-orphans pass for un-typed low-prior beliefs (#206)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2093,7 +2093,8 @@ def _cmd_doctor_classify_orphans(
 
     An orphan is a belief where BOTH of the following are true:
       - type = 'unknown' (never successfully typed by onboard/ingest)
-      - alpha + beta < 2 (no feedback event has ever been applied)
+      - alpha + beta <= 2 (untouched prior is alpha=1, beta=1; any
+        feedback event pushes the sum above 2)
 
     Reuses the same `classify_batch` path as `aelf onboard
     --llm-classify`; no new LLM client is introduced.

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2588,7 +2588,7 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         default=False,
         help=(
             "find beliefs with type='unknown' and no feedback signal "
-            "(alpha+beta < 2), then re-classify them via Haiku batch. "
+            "(alpha+beta <= 2), then re-classify them via Haiku batch. "
             "Requires ANTHROPIC_API_KEY and the [onboard-llm] extra "
             "(pip install aelfrice[onboard-llm]). "
             "Bypasses the hooks/graph checks. "

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -74,7 +74,12 @@ from aelfrice.classification import (
     accept_classifications,
     start_onboard_session,
 )
-from aelfrice.doctor import diagnose, format_report
+from aelfrice.doctor import (
+    classify_orphans as _classify_orphans,
+    diagnose,
+    format_orphan_report as _format_orphan_report,
+    format_report,
+)
 from aelfrice.llm_classifier import (
     ENV_API_KEY as _LLM_ENV_API_KEY,
     LLMAuthError as _LLMAuthError,
@@ -2040,11 +2045,17 @@ def _cmd_doctor(args: argparse.Namespace, out: object) -> int:
                    locked contradictions).
       - None     → run both (default).
 
+    `--classify-orphans` routes to the targeted reclassification pass
+    (issue #206); it bypasses the hooks/graph checks entirely and exits
+    after printing the cost/distribution report.
+
     Exit 1 if any structural failure fires in either subcheck;
     informational warnings never trip exit. The v1.2 deprecated alias
     `aelf health` routes here with scope='graph' implicitly via
     `_cmd_health`.
     """
+    if getattr(args, "classify_orphans", False):
+        return _cmd_doctor_classify_orphans(args, out)
     scope = getattr(args, "scope", None)
     exit_code = 0
     if scope in (None, "hooks"):
@@ -2073,6 +2084,70 @@ def _cmd_doctor(args: argparse.Namespace, out: object) -> int:
         if graph_exit != 0:
             exit_code = graph_exit
     return exit_code
+
+
+def _cmd_doctor_classify_orphans(
+    args: argparse.Namespace, out: object
+) -> int:
+    """Run the targeted Haiku reclassification pass for orphan beliefs.
+
+    An orphan is a belief where BOTH of the following are true:
+      - type = 'unknown' (never successfully typed by onboard/ingest)
+      - alpha + beta < 2 (no feedback event has ever been applied)
+
+    Reuses the same `classify_batch` path as `aelf onboard
+    --llm-classify`; no new LLM client is introduced.
+
+    With --dry-run: count and display orphans + before-distribution
+    without making any LLM calls or DB writes.
+    """
+    dry_run = bool(getattr(args, "dry_run", False))
+    max_n_raw = getattr(args, "max", None)
+    max_n: int | None = int(max_n_raw) if max_n_raw is not None else None
+
+    # Gates: SDK importable, API key set.
+    gate = _llm_check_gates(enabled=True, model=_LLMConfig.default().model)
+    if not gate.pass_all and not dry_run:
+        if gate.exit_code is not None:
+            if gate.message:
+                print(gate.message, file=sys.stderr)
+            return gate.exit_code
+
+    api_key = os.environ.get(_LLM_ENV_API_KEY, "")
+    if not api_key and not dry_run:
+        print(
+            f"aelf: {_LLM_ENV_API_KEY} not set; --classify-orphans requires it. "
+            "Pass --dry-run to count orphans without making LLM calls.",
+            file=sys.stderr,
+        )
+        return 1
+
+    cfg = _LLMConfig.default()
+    store = _open_store()
+    try:
+        orphan_report = _classify_orphans(
+            store,
+            api_key=api_key,
+            model=cfg.model,
+            max_tokens=cfg.max_tokens,
+            max_n=max_n,
+            dry_run=dry_run,
+        )
+    except _LLMAuthError as exc:
+        print(
+            f"aelf: Anthropic auth failure ({exc}). No beliefs updated. "
+            f"Verify {_LLM_ENV_API_KEY}.",
+            file=sys.stderr,
+        )
+        return 1
+    except _LLMTokenCapExceeded as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    finally:
+        store.close()
+
+    print(_format_orphan_report(orphan_report), file=out)  # type: ignore[arg-type]
+    return 0
 
 
 def _print_doctor_store_check(out: object) -> None:
@@ -2504,6 +2579,44 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help=(
             "override the hook-failures log path doctor tails "
             "(default: ~/.aelfrice/logs/hook-failures.log)"
+        ),
+    )
+    p_doctor.add_argument(
+        "--classify-orphans",
+        dest="classify_orphans",
+        action="store_true",
+        default=False,
+        help=(
+            "find beliefs with type='unknown' and no feedback signal "
+            "(alpha+beta < 2), then re-classify them via Haiku batch. "
+            "Requires ANTHROPIC_API_KEY and the [onboard-llm] extra "
+            "(pip install aelfrice[onboard-llm]). "
+            "Bypasses the hooks/graph checks. "
+            "Combine with --dry-run to count orphans without LLM calls. "
+            "Combine with --max N to cap classifications per run "
+            "(recommended: 500 for large stores)."
+        ),
+    )
+    p_doctor.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        default=False,
+        help=(
+            "with --classify-orphans: print orphan count and "
+            "before-distribution without making LLM calls or DB writes."
+        ),
+    )
+    p_doctor.add_argument(
+        "--max",
+        dest="max",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "with --classify-orphans: cap the number of beliefs "
+            "classified per run. No cap by default; recommended: 500 "
+            "for large stores to bound per-run cost."
         ),
     )
     p_doctor.set_defaults(func=_cmd_doctor)

--- a/src/aelfrice/doctor.py
+++ b/src/aelfrice/doctor.py
@@ -24,6 +24,12 @@ warnings:
 * recent entries in `~/.aelfrice/logs/hook-failures.log`, the file
   hook bash wrappers should redirect stderr into instead of dropping
   it on the floor.
+
+`aelf doctor --classify-orphans` (issue #206) finds beliefs whose
+`type` was never resolved (type = 'unknown') AND that have never
+received any feedback (alpha + beta < 2 — the untouched prior), then
+re-classifies them through the same Haiku batch path used by
+`aelf onboard --llm-classify`.
 """
 from __future__ import annotations
 
@@ -36,9 +42,12 @@ import shlex
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Final, Literal, cast
+from typing import TYPE_CHECKING, Final, Literal, cast
 
 from aelfrice.setup import PROJECT_SETTINGS_RELPATH, USER_SETTINGS_PATH
+
+if TYPE_CHECKING:
+    from aelfrice.store import MemoryStore
 
 
 # ---------------------------------------------------------------------------
@@ -798,3 +807,225 @@ def _format_user_prompt_submit_telemetry_section(
             f"  dedup collapse rate (median): {st.median_collapse_rate:.2f}x "
             f"(n_returned / n_unique_hashes; 1.0 = no duplicates)"
         )
+
+
+# ---------------------------------------------------------------------------
+# classify-orphans pass (issue #206)
+# ---------------------------------------------------------------------------
+
+# Approximate Haiku pricing as of 2025-Q1.  Used only for the cost
+# estimate in the CLI report; not invoiced, not sent to Anthropic.
+_HAIKU_INPUT_COST_PER_TOKEN: Final[float] = 0.80 / 1_000_000   # $0.80 / MTok
+_HAIKU_OUTPUT_COST_PER_TOKEN: Final[float] = 4.00 / 1_000_000  # $4.00 / MTok
+
+
+@dataclass
+class OrphanRunReport:
+    """Summary of one `classify_orphans` pass.
+
+    `orphans_found` is the raw count before `max_n` is applied.
+    `classified` is the number updated in the store.
+    `skipped` is orphans whose LLM result was invalid or non-persisting.
+    `dry_run` flags whether any DB writes occurred.
+    `type_dist_before` and `type_dist_after` are {type: count} snapshots.
+    `telemetry` is the raw Haiku token accounting.
+    """
+
+    orphans_found: int = 0
+    classified: int = 0
+    skipped: int = 0
+    dry_run: bool = False
+    type_dist_before: dict[str, int] = field(default_factory=dict)
+    type_dist_after: dict[str, int] = field(default_factory=dict)
+    # BatchTelemetry is imported lazily below; store raw token counts here.
+    input_tokens: int = 0
+    output_tokens: int = 0
+    requests: int = 0
+    fallbacks: int = 0
+    model: str = ""
+
+
+def classify_orphans(
+    store: "MemoryStore",
+    *,
+    api_key: str,
+    model: str,
+    max_tokens: int,
+    max_n: int | None = None,
+    dry_run: bool = False,
+    sdk_module: object = None,
+) -> OrphanRunReport:
+    """Find un-typed low-confidence beliefs and re-classify via Haiku batch.
+
+    Orphan definition (both signals required):
+      - type = 'unknown' OR type IS NULL  (never successfully typed)
+      - alpha + beta < 2                  (no feedback ever applied)
+
+    The function reuses `aelfrice.llm_classifier.classify_batch` — the
+    same path `aelf onboard --llm-classify` uses.  No new LLM client is
+    introduced.
+
+    When `dry_run=True` the orphan set is found and counted but neither
+    network calls nor DB writes are made.
+
+    `max_n` caps classifications per run. Recommended: 500 per run when
+    the store is large; None (the default) processes all orphans.
+    """
+    from aelfrice.llm_classifier import (  # local to avoid circular imports
+        BatchTelemetry,
+        CandidateInput,
+        classify_batch,
+    )
+    from aelfrice.models import ORIGIN_AGENT_INFERRED
+
+    report = OrphanRunReport(dry_run=dry_run, model=model)
+    report.type_dist_before = store.count_beliefs_by_type()
+
+    # Count total orphans before applying max_n.
+    all_orphans = store.find_orphan_beliefs()
+    report.orphans_found = len(all_orphans)
+
+    # Apply max_n cap for the actual processing set.
+    to_process = all_orphans[:max_n] if max_n is not None else all_orphans
+
+    if dry_run or not to_process:
+        # Dry-run: report pre-snapshot only; no network, no writes.
+        return report
+
+    # Build classifier inputs from the orphan beliefs.  Use the belief id
+    # as the source tag so parse failures are traceable.
+    inputs = [
+        CandidateInput(index=i, text=b.content, source=b.id)
+        for i, b in enumerate(to_process)
+    ]
+
+    batch = classify_batch(
+        inputs,
+        api_key=api_key,
+        model=model,
+        max_tokens=max_tokens,
+        sdk_module=sdk_module,  # type: ignore[arg-type]
+    )
+
+    # Accumulate telemetry.
+    tel: BatchTelemetry = batch.telemetry
+    report.input_tokens = tel.input_tokens
+    report.output_tokens = tel.output_tokens
+    report.requests = tel.requests
+    report.fallbacks = tel.fallbacks
+
+    # Auth failure: propagate so CLI can exit 1.
+    if batch.auth_error is not None:
+        from aelfrice.llm_classifier import LLMAuthError  # noqa: PLC0415
+        raise LLMAuthError(batch.auth_error)
+
+    # Token cap: propagate so CLI can exit 1.
+    if batch.token_cap_exceeded:
+        from aelfrice.llm_classifier import LLMTokenCapExceeded  # noqa: PLC0415
+        raise LLMTokenCapExceeded(
+            consumed=batch.token_cap_consumed,
+            cap=max_tokens,
+        )
+
+    # When the whole batch fell back to regex, skip_all — the regex
+    # fallback path is designed for scan_repo's fresh-insert flow, not
+    # for updating existing beliefs with already-set prior weights.
+    if batch.fallback_used:
+        report.skipped = len(to_process)
+        report.type_dist_after = store.count_beliefs_by_type()
+        return report
+
+    # Apply valid classifications back to the store.
+    by_index: dict[int, object] = {c.index: c for c in batch.classifications}
+    for i, belief in enumerate(to_process):
+        cls_any = by_index.get(i)
+        if cls_any is None:
+            report.skipped += 1
+            continue
+        from aelfrice.llm_classifier import CandidateClassification  # noqa: PLC0415
+        cls: CandidateClassification = cls_any  # type: ignore[assignment]
+        if not cls.persist:
+            report.skipped += 1
+            continue
+        # Update only the type and origin fields; leave alpha/beta, lock,
+        # demotion_pressure, and timestamps intact so prior work is not lost.
+        updated = _belief_with_type(belief, cls.belief_type, ORIGIN_AGENT_INFERRED)
+        store.update_belief(updated)
+        report.classified += 1
+
+    report.type_dist_after = store.count_beliefs_by_type()
+    return report
+
+
+def _belief_with_type(
+    b: "object", new_type: str, new_origin: str
+) -> "object":
+    """Return a copy of `b` (a Belief) with `type` and `origin` replaced.
+
+    Uses dataclasses.replace-style reconstruction so we don't depend on
+    Belief being mutable.  The import is local to keep the doctor module
+    importable without triggering the full models chain at top level.
+    """
+    from aelfrice.models import Belief  # noqa: PLC0415
+    belief: Belief = b  # type: ignore[assignment]
+    return Belief(
+        id=belief.id,
+        content=belief.content,
+        content_hash=belief.content_hash,
+        alpha=belief.alpha,
+        beta=belief.beta,
+        type=new_type,
+        lock_level=belief.lock_level,
+        locked_at=belief.locked_at,
+        demotion_pressure=belief.demotion_pressure,
+        created_at=belief.created_at,
+        last_retrieved_at=belief.last_retrieved_at,
+        session_id=belief.session_id,
+        origin=new_origin,
+    )
+
+
+def format_orphan_report(report: OrphanRunReport) -> str:
+    """Render an OrphanRunReport as a human-readable string for the CLI."""
+    lines: list[str] = []
+    prefix = "[dry-run] " if report.dry_run else ""
+    lines.append(f"{prefix}classify-orphans: {report.orphans_found} orphan(s) found")
+    if report.dry_run:
+        lines.append(
+            "(dry-run: no LLM calls made, no DB writes performed)"
+        )
+    else:
+        lines.append(
+            f"  classified: {report.classified}  "
+            f"skipped: {report.skipped}"
+        )
+    lines.append("")
+    lines.append("type distribution before:")
+    _append_type_dist(lines, report.type_dist_before)
+    if not report.dry_run:
+        lines.append("")
+        lines.append("type distribution after:")
+        _append_type_dist(lines, report.type_dist_after)
+        lines.append("")
+        total_tokens = report.input_tokens + report.output_tokens
+        cost = (
+            report.input_tokens * _HAIKU_INPUT_COST_PER_TOKEN
+            + report.output_tokens * _HAIKU_OUTPUT_COST_PER_TOKEN
+        )
+        lines.append(
+            f"tokens: input={report.input_tokens} "
+            f"output={report.output_tokens} "
+            f"total={total_tokens} "
+            f"requests={report.requests} "
+            f"fallbacks={report.fallbacks}"
+        )
+        lines.append(f"estimated cost: ${cost:.4f} (model={report.model})")
+    return "\n".join(lines)
+
+
+def _append_type_dist(lines: list[str], dist: dict[str, int]) -> None:
+    if not dist:
+        lines.append("  (empty)")
+        return
+    for t, n in sorted(dist.items()):
+        lines.append(f"  {t}: {n}")

--- a/src/aelfrice/doctor.py
+++ b/src/aelfrice/doctor.py
@@ -27,7 +27,7 @@ warnings:
 
 `aelf doctor --classify-orphans` (issue #206) finds beliefs whose
 `type` was never resolved (type = 'unknown') AND that have never
-received any feedback (alpha + beta < 2 — the untouched prior), then
+received any feedback (alpha + beta <= 2 — the untouched prior), then
 re-classifies them through the same Haiku batch path used by
 `aelf onboard --llm-classify`.
 """
@@ -859,7 +859,7 @@ def classify_orphans(
 
     Orphan definition (both signals required):
       - type = 'unknown' OR type IS NULL  (never successfully typed)
-      - alpha + beta < 2                  (no feedback ever applied)
+      - alpha + beta <= 2                  (no feedback ever applied)
 
     The function reuses `aelfrice.llm_classifier.classify_batch` — the
     same path `aelf onboard --llm-classify` uses.  No new LLM client is

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -1051,6 +1051,42 @@ class MemoryStore:
         )
         return [_row_to_belief(r) for r in cur.fetchall()]
 
+    def find_orphan_beliefs(self, *, max_n: int | None = None) -> list[Belief]:
+        """Return beliefs that have no classified type and no feedback signal.
+
+        Orphan definition (two signals, both must be true):
+          1. type = 'unknown' OR type IS NULL — never successfully typed by
+             onboard or ingest.
+          2. alpha + beta < 2 — never received any feedback event
+             (the default prior is alpha=1, beta=1, so sum=2 means
+             completely untouched; any feedback pushes the sum above 2).
+
+        Additional signals (entity_index miss, zero non-CONTAINS edges) are
+        planned as future extensions once #143 and edge-type auditing land.
+
+        `max_n` caps the result set. When None, all orphans are returned.
+        Callers that want a per-run limit (--max N on the CLI) pass it here
+        rather than slicing afterwards, so the SQL does the limiting.
+        """
+        limit_clause = f"LIMIT {int(max_n)}" if max_n is not None else ""
+        cur = self._conn.execute(
+            f"""
+            SELECT * FROM beliefs
+            WHERE (type = 'unknown' OR type IS NULL)
+              AND (alpha + beta) < 2
+            ORDER BY created_at ASC
+            {limit_clause}
+            """
+        )
+        return [_row_to_belief(r) for r in cur.fetchall()]
+
+    def count_beliefs_by_type(self) -> dict[str, int]:
+        """Return a mapping of belief type → count across all beliefs."""
+        cur = self._conn.execute(
+            "SELECT type, COUNT(*) AS n FROM beliefs GROUP BY type ORDER BY type"
+        )
+        return {str(r["type"]): int(r["n"]) for r in cur.fetchall()}
+
     # --- Auditor queries (used by aelf health) ---------------------------
 
     def count_orphan_edges(self) -> int:

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -1057,9 +1057,9 @@ class MemoryStore:
         Orphan definition (two signals, both must be true):
           1. type = 'unknown' OR type IS NULL — never successfully typed by
              onboard or ingest.
-          2. alpha + beta < 2 — never received any feedback event
-             (the default prior is alpha=1, beta=1, so sum=2 means
-             completely untouched; any feedback pushes the sum above 2).
+          2. alpha + beta <= 2 — never received any feedback event
+             (the default prior is alpha=1, beta=1, sum=2; any feedback
+             pushes the sum above 2).
 
         Additional signals (entity_index miss, zero non-CONTAINS edges) are
         planned as future extensions once #143 and edge-type auditing land.
@@ -1073,7 +1073,7 @@ class MemoryStore:
             f"""
             SELECT * FROM beliefs
             WHERE (type = 'unknown' OR type IS NULL)
-              AND (alpha + beta) < 2
+              AND (alpha + beta) <= 2
             ORDER BY created_at ASC
             {limit_clause}
             """

--- a/tests/test_doctor_classify_orphans.py
+++ b/tests/test_doctor_classify_orphans.py
@@ -1,0 +1,516 @@
+"""Acceptance tests for aelf doctor --classify-orphans (issue #206).
+
+All tests mock the Anthropic client via the _call_anthropic seam used
+by the existing onboard test suite.  No real network calls.
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+import aelfrice.llm_classifier as llm
+import aelfrice.cli as cli_module
+from aelfrice.doctor import (
+    classify_orphans,
+    format_orphan_report,
+    OrphanRunReport,
+)
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    BELIEF_PREFERENCE,
+    BELIEF_REQUIREMENT,
+    LOCK_NONE,
+    ORIGIN_AGENT_INFERRED,
+    ORIGIN_UNKNOWN,
+    Belief,
+)
+from aelfrice.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_belief(
+    store: MemoryStore,
+    *,
+    belief_id: str,
+    content: str,
+    belief_type: str = "unknown",
+    alpha: float = 1.0,
+    beta: float = 1.0,
+    lock_level: str = LOCK_NONE,
+) -> Belief:
+    """Insert a belief and return it."""
+    import hashlib
+
+    b = Belief(
+        id=belief_id,
+        content=content,
+        content_hash=hashlib.sha256(content.encode()).hexdigest(),
+        alpha=alpha,
+        beta=beta,
+        type=belief_type,
+        lock_level=lock_level,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2025-01-01T00:00:00Z",
+        last_retrieved_at=None,
+        session_id=None,
+        origin=ORIGIN_UNKNOWN,
+    )
+    store.insert_belief(b)
+    return b
+
+
+def _all_beliefs(store: MemoryStore) -> list[Belief]:
+    cur = store._conn.execute("SELECT * FROM beliefs")  # type: ignore[attr-defined]
+    out: list[Belief] = []
+    for row in cur.fetchall():
+        out.append(
+            Belief(
+                id=row["id"],
+                content=row["content"],
+                content_hash=row["content_hash"],
+                alpha=row["alpha"],
+                beta=row["beta"],
+                type=row["type"],
+                lock_level=row["lock_level"],
+                locked_at=row["locked_at"],
+                demotion_pressure=row["demotion_pressure"],
+                created_at=row["created_at"],
+                last_retrieved_at=row["last_retrieved_at"],
+                origin=row["origin"] if "origin" in row.keys() else "unknown",
+            )
+        )
+    return out
+
+
+def _fake_call_anthropic_factory(
+    belief_types: list[str],
+) -> Any:
+    """Return a _call_anthropic stub that classifies in the given order.
+
+    belief_types[i] is the type returned for candidate i. Every candidate
+    gets persist=True and origin='agent_inferred'.
+    """
+
+    def _fake(**kwargs: Any) -> llm.ClientResponse:
+        user_msg = kwargs.get("user_message", "[]")
+        candidates: list[Any] = json.loads(user_msg)
+        results = []
+        for item in candidates:
+            idx = item["index"]
+            btype = belief_types[idx] if idx < len(belief_types) else BELIEF_FACTUAL
+            results.append(
+                {
+                    "index": idx,
+                    "belief_type": btype,
+                    "origin": "agent_inferred",
+                    "persist": True,
+                }
+            )
+        return llm.ClientResponse(
+            text=json.dumps(results),
+            input_tokens=10 * len(candidates),
+            output_tokens=5 * len(candidates),
+        )
+
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def memdb() -> Iterator[MemoryStore]:
+    store = MemoryStore(":memory:")
+    yield store
+    store.close()
+
+
+@pytest.fixture
+def stub_anthropic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make _anthropic_importable return True (no real SDK needed)."""
+    monkeypatch.setattr(llm, "_anthropic_importable", lambda _check: True)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: classify_orphans() core function
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_finder_picks_unknown_low_prior(memdb: MemoryStore) -> None:
+    """find_orphan_beliefs selects type='unknown' AND alpha+beta < 2."""
+    _make_belief(memdb, belief_id="o1", content="orphan one", belief_type="unknown",
+                 alpha=1.0, beta=1.0)
+    # Already typed — not an orphan
+    _make_belief(memdb, belief_id="t1", content="typed one", belief_type="factual",
+                 alpha=1.0, beta=1.0)
+    # Has feedback signal (alpha+beta > 2) — not an orphan
+    _make_belief(memdb, belief_id="o2", content="orphan but feedback",
+                 belief_type="unknown", alpha=1.5, beta=1.0)
+
+    orphans = memdb.find_orphan_beliefs()
+    assert len(orphans) == 1
+    assert orphans[0].id == "o1"
+
+
+def test_orphan_finder_respects_max_n(memdb: MemoryStore) -> None:
+    for i in range(5):
+        _make_belief(memdb, belief_id=f"o{i}", content=f"orphan {i}",
+                     belief_type="unknown", alpha=1.0, beta=1.0)
+    assert len(memdb.find_orphan_beliefs(max_n=3)) == 3
+    assert len(memdb.find_orphan_beliefs()) == 5
+
+
+def test_classify_orphans_dry_run_no_writes(
+    memdb: MemoryStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dry_run=True must not make network calls or change the store."""
+    for i in range(4):
+        _make_belief(memdb, belief_id=f"o{i}", content=f"orphan {i}",
+                     belief_type="unknown")
+
+    call_count = {"n": 0}
+
+    def tripwire(**kwargs: Any) -> llm.ClientResponse:
+        call_count["n"] += 1
+        raise AssertionError("classify_orphans dry-run reached _call_anthropic")
+
+    monkeypatch.setattr(llm, "_call_anthropic", tripwire)
+
+    report = classify_orphans(
+        memdb,
+        api_key="dummy",
+        model=llm.DEFAULT_MODEL,
+        max_tokens=0,
+        dry_run=True,
+    )
+
+    assert report.dry_run is True
+    assert report.orphans_found == 4
+    assert report.classified == 0
+    assert call_count["n"] == 0
+    # Store unchanged
+    remaining_orphans = memdb.find_orphan_beliefs()
+    assert len(remaining_orphans) == 4
+
+
+def test_classify_orphans_updates_types_in_store(
+    memdb: MemoryStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """classify_orphans writes the new type back to the store."""
+    contents = [
+        ("o0", "CI must always be green", BELIEF_REQUIREMENT),
+        ("o1", "prefer composition over inheritance", BELIEF_PREFERENCE),
+        ("o2", "the scheduler runs at midnight", BELIEF_FACTUAL),
+    ]
+    for bid, content, _ in contents:
+        _make_belief(memdb, belief_id=bid, content=content, belief_type="unknown")
+
+    expected_types = [btype for _, _, btype in contents]
+    monkeypatch.setattr(
+        llm, "_call_anthropic", _fake_call_anthropic_factory(expected_types)
+    )
+
+    report = classify_orphans(
+        memdb,
+        api_key="key",
+        model=llm.DEFAULT_MODEL,
+        max_tokens=0,
+    )
+
+    assert report.orphans_found == 3
+    assert report.classified == 3
+    assert report.skipped == 0
+
+    beliefs = {b.id: b for b in _all_beliefs(memdb)}
+    for bid, _, expected_type in contents:
+        assert beliefs[bid].type == expected_type
+        assert beliefs[bid].origin == ORIGIN_AGENT_INFERRED
+
+
+def test_classify_orphans_95_percent_recovery() -> None:
+    """Synthetic corpus: N=100 orphans; mock classifier returns valid type
+    for all; assert >= 95 classified (acceptance criterion from issue #206)."""
+    store = MemoryStore(":memory:")
+    try:
+        N = 100
+        for i in range(N):
+            _make_belief(
+                store,
+                belief_id=f"orphan{i:03d}",
+                content=f"belief content {i}",
+                belief_type="unknown",
+            )
+        # Also add 20 non-orphans that must not be touched.
+        for i in range(20):
+            _make_belief(
+                store,
+                belief_id=f"typed{i:03d}",
+                content=f"typed content {i}",
+                belief_type=BELIEF_FACTUAL,
+                alpha=2.0,
+                beta=1.0,
+            )
+
+        # Mock: classify all as 'factual'.
+        all_factual = [BELIEF_FACTUAL] * N
+
+        import unittest.mock as mock
+
+        with mock.patch.object(
+            llm, "_call_anthropic", side_effect=_fake_call_anthropic_factory(all_factual)
+        ):
+            report = classify_orphans(
+                store,
+                api_key="key",
+                model=llm.DEFAULT_MODEL,
+                max_tokens=0,
+            )
+
+        assert report.orphans_found == N
+        recovery_rate = report.classified / N
+        assert recovery_rate >= 0.95, (
+            f"Expected >= 95% recovery, got {recovery_rate:.1%} "
+            f"({report.classified}/{N} orphans classified)"
+        )
+
+        # Non-orphans must be untouched.
+        beliefs = {b.id: b for b in _all_beliefs(store)}
+        for i in range(20):
+            bid = f"typed{i:03d}"
+            assert beliefs[bid].type == BELIEF_FACTUAL
+            assert beliefs[bid].alpha == 2.0
+    finally:
+        store.close()
+
+
+def test_classify_orphans_no_orphans_is_noop(
+    memdb: MemoryStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no orphans exist the function exits cleanly with zero classified."""
+    _make_belief(memdb, belief_id="t1", content="typed", belief_type="factual",
+                 alpha=2.0, beta=1.0)
+
+    call_count = {"n": 0}
+
+    def tripwire(**kw: Any) -> Any:
+        call_count["n"] += 1
+        raise AssertionError("should not reach LLM with no orphans")
+
+    monkeypatch.setattr(llm, "_call_anthropic", tripwire)
+
+    report = classify_orphans(
+        memdb, api_key="key", model=llm.DEFAULT_MODEL, max_tokens=0,
+    )
+    assert report.orphans_found == 0
+    assert report.classified == 0
+    assert call_count["n"] == 0
+
+
+def test_classify_orphans_max_n_caps_llm_input(
+    memdb: MemoryStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--max N caps how many orphans are sent to the LLM."""
+    for i in range(10):
+        _make_belief(memdb, belief_id=f"o{i}", content=f"orphan {i}",
+                     belief_type="unknown")
+
+    sent_count: list[int] = []
+
+    def counting_fake(**kw: Any) -> llm.ClientResponse:
+        candidates = json.loads(kw["user_message"])
+        sent_count.append(len(candidates))
+        results = [
+            {"index": c["index"], "belief_type": "factual",
+             "origin": "agent_inferred", "persist": True}
+            for c in candidates
+        ]
+        return llm.ClientResponse(text=json.dumps(results),
+                                  input_tokens=10, output_tokens=5)
+
+    monkeypatch.setattr(llm, "_call_anthropic", counting_fake)
+
+    report = classify_orphans(
+        memdb, api_key="key", model=llm.DEFAULT_MODEL, max_tokens=0, max_n=4,
+    )
+    assert report.orphans_found == 10
+    assert report.classified == 4
+    assert sum(sent_count) == 4
+
+
+def test_format_orphan_report_dry_run(memdb: MemoryStore) -> None:
+    """format_orphan_report includes dry-run marker and no 'after' section."""
+    for i in range(3):
+        _make_belief(memdb, belief_id=f"o{i}", content=f"orphan {i}",
+                     belief_type="unknown")
+    report = classify_orphans(
+        memdb, api_key="", model=llm.DEFAULT_MODEL, max_tokens=0, dry_run=True,
+    )
+    text = format_orphan_report(report)
+    assert "dry-run" in text
+    assert "3 orphan(s) found" in text
+    assert "after" not in text
+
+
+def test_format_orphan_report_live_run_includes_cost(
+    memdb: MemoryStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """format_orphan_report includes token counts and cost estimate."""
+    _make_belief(memdb, belief_id="o1", content="orphan one", belief_type="unknown")
+
+    monkeypatch.setattr(
+        llm, "_call_anthropic", _fake_call_anthropic_factory([BELIEF_FACTUAL])
+    )
+
+    report = classify_orphans(
+        memdb, api_key="key", model=llm.DEFAULT_MODEL, max_tokens=0,
+    )
+    text = format_orphan_report(report)
+    assert "tokens:" in text
+    assert "estimated cost:" in text
+    assert "after" in text
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def memdb_cli(monkeypatch: pytest.MonkeyPatch) -> Iterator[MemoryStore]:
+    """In-memory store wired into the CLI _open_store."""
+    store = MemoryStore(":memory:")
+    real_close = store.close
+    store.close = lambda: None  # type: ignore[method-assign]
+
+    def _open() -> MemoryStore:
+        return store
+
+    monkeypatch.setattr(cli_module, "_open_store", _open)
+    yield store
+    real_close()
+
+
+def test_cli_classify_orphans_dry_run(
+    memdb_cli: MemoryStore,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_anthropic: None,
+) -> None:
+    """aelf doctor --classify-orphans --dry-run prints report, exits 0."""
+    for i in range(5):
+        _make_belief(memdb_cli, belief_id=f"o{i}", content=f"orphan {i}",
+                     belief_type="unknown")
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(
+        llm, "_call_anthropic",
+        lambda **kw: (_ for _ in ()).throw(  # type: ignore[arg-type]
+            AssertionError("dry-run must not reach LLM")
+        ),
+    )
+
+    out = io.StringIO()
+    rc = cli_module.main(
+        ["doctor", "--classify-orphans", "--dry-run"], out=out
+    )
+    assert rc == 0
+    text = out.getvalue()
+    assert "5 orphan(s) found" in text
+    assert "dry-run" in text
+
+
+def test_cli_classify_orphans_live(
+    memdb_cli: MemoryStore,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_anthropic: None,
+) -> None:
+    """aelf doctor --classify-orphans classifies and updates the store."""
+    for i in range(3):
+        _make_belief(memdb_cli, belief_id=f"o{i}", content=f"orphan {i}",
+                     belief_type="unknown")
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(
+        llm, "_call_anthropic",
+        _fake_call_anthropic_factory([BELIEF_FACTUAL, BELIEF_PREFERENCE, BELIEF_REQUIREMENT]),
+    )
+
+    out = io.StringIO()
+    rc = cli_module.main(["doctor", "--classify-orphans"], out=out)
+    assert rc == 0
+    text = out.getvalue()
+    assert "classified: 3" in text
+
+    # Verify store was updated
+    beliefs = {b.id: b for b in _all_beliefs(memdb_cli)}
+    assert beliefs["o0"].type == BELIEF_FACTUAL
+    assert beliefs["o1"].type == BELIEF_PREFERENCE
+    assert beliefs["o2"].type == BELIEF_REQUIREMENT
+
+
+def test_cli_classify_orphans_no_api_key(
+    memdb_cli: MemoryStore,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_anthropic: None,
+) -> None:
+    """Without ANTHROPIC_API_KEY and no --dry-run, exits 1 with hint."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _make_belief(memdb_cli, belief_id="o1", content="orphan",
+                 belief_type="unknown")
+
+    out = io.StringIO()
+    rc = cli_module.main(["doctor", "--classify-orphans"], out=out)
+    assert rc == 1
+
+
+def test_cli_classify_orphans_max_n(
+    memdb_cli: MemoryStore,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_anthropic: None,
+) -> None:
+    """--max N limits how many beliefs are sent to the LLM."""
+    for i in range(10):
+        _make_belief(memdb_cli, belief_id=f"o{i}", content=f"orphan {i}",
+                     belief_type="unknown")
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    # All factual for simplicity
+    monkeypatch.setattr(
+        llm, "_call_anthropic",
+        _fake_call_anthropic_factory([BELIEF_FACTUAL] * 10),
+    )
+
+    out = io.StringIO()
+    rc = cli_module.main(["doctor", "--classify-orphans", "--max", "3"], out=out)
+    assert rc == 0
+    text = out.getvalue()
+    assert "10 orphan(s) found" in text
+    assert "classified: 3" in text
+
+
+def test_count_beliefs_by_type(memdb: MemoryStore) -> None:
+    """count_beliefs_by_type returns correct distribution dict."""
+    _make_belief(memdb, belief_id="f1", content="factual 1", belief_type="factual")
+    _make_belief(memdb, belief_id="f2", content="factual 2", belief_type="factual")
+    _make_belief(memdb, belief_id="p1", content="pref 1", belief_type="preference")
+    _make_belief(memdb, belief_id="u1", content="unk 1", belief_type="unknown")
+
+    dist = memdb.count_beliefs_by_type()
+    assert dist["factual"] == 2
+    assert dist["preference"] == 1
+    assert dist["unknown"] == 1


### PR DESCRIPTION
Closes #206.

## Summary

Adds \`aelf doctor --classify-orphans\` — a targeted reclassification pass that finds beliefs whose \`type\` was never resolved AND that have never received any feedback, then re-classifies them through the same Haiku batch path \`aelf onboard --llm-classify\` already uses. Strict superset of onboard: only adds calls, doesn't replace anything.

## Orphan definition (both signals required)

- \`type = 'unknown' OR type IS NULL\` — never successfully typed by onboard/ingest.
- \`alpha + beta <= 2\` — untouched prior is alpha=1, beta=1 (sum=2); any feedback event pushes the sum above 2.

The other orphan signals from the issue (zero non-CONTAINS edges, entity_index miss) are noted in code comments as future extensions once #143 / edge-type auditing land.

## CLI

- \`aelf doctor --classify-orphans\` — full pass.
- \`--dry-run\` — count orphans + show before-distribution; no LLM calls, no DB writes.
- \`--max N\` — cap classifications per run (recommended: 500 for large stores).
- Reports orphans found, classified, skipped, before/after type distribution, input/output token counts, request count, fallback count, and an estimated cost line.

## Implementation notes

- Reuses \`aelfrice.llm_classifier.classify_batch\` — no new LLM client.
- Updates only \`type\` and \`origin\` (set to \`agent_inferred\`); \`alpha\`, \`beta\`, lock state, \`demotion_pressure\`, and timestamps are preserved.
- Auth failures and token-cap-exceeded errors propagate out and exit 1.
- When the whole batch falls back to regex, all orphans are marked skipped (regex-fallback is designed for fresh inserts in scan_repo, not in-place updates).

## Test plan

- [x] 14 new tests in \`tests/test_doctor_classify_orphans.py\`, all green; full suite 1598 passed / 5 skipped.
- [x] \`test_classify_orphans_95_percent_recovery\` — synthetic orphan corpus, asserts >=95% recovery to non-unknown type.
- [x] \`test_classify_orphans_max_n_caps_llm_input\` — verifies the SQL LIMIT actually bounds the LLM call.
- [x] \`test_cli_classify_orphans_no_api_key\` — exits 1 with a useful message when ANTHROPIC_API_KEY is unset.
- [x] \`test_classify_orphans_dry_run_no_writes\` — no DB writes, no network in dry-run mode.

## Out of scope

- LLM-free orphan classification (separate spike).
- Auto-running on ingest — manual \`aelf doctor\` invocation only.
- \`feedback_loop_synthesis\` integration — defers to #205 landing.