### PR TITLE
fix: ingest entry points stamp origin (#224)

### DIFF
--- a/src/aelfrice/benchmark.py
+++ b/src/aelfrice/benchmark.py
@@ -39,7 +39,7 @@ import time
 from dataclasses import asdict, dataclass
 from typing import Final
 
-from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, ORIGIN_UNKNOWN, Belief
 from aelfrice.retrieval import retrieve
 from aelfrice.store import MemoryStore
 
@@ -175,6 +175,7 @@ def seed_corpus(store: MemoryStore, *, created_at: str = "2026-04-26T00:00:00Z")
                 demotion_pressure=0,
                 created_at=created_at,
                 last_retrieved_at=None,
+                origin=ORIGIN_UNKNOWN,
             )
         )
         inserted += 1

--- a/src/aelfrice/classification.py
+++ b/src/aelfrice/classification.py
@@ -42,6 +42,7 @@ from aelfrice.models import (
     BELIEF_TYPES,
     LOCK_NONE,
     ONBOARD_STATE_PENDING,
+    ORIGIN_AGENT_INFERRED,
     Belief,
     OnboardSession,
 )
@@ -512,6 +513,7 @@ def accept_classifications(
                 demotion_pressure=0,
                 created_at=timestamp,
                 last_retrieved_at=None,
+                origin=ORIGIN_AGENT_INFERRED,
             )
         )
         inserted += 1

--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -30,6 +30,7 @@ from aelfrice.models import (
     CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
     EDGE_DERIVED_FROM,
     LOCK_NONE,
+    ORIGIN_AGENT_INFERRED,
     Belief,
     Edge,
 )
@@ -139,6 +140,7 @@ def _ingest_turn_ids(
             created_at=ts,
             last_retrieved_at=None,
             session_id=session_id,
+            origin=ORIGIN_AGENT_INFERRED,
         )
         store.insert_belief(belief)
         inserted.append(belief_id)

--- a/src/aelfrice/migrate.py
+++ b/src/aelfrice/migrate.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
 
-from aelfrice.models import Belief, Edge
+from aelfrice.models import ORIGIN_UNKNOWN, Belief, Edge
 from aelfrice.store import MemoryStore
 
 LEGACY_DB_NAME: Final[str] = "memory.db"
@@ -73,8 +73,10 @@ def _belongs_to_project(content: str, project_root: Path) -> bool:
 
 def _read_legacy_beliefs(conn: sqlite3.Connection) -> list[Belief]:
     cur = conn.execute("SELECT * FROM beliefs")
+    rows = cur.fetchall()
+    has_origin = bool(rows) and "origin" in rows[0].keys()
     out: list[Belief] = []
-    for row in cur.fetchall():
+    for row in rows:
         out.append(Belief(
             id=row["id"],
             content=row["content"],
@@ -87,6 +89,7 @@ def _read_legacy_beliefs(conn: sqlite3.Connection) -> list[Belief]:
             demotion_pressure=int(row["demotion_pressure"]),
             created_at=row["created_at"],
             last_retrieved_at=row["last_retrieved_at"],
+            origin=row["origin"] if has_origin else ORIGIN_UNKNOWN,
         ))
     return out
 

--- a/src/aelfrice/triple_extractor.py
+++ b/src/aelfrice/triple_extractor.py
@@ -39,6 +39,7 @@ from aelfrice.models import (
     EDGE_SUPERSEDES,
     EDGE_SUPPORTS,
     LOCK_NONE,
+    ORIGIN_AGENT_INFERRED,
     Belief,
     Edge,
 )
@@ -278,6 +279,7 @@ def _resolve_or_create_belief(
         created_at=_now_iso(),
         last_retrieved_at=None,
         session_id=session_id,
+        origin=ORIGIN_AGENT_INFERRED,
     )
     store.insert_belief(belief)
     created_ids.append(bid)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -75,6 +75,19 @@ def test_ingest_turn_accepts_session_id_and_source_id(store: MemoryStore) -> Non
     assert n == 1
 
 
+def test_ingest_turn_stamps_origin_agent_inferred(store: MemoryStore) -> None:
+    """Ingested-via-classifier beliefs land with origin=agent_inferred,
+    not the model default ORIGIN_UNKNOWN. Regression for #224."""
+    ingest_turn(
+        store,
+        "The default port is 8080 for the dashboard service.",
+        source="user",
+    )
+    hits = store.search_beliefs("dashboard", limit=10)
+    assert len(hits) == 1
+    assert hits[0].origin == "agent_inferred"
+
+
 def test_ingest_turn_uses_provided_created_at(store: MemoryStore) -> None:
     ingest_turn(
         store,

--- a/tests/test_ingest_triples_idempotency.py
+++ b/tests/test_ingest_triples_idempotency.py
@@ -70,6 +70,23 @@ def test_no_session_id_leaves_field_null() -> None:
         store.close()
 
 
+def test_origin_stamped_agent_inferred() -> None:
+    """Beliefs created by triple-extraction land with
+    origin=agent_inferred, not the model default. Regression for #224."""
+    store = MemoryStore(":memory:")
+    try:
+        triples = extract_triples("the new index supports faster queries")
+        ingest_triples(store, triples)
+        rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+            "SELECT origin FROM beliefs"
+        ).fetchall()
+        assert rows
+        for row in rows:
+            assert row["origin"] == "agent_inferred"
+    finally:
+        store.close()
+
+
 def test_self_edge_skipped() -> None:
     """A triple whose subject and object normalize to the same phrase
     must not produce an edge."""

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -181,6 +181,34 @@ def test_apply_writes_only_filtered_beliefs(
         s.close()
 
 
+def test_apply_preserves_origin_from_legacy_row(
+    tmp_path: Path, project_root: Path, legacy_db: Path,
+) -> None:
+    """Migrating from a v1.2+ legacy DB preserves the origin column.
+    The seeded locked belief is backfilled to 'user_stated' by the
+    v1.2 catch-up migration (lock_level=user → user_stated); we assert
+    the migrate path passes that value through to the target store
+    rather than dropping it. Regression for #224."""
+    target = tmp_path / "tgt.db"
+    migrate(
+        legacy_path=legacy_db,
+        target_path=target,
+        project_root=project_root,
+        apply=True,
+        copy_all=True,
+    )
+    s = MemoryStore(str(target))
+    try:
+        b = s.get_belief("aaaa")
+        assert b is not None
+        assert b.origin == "user_stated"
+        b2 = s.get_belief("bbbb")
+        assert b2 is not None
+        assert b2.origin == "unknown"
+    finally:
+        s.close()
+
+
 def test_apply_all_writes_every_legacy_belief(
     tmp_path: Path, project_root: Path, legacy_db: Path,
 ) -> None:

--- a/tests/test_onboard_handshake.py
+++ b/tests/test_onboard_handshake.py
@@ -198,6 +198,26 @@ def test_accept_inserts_one_belief_per_persisting_classification(
     assert outcome.inserted == len(result.sentences)
 
 
+def test_accept_stamps_origin_agent_inferred(
+    store: MemoryStore, tmp_path: Path
+) -> None:
+    """Beliefs from accept_classifications land with origin=agent_inferred,
+    not the model default ORIGIN_UNKNOWN. Regression for #224."""
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    cls = [
+        HostClassification(index=s.index, belief_type=BELIEF_FACTUAL, persist=True)
+        for s in result.sentences
+    ]
+    accept_classifications(store, result.session_id, cls, now="2026-04-26T01:00:00Z")
+    ids = store.list_belief_ids()
+    assert ids, "expected at least one belief inserted"
+    rows = [store.get_belief(b) for b in ids]
+    assert all(r is not None and r.origin == "agent_inferred" for r in rows), (
+        f"unexpected origins: {sorted({r.origin for r in rows if r})}"
+    )
+
+
 def test_accept_skips_non_persisting_classifications(
     store: MemoryStore, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

Closes #224. Five ingest entry points constructed `Belief` without
an `origin` keyword, falling through to the model default
`ORIGIN_UNKNOWN`. Audited every `Belief(` construction in the
codebase; five sites needed fixing. Each is now explicit.

| Site | Origin | Rationale |
|---|---|---|
| `ingest.py:129` | `ORIGIN_AGENT_INFERRED` | transcript ingest, classifier-typed |
| `classification.py:503` | `ORIGIN_AGENT_INFERRED` | onboard-accept, classifier-typed |
| `triple_extractor.py:268` | `ORIGIN_AGENT_INFERRED` | commit-ingest, extractor-typed |
| `migrate.py:78` | preserve from row, else `ORIGIN_UNKNOWN` | data migration must not drop the column |
| `benchmark.py:166` | explicit `ORIGIN_UNKNOWN` | seed corpus, neither user nor agent |

Sites already passing `origin` (no change): `store.py:267` (read
path), `scanner.py:236/279`, `mcp_server.py:217`, `cli.py:797`.

## Test plan

- 4 new regression tests (`test_ingest`, `test_onboard_handshake`,
  `test_ingest_triples_idempotency`, `test_migrate`).
- Full suite: 1,688 passed, 8 pre-existing skips, 0 failures.
- Each commit isolates one site and its regression test.

## Notes for reviewer

- Adjacent finding outside this PR's scope: T1 corroboration
  recorder (#190, merged via #212) is wired to a `content_hash
  UNIQUE` constraint that doesn't exist in `_SCHEMA` or any
  migration. Filed as **#254** for v2.0; deferred per maintainer
  call.
- Empirical follow-ups posted on **#219**, **#222**, **#223**
  with reproduction results against current live stores. Those
  three issues remain open pending user verification of which
  store remains canonical for the original measurements.

## Commits

1. `dbe2e93` fix: ingest_turn stamps origin=agent_inferred
2. `90b7592` fix: accept_classifications stamps origin=agent_inferred
3. `30411c7` fix: triple_extractor stamps origin=agent_inferred
4. `6122c70` fix: migrate preserves origin column when present
5. `2302e5a` fix: benchmark seed_corpus passes explicit ORIGIN_UNKNOWN
6. `aa64357` gate: #224 origin propagation — 5 ingest entry points stamp origin
