### PR TITLE
feat: deferred-feedback sweeper — implicit retrieval-driven posterior signal (#191)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2379,6 +2379,67 @@ def _print_doctor_store_check(out: object) -> None:
         )
 
 
+def _cmd_sweep_feedback(args: argparse.Namespace, out: object) -> int:
+    """Process the deferred-feedback queue (#191).
+
+    Applies +epsilon to the alpha of each belief whose retrieval-
+    exposure row has cleared its grace window without a contradicting
+    explicit-feedback event. Cancels rows where an explicit signal
+    landed within the grace window. Idempotent.
+
+    Exits 0 unless `--strict` is passed and an exception escapes.
+    Without `--strict`, errors are logged to stderr and the command
+    exits 0 so the subcommand is safe to wire into cron.
+    """
+    from aelfrice.deferred_feedback import (
+        resolve_epsilon,
+        resolve_grace_seconds,
+        sweep_deferred_feedback,
+    )
+
+    grace = (
+        int(args.grace_seconds)
+        if args.grace_seconds is not None
+        else resolve_grace_seconds()
+    )
+    eps = (
+        float(args.epsilon)
+        if args.epsilon is not None
+        else resolve_epsilon()
+    )
+    limit = int(args.limit) if args.limit is not None else 10_000
+
+    store = _open_store()
+    try:
+        result = sweep_deferred_feedback(
+            store,
+            grace_seconds=grace,
+            epsilon=eps,
+            limit=limit,
+        )
+    except Exception as exc:  # noqa: BLE001 - cron-safe by default
+        print(f"aelf sweep-feedback: {exc}", file=sys.stderr)
+        if getattr(args, "strict", False):
+            return 1
+        return 0
+    finally:
+        try:
+            store.close()
+        except Exception:  # pragma: no cover
+            pass
+
+    print(
+        f"sweep-feedback: applied={result.applied} "
+        f"cancelled={result.cancelled} "
+        f"skipped_no_belief={result.skipped_no_belief} "
+        f"pending_in_grace={result.pending_unmet_grace} "
+        f"epsilon={result.epsilon_used} "
+        f"grace_seconds={result.grace_seconds_used}",
+        file=out,  # type: ignore[arg-type]
+    )
+    return 0
+
+
 def _cmd_session_delta(args: argparse.Namespace, out: object) -> int:
     """Compute per-session telemetry and append one v=1 row.
 
@@ -2883,6 +2944,41 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         ),
     )
     p_doctor.set_defaults(func=_cmd_doctor)
+
+    p_sweep_feedback = sub.add_parser(
+        "sweep-feedback",
+        help=(
+            "process deferred retrieval-exposure feedback queue (#191): "
+            "apply +epsilon to beliefs whose grace window elapsed without "
+            "a contradicting explicit signal"
+        ),
+    )
+    p_sweep_feedback.add_argument(
+        "--grace-seconds", type=int, default=None,
+        help=(
+            "override grace window in seconds. Default: "
+            "AELFRICE_IMPLICIT_FEEDBACK_GRACE_SECONDS env > "
+            "[implicit_feedback] grace_window_seconds in .aelfrice.toml > "
+            "1800"
+        ),
+    )
+    p_sweep_feedback.add_argument(
+        "--epsilon", type=float, default=None,
+        help=(
+            "override per-row alpha increment. Default: "
+            "AELFRICE_IMPLICIT_FEEDBACK_EPSILON env > "
+            "[implicit_feedback] epsilon in .aelfrice.toml > 0.05"
+        ),
+    )
+    p_sweep_feedback.add_argument(
+        "--limit", type=int, default=None,
+        help="max queue rows to process per invocation (default 10000)",
+    )
+    p_sweep_feedback.add_argument(
+        "--strict", action="store_true",
+        help="exit non-zero on any exception (default: log + exit 0 for cron)",
+    )
+    p_sweep_feedback.set_defaults(func=_cmd_sweep_feedback)
 
     p_setup = sub.add_parser(
         "setup",

--- a/src/aelfrice/deferred_feedback.py
+++ b/src/aelfrice/deferred_feedback.py
@@ -1,0 +1,369 @@
+"""Implicit retrieval-driven feedback sweeper (#191, T2 of phantom-prereqs).
+
+`apply_feedback` is invoked rarely in normal use, but `retrieve()`
+fires constantly. This module turns retrieval exposure into a small,
+deferred posterior signal: the retrieval path enqueues one row per
+surfaced belief; a periodic sweeper (CLI: `aelf sweep-feedback`)
+applies `+epsilon` to each belief whose grace window has elapsed
+without an explicit correction or contradiction landing on it.
+
+Contracts (see issue #191 for full spec):
+
+  * `T_grace`: enqueue_at + T_grace must be <= now before a row is
+    eligible. Default 1800 s (30 min). Configurable via
+    `[implicit_feedback] grace_window_seconds` in `.aelfrice.toml`
+    or `AELFRICE_IMPLICIT_FEEDBACK_GRACE_SECONDS` env var.
+  * `epsilon`: alpha increment per applied row. Default 0.05.
+    Configurable via `[implicit_feedback] epsilon` /
+    `AELFRICE_IMPLICIT_FEEDBACK_EPSILON`.
+  * `RETRIEVAL_DRIVEN_FEEDBACK_SOURCE`: the source string written to
+    feedback_history for every applied row. Distinct from any
+    explicit-user-feedback source so the audit trail can split
+    explicit vs implicit signals.
+  * Cancellation: any feedback_history row for the same belief whose
+    `source` is NOT `RETRIEVAL_DRIVEN_FEEDBACK_SOURCE` and whose
+    `created_at` is in [enqueued_at, now] cancels the pending row
+    (no alpha change). This implements the "explicit beats implicit"
+    + "contradiction within grace" contracts in one query, since
+    contradiction-tiebreaker resolutions also write to
+    feedback_history with a distinct source prefix.
+  * Idempotency: only `status='enqueued'` rows are processed.
+    `applied`/`cancelled` rows are skipped on re-run.
+  * Atomicity per row: belief alpha update + feedback_history insert
+    + queue status update share a single explicit transaction. A
+    crash mid-row leaves the row `enqueued` (the alpha update is
+    rolled back with the rest); re-run applies it once and only once.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import IO, Any, Final
+
+try:
+    import tomllib
+except ImportError:  # pragma: no cover - py < 3.11 fallback path
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from aelfrice.store import MemoryStore
+
+# --- Public constants ---------------------------------------------------
+
+DEFAULT_T_GRACE_SECONDS: Final[int] = 1800
+DEFAULT_EPSILON: Final[float] = 0.05
+
+CONFIG_FILENAME: Final[str] = ".aelfrice.toml"
+IMPLICIT_FEEDBACK_SECTION: Final[str] = "implicit_feedback"
+GRACE_KEY: Final[str] = "grace_window_seconds"
+EPSILON_KEY: Final[str] = "epsilon"
+ENQUEUE_KEY: Final[str] = "enqueue_on_retrieve"
+
+ENV_GRACE: Final[str] = "AELFRICE_IMPLICIT_FEEDBACK_GRACE_SECONDS"
+ENV_EPSILON: Final[str] = "AELFRICE_IMPLICIT_FEEDBACK_EPSILON"
+ENV_ENQUEUE: Final[str] = "AELFRICE_IMPLICIT_FEEDBACK_ENQUEUE"
+
+EVENT_RETRIEVAL_EXPOSURE: Final[str] = "retrieval_exposure"
+RETRIEVAL_DRIVEN_FEEDBACK_SOURCE: Final[str] = "retrieval_driven_feedback"
+
+_ENV_FALSY: Final[frozenset[str]] = frozenset({"0", "false", "no", "off"})
+_ENV_TRUTHY: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+
+
+# --- Result shape -------------------------------------------------------
+
+
+@dataclass
+class SweepResult:
+    """Outcome of one `sweep_deferred_feedback` invocation.
+
+    `applied` and `cancelled` count rows whose status transitioned
+    during this call. `skipped_no_belief` counts rows whose belief_id
+    no longer resolves (the belief was deleted between enqueue and
+    sweep) — those rows are marked cancelled so the queue drains.
+    """
+
+    applied: int = 0
+    cancelled: int = 0
+    skipped_no_belief: int = 0
+    pending_unmet_grace: int = 0
+    epsilon_used: float = 0.0
+    grace_seconds_used: int = 0
+    applied_belief_ids: list[str] = field(default_factory=list)
+    cancelled_belief_ids: list[str] = field(default_factory=list)
+
+
+# --- Time helpers -------------------------------------------------------
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(ts: str) -> datetime:
+    """Parse an ISO-8601 timestamp; tolerate both `Z` and `+00:00` suffixes."""
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return datetime.fromisoformat(ts)
+
+
+# --- Config resolution --------------------------------------------------
+
+
+def _read_toml_value(
+    key: str, *, start: Path | None = None
+) -> Any:  # noqa: ANN401 - typed by callers
+    """Walk up from `start` finding `[implicit_feedback] <key>`. Returns
+    the raw TOML value, or None when no file / no key. Fail-soft."""
+    serr: IO[str] = sys.stderr
+    current = (start if start is not None else Path.cwd()).resolve()
+    seen: set[Path] = set()
+    while current not in seen:
+        seen.add(current)
+        candidate = current / CONFIG_FILENAME
+        if candidate.is_file():
+            try:
+                raw = candidate.read_bytes()
+                parsed: dict[str, Any] = tomllib.loads(
+                    raw.decode("utf-8", errors="replace"),
+                )
+            except (OSError, tomllib.TOMLDecodeError) as exc:
+                print(
+                    f"aelfrice implicit_feedback: cannot read {candidate}: "
+                    f"{exc}",
+                    file=serr,
+                )
+                return None
+            section = parsed.get(IMPLICIT_FEEDBACK_SECTION, {})
+            if not isinstance(section, dict):
+                return None
+            return section.get(key)  # type: ignore[no-any-return]
+        if current.parent == current:
+            break
+        current = current.parent
+    return None
+
+
+def resolve_grace_seconds(
+    explicit: int | None = None, *, start: Path | None = None
+) -> int:
+    """Env > kwarg > TOML > DEFAULT_T_GRACE_SECONDS. Negative clamps to 0."""
+    raw_env = os.environ.get(ENV_GRACE)
+    if raw_env is not None and raw_env.strip():
+        try:
+            return max(0, int(raw_env.strip()))
+        except ValueError:
+            print(
+                f"aelfrice implicit_feedback: ignoring {ENV_GRACE}={raw_env!r}"
+                " (expected int)",
+                file=sys.stderr,
+            )
+    if explicit is not None:
+        return max(0, int(explicit))
+    toml_v = _read_toml_value(GRACE_KEY, start=start)
+    if isinstance(toml_v, int) and not isinstance(toml_v, bool):
+        return max(0, toml_v)
+    return DEFAULT_T_GRACE_SECONDS
+
+
+def resolve_epsilon(
+    explicit: float | None = None, *, start: Path | None = None
+) -> float:
+    """Env > kwarg > TOML > DEFAULT_EPSILON. Negative clamps to 0.0."""
+    raw_env = os.environ.get(ENV_EPSILON)
+    if raw_env is not None and raw_env.strip():
+        try:
+            return max(0.0, float(raw_env.strip()))
+        except ValueError:
+            print(
+                f"aelfrice implicit_feedback: ignoring {ENV_EPSILON}={raw_env!r}"
+                " (expected float)",
+                file=sys.stderr,
+            )
+    if explicit is not None:
+        return max(0.0, float(explicit))
+    toml_v = _read_toml_value(EPSILON_KEY, start=start)
+    if isinstance(toml_v, bool):
+        return DEFAULT_EPSILON
+    if isinstance(toml_v, (int, float)):
+        return max(0.0, float(toml_v))
+    return DEFAULT_EPSILON
+
+
+def is_enqueue_on_retrieve_enabled(
+    explicit: bool | None = None, *, start: Path | None = None
+) -> bool:
+    """Env > kwarg > TOML > default True. Default-on because the queue is
+    additive (no consumer reads it until the sweeper runs); operators can
+    flip it off without losing any other functionality."""
+    raw_env = os.environ.get(ENV_ENQUEUE)
+    if raw_env is not None:
+        norm = raw_env.strip().lower()
+        if norm in _ENV_FALSY:
+            return False
+        if norm in _ENV_TRUTHY:
+            return True
+    if explicit is not None:
+        return explicit
+    toml_v = _read_toml_value(ENQUEUE_KEY, start=start)
+    if isinstance(toml_v, bool):
+        return toml_v
+    return True
+
+
+# --- Enqueue path -------------------------------------------------------
+
+
+def enqueue_retrieval_exposures(
+    store: MemoryStore,
+    belief_ids: list[str],
+    *,
+    now: str | None = None,
+) -> int:
+    """Enqueue one `retrieval_exposure` row per belief_id. Returns the
+    count of rows inserted. A single shared `enqueued_at` keeps the
+    grace window well-defined for a batch from one retrieve() call."""
+    if not belief_ids:
+        return 0
+    ts = now if now is not None else _utc_now_iso()
+    n = 0
+    for bid in belief_ids:
+        store.enqueue_deferred_feedback(
+            bid,
+            event_type=EVENT_RETRIEVAL_EXPOSURE,
+            enqueued_at=ts,
+        )
+        n += 1
+    return n
+
+
+# --- Sweeper ------------------------------------------------------------
+
+
+def sweep_deferred_feedback(
+    store: MemoryStore,
+    *,
+    now: str | None = None,
+    grace_seconds: int | None = None,
+    epsilon: float | None = None,
+    limit: int = 10_000,
+    config_start: Path | None = None,
+) -> SweepResult:
+    """Process pending queue rows whose grace window has elapsed.
+
+    For each pending row with `enqueued_at <= now - grace_seconds`:
+
+      * If `feedback_history` has an entry for this belief whose source
+        is not `RETRIEVAL_DRIVEN_FEEDBACK_SOURCE` and whose created_at
+        is in `[enqueued_at, now]`, mark `cancelled` (no posterior
+        change). This covers explicit user feedback AND contradiction
+        tiebreaker events in one query.
+      * Else apply `+epsilon` to belief.alpha, write a feedback_history
+        row with source=RETRIEVAL_DRIVEN_FEEDBACK_SOURCE, and mark
+        `applied`. The three writes share one transaction so a crash
+        mid-row leaves the queue row `enqueued` and the alpha
+        unchanged — re-run applies once.
+      * If the belief no longer exists, mark `cancelled` and count
+        toward `skipped_no_belief` so the queue drains.
+
+    Idempotent: only `enqueued` rows are touched; re-running the
+    sweeper over the resulting state is a no-op for the rows it
+    already processed."""
+    grace_eff = (
+        grace_seconds
+        if grace_seconds is not None
+        else resolve_grace_seconds(start=config_start)
+    )
+    eps_eff = (
+        epsilon
+        if epsilon is not None
+        else resolve_epsilon(start=config_start)
+    )
+    now_iso = now if now is not None else _utc_now_iso()
+    cutoff_dt = _parse_iso(now_iso) - timedelta(seconds=grace_eff)
+    cutoff_iso = cutoff_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    result = SweepResult(
+        epsilon_used=eps_eff,
+        grace_seconds_used=grace_eff,
+    )
+
+    # Pending = enqueued with grace elapsed.
+    pending = store.list_pending_deferred_feedback(
+        cutoff_iso=cutoff_iso, limit=limit
+    )
+
+    # Count rows still in their grace window separately.
+    by_status = store.count_deferred_feedback_by_status()
+    enqueued_total = by_status.get("enqueued", 0)
+    result.pending_unmet_grace = max(0, enqueued_total - len(pending))
+
+    conn = store._conn  # noqa: SLF001 - intentional, atomic per row
+
+    for row_id, belief_id, enqueued_at, _event_type in pending:
+        belief = store.get_belief(belief_id)
+        if belief is None:
+            # Drain; nothing to update.
+            conn.execute(
+                "UPDATE deferred_feedback_queue "
+                "SET status='cancelled', applied_at=? WHERE id=?",
+                (now_iso, row_id),
+            )
+            conn.commit()
+            result.skipped_no_belief += 1
+            result.cancelled += 1
+            result.cancelled_belief_ids.append(belief_id)
+            continue
+
+        cancelled = store.has_explicit_feedback_in_window(
+            belief_id,
+            window_start_iso=enqueued_at,
+            window_end_iso=now_iso,
+            retrieval_source=RETRIEVAL_DRIVEN_FEEDBACK_SOURCE,
+        )
+
+        # Single explicit transaction wrapping the row's writes.
+        # `BEGIN IMMEDIATE` acquires the write lock up-front so a
+        # concurrent writer cannot interleave.
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            if cancelled:
+                conn.execute(
+                    "UPDATE deferred_feedback_queue "
+                    "SET status='cancelled', applied_at=? WHERE id=?",
+                    (now_iso, row_id),
+                )
+                conn.execute("COMMIT")
+                result.cancelled += 1
+                result.cancelled_belief_ids.append(belief_id)
+            else:
+                conn.execute(
+                    "UPDATE beliefs SET alpha = alpha + ? WHERE id = ?",
+                    (eps_eff, belief_id),
+                )
+                conn.execute(
+                    "INSERT INTO feedback_history "
+                    "(belief_id, valence, source, created_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (
+                        belief_id,
+                        eps_eff,
+                        RETRIEVAL_DRIVEN_FEEDBACK_SOURCE,
+                        now_iso,
+                    ),
+                )
+                conn.execute(
+                    "UPDATE deferred_feedback_queue "
+                    "SET status='applied', applied_at=? WHERE id=?",
+                    (now_iso, row_id),
+                )
+                conn.execute("COMMIT")
+                result.applied += 1
+                result.applied_belief_ids.append(belief_id)
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+
+    return result

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -1078,6 +1078,25 @@ def retrieve(
         bm25f_used=bm25f_on,
         posterior_weight=weight,
     )
+
+    # v1.6.0 #191: enqueue one retrieval_exposure row per surfaced
+    # belief for the deferred-feedback sweeper. Default-on; opt-out
+    # via [implicit_feedback] enqueue_on_retrieve = false. Fail-soft:
+    # any DB error here is logged but never breaks retrieval.
+    if out:
+        try:
+            from aelfrice.deferred_feedback import (
+                enqueue_retrieval_exposures,
+                is_enqueue_on_retrieve_enabled,
+            )
+            if is_enqueue_on_retrieve_enabled():
+                enqueue_retrieval_exposures(store, [b.id for b in out])
+        except Exception as exc:  # noqa: BLE001 - retrieval must never raise
+            print(
+                f"aelfrice retrieval: deferred-feedback enqueue failed: {exc}",
+                file=sys.stderr,
+            )
+
     return out
 
 

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -149,6 +149,28 @@ _SCHEMA: tuple[str, ...] = (
     """,
     "CREATE INDEX IF NOT EXISTS idx_belief_corroborations_belief_id "
     "ON belief_corroborations(belief_id)",
+    # v1.6.0 deferred_feedback_queue (#191). One row per surfaced
+    # belief from `retrieve()`; processed by the `aelf sweep-feedback`
+    # CLI subcommand after T_grace elapses. status transitions:
+    # 'enqueued' -> 'applied' (no contradiction in grace window) or
+    # 'cancelled' (explicit feedback / contradiction within grace).
+    # event_type is open-ended so future signals (search exposure,
+    # MCP tool reads) can ride the same sweeper. ON DELETE CASCADE
+    # keeps the queue consistent if a belief is deleted.
+    """
+    CREATE TABLE IF NOT EXISTS deferred_feedback_queue (
+        id           INTEGER PRIMARY KEY AUTOINCREMENT,
+        belief_id    TEXT    NOT NULL REFERENCES beliefs(id) ON DELETE CASCADE,
+        enqueued_at  TEXT    NOT NULL,
+        event_type   TEXT    NOT NULL,
+        applied_at   TEXT,
+        status       TEXT    NOT NULL DEFAULT 'enqueued'
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_dfq_status_enq "
+    "ON deferred_feedback_queue(status, enqueued_at)",
+    "CREATE INDEX IF NOT EXISTS idx_dfq_belief "
+    "ON deferred_feedback_queue(belief_id)",
     "CREATE INDEX IF NOT EXISTS idx_edges_src ON edges(src)",
     "CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst)",
     "CREATE INDEX IF NOT EXISTS idx_feedback_belief ON feedback_history(belief_id)",

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -1869,6 +1869,115 @@ class MemoryStore:
             if isinstance(ids, list) and belief_id in ids:
                 out.append(d)
         return out
+    # --- Deferred feedback queue (v1.6+, #191) ---------------------------
+
+    def enqueue_deferred_feedback(
+        self,
+        belief_id: str,
+        *,
+        event_type: str,
+        enqueued_at: str,
+    ) -> int:
+        """Insert one row into deferred_feedback_queue with status='enqueued'.
+
+        Returns the new rowid. Caller is responsible for grouping bulk
+        enqueues (e.g. one retrieve() call producing N surfaced beliefs)
+        by sharing a single `enqueued_at` timestamp so the grace-window
+        check is well-defined for the batch.
+        """
+        cur = self._conn.execute(
+            """
+            INSERT INTO deferred_feedback_queue
+                (belief_id, enqueued_at, event_type, status)
+            VALUES (?, ?, ?, 'enqueued')
+            """,
+            (belief_id, enqueued_at, event_type),
+        )
+        self._conn.commit()
+        rowid = cur.lastrowid
+        if rowid is None:
+            raise RuntimeError(
+                "deferred_feedback_queue insert returned no rowid"
+            )
+        return rowid
+
+    def list_pending_deferred_feedback(
+        self,
+        *,
+        cutoff_iso: str,
+        limit: int = 1000,
+    ) -> list[tuple[int, str, str, str]]:
+        """Return [(id, belief_id, enqueued_at, event_type)] for queue
+        rows with status='enqueued' and enqueued_at <= cutoff_iso.
+
+        Ordered by id ASC for deterministic processing. The caller
+        provides the cutoff (typically `now - T_grace`) so the sweeper
+        only sees rows whose grace window has elapsed.
+        """
+        cur = self._conn.execute(
+            """
+            SELECT id, belief_id, enqueued_at, event_type
+            FROM deferred_feedback_queue
+            WHERE status = 'enqueued' AND enqueued_at <= ?
+            ORDER BY id ASC
+            LIMIT ?
+            """,
+            (cutoff_iso, limit),
+        )
+        return [
+            (
+                int(r["id"]),
+                str(r["belief_id"]),
+                str(r["enqueued_at"]),
+                str(r["event_type"]),
+            )
+            for r in cur.fetchall()
+        ]
+
+    def has_explicit_feedback_in_window(
+        self,
+        belief_id: str,
+        *,
+        window_start_iso: str,
+        window_end_iso: str,
+        retrieval_source: str,
+    ) -> bool:
+        """True if any feedback_history row exists for `belief_id` whose
+        `created_at` falls within [window_start_iso, window_end_iso] and
+        whose `source` is NOT `retrieval_source`.
+
+        Used by the deferred-feedback sweeper to detect whether an
+        explicit user correction or a contradiction-tiebreaker event
+        landed during the grace window — either case cancels the
+        pending implicit increment per the explicit-beats-implicit
+        contract.
+        """
+        cur = self._conn.execute(
+            """
+            SELECT 1 FROM feedback_history
+            WHERE belief_id = ?
+              AND source != ?
+              AND created_at >= ? AND created_at <= ?
+            LIMIT 1
+            """,
+            (belief_id, retrieval_source, window_start_iso, window_end_iso),
+        )
+        return cur.fetchone() is not None
+
+    def count_deferred_feedback_by_status(self) -> dict[str, int]:
+        """Return a {status: count} dict over deferred_feedback_queue.
+
+        Used by tests and `aelf doctor` to surface queue health.
+        Statuses with zero rows are omitted from the dict.
+        """
+        cur = self._conn.execute(
+            """
+            SELECT status, COUNT(*) AS n
+            FROM deferred_feedback_queue
+            GROUP BY status
+            """
+        )
+        return {str(r["status"]): int(r["n"]) for r in cur.fetchall()}
 
     # --- Aggregations (used by aelf:health) ------------------------------
 

--- a/tests/test_cli_sweep_feedback.py
+++ b/tests/test_cli_sweep_feedback.py
@@ -1,0 +1,108 @@
+"""`aelf sweep-feedback` CLI subcommand (#191).
+
+Round-trips the subcommand through the in-process parser to verify
+flag plumbing, exit codes, and the cron-safe default behaviour.
+"""
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+from aelfrice.cli import build_parser
+from aelfrice.deferred_feedback import (
+    RETRIEVAL_DRIVEN_FEEDBACK_SOURCE,
+    enqueue_retrieval_exposures,
+)
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
+from aelfrice.store import MemoryStore
+
+
+def _mk(bid: str) -> Belief:
+    return Belief(
+        id=bid,
+        content=f"belief {bid}",
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+        session_id=None,
+        origin="unknown",
+        corroboration_count=0,
+    )
+
+
+@pytest.fixture
+def store_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the CLI at an isolated DB path under tmp_path."""
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    return db
+
+
+def _run(*args: str) -> tuple[int, str]:
+    parser = build_parser()
+    ns = parser.parse_args(["sweep-feedback", *args])
+    out = io.StringIO()
+    code: int = ns.func(ns, out)  # type: ignore[attr-defined]
+    return code, out.getvalue()
+
+
+def test_sweep_feedback_subcommand_registered() -> None:
+    from aelfrice.cli import _known_cli_subcommands
+    assert "sweep-feedback" in _known_cli_subcommands()
+
+
+def test_sweep_feedback_empty_queue_exits_zero(store_path: Path) -> None:
+    # Initialize empty store at the path.
+    s = MemoryStore(str(store_path))
+    s.close()
+    code, output = _run()
+    assert code == 0
+    assert "applied=0 cancelled=0" in output
+
+
+def test_sweep_feedback_applies_with_grace_zero(store_path: Path) -> None:
+    s = MemoryStore(str(store_path))
+    s.insert_belief(_mk("b1"))
+    enqueue_retrieval_exposures(s, ["b1"], now="2026-04-28T00:00:00Z")
+    s.close()
+    # grace=0 means everything is immediately eligible.
+    code, output = _run("--grace-seconds", "0", "--epsilon", "0.10")
+    assert code == 0
+    assert "applied=1" in output
+    s2 = MemoryStore(str(store_path))
+    try:
+        b = s2.get_belief("b1")
+        assert b is not None and b.alpha == 1.10
+        events = s2.list_feedback_events(belief_id="b1")
+        assert any(
+            e.source == RETRIEVAL_DRIVEN_FEEDBACK_SOURCE for e in events
+        )
+    finally:
+        s2.close()
+
+
+def test_sweep_feedback_strict_flag_propagates_failure(
+    store_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Force the sweep to raise.
+    import aelfrice.cli as cli_mod
+
+    def boom(*a, **k):
+        raise RuntimeError("simulated")
+
+    monkeypatch.setattr(
+        "aelfrice.deferred_feedback.sweep_deferred_feedback", boom
+    )
+    code, _ = _run("--strict")
+    assert code == 1
+    # Without --strict, exits 0 even on internal error.
+    code2, _ = _run()
+    assert code2 == 0

--- a/tests/test_implicit_feedback.py
+++ b/tests/test_implicit_feedback.py
@@ -1,0 +1,416 @@
+"""Implicit retrieval-driven feedback sweeper (#191).
+
+Covers acceptance criteria 1-8 from the issue:
+
+  1. Schema landed (deferred_feedback_queue exists; smoke-checked at
+     store construction).
+  2. retrieve() post-hook enqueues one row per surfaced belief with
+     event_type='retrieval_exposure'.
+  3. CLI subcommand `aelf sweep-feedback` (covered separately in
+     test_cli_sweep_feedback.py).
+  4. Sweeper applies +epsilon to alpha exactly once per row in the
+     no-contradiction path.
+  5. Sweeper cancels (no alpha change) when an explicit signal lands
+     in the grace window.
+  6. audit_log records 'retrieval_driven_feedback' as the source so
+     it is distinguishable from explicit user feedback.
+  7. Idempotency: sweep x 2 = sweep x 1.
+  8. Configurable T_grace + epsilon (env, kwarg, TOML, default).
+
+All tests deterministic — clock injected, no real time, no real
+sleep. In-memory store. Each test < 100 ms.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from aelfrice.deferred_feedback import (
+    DEFAULT_EPSILON,
+    DEFAULT_T_GRACE_SECONDS,
+    EVENT_RETRIEVAL_EXPOSURE,
+    RETRIEVAL_DRIVEN_FEEDBACK_SOURCE,
+    enqueue_retrieval_exposures,
+    is_enqueue_on_retrieve_enabled,
+    resolve_epsilon,
+    resolve_grace_seconds,
+    sweep_deferred_feedback,
+)
+from aelfrice.models import BELIEF_FACTUAL, EDGE_CONTRADICTS, LOCK_NONE, Belief, Edge
+from aelfrice.retrieval import retrieve
+from aelfrice.store import MemoryStore
+
+T0 = "2026-04-28T00:00:00Z"
+T_BEFORE_GRACE = "2026-04-28T00:10:00Z"  # 10 min after T0
+T_INSIDE_GRACE = "2026-04-28T00:25:00Z"  # 25 min after T0
+T_AFTER_GRACE = "2026-04-28T01:00:00Z"   # 60 min after T0
+
+
+def _mk(bid: str, content: str = "") -> Belief:
+    return Belief(
+        id=bid,
+        content=content or f"belief {bid}",
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+        session_id=None,
+        origin="unknown",
+        corroboration_count=0,
+    )
+
+
+def _store(*beliefs: Belief) -> MemoryStore:
+    s = MemoryStore(":memory:")
+    for b in beliefs:
+        s.insert_belief(b)
+    return s
+
+
+# --- AC1: schema sanity --------------------------------------------------
+
+
+def test_schema_creates_deferred_feedback_queue_table() -> None:
+    s = _store()
+    cur = s._conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name='deferred_feedback_queue'"
+    )
+    assert cur.fetchone() is not None
+
+
+def test_schema_creates_dfq_indexes() -> None:
+    s = _store()
+    cur = s._conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' "
+        "AND name LIKE 'idx_dfq%'"
+    )
+    names = sorted(str(r["name"]) for r in cur.fetchall())
+    assert "idx_dfq_belief" in names
+    assert "idx_dfq_status_enq" in names
+
+
+# --- AC2: retrieve() enqueues -------------------------------------------
+
+
+def test_retrieve_enqueues_one_row_per_surfaced_belief() -> None:
+    s = _store(_mk("b1", "apple banana"), _mk("b2", "cherry"))
+    out = retrieve(s, "apple")
+    assert {b.id for b in out} == {"b1"}
+    rows = s.list_pending_deferred_feedback(cutoff_iso="2099-01-01T00:00:00Z")
+    assert len(rows) == 1
+    assert rows[0][1] == "b1"
+    assert rows[0][3] == EVENT_RETRIEVAL_EXPOSURE
+
+
+def test_retrieve_enqueue_can_be_disabled_via_env(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("AELFRICE_IMPLICIT_FEEDBACK_ENQUEUE", "0")
+    s = _store(_mk("b1", "apple"))
+    retrieve(s, "apple")
+    assert s.count_deferred_feedback_by_status() == {}
+
+
+def test_empty_query_does_not_enqueue() -> None:
+    s = _store(_mk("b1", "apple"))
+    retrieve(s, "")
+    assert s.count_deferred_feedback_by_status() == {}
+
+
+def test_enqueue_failure_does_not_break_retrieve(monkeypatch, capsys) -> None:
+    s = _store(_mk("b1", "apple"))
+    import aelfrice.deferred_feedback as df
+    def boom(*a, **k):
+        raise RuntimeError("simulated failure")
+    monkeypatch.setattr(df, "enqueue_retrieval_exposures", boom)
+    out = retrieve(s, "apple")
+    assert {b.id for b in out} == {"b1"}
+    assert "deferred-feedback enqueue failed" in capsys.readouterr().err
+
+
+# --- AC4: applied path (+epsilon) ---------------------------------------
+
+
+def test_sweep_applies_epsilon_after_grace() -> None:
+    s = _store(_mk("b1"))
+    enqueue_retrieval_exposures(s, ["b1"], now=T0)
+    r = sweep_deferred_feedback(
+        s, now=T_AFTER_GRACE, grace_seconds=1800, epsilon=0.05
+    )
+    assert r.applied == 1
+    assert r.cancelled == 0
+    b = s.get_belief("b1")
+    assert b is not None and b.alpha == 1.05
+    assert s.count_deferred_feedback_by_status() == {"applied": 1}
+
+
+def test_sweep_skips_rows_inside_grace_window() -> None:
+    s = _store(_mk("b1"))
+    enqueue_retrieval_exposures(s, ["b1"], now=T0)
+    r = sweep_deferred_feedback(
+        s, now=T_INSIDE_GRACE, grace_seconds=1800, epsilon=0.05
+    )
+    assert r.applied == 0
+    assert r.pending_unmet_grace == 1
+    b = s.get_belief("b1")
+    assert b is not None and b.alpha == 1.0
+    assert s.count_deferred_feedback_by_status() == {"enqueued": 1}
+
+
+# --- AC5: cancellation path ---------------------------------------------
+
+
+def test_explicit_feedback_in_grace_window_cancels_implicit() -> None:
+    s = _store(_mk("b1"))
+    enqueue_retrieval_exposures(s, ["b1"], now=T0)
+    s.insert_feedback_event(
+        "b1", valence=-1.0, source="user", created_at=T_BEFORE_GRACE
+    )
+    r = sweep_deferred_feedback(
+        s, now=T_AFTER_GRACE, grace_seconds=1800, epsilon=0.05
+    )
+    assert r.applied == 0
+    assert r.cancelled == 1
+    b = s.get_belief("b1")
+    assert b is not None and b.alpha == 1.0
+
+
+def test_contradiction_tiebreaker_event_in_grace_cancels() -> None:
+    s = _store(_mk("b1"))
+    enqueue_retrieval_exposures(s, ["b1"], now=T0)
+    # Contradiction tiebreaker resolutions write to feedback_history
+    # with a distinctive 'contradiction_tiebreaker:' source prefix.
+    s.insert_feedback_event(
+        "b1", valence=-1.0,
+        source="contradiction_tiebreaker:lock_wins",
+        created_at=T_BEFORE_GRACE,
+    )
+    r = sweep_deferred_feedback(
+        s, now=T_AFTER_GRACE, grace_seconds=1800, epsilon=0.05
+    )
+    assert r.applied == 0
+    assert r.cancelled == 1
+
+
+def test_explicit_feedback_outside_grace_does_not_cancel() -> None:
+    s = _store(_mk("b1"))
+    # Explicit feedback BEFORE the enqueue → outside the row's window.
+    s.insert_feedback_event(
+        "b1", valence=-1.0, source="user",
+        created_at="2026-04-27T23:00:00Z",
+    )
+    enqueue_retrieval_exposures(s, ["b1"], now=T0)
+    r = sweep_deferred_feedback(
+        s, now=T_AFTER_GRACE, grace_seconds=1800, epsilon=0.05
+    )
+    assert r.applied == 1
+    assert r.cancelled == 0
+
+
+def test_belief_deleted_between_enqueue_and_sweep_cascades_queue_row() -> None:
+    """ON DELETE CASCADE on the FK means a deleted belief takes its
+    pending queue rows with it. The sweeper sees nothing for that
+    belief — no apply, no cancel, queue stays consistent."""
+    s = _store(_mk("b1"))
+    enqueue_retrieval_exposures(s, ["b1"], now=T0)
+    s._conn.execute("DELETE FROM beliefs WHERE id='b1'")
+    s._conn.commit()
+    r = sweep_deferred_feedback(
+        s, now=T_AFTER_GRACE, grace_seconds=1800, epsilon=0.05
+    )
+    assert r.applied == 0
+    assert r.cancelled == 0
+    assert s.count_deferred_feedback_by_status() == {}
+
+
+# --- AC6: audit-log event type distinct ---------------------------------
+
+
+def test_applied_row_writes_distinctive_audit_source() -> None:
+    s = _store(_mk("b1"))
+    enqueue_retrieval_exposures(s, ["b1"], now=T0)
+    sweep_deferred_feedback(
+        s, now=T_AFTER_GRACE, grace_seconds=1800, epsilon=0.05
+    )
+    events = s.list_feedback_events(belief_id="b1")
+    sources = [e.source for e in events]
+    assert RETRIEVAL_DRIVEN_FEEDBACK_SOURCE in sources
+    # And NOT the same as any explicit-feedback source.
+    assert "user" not in sources
+
+
+# --- AC7: idempotency + crash-safe ---------------------------------------
+
+
+def test_sweep_twice_equals_sweep_once() -> None:
+    s = _store(_mk("b1"), _mk("b2"))
+    enqueue_retrieval_exposures(s, ["b1", "b2"], now=T0)
+    s.insert_feedback_event(
+        "b2", valence=-1.0, source="user", created_at=T_BEFORE_GRACE
+    )
+    sweep_deferred_feedback(
+        s, now=T_AFTER_GRACE, grace_seconds=1800, epsilon=0.05
+    )
+    state_after_first = (
+        s.get_belief("b1").alpha,  # type: ignore[union-attr]
+        s.get_belief("b2").alpha,  # type: ignore[union-attr]
+        s.count_deferred_feedback_by_status(),
+    )
+    r2 = sweep_deferred_feedback(
+        s, now="2026-04-28T02:00:00Z", grace_seconds=1800, epsilon=0.05
+    )
+    assert r2.applied == 0 and r2.cancelled == 0
+    state_after_second = (
+        s.get_belief("b1").alpha,  # type: ignore[union-attr]
+        s.get_belief("b2").alpha,  # type: ignore[union-attr]
+        s.count_deferred_feedback_by_status(),
+    )
+    assert state_after_first == state_after_second
+
+
+def test_already_applied_row_is_not_reapplied() -> None:
+    s = _store(_mk("b1"))
+    enqueue_retrieval_exposures(s, ["b1"], now=T0)
+    sweep_deferred_feedback(
+        s, now=T_AFTER_GRACE, grace_seconds=1800, epsilon=0.05
+    )
+    # Manually re-enqueue the SAME row would be a new row; but an
+    # already-applied row should be skipped on re-scan because
+    # list_pending_deferred_feedback filters by status='enqueued'.
+    pending = s.list_pending_deferred_feedback(
+        cutoff_iso="2099-01-01T00:00:00Z"
+    )
+    assert pending == []
+
+
+def test_partial_progress_resumes_correctly() -> None:
+    """Three rows; sweep one, then sweep again — the remaining two land."""
+    s = _store(_mk("b1"), _mk("b2"), _mk("b3"))
+    enqueue_retrieval_exposures(s, ["b1", "b2", "b3"], now=T0)
+    r1 = sweep_deferred_feedback(
+        s, now=T_AFTER_GRACE, grace_seconds=1800, epsilon=0.05, limit=1
+    )
+    assert r1.applied == 1
+    r2 = sweep_deferred_feedback(
+        s, now=T_AFTER_GRACE, grace_seconds=1800, epsilon=0.05
+    )
+    assert r2.applied == 2
+    # All three got exactly one increment.
+    assert all(
+        s.get_belief(b).alpha == 1.05  # type: ignore[union-attr]
+        for b in ("b1", "b2", "b3")
+    )
+
+
+# --- AC8: configurable T_grace + epsilon -------------------------------
+
+
+def test_resolve_grace_seconds_default() -> None:
+    assert resolve_grace_seconds() == DEFAULT_T_GRACE_SECONDS
+
+
+def test_resolve_grace_seconds_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("AELFRICE_IMPLICIT_FEEDBACK_GRACE_SECONDS", "60")
+    assert resolve_grace_seconds() == 60
+
+
+def test_resolve_grace_seconds_kwarg_override() -> None:
+    assert resolve_grace_seconds(120) == 120
+
+
+def test_resolve_grace_seconds_toml_override(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[implicit_feedback]\ngrace_window_seconds = 90\n"
+    )
+    assert resolve_grace_seconds(start=tmp_path) == 90
+
+
+def test_resolve_grace_seconds_env_invalid_falls_through(monkeypatch) -> None:
+    monkeypatch.setenv("AELFRICE_IMPLICIT_FEEDBACK_GRACE_SECONDS", "not-int")
+    assert resolve_grace_seconds() == DEFAULT_T_GRACE_SECONDS
+
+
+def test_resolve_epsilon_default() -> None:
+    assert resolve_epsilon() == DEFAULT_EPSILON
+
+
+def test_resolve_epsilon_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("AELFRICE_IMPLICIT_FEEDBACK_EPSILON", "0.2")
+    assert resolve_epsilon() == 0.2
+
+
+def test_resolve_epsilon_negative_clamps_to_zero() -> None:
+    assert resolve_epsilon(-1.0) == 0.0
+
+
+def test_resolve_epsilon_toml_override(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[implicit_feedback]\nepsilon = 0.10\n"
+    )
+    assert resolve_epsilon(start=tmp_path) == 0.10
+
+
+def test_is_enqueue_on_retrieve_default_true() -> None:
+    assert is_enqueue_on_retrieve_enabled() is True
+
+
+def test_is_enqueue_on_retrieve_env_off(monkeypatch) -> None:
+    monkeypatch.setenv("AELFRICE_IMPLICIT_FEEDBACK_ENQUEUE", "false")
+    assert is_enqueue_on_retrieve_enabled() is False
+
+
+# --- Integration: epsilon respected end-to-end --------------------------
+
+
+def test_custom_epsilon_landed_in_alpha_and_audit() -> None:
+    s = _store(_mk("b1"))
+    enqueue_retrieval_exposures(s, ["b1"], now=T0)
+    sweep_deferred_feedback(
+        s, now=T_AFTER_GRACE, grace_seconds=1800, epsilon=0.25
+    )
+    b = s.get_belief("b1")
+    assert b is not None and b.alpha == 1.25
+    events = s.list_feedback_events(belief_id="b1")
+    retrieval_events = [
+        e for e in events if e.source == RETRIEVAL_DRIVEN_FEEDBACK_SOURCE
+    ]
+    assert len(retrieval_events) == 1
+    assert retrieval_events[0].valence == 0.25
+
+
+def test_propagate_off_locked_neighbours_unchanged() -> None:
+    """Implicit signal must not pressure user-locked contradictors —
+    only explicit positive feedback fires the demotion-pressure walk."""
+    s = MemoryStore(":memory:")
+    src = _mk("X")
+    locked = Belief(
+        id="Y", content="locked",
+        content_hash="hY", alpha=1.0, beta=1.0,
+        type=BELIEF_FACTUAL, lock_level="user",
+        locked_at="2026-04-26T00:00:00Z",
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+        session_id=None,
+        origin="unknown",
+        corroboration_count=0,
+    )
+    s.insert_belief(src)
+    s.insert_belief(locked)
+    s.insert_edge(Edge(src="X", dst="Y", type=EDGE_CONTRADICTS, weight=1.0))
+
+    enqueue_retrieval_exposures(s, ["X"], now=T0)
+    sweep_deferred_feedback(
+        s, now=T_AFTER_GRACE, grace_seconds=1800, epsilon=0.05
+    )
+    # Y's pressure must be untouched: implicit signals do not propagate.
+    y = s.get_belief("Y")
+    assert y is not None
+    assert y.demotion_pressure == 0
+    assert y.lock_level == "user"

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -98,6 +98,7 @@ HIDDEN_SUBCOMMANDS = frozenset({
     "statusline", "bench", "regime", "migrate", "unsetup",
     "health", "stats", "project-warm", "session-delta",
     "demote", "validate", "resolve", "feedback", "ingest-transcript",
+    "sweep-feedback",
 })
 
 


### PR DESCRIPTION
Closes #191. Track 2 of the phantom-prereqs campaign (#189).

Today `apply_feedback` is invoked rarely — anything downstream that wants to use feedback as a posterior-update signal is starved. Meanwhile `retrieve()` fires constantly. This PR turns retrieval exposure into a small, deferred posterior signal: every surfaced belief enqueues a `retrieval_exposure` row; a CLI sweeper applies `+epsilon` to its alpha after the grace window elapses, unless an explicit correction or contradiction event landed on the same belief in that window.

Hard depends on #190 (T1 belief_corroborations) — shipped today. T3 (#192) lands after.

## What lands

- **Schema** (`store.py`): additive `deferred_feedback_queue(id, belief_id, enqueued_at, event_type, applied_at, status)` with FK to beliefs (ON DELETE CASCADE) + indexes on `(status, enqueued_at)` and `belief_id`.
- **Store API** (`store.py`): `enqueue_deferred_feedback`, `list_pending_deferred_feedback`, `has_explicit_feedback_in_window`, `count_deferred_feedback_by_status`.
- **Module** (`deferred_feedback.py`): `enqueue_retrieval_exposures` + `sweep_deferred_feedback`. Per-row processing wraps the alpha update + audit insert + status update in a single explicit `BEGIN IMMEDIATE / COMMIT` transaction, so a crash mid-row leaves the queue row `enqueued` and the alpha unchanged.
- **Retrieve hook** (`retrieval.py`): post-`retrieve()` enqueues one row per surfaced belief. Default-on; opt-out via `[implicit_feedback] enqueue_on_retrieve = false`. Fail-soft — any DB error is logged to stderr but never breaks retrieval.
- **CLI** (`cli.py`): `aelf sweep-feedback [--grace-seconds N] [--epsilon F] [--limit N] [--strict]`. Cron-safe by default (exits 0 on internal exceptions); `--strict` flips that.
- **Config**: `T_grace` and `epsilon` resolve env > kwarg > `.aelfrice.toml [implicit_feedback]` > defaults (1800 s, 0.05). Same pattern as the rest of aelfrice.

## Cancellation contract

A pending row is cancelled (no alpha change) if any `feedback_history` row exists for the same belief whose `source` is **not** `retrieval_driven_feedback` and whose `created_at` is in `[enqueued_at, now]`. This single check covers both contracts the spec calls out:

- Explicit user feedback in the window (\"explicit beats implicit\").
- Contradiction-tiebreaker resolutions (which already write `feedback_history` rows with a distinctive `contradiction_tiebreaker:` source prefix).

## Acceptance

- [x] AC1 — `deferred_feedback_queue` table; additive migration.
- [x] AC2 — `retrieve()` post-hook enqueues one row per surfaced belief with `event_type='retrieval_exposure'`.
- [x] AC3 — `aelf sweep-feedback` subcommand processes the queue with configurable `T_grace` + `epsilon`.
- [x] AC4 — Sweeper applies `+epsilon` exactly once per row in the no-contradiction path; transitions to `status='applied'`.
- [x] AC5 — Sweeper cancels (no alpha change) when an explicit signal lands in the grace window; transitions to `status='cancelled'`.
- [x] AC6 — `feedback_history` records `retrieval_driven_feedback` distinguishably from user-driven sources.
- [x] AC7 — Idempotent: sweep×2 = sweep×1 (status filter on `enqueued`; transactional row writes).
- [x] AC8 — `T_grace` and `epsilon` configurable via env / kwarg / TOML; defaults documented in the module docstring.

## Tests

- `tests/test_implicit_feedback.py` — 29 tests across schema, retrieve enqueue (env-off, empty-query, fail-soft), apply/cancel paths, audit distinctness, idempotency, partial-progress resume via `--limit`, config resolution for both knobs, FK-cascade on belief delete, and propagate=False on locked neighbours (implicit signals must not pressure user-locked contradictors).
- `tests/test_cli_sweep_feedback.py` — 4 tests: subcommand registered, empty-queue exit, end-to-end apply with `--grace-seconds 0`, `--strict` flag flips error exit code.
- All deterministic; in-memory store; clock injected; total runtime < 250 ms.

```
1707 passed, 8 skipped (full suite)
```

## Out of scope

- Background-daemon scheduling — CLI-driven only at v1.
- Tuning `epsilon` from corpus measurement — defaults ship; re-tune is a separate evaluation issue.
- Any consumer that *acts* on the resulting posterior shifts — downstream of the campaign.