### PR TITLE
docs: v2.0 substrate cascade addenda (#193, #197, #198, #199, #201)

### DIFF
--- a/docs/v2_dedup.md
+++ b/docs/v2_dedup.md
@@ -1,0 +1,43 @@
+# v2.0 evaluation: dedup module
+
+Spec for issue [#197](https://github.com/robotrocketscience/aelfrice/issues/197). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B).
+
+Status: spec, no implementation. Recommendation included; decision is the user's.
+
+## What's being decided
+
+Whether to port the research-line `dedup.py` (~254 LOC, stdlib-only) to v2.0. The module finds near-duplicate beliefs after ingest by token-overlap + edit-distance, then collapses duplicates by inserting `SUPERSEDES` edges (not deletes) to preserve audit trail. v1.x has only `INSERT OR IGNORE` on `(source, sentence)` content_hash — exact-match only, paraphrases survive.
+
+## Substrate dependency
+
+None. dedup operates on text fields only. Substrate ratification (Option B, scalar Beta-Bernoulli) does not affect the port shape.
+
+## Recommendation
+
+**Ship at v2.0.** Port the research-line module as-is.
+
+Three reasons:
+
+1. **The capability fills a gap users will hit.** "don't push to main" inserted via lock plus "never push directly to main" inserted via onboard scanner produce two beliefs with the same intent. Both surface in retrieval. This is observable today; #219's 5.3× re-ingest row inflation makes it worse, not better.
+2. **Stdlib-only port preserves determinism.** Token-overlap + Levenshtein is regex/integer-arithmetic. No learned similarity model, no LLM call, no embedding. Compatible with PHILOSOPHY's determinism property.
+3. **Audit-trail discipline already exists.** The research line uses `SUPERSEDES` edges, which v1.x already has (one of the four edge types in `models.py`). No edge-type expansion needed for the port itself; downstream consumers of `SUPERSEDES` already exist (`aelf resolve`, demotion-pressure scoring).
+
+## Decision asks
+
+- [ ] **Confirm port at v2.0.** If yes, scope is ~254 LOC + write-path hooks (after `ingest_turn`, `onboard`, `apply_feedback`).
+- [ ] **Threshold defaults.** Research line shipped Jaccard ≥ 0.8 + Levenshtein ratio ≥ 0.85. Ship those as defaults? Configurable via `.aelfrice.toml`?
+- [ ] **Sample size.** Research line sampled 5000 candidate pairs to keep dedup O(n) per write. Ship that, or full-pairwise on small corpora?
+- [ ] **Onboard interaction.** Currently `aelf onboard` is non-incremental (LIMITATIONS § Sharp edges). Dedup-on-onboard would partially fix that. Worth advertising as such, or ship dedup quietly and leave the onboard-incrementality issue separate?
+
+## Downstream impact
+
+- `LIMITATIONS.md § Sharp edges`: the "INSERT OR IGNORE only catches exact matches" caveat shrinks (or disappears, depending on dedup confidence).
+- `docs/PHILOSOPHY.md`: one paragraph noting that v2.0 dedup is deterministic (token + edit distance, no embedding).
+- New CLI surface: `aelf doctor dedup` audit command, returning candidate clusters without auto-merging. Lets users review before committing.
+- `aelf:dedup` MCP tool would be the natural pairing; defer to per-tool bench-impact gate per `V2_REENTRY_QUEUE.md` decision #1.
+
+## Provenance
+
+Research-line module: `agentmemory/dedup.py` (254 LOC, stdlib-only).
+Lab parity audit: `aelfrice-lab/docs/agentmemory-parity-audit-2026-04-28.md` § 2.
+Substrate ratification: [substrate_decision.md](substrate_decision.md) (Option B).

--- a/docs/v2_enforcement.md
+++ b/docs/v2_enforcement.md
@@ -1,0 +1,61 @@
+# v2.0 evaluation: enforcement triad
+
+Spec for issue [#199](https://github.com/robotrocketscience/aelfrice/issues/199). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B).
+
+Status: spec, no implementation. **Recommendation: split the triad — ship H3 only at v2.0, defer H1 with a benchmark gate, drop H2.**
+
+## What's being decided
+
+The research-line `enforcement.py` (~347-373 LOC) is three independent submodules with different risk profiles. Issue #199 lumps them as a unit. They should be specced and decided separately.
+
+- **H1 — Directive detection.** Regex over 29 imperative verbs ("never", "always", "must", "don't", ...) + question/hedging filters. Auto-creates TODO-tagged beliefs.
+- **H2 — Compliance audit.** `check_compliance(store)` evaluates predicate strings on locked beliefs: `file_contains:path:content`, `config_value:path:key:expected`, `command_succeeds:cmd`. **`command_succeeds` runs arbitrary shell.**
+- **H3 — Selective injection.** Scores locked beliefs against the *current* prompt; injects top-K instead of all-locked at SessionStart.
+
+## Substrate dependency
+
+None for any of the three. Substrate-neutral.
+
+## Recommendation per submodule
+
+### H3 selective injection — ship at v2.0
+
+1. **Highest leverage, lowest risk.** Currently every locked belief is unconditionally injected at SessionStart (`hook.py:329-398`). Users with growing locked sets see context bloat that's mostly irrelevant to the current task.
+2. **Substrate-neutral scoring.** Top-K by query overlap × `posterior_mean` works on scalar Beta-Bernoulli (Option B). Locked beliefs have saturated posteriors anyway, so the scoring degenerates to query overlap — clean.
+3. **Reversible.** If selective injection misses a locked belief the user expected to see, fallback is a `--inject-all` flag. No data loss.
+4. **Effort: small.** ~80 LOC of the ~347 total in `enforcement.py`. Self-contained.
+
+### H1 directive detection — defer to v2.x with benchmark gate
+
+1. **High false-positive risk on coding prompts.** "never push directly to main" is a directive; "I never push to main when I'm tired" is not. The 29-verb regex doesn't disambiguate. Auto-creating TODO beliefs from every imperative-sounding sentence will pollute the belief graph.
+2. **No benchmark backs the precision/recall tradeoff.** Research line shipped without published numbers on directive-detection precision. Per `V2_REENTRY_QUEUE.md` decision #1 (strict bench gate), this defers until evidence lands.
+3. **Effort: medium.** ~150 LOC + the TODO lifecycle (escalation, `detect_repetition`, `check_escalation`) is meaningful surface.
+
+### H2 compliance audit — drop
+
+1. **`command_succeeds:cmd` runs arbitrary shell on the user's machine.** Predicate strings come from belief content. Belief content comes from prompts, scanner output, and onboard. Any path that can write a belief can therefore inject a shell command.
+2. **No security model for the predicate language.** The research line stored predicates as `TEXT` and evaluated them. There's no allowlist, no sandbox, no provenance check on the predicate's origin.
+3. **No benchmark backs the capability.** "These compliance checks would be useful" is editorial; "this audit moves a measured number" is not demonstrated.
+4. **`file_contains` and `config_value` alone aren't worth the schema cost.** A subset port that excludes `command_succeeds` is mechanically possible but loses most of the original value, and the schema (predicate column on locked beliefs) still has to ship.
+
+If a future user actually needs compliance auditing, the right path is a separate, opt-in module with: an explicit allowlist of predicate types, a security review, and a benchmark. Not a quiet port at v2.0.
+
+## Decision asks
+
+- [ ] **Confirm split.** Issue #199 becomes three sub-issues: H3 (ship), H1 (defer + benchmark gate), H2 (drop).
+- [ ] **H3 scoring.** Query overlap × `posterior_mean` is the recommended formula. Confirm, or specify alternative? Locked beliefs have saturated posteriors so the second factor is approximately constant — could simplify to query overlap alone.
+- [ ] **H3 max_k default.** Research line used 5. Ship 5? Configurable?
+- [ ] **H1 deferral language.** What evidence reopens H1? (Recommendation: ≥80% precision + ≥60% recall on a labeled sample of 200 coding prompts. If that bar isn't met, H1 stays deferred.)
+- [ ] **H2 drop confirmation.** Final decision: drop, not defer. Removing the temptation to revisit "just port the safe predicates" prevents incremental erosion of the security stance.
+
+## Downstream impact (recommended path)
+
+- **H3 ships.** `hook.py:329-398` SessionStart injection becomes top-K instead of all-locked. New CLI: `aelf health` shows per-session injection counts. Test: a session with 50 locked beliefs and a "git commit" prompt should inject git-relevant beliefs, not all 50.
+- **H1 stays open.** Issue #199 splits; H1 issue gets `bench-gated` label.
+- **H2 closes as `wontfix`.** Documented in CHANGELOG.md notes for v2.0: "v2.0 deliberately ships without a compliance-audit predicate language; the research line's `enforcement.py` H2 is not ported. See [v2_enforcement.md § H2](v2_enforcement.md#h2-compliance-audit--drop)."
+
+## Provenance
+
+Research-line module: `agentmemory/enforcement.py` (~347-373 LOC depending on extension surface).
+Lab parity audit: `aelfrice-lab/docs/agentmemory-parity-audit-2026-04-28.md` § 14.
+Substrate ratification: [substrate_decision.md](substrate_decision.md) (Option B). Substrate-neutral; H3 scoring works on scalar `posterior_mean`.

--- a/docs/v2_multimodel.md
+++ b/docs/v2_multimodel.md
@@ -1,0 +1,43 @@
+# v2.0 evaluation: multi-LLM consensus module
+
+Spec for issue [#198](https://github.com/robotrocketscience/aelfrice/issues/198). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B).
+
+Status: spec, no implementation. **Recommendation: defer to v2.x with a strict evidence-gate.**
+
+## What's being decided
+
+Whether to port the research-line `multimodel.py` (~143-189 LOC) to v2.0. The module runs the same prompt across multiple providers (Claude + GPT + local), takes a majority vote, and tags low-consensus beliefs `origin = multi_model_disagreement`. v1.x routes `--llm-classify` through Claude Haiku alone.
+
+## Substrate dependency
+
+None mechanically. But under Option B (substrate_decision.md ratified), per-axis uncertainty was deliberately dropped — and the research line used cross-model classification primarily to populate per-aspect `(α_i, β_i)` from prose. With single-axis substrate, multimodel's strongest historical justification disappears.
+
+## Recommendation
+
+**Defer to v2.x. Ship only with a benchmark.**
+
+Five reasons:
+
+1. **Privacy regression.** PRIVACY.md caps optional outbound at "Claude Haiku via `ANTHROPIC_API_KEY` for `--llm-classify`." Multi-provider consensus expands the trust surface to *N* third parties. That requires a deliberate PRIVACY.md rewrite, not a quiet ship. Some users running aelfrice precisely *because* it's local-first would treat this as a regression.
+2. **Determinism regression.** Multi-model consensus is non-deterministic by construction. Same prompt, different runs, different outputs. PHILOSOPHY's determinism property breaks.
+3. **Cost.** *N×* the per-onboard token spend. Onboard is already the most expensive operation in the system.
+4. **No benchmark backs cross-model improvement.** The research line shipped multimodel without publishing evidence that consensus measurably improves classification quality over single-model. `V2_REENTRY_QUEUE.md` decision #1 (strict bench-impact gate) applies. Until consensus moves an `aelf bench` number ≥ 3pp on classification accuracy or onboard quality, the cost isn't justified.
+5. **Substrate decision removed the strongest use case.** Under single-axis substrate, the per-aspect classification that multimodel was originally meant to support doesn't exist.
+
+## Decision asks
+
+- [ ] **Confirm defer.** If yes, this issue moves from `v2.0` to `v2.x` and gets a `bench-gated` label. No port until evidence lands.
+- [ ] **If override (ship at v2.0):** what evidence justifies it? Without a benchmark, the privacy + determinism + cost trio outweighs the speculative gain.
+- [ ] **Alternative:** ship `multimodel` as opt-in via `.aelfrice.toml` with explicit user consent and a flag in `aelf health` showing it's enabled. Reduces the surprise factor but doesn't fix the determinism break for users who turn it on.
+
+## Downstream impact (defer path)
+
+- No code change at v2.0.
+- `V2_REENTRY_QUEUE.md` row stays "defer" with the new gate language: "≥3pp classification accuracy improvement on `aelf bench` AND a privacy-doc rewrite."
+- Issue #198 keeps `v2.0` label removed; gains `bench-gated` label.
+
+## Provenance
+
+Research-line module: `agentmemory/multimodel.py` (~143-189 LOC depending on extension surface).
+Lab parity audit: `aelfrice-lab/docs/agentmemory-parity-audit-2026-04-28.md` § 5.
+Substrate ratification: [substrate_decision.md](substrate_decision.md) (Option B). Note: the substrate decision removed multimodel's strongest historical justification.

--- a/docs/v2_relationship_detector.md
+++ b/docs/v2_relationship_detector.md
@@ -1,0 +1,51 @@
+# v2.0 evaluation: semantic contradiction detector
+
+Spec for issue [#201](https://github.com/robotrocketscience/aelfrice/issues/201). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B).
+
+Status: spec, no implementation. **Recommendation: ship at v2.0.**
+
+## What's being decided
+
+Whether to port the research-line `relationship_detector.py` (~147 LOC) to v2.0. The module detects contradictions between beliefs by **negation/quantifier signal divergence** rather than by explicit-prose extraction. v1.x has explicit-only via `triple_extractor.py` (catches "X contradicts Y"); the implicit-divergence path is missing, and `contradiction.py`'s docstring acknowledges the gap.
+
+## Substrate dependency
+
+None. Operates on text fields and belief-pair similarity. Output is a relationship verdict + scalar confidence — substrate Option B handles this directly.
+
+## Recommendation
+
+**Ship at v2.0.**
+
+Four reasons:
+
+1. **Closes a public README promise.** Research-line README claimed *"It catches contradictions ... flags them: 'these contradict each other — resolve before proceeding.'"* Public LIMITATIONS.md § Sharp edges (line 36) walks part of that back: *"`CONTRADICTS` edges drive demotion pressure. The regex classifier rarely produces them."* That's a real gap between advertised behavior and shipped behavior. Porting closes it.
+2. **Stdlib-only.** Regex over modality (negation, hedging, certainty markers) and quantifiers (always/never/sometimes/often). No LLM, no embedding. Compatible with PHILOSOPHY's determinism property.
+3. **Edge type already exists.** `CONTRADICTS` is one of v1.x's four edge types (`models.py`). Downstream consumers (`aelf resolve`, demotion-pressure scoring) are already wired. The detector ships as a write-path hook; no schema migration.
+4. **Pairs cleanly with #197 dedup.** Both modules examine candidate pairs after writes. Reuse the same candidate-generation pass (token-overlap on subject + predicate) and split the verdict path: high overlap + agreeing modality → SUPERSEDES (dedup); high overlap + disagreeing modality → CONTRADICTS (this module). Reduces total cost vs porting them as independent passes.
+
+## Decision asks
+
+- [ ] **Confirm port at v2.0.** If yes, scope is ~147 LOC + write-path hook (after `ingest_turn`, `apply_feedback`).
+- [ ] **High-confidence threshold for auto-insert.** Research line shipped 0.85. Defaults to 0.85 in v2.0? Lower threshold flags more, requires more `aelf resolve` traffic; higher threshold misses softer contradictions.
+- [ ] **Lower-confidence flagging path.** Should low-confidence pairs (verdict = "contradicts" but confidence < threshold) get a separate `POTENTIALLY_STALE` edge or just sit unflagged? `V2_REENTRY_QUEUE.md` has `POTENTIALLY_STALE` listed as a candidate new edge type; this is the natural use case.
+- [ ] **Pair with #197 dedup.** Recommendation: ship as a unified "near-pair classifier" pass that produces SUPERSEDES, CONTRADICTS, or REFINES verdicts from the same candidate pool. If preferred separately, both ship at v2.0 with overlapping but distinct write-path hooks.
+- [ ] **Quantifier vocabulary.** Research line: always / never / sometimes / often / usually / rarely. Ship as-is? Extend to compound forms ("almost never", "in most cases")?
+
+## Edge case worth flagging
+
+The detector compares modality signals between beliefs that share subject + predicate. False positives surface when two beliefs about the same subject describe *different aspects*: "use uv for Python deps" + "never use pip in this project" both have negation/imperative signals on overlapping tokens but aren't contradicting. Mitigation in the research line: subject-extraction granularity (the predicate-similarity check requires high overlap on the *object*, not just the subject). Ship that, or document the limitation in LIMITATIONS.md and let `aelf resolve` adjudicate?
+
+Recommendation: ship the research-line subject-extraction granularity. The `aelf resolve` surface is the safety net, not the primary defense.
+
+## Downstream impact
+
+- New write-path hook after `ingest_turn` and `apply_feedback`. Cost: O(k) per write where k is the candidate-pair pool size. Same cost shape as the recommended dedup pass; can share the candidate pool.
+- LIMITATIONS.md § Sharp edges line 36 ("regex classifier rarely produces CONTRADICTS edges") gets rewritten or removed.
+- Closes the open gap in `contradiction.py`'s docstring.
+- Pairs with #197 (dedup); both modules can share candidate-generation if shipped together.
+
+## Provenance
+
+Research-line module: `agentmemory/relationship_detector.py` (~147 LOC, stdlib-only).
+Lab parity audit: `aelfrice-lab/docs/agentmemory-parity-audit-2026-04-28.md` § 16.
+Substrate ratification: [substrate_decision.md](substrate_decision.md) (Option B). Substrate-neutral.

--- a/docs/v2_sentiment_feedback.md
+++ b/docs/v2_sentiment_feedback.md
@@ -1,0 +1,53 @@
+# v2.0 evaluation: sentiment-from-prose feedback
+
+Spec for issue [#193](https://github.com/robotrocketscience/aelfrice/issues/193). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B).
+
+Status: spec, no implementation. **Recommendation: ship at v2.0, opt-in via `.aelfrice.toml`, off by default.**
+
+## What's being decided
+
+Whether to port the research-line `sentiment_feedback.py` (~174 LOC, stdlib-only) to v2.0. The module reads each user prompt, regex-matches against ~24 patterns ("ok good", "yes", "perfect" / "no thats wrong", "fix it", "i told you"), and distributes the resulting `SentimentSignal` across the previous turn's retrieved beliefs as `feedback_history` rows. v1.x requires explicit `aelf feedback <id> used|harmful`.
+
+## Substrate dependency
+
+None. The module emits scalar `(used|harmful, weight)` events compatible with v1.x's existing `apply_feedback` path. Substrate Option B is exactly what this module wants.
+
+## Recommendation
+
+**Ship at v2.0. Opt-in only. Default off.**
+
+Three reasons:
+
+1. **Real UX gap.** Explicit `aelf feedback` calls are the right primitive but practically no one uses them mid-session. The implicit feedback loop is what makes the feedback mechanism actually closed in chat-driven workflows. Without it, `apply_feedback` is plumbing nobody exercises (the existing concern flagged in #127's history).
+2. **Cheap and deterministic.** Pure regex over text. No LLM, no outbound calls. Compatible with PHILOSOPHY's determinism + local-first properties.
+3. **Privacy concern is real but addressable.** The hook reads every prompt and silently mutates belief confidence. That's a meaningful change in what aelfrice does with user prose. Solution: opt-in via `.aelfrice.toml`, explicit `aelf health` surfacing showing it's enabled, and a PRIVACY.md entry covering the prose-inspection surface. Off by default means existing users see no behavior change.
+
+## Decision asks
+
+- [ ] **Confirm opt-in port at v2.0.** If yes: ~174 LOC port + `.aelfrice.toml` flag (`[feedback] sentiment_from_prose = false`) + PRIVACY.md entry + `aelf health` surfacing.
+- [ ] **Pattern set.** Research line shipped 12 positive + 12 negative patterns. Ship those verbatim, or curate? (Recommendation: ship verbatim to minimize port surface; users can override via config in v2.x if needed.)
+- [ ] **`detect_correction_frequency` (the ≥40% recent-turns escalator).** Ship with the base module, or defer? (Recommendation: ship together; it's the strongest signal the regex-only path produces and it's stateless beyond a sliding window.)
+- [ ] **Distribution target.** Apply the signal to *all* previous-turn retrieved beliefs equally, or scale by retrieval rank? (Recommendation: equally — matches the research-line behavior; ranked distribution adds a knob without an evidence-gate.)
+- [ ] **Audit row schema.** `feedback_history` already has the columns. Confirm the new event tag (`origin = sentiment_inferred`) doesn't collide with #224's `origin always 'unknown'` fix path.
+
+## Privacy review (the v2.0 decision the title asks for)
+
+- **What's read:** every user prompt the hook sees (already true today for retrieval — the new behavior is regex matching, not new data access).
+- **What's stored:** an audit row in `feedback_history` per matched pattern, with the matched substring + pattern ID + affected belief IDs. No raw prompt text is stored.
+- **What leaves the machine:** nothing. Stdlib regex; no outbound calls.
+- **Determinism:** same prompt, same matches, same updates. Reproducible.
+
+The privacy story is "we are now doing more with prompts you already submitted to the hook" — not "we are seeing new content." That distinction belongs in PRIVACY.md as the second-paragraph clarification.
+
+## Downstream impact
+
+- New `.aelfrice.toml` section: `[feedback] sentiment_from_prose = false`.
+- New `aelf health` line: `Sentiment-from-prose feedback: enabled / disabled` and pattern-match count if enabled.
+- New PRIVACY.md paragraph under "Optional outbound": clarify that this feature is *inbound* prose inspection, no outbound traffic.
+- Tied to #224 (origin tagging) — sentiment-inferred events need a stable origin tag that survives the #224 fix.
+
+## Provenance
+
+Research-line module: `agentmemory/sentiment_feedback.py` (~174 LOC, stdlib-only).
+Lab parity audit: `aelfrice-lab/docs/agentmemory-parity-audit-2026-04-28.md` § 9.
+Substrate ratification: [substrate_decision.md](substrate_decision.md) (Option B). Substrate-neutral; this module emits scalar feedback events.


### PR DESCRIPTION
## Summary

Five short evaluation memos cascading from #196's substrate ratification (Option B, single-axis Beta-Bernoulli, merged at PR #203). Each memo gives a recommendation, decision asks, and downstream impact.

| Issue | Memo | Recommendation |
|-------|------|----------------|
| #197 dedup | docs/v2_dedup.md | Ship at v2.0 — stdlib-only port, substrate-neutral |
| #198 multimodel | docs/v2_multimodel.md | Defer to v2.x — strict bench-impact gate; substrate decision removed strongest use case |
| #193 sentiment-from-prose | docs/v2_sentiment_feedback.md | Ship at v2.0, opt-in via .aelfrice.toml, default off |
| #199 enforcement | docs/v2_enforcement.md | Split — H3 ships, H1 defers with bench gate, H2 drops (security) |
| #201 relationship_detector | docs/v2_relationship_detector.md | Ship at v2.0 — closes README promise gap |

All recommendations; user decides per memo's Decision asks section.

## Notes

- Spec for #196 (substrate decision) already merged at \`docs/substrate_decision.md\` via PR #203. The \`needs-spec\` label on #196 was stale; ratified to Option B in [comment-4339753446](https://github.com/robotrocketscience/aelfrice/issues/196#issuecomment-4339753446) and label removed.
- After this PR: 8 \`needs-spec\` v2.0 issues → 2 (only #228 wonder-consolidation and #229 phantom promotion-trigger remain genuinely undrafted).
- Lab-side primary source: \`aelfrice-lab/docs/agentmemory-parity-audit-2026-04-28.md\` §§ 2, 5, 9, 14, 16.

## Test plan

- [ ] Each memo reviewed in isolation; recommendations adopted, modified, or overridden per Decision asks.
- [ ] On adoption: \`needs-spec\` label removed from each issue; downstream tracker labels (e.g. \`bench-gated\`, \`wontfix\`) applied per memo.
- [ ] No code changes; CI is docs-only.