### PR TITLE
fix: stamp beliefs.last_retrieved_at on hook-driven retrieval (#222)

### DIFF
--- a/src/aelfrice/hook_search.py
+++ b/src/aelfrice/hook_search.py
@@ -103,6 +103,7 @@ def record_retrieval(
     """
     serr: IO[str] = stderr if stderr is not None else sys.stderr
     written: int = 0
+    stamped_ids: list[str] = []
     for b in beliefs:
         try:
             apply_feedback(
@@ -113,6 +114,16 @@ def record_retrieval(
                 propagate=False,
             )
             written += 1
+            stamped_ids.append(b.id)
         except Exception:  # non-blocking: log and continue
+            traceback.print_exc(file=serr)
+    # Mirror the audit row to beliefs.last_retrieved_at so downstream
+    # consumers (decay moderation, recency-aware ranking, telemetry) get
+    # an O(1) read instead of having to join feedback_history. Same
+    # best-effort posture as the loop above.
+    if stamped_ids:
+        try:
+            store.stamp_retrieved(stamped_ids)
+        except Exception:
             traceback.print_exc(file=serr)
     return written

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -1039,6 +1039,38 @@ class MemoryStore:
             out.append((_row_to_belief(r), score))
         return out
 
+    # --- Retrieval recency -----------------------------------------------
+
+    def stamp_retrieved(
+        self,
+        belief_ids: Iterable[str],
+        ts: str | None = None,
+    ) -> int:
+        """Mark beliefs as retrieved at `ts` (defaults to UTC now).
+
+        Single batched UPDATE; ids not present in the table are silently
+        skipped (UPDATE matches zero rows). Returns the number of rows
+        actually updated. Empty input is a no-op returning 0.
+
+        This is the belief-side mirror of feedback_history writes for
+        retrieval-driven feedback. The retrieval-audit-loop spec
+        (v1.0.1 #127) requires both: feedback_history records the event,
+        last_retrieved_at gives downstream consumers (decay moderation,
+        recency-aware ranking, telemetry) an O(1) read.
+        """
+        ids = [bid for bid in belief_ids if bid]
+        if not ids:
+            return 0
+        if ts is None:
+            ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        placeholders = ",".join("?" * len(ids))
+        cur = self._conn.execute(
+            f"UPDATE beliefs SET last_retrieved_at = ? WHERE id IN ({placeholders})",
+            (ts, *ids),
+        )
+        self._conn.commit()
+        return cur.rowcount or 0
+
     # --- Feedback history ------------------------------------------------
 
     def insert_feedback_event(

--- a/tests/test_hook_search.py
+++ b/tests/test_hook_search.py
@@ -202,6 +202,48 @@ def test_search_for_prompt_record_failure_does_not_block_read() -> None:
     assert written == 0
 
 
+# --- last_retrieved_at mirror (issue #222) -------------------------------
+
+
+def test_record_retrieval_stamps_last_retrieved_at() -> None:
+    """Per #222: feedback_history write must mirror to beliefs.last_retrieved_at
+    so downstream consumers don't have to join the audit log."""
+    s = _seed(_mk("b1"), _mk("b2"), _mk("b3"))
+    record_retrieval(s, [s.get_belief("b1"), s.get_belief("b2")])  # type: ignore[list-item]
+    assert s.get_belief("b1").last_retrieved_at is not None  # type: ignore[union-attr]
+    assert s.get_belief("b2").last_retrieved_at is not None  # type: ignore[union-attr]
+    assert s.get_belief("b3").last_retrieved_at is None  # type: ignore[union-attr]
+
+
+def test_record_retrieval_stamp_skips_failed_writes() -> None:
+    """Beliefs whose apply_feedback failed must NOT get the recency stamp."""
+    s = _seed(_mk("b1"), _mk("b2"))
+    ghost = _mk("ghost")
+    err = io.StringIO()
+    record_retrieval(
+        s, [s.get_belief("b1"), ghost, s.get_belief("b2")], stderr=err,  # type: ignore[list-item]
+    )
+    assert s.get_belief("b1").last_retrieved_at is not None  # type: ignore[union-attr]
+    assert s.get_belief("b2").last_retrieved_at is not None  # type: ignore[union-attr]
+    assert s.get_belief("ghost") is None
+
+
+def test_record_retrieval_empty_input_does_not_stamp() -> None:
+    s = _seed(_mk("b1"))
+    record_retrieval(s, [])
+    assert s.get_belief("b1").last_retrieved_at is None  # type: ignore[union-attr]
+
+
+def test_search_for_prompt_stamps_returned_hits() -> None:
+    s = _seed(_mk("b1", "the quick brown fox"), _mk("b2", "unrelated"))
+    hits = search_for_prompt(s, "quick fox")
+    hit_ids = {h.id for h in hits}
+    assert "b1" in hit_ids
+    assert s.get_belief("b1").last_retrieved_at is not None  # type: ignore[union-attr]
+    if "b2" not in hit_ids:
+        assert s.get_belief("b2").last_retrieved_at is None  # type: ignore[union-attr]
+
+
 # --- Locked beliefs are still recorded -----------------------------------
 
 

--- a/tests/test_store_crud.py
+++ b/tests/test_store_crud.py
@@ -120,3 +120,46 @@ def test_fts5_search_after_update_reflects_new_content() -> None:
     s.update_belief(b)
     assert s.search_beliefs("cats") == []
     assert {h.id for h in s.search_beliefs("dogs")} == {"b1"}
+
+
+# --- stamp_retrieved (issue #222) ----------------------------------------
+
+
+def test_stamp_retrieved_populates_column() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk_belief("b1"))
+    s.insert_belief(_mk_belief("b2"))
+    n = s.stamp_retrieved(["b1", "b2"])
+    assert n == 2
+    assert s.get_belief("b1").last_retrieved_at is not None  # type: ignore[union-attr]
+    assert s.get_belief("b2").last_retrieved_at is not None  # type: ignore[union-attr]
+
+
+def test_stamp_retrieved_uses_explicit_ts_when_given() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk_belief("b1"))
+    s.stamp_retrieved(["b1"], ts="2026-04-28T12:00:00Z")
+    assert s.get_belief("b1").last_retrieved_at == "2026-04-28T12:00:00Z"  # type: ignore[union-attr]
+
+
+def test_stamp_retrieved_empty_input_is_noop() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk_belief("b1"))
+    assert s.stamp_retrieved([]) == 0
+    assert s.get_belief("b1").last_retrieved_at is None  # type: ignore[union-attr]
+
+
+def test_stamp_retrieved_silently_skips_missing_ids() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk_belief("b1"))
+    n = s.stamp_retrieved(["b1", "ghost"])
+    assert n == 1
+    assert s.get_belief("b1").last_retrieved_at is not None  # type: ignore[union-attr]
+
+
+def test_stamp_retrieved_overwrites_prior_timestamp() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk_belief("b1"))
+    s.stamp_retrieved(["b1"], ts="2026-04-28T01:00:00Z")
+    s.stamp_retrieved(["b1"], ts="2026-04-28T02:00:00Z")
+    assert s.get_belief("b1").last_retrieved_at == "2026-04-28T02:00:00Z"  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary

Closes #222. The retrieval audit loop was structurally half-implemented — the hook wrote `feedback_history` rows but never stamped `beliefs.last_retrieved_at`. Verified live: 0 of 20,852 beliefs populated on canonical store despite 586 hook-tagged feedback rows from one day.

Root cause: no code path anywhere in `src/aelfrice/` issued `UPDATE beliefs SET last_retrieved_at = ?` outside `update_belief()`'s full-row rewrite (which fires on belief edits, not retrieval). All INSERT sites hard-coded `None`.

## Changes

- `MemoryStore.stamp_retrieved(belief_ids, ts=None)` — single batched UPDATE; defaults ts to UTC now; returns rowcount; no-op on empty.
- `hook_search.record_retrieval` — after the `apply_feedback` loop, calls `stamp_retrieved` with only the ids whose feedback write succeeded. Same best-effort posture as the audit loop (errors logged to stderr, never block).

## Test plan

- [x] `tests/test_store_crud.py` — 5 new: populate, explicit ts, empty input, missing id, overwrite prior ts.
- [x] `tests/test_hook_search.py` — 4 new: stamp on retrieval, skip-on-failure, no-op on empty, search_for_prompt end-to-end.
- [x] Full suite: 1052 passed, 1 pre-existing unrelated failure (`test_serve_raises_clear_error_when_fastmcp_missing` — environment-dependent, fails on `main` HEAD too).

## Out of scope

No backfill of historic rows. The 20,852 already-`NULL` beliefs stay `NULL` — column is now populated forward from this commit. If a backfill is wanted, a separate `aelf migrate --backfill-retrieval` could derive timestamps from `feedback_history.created_at WHERE source='hook'` for the 413 belief ids that have any hook-tagged event. Filing a follow-up issue if the user wants this.