### PR TITLE
feat: hibernation_score + activation_condition columns (#196 storage half)

### DIFF
--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -133,7 +133,7 @@ class Belief:
 
     Fields: id, content, content_hash, alpha, beta, type, lock_level,
     locked_at, demotion_pressure, created_at, last_retrieved_at,
-    session_id, origin.
+    session_id, origin, hibernation_score, activation_condition.
 
     `session_id` (v1.2+) tags the belief with the ingest session that
     inserted it. Optional: ingest paths that don't open a session
@@ -146,6 +146,13 @@ class Belief:
     to `user_stated` and correction beliefs to `user_corrected`. New
     inserts should pass an explicit value (scanner: `agent_inferred`;
     lock: `user_stated`).
+
+    `hibernation_score` and `activation_condition` (v2.0 #196) are the
+    storage half of the hibernation lifecycle ratified in
+    docs/substrate_decision.md. Both nullable; `None` means the belief
+    is active. `activation_condition` is JSON-encoded TEXT when set.
+    Behavior (when to set, when to wake, predicate evaluator) is a
+    follow-up issue; this commit only locks in the round-trip shape.
     """
 
     id: str
@@ -162,6 +169,8 @@ class Belief:
     session_id: str | None = None
     origin: str = ORIGIN_UNKNOWN
     corroboration_count: int = 0
+    hibernation_score: float | None = None
+    activation_condition: str | None = None
 
 
 ANCHOR_TEXT_MAX_LEN: Final[int] = 1000

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -52,7 +52,9 @@ _SCHEMA: tuple[str, ...] = (
         created_at          TEXT NOT NULL,
         last_retrieved_at   TEXT,
         session_id          TEXT,
-        origin              TEXT NOT NULL DEFAULT 'unknown'
+        origin              TEXT NOT NULL DEFAULT 'unknown',
+        hibernation_score   REAL,
+        activation_condition TEXT
     )
     """,
     """
@@ -274,6 +276,12 @@ _MIGRATIONS: tuple[str, ...] = (
     "ALTER TABLE beliefs ADD COLUMN session_id TEXT",
     "ALTER TABLE edges ADD COLUMN anchor_text TEXT",
     "ALTER TABLE beliefs ADD COLUMN origin TEXT NOT NULL DEFAULT 'unknown'",
+    # v2.0 #196 hibernation lifecycle columns. Both nullable; behavior
+    # is deferred to a follow-up issue. Storage round-trip only at this
+    # commit. activation_condition is JSON-encoded TEXT (predicate
+    # language ratified at substrate_decision.md § Decision asks #4).
+    "ALTER TABLE beliefs ADD COLUMN hibernation_score REAL",
+    "ALTER TABLE beliefs ADD COLUMN activation_condition TEXT",
 )
 
 # Indexes that depend on migrated columns. Run after _MIGRATIONS so
@@ -339,6 +347,8 @@ def _row_to_belief(row: sqlite3.Row) -> Belief:
         session_id=row["session_id"],
         origin=row["origin"],
         corroboration_count=corroboration_count,
+        hibernation_score=row["hibernation_score"],
+        activation_condition=row["activation_condition"],
     )
 
 
@@ -798,13 +808,15 @@ class MemoryStore:
             INSERT INTO beliefs (
                 id, content, content_hash, alpha, beta, type,
                 lock_level, locked_at, demotion_pressure,
-                created_at, last_retrieved_at, session_id, origin
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                created_at, last_retrieved_at, session_id, origin,
+                hibernation_score, activation_condition
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 b.id, b.content, b.content_hash, b.alpha, b.beta, b.type,
                 b.lock_level, b.locked_at, b.demotion_pressure,
                 b.created_at, b.last_retrieved_at, b.session_id, b.origin,
+                b.hibernation_score, b.activation_condition,
             ),
         )
         self._conn.execute(

--- a/tests/test_hibernation_columns.py
+++ b/tests/test_hibernation_columns.py
@@ -1,0 +1,163 @@
+"""Storage round-trip for the v2.0 #196 hibernation columns.
+
+Behavior (when to set hibernation_score, predicate evaluator,
+sweeper integration) is deferred to a follow-up issue. This file
+locks in the storage shape ratified in
+docs/substrate_decision.md § Decision asks #3 + #4: both columns
+nullable, `None` means active, `activation_condition` is JSON-
+encoded TEXT.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    LOCK_NONE,
+    Belief,
+)
+from aelfrice.store import MemoryStore
+
+
+def _mk_belief(
+    bid: str = "b1",
+    *,
+    hibernation_score: float | None = None,
+    activation_condition: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content="the sky is blue",
+        content_hash="h_" + bid,
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-29T00:00:00Z",
+        last_retrieved_at=None,
+        hibernation_score=hibernation_score,
+        activation_condition=activation_condition,
+    )
+
+
+def test_default_hibernation_columns_are_null() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk_belief())
+    got = s.get_belief("b1")
+    assert got is not None
+    assert got.hibernation_score is None
+    assert got.activation_condition is None
+
+
+def test_hibernation_columns_round_trip() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(
+        _mk_belief(
+            hibernation_score=0.42,
+            activation_condition='{"kind": "retrieval_count_gte", "n": 3}',
+        )
+    )
+    got = s.get_belief("b1")
+    assert got is not None
+    assert got.hibernation_score == 0.42
+    assert got.activation_condition == (
+        '{"kind": "retrieval_count_gte", "n": 3}'
+    )
+
+
+def test_hibernation_score_accepts_zero_and_one() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk_belief("low", hibernation_score=0.0))
+    s.insert_belief(_mk_belief("high", hibernation_score=1.0))
+    assert s.get_belief("low").hibernation_score == 0.0  # type: ignore[union-attr]
+    assert s.get_belief("high").hibernation_score == 1.0  # type: ignore[union-attr]
+
+
+def test_get_belief_by_content_hash_returns_hibernation_fields() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(
+        _mk_belief(hibernation_score=0.7, activation_condition="{}")
+    )
+    got = s.get_belief_by_content_hash("h_b1")
+    assert got is not None
+    assert got.hibernation_score == 0.7
+    assert got.activation_condition == "{}"
+
+
+def test_legacy_db_without_hibernation_columns_migrates(tmp_path: Path) -> None:
+    """A pre-#196 DB (only the v1.2 column set) must gain the new columns
+    on next open. Idempotent — second open is a no-op. Existing rows
+    return NULL for both."""
+    db_path = tmp_path / "legacy.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE beliefs (
+            id                  TEXT PRIMARY KEY,
+            content             TEXT NOT NULL,
+            content_hash        TEXT NOT NULL,
+            alpha               REAL NOT NULL,
+            beta                REAL NOT NULL,
+            type                TEXT NOT NULL,
+            lock_level          TEXT NOT NULL,
+            locked_at           TEXT,
+            demotion_pressure   INTEGER NOT NULL DEFAULT 0,
+            created_at          TEXT NOT NULL,
+            last_retrieved_at   TEXT,
+            session_id          TEXT,
+            origin              TEXT NOT NULL DEFAULT 'unknown'
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO beliefs (id, content, content_hash, alpha, beta, "
+        "type, lock_level, demotion_pressure, created_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?)",
+        (
+            "old1",
+            "pre-#196 row",
+            "h_old1",
+            1.0,
+            1.0,
+            BELIEF_FACTUAL,
+            LOCK_NONE,
+            0,
+            "2026-04-01T00:00:00Z",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    # Open via MemoryStore — migration runs.
+    s = MemoryStore(str(db_path))
+    cols = {
+        r[1]
+        for r in s._conn.execute("PRAGMA table_info(beliefs)").fetchall()  # noqa: SLF001
+    }
+    assert "hibernation_score" in cols
+    assert "activation_condition" in cols
+
+    legacy = s.get_belief("old1")
+    assert legacy is not None
+    assert legacy.hibernation_score is None
+    assert legacy.activation_condition is None
+
+    # New row writes both fields after migration.
+    s.insert_belief(
+        _mk_belief("new1", hibernation_score=0.5, activation_condition="{}")
+    )
+    fresh = s.get_belief("new1")
+    assert fresh is not None
+    assert fresh.hibernation_score == 0.5
+    assert fresh.activation_condition == "{}"
+    s.close()
+
+    # Re-open: migration is idempotent.
+    s2 = MemoryStore(str(db_path))
+    again = s2.get_belief("new1")
+    assert again is not None
+    assert again.hibernation_score == 0.5
+    s2.close()


### PR DESCRIPTION
Refs #196 — does **not** close it. Substrate decision is ratified (Option B); issue stays open until hibernation behavior also ships.

This PR is the storage half only.

## What lands

- `beliefs.hibernation_score REAL` (nullable) and `beliefs.activation_condition TEXT` (nullable, JSON-encoded when set), per `docs/substrate_decision.md` ratification asks #3 (hibernation: yes) and #4 (predicate language: JSON).
- Idempotent `ALTER TABLE … ADD COLUMN` for both, inserted into the existing `_MIGRATIONS` tuple. Legacy DBs gain the columns on next open; existing rows return `NULL`.
- `Belief.hibernation_score: float | None = None` and `Belief.activation_condition: str | None = None`. Defaults preserve every existing call site.
- `insert_belief` writes the new fields. `_row_to_belief` reads them. `get_belief` and `get_belief_by_content_hash` both surface them (verified by test).

## What does NOT land

- Hibernation lifecycle behavior — when to set `hibernation_score`, what wakes a belief, the predicate evaluator. That's a follow-up issue. The columns are nullable precisely so this PR doesn't pin behavior down.
- Any retrieval-path consumer of these fields. Locked beliefs / scoring / wonder are untouched.

## Tests

`tests/test_hibernation_columns.py` (5 tests):
- defaults are NULL on a fresh insert
- non-null round-trip (`hibernation_score=0.42`, JSON activation_condition)
- 0.0 / 1.0 boundary values
- `get_belief_by_content_hash` returns the new fields
- pre-#196 legacy DB (raw sqlite, only v1.2 column set) gains the columns on next `MemoryStore` open; second open is idempotent; legacy rows return NULL

Full suite: 1833 passed, 8 skipped.

## Why this size

Per Kulili session triage (2026-04-29): the substrate_decision.md ratification recommended hibernation but didn't spec the behavior. Splitting the column add (mechanical) from the behavior (queen-scoped) lets downstream issues — #195 (already merged scalar `uncertainty_score`), wonder/reason ports — depend on the column shape without waiting for the behavior debate to close.