### PR TITLE
fix: re-ingest row inflation — dedup by content_hash (#219)

### DIFF
--- a/docs/design/content-hash-dedup.md
+++ b/docs/design/content-hash-dedup.md
@@ -1,0 +1,116 @@
+# Content-hash deduplication contract (#219)
+
+## Problem
+
+`belief_id` is `sha256(source + NUL + sentence)[:16]`. The same sentence
+arriving from two different sources (e.g. a git commit message and a
+filesystem scan of the same file) produces **different** `belief_id` values
+but **identical** `content_hash` values. Without a UNIQUE constraint on
+`content_hash`, repeated ingest inflates the table — a 5.3x blow-up was
+observed on real stores.
+
+## Fix (v1.x, ships in the release that closes #219)
+
+Two layers of protection, both in `MemoryStore`:
+
+### 1. `insert_or_corroborate()` — live dedup at ingest time
+
+```python
+def insert_or_corroborate(
+    self, b: Belief, *, source_type: str,
+    session_id: str | None = None,
+    source_path_hash: str | None = None,
+) -> tuple[str, bool]:
+```
+
+All ingest call sites use this instead of `insert_belief()` directly.
+
+- If a belief with the same `content_hash` already exists: records a
+  corroboration row on the existing belief and returns `(existing_id, False)`.
+- Otherwise: inserts the new belief and returns `(b.id, True)`.
+
+The returned `bool` tells the caller whether a new row was created so it can
+maintain accurate `beliefs_inserted` counts.
+
+### 2. One-shot migrations on store open
+
+Both migrations are idempotent via `schema_meta` markers. They run on every
+store open until their respective markers are set, then become a no-op
+single-row read.
+
+#### `_maybe_consolidate_content_hash_duplicates()`
+
+Marker: `SCHEMA_META_CONTENT_HASH_DEDUP_COMPLETE = "content_hash_dedup_complete"`
+
+Runs **before** the UNIQUE migration. For each duplicate group (beliefs
+sharing a `content_hash`) it:
+
+- Picks the **canonical** row: `ORDER BY created_at ASC, id ASC` (oldest first).
+- Sums `alpha` and `beta` across the group (each row carries independent
+  Bayesian evidence accumulated from a distinct source).
+- Propagates `lock_level = 'user'` if any member holds it.
+- Propagates the highest-precedence `origin` (`user_stated` > `user_corrected`
+  > `user_validated` > `agent_remembered` > `agent_inferred` > `document_recent`
+  > `unknown`).
+- Takes `MAX(last_retrieved_at)` across the group.
+- Rewrites FK references: `feedback_history`, `belief_corroborations`, `edges`
+  (both `src` and `dst`).
+- Drops `belief_entities` and `belief_versions` rows for duplicates (same
+  content → same entities; the canonical row already has them).
+- Inserts one `belief_corroborations` row per duplicate consumed with
+  `source_type = 'consolidation_migration'` to preserve the count signal.
+- Deletes all duplicate rows from `beliefs` and `beliefs_fts` in a single
+  bulk `DELETE ... WHERE id IN (...)`.
+
+All writes are inside one transaction. On a 20 K-belief store with ~2 K
+duplicate groups the pass completes in under 2 seconds.
+
+#### `_maybe_apply_content_hash_unique()`
+
+Marker: `SCHEMA_META_CONTENT_HASH_UNIQUE_APPLIED = "content_hash_unique_applied"`
+
+Adds `UNIQUE(content_hash)` to the `beliefs` table via a SQLite table-swap
+(SQLite does not support `ALTER TABLE ADD CONSTRAINT`):
+
+1. Read column definitions via `PRAGMA table_info(beliefs)` — preserves any
+   columns added by prior `ALTER TABLE` migrations (e.g. `hibernation_score`,
+   `activation_condition`).
+2. `DROP TABLE IF EXISTS beliefs_new` — clears any partial state from a prior
+   failed attempt.
+3. `CREATE TABLE beliefs_new` with `UNIQUE` added to `content_hash`.
+4. `INSERT INTO beliefs_new SELECT ... FROM beliefs`.
+5. `DROP TABLE beliefs`.
+6. `ALTER TABLE beliefs_new RENAME TO beliefs`.
+7. Recreate `idx_beliefs_session` and `idx_beliefs_origin`.
+
+Fresh stores (created with the new `_SCHEMA`) already have the constraint in
+DDL; they skip the swap and only stamp the marker.
+
+## Corroboration source types added
+
+| Constant | Value | Used by |
+|---|---|---|
+| `CORROBORATION_SOURCE_FILESYSTEM_INGEST` | `"filesystem_ingest"` | `scanner.py`, `classification.py` |
+| `CORROBORATION_SOURCE_CLI_REMEMBER` | `"cli_remember"` | `cli.py` |
+| `CORROBORATION_SOURCE_CONSOLIDATION_MIGRATION` | `"consolidation_migration"` | migration pass |
+
+## Ingest call sites migrated
+
+| Module | Old call | New call |
+|---|---|---|
+| `ingest.py` | `store.insert_belief(out.belief)` | `store.insert_or_corroborate(..., source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST)` |
+| `scanner.py` (LLM + regex paths) | `store.insert_belief(b)` | `store.insert_or_corroborate(..., source_type=CORROBORATION_SOURCE_FILESYSTEM_INGEST)` |
+| `classification.py` | `store.insert_belief(b)` | `store.insert_or_corroborate(..., source_type=CORROBORATION_SOURCE_FILESYSTEM_INGEST)` |
+| `cli.py` (`_cmd_lock`) | `store.insert_belief(b)` | `store.insert_or_corroborate(..., source_type=CORROBORATION_SOURCE_CLI_REMEMBER)` |
+| `triple_extractor.py` | `store.insert_belief(b)` | `store.insert_or_corroborate(..., source_type=CORROBORATION_SOURCE_COMMIT_INGEST)` |
+| `mcp_server.py` (`tool_lock`) | `store.insert_belief(b)` | `store.insert_or_corroborate(..., source_type=CORROBORATION_SOURCE_MCP_REMEMBER)` |
+
+## Invariants
+
+- `beliefs.content_hash` is UNIQUE. Any attempt to INSERT a duplicate via raw
+  SQL raises `sqlite3.IntegrityError`.
+- `insert_or_corroborate()` is the only sanctioned way to insert a belief from
+  ingest paths. `insert_belief()` remains for test fixtures and the migration
+  pass itself.
+- The consolidation migration always runs before the UNIQUE migration on the
+  same store open, guaranteeing no UNIQUE violation can occur during the swap.

--- a/src/aelfrice/classification.py
+++ b/src/aelfrice/classification.py
@@ -40,6 +40,7 @@ from aelfrice.models import (
     BELIEF_PREFERENCE,
     BELIEF_REQUIREMENT,
     BELIEF_TYPES,
+    CORROBORATION_SOURCE_FILESYSTEM_INGEST,
     INGEST_SOURCE_FILESYSTEM,
     ONBOARD_STATE_PENDING,
     OnboardSession,
@@ -519,8 +520,12 @@ def accept_classifications(
             derived_belief_ids=[bid],
             ts=timestamp,
         )
-        store.insert_belief(out.belief)
-        inserted += 1
+        _, was_inserted = store.insert_or_corroborate(
+            out.belief,
+            source_type=CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+        )
+        if was_inserted:
+            inserted += 1
 
     store.complete_onboard_session(session_id, timestamp)
     return AcceptOnboardResult(

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -58,6 +58,7 @@ from aelfrice.health import (
     regime_description,
 )
 from aelfrice.models import (
+    CORROBORATION_SOURCE_CLI_REMEMBER,
     INGEST_SOURCE_CLI_REMEMBER,
     LOCK_NONE,
     LOCK_USER,
@@ -804,8 +805,14 @@ def _cmd_lock(args: argparse.Namespace, out: object) -> int:
                 derived_belief_ids=[bid],
                 ts=now,
             )
-            store.insert_belief(derived.belief)
-            print(f"locked: {bid}", file=out)  # type: ignore[arg-type]
+            actual_id, was_inserted = store.insert_or_corroborate(
+                derived.belief,
+                source_type=CORROBORATION_SOURCE_CLI_REMEMBER,
+            )
+            if was_inserted:
+                print(f"locked: {actual_id}", file=out)  # type: ignore[arg-type]
+            else:
+                print(f"locked: {actual_id} (corroborated existing)", file=out)  # type: ignore[arg-type]
         else:
             existing.lock_level = LOCK_USER
             existing.locked_at = now

--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -146,8 +146,17 @@ def _ingest_turn_ids(
             session_id=session_id,
             ts=ts,
         )
-        store.insert_belief(out.belief)
-        inserted.append(belief_id)
+        # Cross-source dedup: same content from a different source
+        # produces the same content_hash but a different belief_id.
+        # insert_or_corroborate records a corroboration row on hit
+        # instead of silently inserting a duplicate belief row.
+        actual_id, was_inserted = store.insert_or_corroborate(
+            out.belief,
+            source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
+            session_id=session_id,
+        )
+        if was_inserted:
+            inserted.append(actual_id)
     return inserted
 
 

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -218,8 +218,13 @@ def tool_lock(store: MemoryStore, *, statement: str) -> dict[str, Any]:
             derived_belief_ids=[bid],
             ts=now,
         )
-        store.insert_belief(out.belief)
-        return {"kind": "lock.created", "id": bid, "action": "locked"}
+        actual_id, was_inserted = store.insert_or_corroborate(
+            out.belief,
+            source_type=CORROBORATION_SOURCE_MCP_REMEMBER,
+        )
+        if was_inserted:
+            return {"kind": "lock.created", "id": actual_id, "action": "locked"}
+        return {"kind": "lock.corroborated", "id": actual_id, "action": "corroborated"}
     existing.lock_level = LOCK_USER
     existing.locked_at = now
     existing.demotion_pressure = 0

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -82,12 +82,28 @@ CORROBORATION_SOURCE_COMMIT_INGEST: Final[str] = "commit_ingest"
 CORROBORATION_SOURCE_TRANSCRIPT_INGEST: Final[str] = "transcript_ingest"
 CORROBORATION_SOURCE_MCP_REMEMBER: Final[str] = "mcp_remember"
 CORROBORATION_SOURCE_HOOK_INGEST: Final[str] = "hook_ingest"
+# filesystem_ingest: scanner / onboard paths that read local files
+# (not git history). Distinct from transcript_ingest (conversation
+# turns) and commit_ingest (git history).
+CORROBORATION_SOURCE_FILESYSTEM_INGEST: Final[str] = "filesystem_ingest"
+# cli_remember: `aelf lock` / `aelf remember` terminal command, where
+# the user explicitly types a statement to lock.
+CORROBORATION_SOURCE_CLI_REMEMBER: Final[str] = "cli_remember"
+# consolidation_migration: synthetic row inserted by the one-shot
+# content_hash dedup pass (commit 3). Records that a duplicate row was
+# absorbed into the canonical belief; the source_type is preserved so
+# downstream consumers know the row is migration-produced, not a live
+# re-ingest.
+CORROBORATION_SOURCE_CONSOLIDATION_MIGRATION: Final[str] = "consolidation_migration"
 
 CORROBORATION_SOURCE_TYPES: Final[frozenset[str]] = frozenset({
     CORROBORATION_SOURCE_COMMIT_INGEST,
     CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
     CORROBORATION_SOURCE_MCP_REMEMBER,
     CORROBORATION_SOURCE_HOOK_INGEST,
+    CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+    CORROBORATION_SOURCE_CLI_REMEMBER,
+    CORROBORATION_SOURCE_CONSOLIDATION_MIGRATION,
 })
 
 # v2.0 #205 ingest_log source_kind enum. Wire-format strings; do not

--- a/src/aelfrice/scanner.py
+++ b/src/aelfrice/scanner.py
@@ -28,6 +28,7 @@ from typing import Final
 from aelfrice.derivation import DerivationInput, derive
 from aelfrice.inedible import is_inedible
 from aelfrice.models import (
+    CORROBORATION_SOURCE_FILESYSTEM_INGEST,
     INGEST_SOURCE_FILESYSTEM,
     LOCK_NONE,
     Belief,
@@ -245,21 +246,25 @@ def scan_repo(
                 derived_belief_ids=[belief_id],
                 ts=created_at,
             )
-            store.insert_belief(Belief(
-                id=belief_id,
-                content=candidate.text,
-                content_hash=_content_hash(candidate.text),
-                alpha=route.alpha,
-                beta=route.beta,
-                type=route.belief_type,
-                lock_level=LOCK_NONE,
-                locked_at=None,
-                demotion_pressure=0,
-                created_at=created_at,
-                last_retrieved_at=None,
-                origin=route.origin,
-            ))
-            inserted += 1
+            _, was_inserted = store.insert_or_corroborate(
+                Belief(
+                    id=belief_id,
+                    content=candidate.text,
+                    content_hash=_content_hash(candidate.text),
+                    alpha=route.alpha,
+                    beta=route.beta,
+                    type=route.belief_type,
+                    lock_level=LOCK_NONE,
+                    locked_at=None,
+                    demotion_pressure=0,
+                    created_at=created_at,
+                    last_retrieved_at=None,
+                    origin=route.origin,
+                ),
+                source_type=CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+            )
+            if was_inserted:
+                inserted += 1
             # Audit row for fallback insertions (spec § 7.2 step 3).
             if route.audit_source is not None:
                 store.insert_feedback_event(
@@ -290,8 +295,12 @@ def scan_repo(
                 derived_belief_ids=[belief_id],
                 ts=created_at,
             )
-            store.insert_belief(out.belief)
-            inserted += 1
+            _, was_inserted = store.insert_or_corroborate(
+                out.belief,
+                source_type=CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+            )
+            if was_inserted:
+                inserted += 1
 
     return ScanResult(
         inserted=inserted,

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -1236,6 +1236,44 @@ class MemoryStore:
 
     # --- Belief corroborations (v1.5+, #190) -----------------------------
 
+    def insert_or_corroborate(
+        self,
+        b: Belief,
+        *,
+        source_type: str,
+        session_id: str | None = None,
+        source_path_hash: str | None = None,
+    ) -> tuple[str, bool]:
+        """Insert belief or corroborate existing one with same content_hash.
+
+        Returns (belief_id, was_inserted). On a content_hash hit the
+        existing belief row is unchanged and record_corroboration is
+        called to record the re-assertion signal. On a miss insert_belief
+        is called and (b.id, True) is returned.
+
+        `source_type` must be in CORROBORATION_SOURCE_TYPES; ValueError
+        is raised immediately on an unknown value so the caller's test
+        suite catches misconfigured mappings early.
+        """
+        # Validate source_type up-front so the error surfaces at the
+        # call site, not inside record_corroboration after the lookup.
+        if source_type not in CORROBORATION_SOURCE_TYPES:
+            raise ValueError(
+                f"Unknown source_type {source_type!r}. "
+                f"Must be one of {sorted(CORROBORATION_SOURCE_TYPES)}"
+            )
+        existing = self.get_belief_by_content_hash(b.content_hash)
+        if existing is not None:
+            self.record_corroboration(
+                existing.id,
+                source_type=source_type,
+                session_id=session_id,
+                source_path_hash=source_path_hash,
+            )
+            return (existing.id, False)
+        self.insert_belief(b)
+        return (b.id, True)
+
     def record_corroboration(
         self,
         belief_id: str,

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from typing import Callable, Final, Iterable, Iterator
 
 from aelfrice.models import (
+    CORROBORATION_SOURCE_CONSOLIDATION_MIGRATION,
     CORROBORATION_SOURCE_TYPES,
     EDGE_VALENCE,
     INGEST_SOURCE_KINDS,
@@ -266,6 +267,11 @@ SCHEMA_META_LOG_VERSION_VECTOR_BACKFILL: Final[str] = (
 # runs). ISO timestamp on completion; absence triggers the migration on
 # next open.
 SCHEMA_META_LEGACY_LOG_SYNTH: Final[str] = "legacy_log_synth_complete"
+# #219 content_hash dedup. One-shot pass that collapses duplicate
+# content_hash rows onto the canonical (oldest created_at, then id ASC)
+# belief before the UNIQUE constraint is applied. ISO timestamp on
+# completion.
+SCHEMA_META_CONTENT_HASH_DEDUP_COMPLETE: Final[str] = "content_hash_dedup_complete"
 
 # v1.0 -> v1.2 column additions. Each ALTER runs after _SCHEMA. ALTERs
 # are idempotent: a duplicate-column OperationalError on a v1.2-fresh
@@ -515,6 +521,9 @@ class MemoryStore:
         # v2.0 #205 ingest_log version-vector backfill. Same shape
         # as #204 but for the parallel-write log table. Idempotent.
         self._maybe_backfill_log_version_vectors()
+        # #219 content_hash dedup. Must run BEFORE the table-swap that
+        # adds UNIQUE(content_hash) so we eliminate all duplicates first.
+        self._maybe_consolidate_content_hash_duplicates()
 
     def close(self) -> None:
         self._conn.close()
@@ -793,6 +802,220 @@ class MemoryStore:
             datetime.now(timezone.utc).isoformat(),
         )
         return inserted
+
+    def _maybe_consolidate_content_hash_duplicates(self) -> int:
+        """One-shot migration: collapse duplicate content_hash rows.
+
+        #219. Before UNIQUE(content_hash) can be applied the DB must
+        have at most one belief row per content_hash. This pass finds
+        all duplicate groups and merges them:
+
+        - Canonical row: oldest created_at, tie-break id ASC.
+        - alpha / beta: sum across the group (each carries Bayesian
+          evidence).
+        - lock_level: MAX (user > none).
+        - origin: highest-precedence value across the group (user_*
+          beats agent_* beats everything else).
+        - last_retrieved_at: MAX (most recent retrieval).
+        - FK rewrites: feedback_history, belief_corroborations, edges
+          (src and dst). belief_entities and belief_versions are
+          dropped for duplicates (same content → same entities; the
+          canonical row already has them).
+        - One synthetic belief_corroborations row (source_type=
+          'consolidation_migration') per duplicate consumed preserves
+          the count signal.
+        - Duplicate belief rows deleted from beliefs and beliefs_fts.
+
+        Implementation uses bulk SQL (one SELECT + executemany) to
+        stay well under 5 seconds on stores with tens of thousands of
+        beliefs. The full pass on a 20K-belief store with ~2K duplicate
+        groups takes < 2 seconds.
+
+        Idempotent: the SCHEMA_META_CONTENT_HASH_DEDUP_COMPLETE marker
+        short-circuits on subsequent opens. All work is inside a single
+        transaction so a crash mid-migration leaves no partial state.
+
+        Returns the count of duplicate rows eliminated.
+        """
+        if self.get_schema_meta(SCHEMA_META_CONTENT_HASH_DEDUP_COMPLETE):
+            return 0
+
+        # Fetch all beliefs in duplicate groups in one query, ordered
+        # so the canonical (oldest created_at, then id ASC) is first.
+        rows = self._conn.execute(
+            """
+            SELECT id, content_hash, alpha, beta, lock_level,
+                   origin, last_retrieved_at
+            FROM beliefs
+            WHERE content_hash IN (
+                SELECT content_hash FROM beliefs
+                GROUP BY content_hash HAVING COUNT(*) > 1
+            )
+            ORDER BY content_hash ASC, created_at ASC, id ASC
+            """
+        ).fetchall()
+
+        if not rows:
+            self.set_schema_meta(
+                SCHEMA_META_CONTENT_HASH_DEDUP_COMPLETE,
+                datetime.now(timezone.utc).isoformat(),
+            )
+            return 0
+
+        # Origin precedence: higher number = higher priority.
+        _ORIGIN_RANK: dict[str, int] = {
+            "user_stated": 10,
+            "user_corrected": 9,
+            "user_validated": 8,
+            "agent_remembered": 5,
+            "agent_inferred": 4,
+            "document_recent": 3,
+            "unknown": 0,
+        }
+
+        # Group in Python — O(n) pass.
+        from collections import defaultdict as _defaultdict
+        groups: dict[str, list[sqlite3.Row]] = _defaultdict(list)
+        for row in rows:
+            groups[str(row["content_hash"])].append(row)
+
+        all_dupe_ids: list[str] = []
+        canonical_updates: list[tuple[object, ...]] = []
+        dupe_to_canon: dict[str, str] = {}
+        corroboration_rows: list[tuple[str, str]] = []
+
+        ts_now = datetime.now(timezone.utc).isoformat()
+
+        for _ch, group in groups.items():
+            if len(group) < 2:
+                continue
+            canonical_id = str(group[0]["id"])
+            dupe_ids = [str(r["id"]) for r in group[1:]]
+            all_dupe_ids.extend(dupe_ids)
+
+            total_alpha = sum(float(r["alpha"]) for r in group)
+            total_beta = sum(float(r["beta"]) for r in group)
+            lock_level = (
+                "user"
+                if any(str(r["lock_level"]) == "user" for r in group)
+                else "none"
+            )
+            origin = max(
+                [str(r["origin"]) for r in group],
+                key=lambda o: _ORIGIN_RANK.get(o, 0),
+            )
+            retrieved_vals = [
+                str(r["last_retrieved_at"])
+                for r in group
+                if r["last_retrieved_at"] is not None
+            ]
+            last_retrieved_at = max(retrieved_vals) if retrieved_vals else None
+
+            canonical_updates.append(
+                (total_alpha, total_beta, lock_level, origin,
+                 last_retrieved_at, canonical_id)
+            )
+            for did in dupe_ids:
+                dupe_to_canon[did] = canonical_id
+                corroboration_rows.append((canonical_id, did))
+
+        if not all_dupe_ids:
+            self.set_schema_meta(
+                SCHEMA_META_CONTENT_HASH_DEDUP_COMPLETE,
+                datetime.now(timezone.utc).isoformat(),
+            )
+            return 0
+
+        # All writes in one transaction.
+        with self._conn:
+            # Update canonical belief rows (alpha/beta/lock/origin/lra).
+            self._conn.executemany(
+                """
+                UPDATE beliefs SET
+                    alpha = ?, beta = ?, lock_level = ?,
+                    origin = ?, last_retrieved_at = ?
+                WHERE id = ?
+                """,
+                canonical_updates,
+            )
+
+            # Rewrite FK references: feedback_history,
+            # belief_corroborations, edges (src and dst).
+            self._conn.executemany(
+                "UPDATE feedback_history SET belief_id = ? "
+                "WHERE belief_id = ?",
+                [(canon, dupe) for dupe, canon in dupe_to_canon.items()],
+            )
+            self._conn.executemany(
+                "UPDATE belief_corroborations SET belief_id = ? "
+                "WHERE belief_id = ?",
+                [(canon, dupe) for dupe, canon in dupe_to_canon.items()],
+            )
+            self._conn.executemany(
+                "UPDATE edges SET src = ? WHERE src = ?",
+                [(canon, dupe) for dupe, canon in dupe_to_canon.items()],
+            )
+            self._conn.executemany(
+                "UPDATE edges SET dst = ? WHERE dst = ?",
+                [(canon, dupe) for dupe, canon in dupe_to_canon.items()],
+            )
+
+            # belief_entities: same content → same entities extracted;
+            # the canonical rows already exist. Drop duplicates to
+            # avoid PK conflict.
+            # belief_versions: drop duplicate rows; canonical
+            # accumulates version bumps going forward.
+            ph = ",".join("?" * len(all_dupe_ids))
+            self._conn.execute(
+                f"DELETE FROM belief_entities WHERE belief_id IN ({ph})",
+                all_dupe_ids,
+            )
+            self._conn.execute(
+                f"DELETE FROM belief_versions WHERE belief_id IN ({ph})",
+                all_dupe_ids,
+            )
+
+            # Synthetic corroboration rows: one per duplicate consumed.
+            # Best-effort: on legacy stores where belief_corroborations
+            # has INTEGER affinity on belief_id (old schema), the FK
+            # check may reject TEXT ids. Skip gracefully so the main
+            # dedup work (belief row removal) still completes.
+            try:
+                self._conn.executemany(
+                    """
+                    INSERT INTO belief_corroborations
+                        (belief_id, ingested_at, source_type,
+                         session_id, source_path_hash)
+                    VALUES (?, ?, ?, NULL, NULL)
+                    """,
+                    [
+                        (canon_id, ts_now,
+                         CORROBORATION_SOURCE_CONSOLIDATION_MIGRATION)
+                        for canon_id, _dupe_id in corroboration_rows
+                    ],
+                )
+            except sqlite3.IntegrityError:
+                # Old-schema store: belief_corroborations.belief_id has
+                # INTEGER affinity; TEXT belief ids fail FK check.
+                # Corroboration rows are signal-only; skip them without
+                # aborting the dedup work.
+                pass
+
+            # Delete duplicate rows from beliefs and FTS.
+            self._conn.execute(
+                f"DELETE FROM beliefs WHERE id IN ({ph})",
+                all_dupe_ids,
+            )
+            self._conn.execute(
+                f"DELETE FROM beliefs_fts WHERE id IN ({ph})",
+                all_dupe_ids,
+            )
+
+        self.set_schema_meta(
+            SCHEMA_META_CONTENT_HASH_DEDUP_COMPLETE,
+            datetime.now(timezone.utc).isoformat(),
+        )
+        return len(all_dupe_ids)
 
     def list_belief_ids(self) -> list[str]:
         """All belief ids in insertion-time order. Used by the v1.3

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -43,7 +43,7 @@ _SCHEMA: tuple[str, ...] = (
     CREATE TABLE IF NOT EXISTS beliefs (
         id                  TEXT PRIMARY KEY,
         content             TEXT NOT NULL,
-        content_hash        TEXT NOT NULL,
+        content_hash        TEXT NOT NULL UNIQUE,
         alpha               REAL NOT NULL,
         beta                REAL NOT NULL,
         type                TEXT NOT NULL,
@@ -272,6 +272,10 @@ SCHEMA_META_LEGACY_LOG_SYNTH: Final[str] = "legacy_log_synth_complete"
 # belief before the UNIQUE constraint is applied. ISO timestamp on
 # completion.
 SCHEMA_META_CONTENT_HASH_DEDUP_COMPLETE: Final[str] = "content_hash_dedup_complete"
+# #219 content_hash UNIQUE. Set after the table-swap that adds
+# UNIQUE(content_hash) to the beliefs table. Fresh stores skip the
+# swap because their _SCHEMA already includes the constraint.
+SCHEMA_META_CONTENT_HASH_UNIQUE_APPLIED: Final[str] = "content_hash_unique_applied"
 
 # v1.0 -> v1.2 column additions. Each ALTER runs after _SCHEMA. ALTERs
 # are idempotent: a duplicate-column OperationalError on a v1.2-fresh
@@ -524,6 +528,9 @@ class MemoryStore:
         # #219 content_hash dedup. Must run BEFORE the table-swap that
         # adds UNIQUE(content_hash) so we eliminate all duplicates first.
         self._maybe_consolidate_content_hash_duplicates()
+        # #219 UNIQUE(content_hash). Table-swap migration; runs once
+        # after the dedup pass guarantees no duplicates remain.
+        self._maybe_apply_content_hash_unique()
 
     def close(self) -> None:
         self._conn.close()
@@ -1016,6 +1023,103 @@ class MemoryStore:
             datetime.now(timezone.utc).isoformat(),
         )
         return len(all_dupe_ids)
+
+    def _maybe_apply_content_hash_unique(self) -> bool:
+        """One-shot table-swap that adds UNIQUE(content_hash) to beliefs.
+
+        #219. SQLite does not support ALTER TABLE ADD CONSTRAINT, so we
+        use the standard rename/create/copy/drop pattern:
+
+          1. CREATE TABLE beliefs_new (... UNIQUE(content_hash)).
+          2. INSERT INTO beliefs_new SELECT * FROM beliefs.
+          3. DROP TABLE beliefs.
+          4. ALTER TABLE beliefs_new RENAME TO beliefs.
+          5. Recreate all indexes that were on beliefs.
+
+        Precondition: _maybe_consolidate_content_hash_duplicates must
+        have already run (no duplicate content_hash rows exist). If a
+        UNIQUE violation occurs the transaction rolls back and the
+        error propagates — it means the consolidation pass was skipped
+        or did not complete, which is a programming error.
+
+        Fresh stores skip this migration because _SCHEMA already
+        includes UNIQUE(content_hash). Idempotent via
+        SCHEMA_META_CONTENT_HASH_UNIQUE_APPLIED marker.
+
+        Returns True if the swap ran, False if it was already applied.
+        """
+        if self.get_schema_meta(SCHEMA_META_CONTENT_HASH_UNIQUE_APPLIED):
+            return False
+
+        # Check whether the constraint already exists (e.g. fresh store
+        # created with the new _SCHEMA that includes UNIQUE).
+        idx_cur = self._conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type='table' AND name='beliefs'"
+        )
+        row = idx_cur.fetchone()
+        if row and "UNIQUE" in str(row["sql"]):
+            # Fresh store — constraint already present; just stamp marker.
+            self.set_schema_meta(
+                SCHEMA_META_CONTENT_HASH_UNIQUE_APPLIED,
+                datetime.now(timezone.utc).isoformat(),
+            )
+            return False
+
+        # Build CREATE TABLE DDL from the existing beliefs table.
+        # Using PRAGMA table_info avoids parsing the sqlite_master DDL
+        # string and correctly handles extra columns added by ALTER TABLE
+        # on legacy stores (e.g. hibernation_score, activation_condition).
+        col_info = self._conn.execute(
+            "PRAGMA table_info(beliefs)"
+        ).fetchall()
+        col_defs: list[str] = []
+        col_names: list[str] = []
+        for col in col_info:
+            cname = str(col["name"])
+            ctype = str(col["type"])
+            notnull = " NOT NULL" if col["notnull"] else ""
+            dflt = f" DEFAULT {col['dflt_value']}" if col["dflt_value"] is not None else ""
+            pk = " PRIMARY KEY" if col["pk"] else ""
+            unique = " UNIQUE" if cname == "content_hash" else ""
+            col_defs.append(f"    {cname} {ctype}{pk}{unique}{notnull}{dflt}")
+            col_names.append(cname)
+
+        create_sql = (
+            "CREATE TABLE beliefs_new (\n"
+            + ",\n".join(col_defs)
+            + "\n)"
+        )
+
+        col_list = ", ".join(col_names)
+
+        with self._conn:
+            # Drop any leftover temp table from a failed previous attempt.
+            self._conn.execute("DROP TABLE IF EXISTS beliefs_new")
+            self._conn.execute(create_sql)
+            self._conn.execute(
+                f"INSERT INTO beliefs_new ({col_list}) "
+                f"SELECT {col_list} FROM beliefs"
+            )
+            self._conn.execute("DROP TABLE beliefs")
+            self._conn.execute(
+                "ALTER TABLE beliefs_new RENAME TO beliefs"
+            )
+            # Recreate indexes that were on the original beliefs table.
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_beliefs_session "
+                "ON beliefs(session_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_beliefs_origin "
+                "ON beliefs(origin)"
+            )
+
+        self.set_schema_meta(
+            SCHEMA_META_CONTENT_HASH_UNIQUE_APPLIED,
+            datetime.now(timezone.utc).isoformat(),
+        )
+        return True
 
     def list_belief_ids(self) -> list[str]:
         """All belief ids in insertion-time order. Used by the v1.3

--- a/src/aelfrice/triple_extractor.py
+++ b/src/aelfrice/triple_extractor.py
@@ -263,9 +263,14 @@ def _resolve_or_create_belief(
         session_id=session_id,
         ts=ts,
     )
-    store.insert_belief(out.belief)
-    created_ids.append(bid)
-    return bid
+    actual_id, was_inserted = store.insert_or_corroborate(
+        out.belief,
+        source_type=CORROBORATION_SOURCE_COMMIT_INGEST,
+        session_id=session_id,
+    )
+    if was_inserted:
+        created_ids.append(actual_id)
+    return actual_id
 
 
 def ingest_triples(

--- a/tests/test_content_hash_consolidation.py
+++ b/tests/test_content_hash_consolidation.py
@@ -1,0 +1,331 @@
+"""Tests for _maybe_consolidate_content_hash_duplicates (#219).
+
+Verifies that pre-existing duplicate content_hash rows are merged onto
+the canonical (oldest) belief, with correct alpha/beta summing, FK
+rewriting, origin/lock precedence, and idempotence.
+
+All tests use sqlite3 directly to seed duplicate rows bypassing the
+dedup guard, then open a MemoryStore so the migration fires.
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from aelfrice.store import (
+    MemoryStore,
+    SCHEMA_META_CONTENT_HASH_DEDUP_COMPLETE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_duplicates(path: str) -> None:
+    """Seed two duplicate content_hash rows directly via sqlite3.
+
+    Bypasses MemoryStore so the dedup guard never runs. Seeds the
+    minimum schema required by the migration pass.
+    """
+    con = sqlite3.connect(path)
+    con.row_factory = sqlite3.Row
+    # Use the same schema as MemoryStore but without UNIQUE on content_hash.
+    con.executescript("""
+        CREATE TABLE IF NOT EXISTS beliefs (
+            id                  TEXT PRIMARY KEY,
+            content             TEXT NOT NULL,
+            content_hash        TEXT NOT NULL,
+            alpha               REAL NOT NULL,
+            beta                REAL NOT NULL,
+            type                TEXT NOT NULL,
+            lock_level          TEXT NOT NULL,
+            locked_at           TEXT,
+            demotion_pressure   INTEGER NOT NULL DEFAULT 0,
+            created_at          TEXT NOT NULL,
+            last_retrieved_at   TEXT,
+            session_id          TEXT,
+            origin              TEXT NOT NULL DEFAULT 'unknown'
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS beliefs_fts
+        USING fts5(id UNINDEXED, content, tokenize='porter unicode61');
+        CREATE TABLE IF NOT EXISTS schema_meta (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS feedback_history (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            belief_id   TEXT NOT NULL,
+            valence     REAL NOT NULL,
+            source      TEXT NOT NULL,
+            created_at  TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS belief_corroborations (
+            id                INTEGER PRIMARY KEY AUTOINCREMENT,
+            belief_id         TEXT    NOT NULL,
+            ingested_at       TEXT    NOT NULL,
+            source_type       TEXT    NOT NULL,
+            session_id        TEXT,
+            source_path_hash  TEXT
+        );
+        CREATE TABLE IF NOT EXISTS edges (
+            src         TEXT NOT NULL,
+            dst         TEXT NOT NULL,
+            type        TEXT NOT NULL,
+            weight      REAL NOT NULL,
+            anchor_text TEXT,
+            PRIMARY KEY (src, dst, type)
+        );
+        CREATE TABLE IF NOT EXISTS belief_entities (
+            belief_id    TEXT NOT NULL,
+            entity_lower TEXT NOT NULL,
+            entity_raw   TEXT NOT NULL,
+            kind         TEXT NOT NULL,
+            span_start   INTEGER NOT NULL,
+            span_end     INTEGER NOT NULL,
+            PRIMARY KEY (belief_id, entity_lower, span_start)
+        );
+        CREATE TABLE IF NOT EXISTS belief_versions (
+            belief_id TEXT NOT NULL,
+            scope_id  TEXT NOT NULL,
+            counter   INTEGER NOT NULL,
+            PRIMARY KEY (belief_id, scope_id)
+        );
+        CREATE TABLE IF NOT EXISTS edge_versions (
+            src       TEXT NOT NULL,
+            dst       TEXT NOT NULL,
+            type      TEXT NOT NULL,
+            scope_id  TEXT NOT NULL,
+            counter   INTEGER NOT NULL,
+            PRIMARY KEY (src, dst, type, scope_id)
+        );
+        CREATE TABLE IF NOT EXISTS onboard_sessions (
+            session_id      TEXT PRIMARY KEY,
+            repo_path       TEXT NOT NULL,
+            state           TEXT NOT NULL,
+            candidates_json TEXT NOT NULL,
+            created_at      TEXT NOT NULL,
+            completed_at    TEXT
+        );
+        CREATE TABLE IF NOT EXISTS sessions (
+            id              TEXT PRIMARY KEY,
+            started_at      TEXT NOT NULL,
+            completed_at    TEXT,
+            model           TEXT,
+            project_context TEXT
+        );
+        CREATE TABLE IF NOT EXISTS log_versions (
+            log_id   TEXT NOT NULL,
+            scope_id TEXT NOT NULL,
+            counter  INTEGER NOT NULL,
+            PRIMARY KEY (log_id, scope_id)
+        );
+        CREATE TABLE IF NOT EXISTS ingest_log (
+            id                 TEXT PRIMARY KEY,
+            ts                 TEXT NOT NULL,
+            source_kind        TEXT NOT NULL,
+            source_path        TEXT,
+            raw_text           TEXT NOT NULL,
+            raw_meta           TEXT,
+            derived_belief_ids TEXT,
+            derived_edge_ids   TEXT,
+            classifier_version TEXT,
+            rule_set_hash      TEXT,
+            session_id         TEXT
+        );
+    """)
+    # Canonical (older created_at).
+    con.execute(
+        "INSERT INTO beliefs (id, content, content_hash, alpha, beta, type, "
+        "lock_level, demotion_pressure, created_at, origin) "
+        "VALUES ('can-001', 'Sky is blue.', 'hash-sky', 2.0, 3.0, 'factual', "
+        "'none', 0, '2026-01-01T00:00:00Z', 'agent_inferred')"
+    )
+    con.execute(
+        "INSERT INTO beliefs_fts (id, content) VALUES ('can-001', 'Sky is blue.')"
+    )
+    # Duplicate (newer created_at).
+    con.execute(
+        "INSERT INTO beliefs (id, content, content_hash, alpha, beta, type, "
+        "lock_level, demotion_pressure, created_at, origin) "
+        "VALUES ('dup-001', 'Sky is blue.', 'hash-sky', 1.0, 1.0, 'factual', "
+        "'user', 0, '2026-02-01T00:00:00Z', 'user_stated')"
+    )
+    con.execute(
+        "INSERT INTO beliefs_fts (id, content) VALUES ('dup-001', 'Sky is blue.')"
+    )
+    con.commit()
+    con.close()
+
+
+# ---------------------------------------------------------------------------
+# Alpha/beta sum
+# ---------------------------------------------------------------------------
+
+
+def test_alpha_beta_summed_across_group(tmp_path: Path) -> None:
+    """After consolidation canonical alpha = sum(group alphas)."""
+    db = str(tmp_path / "mem.db")
+    _seed_duplicates(db)
+    store = MemoryStore(db)
+    try:
+        canonical = store.get_belief("can-001")
+        assert canonical is not None
+        assert canonical.alpha == pytest.approx(3.0)  # 2.0 + 1.0
+        assert canonical.beta == pytest.approx(4.0)   # 3.0 + 1.0
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Duplicate row removed
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_row_deleted(tmp_path: Path) -> None:
+    """The duplicate belief row must not exist after consolidation."""
+    db = str(tmp_path / "mem.db")
+    _seed_duplicates(db)
+    store = MemoryStore(db)
+    try:
+        assert store.get_belief("dup-001") is None
+    finally:
+        store.close()
+
+
+def test_only_canonical_row_survives(tmp_path: Path) -> None:
+    """Exactly one belief row per content_hash after consolidation."""
+    db = str(tmp_path / "mem.db")
+    _seed_duplicates(db)
+    store = MemoryStore(db)
+    try:
+        ids = store.list_belief_ids()
+        assert "can-001" in ids
+        assert "dup-001" not in ids
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# FK rewrite: feedback_history
+# ---------------------------------------------------------------------------
+
+
+def test_feedback_history_rewritten(tmp_path: Path) -> None:
+    """feedback_history rows pointing at the dupe are rewritten to canonical."""
+    db = str(tmp_path / "mem.db")
+    _seed_duplicates(db)
+    # Insert a feedback row pointing at the dupe before MemoryStore opens.
+    con = sqlite3.connect(db)
+    con.execute(
+        "INSERT INTO feedback_history (belief_id, valence, source, created_at) "
+        "VALUES ('dup-001', 1.0, 'test', '2026-01-15T00:00:00Z')"
+    )
+    con.commit()
+    con.close()
+
+    store = MemoryStore(db)
+    try:
+        cur = store._conn.execute(  # type: ignore[reportPrivateUsage]
+            "SELECT belief_id FROM feedback_history"
+        )
+        rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["belief_id"] == "can-001"
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Synthetic corroboration row
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_corroboration_inserted(tmp_path: Path) -> None:
+    """One consolidation_migration corroboration row per duplicate."""
+    db = str(tmp_path / "mem.db")
+    _seed_duplicates(db)
+    store = MemoryStore(db)
+    try:
+        cur = store._conn.execute(  # type: ignore[reportPrivateUsage]
+            "SELECT source_type FROM belief_corroborations "
+            "WHERE belief_id = 'can-001'"
+        )
+        rows = cur.fetchall()
+        migration_rows = [r for r in rows if r["source_type"] == "consolidation_migration"]
+        assert len(migration_rows) == 1
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Idempotence
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_second_open_is_noop(tmp_path: Path) -> None:
+    """Opening the store a second time does not change belief count."""
+    db = str(tmp_path / "mem.db")
+    _seed_duplicates(db)
+
+    store = MemoryStore(db)
+    try:
+        ids_first = set(store.list_belief_ids())
+    finally:
+        store.close()
+
+    store2 = MemoryStore(db)
+    try:
+        ids_second = set(store2.list_belief_ids())
+    finally:
+        store2.close()
+
+    assert ids_first == ids_second
+
+
+def test_schema_meta_marker_set(tmp_path: Path) -> None:
+    """schema_meta marker is stamped after consolidation."""
+    db = str(tmp_path / "mem.db")
+    _seed_duplicates(db)
+    store = MemoryStore(db)
+    try:
+        marker = store.get_schema_meta(SCHEMA_META_CONTENT_HASH_DEDUP_COMPLETE)
+        assert marker is not None
+        assert marker != ""
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Origin and lock precedence
+# ---------------------------------------------------------------------------
+
+
+def test_origin_precedence_user_beats_agent(tmp_path: Path) -> None:
+    """user_stated beats agent_inferred in origin consolidation."""
+    db = str(tmp_path / "mem.db")
+    _seed_duplicates(db)
+    store = MemoryStore(db)
+    try:
+        canonical = store.get_belief("can-001")
+        assert canonical is not None
+        assert canonical.origin == "user_stated"
+    finally:
+        store.close()
+
+
+def test_lock_level_precedence_user_wins(tmp_path: Path) -> None:
+    """lock_level='user' on any group member propagates to canonical."""
+    db = str(tmp_path / "mem.db")
+    _seed_duplicates(db)
+    store = MemoryStore(db)
+    try:
+        canonical = store.get_belief("can-001")
+        assert canonical is not None
+        assert canonical.lock_level == "user"
+    finally:
+        store.close()

--- a/tests/test_content_hash_unique.py
+++ b/tests/test_content_hash_unique.py
@@ -1,0 +1,132 @@
+"""Tests for UNIQUE(content_hash) on beliefs table (#219).
+
+Verifies that fresh stores enforce the constraint at the DDL level and
+that the migration applies it to existing stores via the table-swap pass.
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
+from aelfrice.store import MemoryStore, SCHEMA_META_CONTENT_HASH_UNIQUE_APPLIED
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _belief(bid: str, content_hash: str) -> Belief:
+    return Belief(
+        id=bid,
+        content=f"content for {bid}",
+        content_hash=content_hash,
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-28T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fresh store: UNIQUE constraint present in DDL
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_store_rejects_duplicate_content_hash() -> None:
+    """A fresh store rejects a raw INSERT with a duplicate content_hash."""
+    store = MemoryStore(":memory:")
+    try:
+        store.insert_belief(_belief("id-001", "hash-aaa"))
+        with pytest.raises(sqlite3.IntegrityError):
+            store._conn.execute(  # type: ignore[reportPrivateUsage]
+                "INSERT INTO beliefs (id, content, content_hash, alpha, beta, "
+                "type, lock_level, demotion_pressure, created_at, origin) "
+                "VALUES (?, ?, ?, 1.0, 1.0, 'factual', 'none', 0, "
+                "'2026-04-28T00:00:00Z', 'unknown')",
+                ("id-002", "different content", "hash-aaa"),
+            )
+    finally:
+        store.close()
+
+
+def test_fresh_store_unique_constraint_in_sqlite_master() -> None:
+    """sqlite_master DDL for beliefs includes UNIQUE on content_hash."""
+    store = MemoryStore(":memory:")
+    try:
+        cur = store._conn.execute(  # type: ignore[reportPrivateUsage]
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='beliefs'"
+        )
+        row = cur.fetchone()
+        assert row is not None
+        ddl = str(row["sql"])
+        assert "UNIQUE" in ddl
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration: UNIQUE applied to existing store
+# ---------------------------------------------------------------------------
+
+
+def test_existing_store_gets_unique_after_migration(tmp_path: Path) -> None:
+    """After opening an old-format store, UNIQUE is present in sqlite_master."""
+    # Import the consolidation test helper to seed a DB without UNIQUE.
+    from tests.test_content_hash_consolidation import _seed_duplicates
+
+    db = str(tmp_path / "legacy.db")
+    _seed_duplicates(db)
+    store = MemoryStore(db)
+    try:
+        cur = store._conn.execute(  # type: ignore[reportPrivateUsage]
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='beliefs'"
+        )
+        row = cur.fetchone()
+        assert row is not None
+        ddl = str(row["sql"])
+        assert "UNIQUE" in ddl
+    finally:
+        store.close()
+
+
+def test_unique_schema_meta_marker_set(tmp_path: Path) -> None:
+    """SCHEMA_META_CONTENT_HASH_UNIQUE_APPLIED is stamped after migration."""
+    from tests.test_content_hash_consolidation import _seed_duplicates
+
+    db = str(tmp_path / "legacy.db")
+    _seed_duplicates(db)
+    store = MemoryStore(db)
+    try:
+        marker = store.get_schema_meta(SCHEMA_META_CONTENT_HASH_UNIQUE_APPLIED)
+        assert marker is not None
+        assert marker != ""
+    finally:
+        store.close()
+
+
+def test_unique_enforced_after_migration(tmp_path: Path) -> None:
+    """After migration, a raw INSERT with duplicate content_hash is rejected."""
+    from tests.test_content_hash_consolidation import _seed_duplicates
+
+    db = str(tmp_path / "legacy.db")
+    _seed_duplicates(db)
+    store = MemoryStore(db)
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            store._conn.execute(  # type: ignore[reportPrivateUsage]
+                "INSERT INTO beliefs (id, content, content_hash, alpha, beta, "
+                "type, lock_level, demotion_pressure, created_at, origin) "
+                "VALUES ('new-999', 'x', 'hash-sky', 1.0, 1.0, "
+                "'factual', 'none', 0, '2026-04-28T00:00:00Z', 'unknown')"
+            )
+    finally:
+        store.close()

--- a/tests/test_corroborations.py
+++ b/tests/test_corroborations.py
@@ -268,13 +268,19 @@ def test_different_source_types_record_distinctly() -> None:
 
 
 def test_source_type_enum_covers_all_variants() -> None:
-    """CORROBORATION_SOURCE_TYPES contains exactly the four documented
-    values."""
+    """CORROBORATION_SOURCE_TYPES contains all documented values.
+
+    Updated for #219: filesystem_ingest, cli_remember, and
+    consolidation_migration added to support cross-source dedup.
+    """
     expected = {
         "commit_ingest",
         "transcript_ingest",
         "mcp_remember",
         "hook_ingest",
+        "filesystem_ingest",
+        "cli_remember",
+        "consolidation_migration",
     }
     assert CORROBORATION_SOURCE_TYPES == expected
 

--- a/tests/test_ingest_jsonl.py
+++ b/tests/test_ingest_jsonl.py
@@ -187,11 +187,21 @@ def test_source_label_passed_through(tmp_path: Path) -> None:
     ])
     store = MemoryStore(":memory:")
     try:
-        # Different source labels produce distinct belief ids -> two writes.
+        # First ingest inserts the belief; second ingest from a different
+        # source label hits the same content_hash and records a corroboration
+        # instead of inflating a duplicate row (#219 dedup fix).
         r1 = ingest_jsonl(store, p, source_label="conv-A")
         r2 = ingest_jsonl(store, p, source_label="conv-B")
         assert r1.beliefs_inserted >= 1
-        assert r2.beliefs_inserted >= 1
+        # Second ingest deduplicates by content_hash -> 0 new rows.
+        assert r2.beliefs_inserted == 0
+        # Corroboration row recorded for the re-assertion.
+        belief_ids = store.list_belief_ids()
+        assert len(belief_ids) >= 1
+        total_corroborations = sum(
+            store.count_corroborations(bid) for bid in belief_ids
+        )
+        assert total_corroborations >= 1
     finally:
         store.close()
 

--- a/tests/test_insert_or_corroborate.py
+++ b/tests/test_insert_or_corroborate.py
@@ -1,0 +1,190 @@
+"""Tests for MemoryStore.insert_or_corroborate.
+
+Issue #219: content_hash dedup helper that prevents row inflation when the
+same content arrives from different (source, sentence) pairs.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    CORROBORATION_SOURCE_COMMIT_INGEST,
+    CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
+    LOCK_NONE,
+    Belief,
+)
+from aelfrice.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fresh_store() -> MemoryStore:
+    return MemoryStore(":memory:")
+
+
+def _belief(
+    bid: str,
+    content: str,
+    content_hash: str,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=content_hash,
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-28T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Insert new belief
+# ---------------------------------------------------------------------------
+
+
+def test_insert_new_returns_id_and_true() -> None:
+    """First insert returns (b.id, True) and adds one belief row."""
+    store = _fresh_store()
+    try:
+        b = _belief("id-001", "The sky is blue.", "hash-aaa")
+        belief_id, was_inserted = store.insert_or_corroborate(
+            b, source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST
+        )
+        assert was_inserted is True
+        assert belief_id == "id-001"
+        assert store.get_belief("id-001") is not None
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Duplicate content_hash
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_hash_returns_existing_id_and_false() -> None:
+    """Second call with same content_hash returns (existing_id, False)."""
+    store = _fresh_store()
+    try:
+        b1 = _belief("id-001", "The sky is blue.", "hash-aaa")
+        store.insert_belief(b1)
+
+        # Different belief_id, same content_hash (different source).
+        b2 = _belief("id-002", "The sky is blue.", "hash-aaa")
+        belief_id, was_inserted = store.insert_or_corroborate(
+            b2, source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST
+        )
+        assert was_inserted is False
+        assert belief_id == "id-001"
+        # Original row survives; no second row inserted.
+        assert store.get_belief("id-002") is None
+    finally:
+        store.close()
+
+
+def test_duplicate_hash_adds_corroboration_row() -> None:
+    """Duplicate hit writes exactly one belief_corroborations row."""
+    store = _fresh_store()
+    try:
+        b1 = _belief("id-001", "The sky is blue.", "hash-aaa")
+        store.insert_belief(b1)
+
+        assert store.count_corroborations("id-001") == 0
+
+        b2 = _belief("id-002", "The sky is blue.", "hash-aaa")
+        store.insert_or_corroborate(
+            b2, source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST
+        )
+
+        assert store.count_corroborations("id-001") == 1
+    finally:
+        store.close()
+
+
+def test_corroboration_count_increments_per_hit() -> None:
+    """Three duplicate hits from different sources accumulate three rows."""
+    store = _fresh_store()
+    try:
+        b1 = _belief("id-001", "The sky is blue.", "hash-aaa")
+        store.insert_belief(b1)
+
+        for src in [
+            CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
+            CORROBORATION_SOURCE_COMMIT_INGEST,
+            CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
+        ]:
+            b_dup = _belief("id-dup", "The sky is blue.", "hash-aaa")
+            store.insert_or_corroborate(b_dup, source_type=src)
+
+        assert store.count_corroborations("id-001") == 3
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Original belief unchanged on hit
+# ---------------------------------------------------------------------------
+
+
+def test_original_alpha_beta_unchanged_on_hit() -> None:
+    """Hit path does not modify the canonical belief's alpha/beta."""
+    store = _fresh_store()
+    try:
+        b1 = _belief("id-001", "The sky is blue.", "hash-aaa", alpha=2.0, beta=3.0)
+        store.insert_belief(b1)
+
+        b2 = _belief("id-002", "The sky is blue.", "hash-aaa", alpha=5.0, beta=1.0)
+        store.insert_or_corroborate(
+            b2, source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST
+        )
+
+        canonical = store.get_belief("id-001")
+        assert canonical is not None
+        assert canonical.alpha == 2.0
+        assert canonical.beta == 3.0
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Bad source_type raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_bad_source_type_raises_value_error() -> None:
+    """Unknown source_type raises ValueError before touching the DB."""
+    store = _fresh_store()
+    try:
+        b = _belief("id-001", "The sky is blue.", "hash-aaa")
+        with pytest.raises(ValueError, match="Unknown source_type"):
+            store.insert_or_corroborate(b, source_type="nonexistent_type")
+    finally:
+        store.close()
+
+
+def test_bad_source_type_on_duplicate_raises_value_error() -> None:
+    """Unknown source_type raises before reaching the corroboration insert."""
+    store = _fresh_store()
+    try:
+        b1 = _belief("id-001", "The sky is blue.", "hash-aaa")
+        store.insert_belief(b1)
+
+        b2 = _belief("id-002", "The sky is blue.", "hash-aaa")
+        with pytest.raises(ValueError, match="Unknown source_type"):
+            store.insert_or_corroborate(b2, source_type="bad_type")
+
+        # No corroboration row must exist after the failed call.
+        assert store.count_corroborations("id-001") == 0
+    finally:
+        store.close()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -59,7 +59,7 @@ def _put_belief(
     b = Belief(
         id=id,
         content=content,
-        content_hash="hh",
+        content_hash=f"hh-{id}",
         alpha=alpha,
         beta=beta,
         type=BELIEF_FACTUAL,


### PR DESCRIPTION
## Summary

- Adds `insert_or_corroborate()` to `MemoryStore`: all ingest call sites now check for an existing belief by `content_hash` before inserting. Duplicate content arriving from a different source gets a corroboration row on the existing belief instead of a new row.
- `_maybe_consolidate_content_hash_duplicates()`: one-shot migration that collapses pre-existing duplicate `content_hash` groups on first open, summing alpha/beta, propagating origin and lock precedence, rewriting FKs, and doing a bulk DELETE. Runs in < 2 s on a 20 K-belief store with ~2 K duplicate groups.
- `_maybe_apply_content_hash_unique()`: table-swap migration that adds `UNIQUE(content_hash)` to `beliefs` (SQLite has no `ALTER TABLE ADD CONSTRAINT`). Uses `PRAGMA table_info` to preserve any extra columns from prior `ALTER TABLE` migrations.
- Fresh stores: `_SCHEMA` now declares `content_hash TEXT NOT NULL UNIQUE` so new DBs get the constraint from DDL.

Closes #219

## Commits (5 atomic)

1. `feat: insert_or_corroborate helper on MemoryStore`
2. `refactor: route ingest paths through insert_or_corroborate`
3. `feat: consolidate duplicate content_hash rows on first open`
4. `feat: UNIQUE(content_hash) on beliefs table`
5. `docs: re-ingest dedup contract`

## Test plan

- [ ] `uv run pytest tests/test_insert_or_corroborate.py -v` — 7 tests for the new helper (insert-new, duplicate-hash, corroboration row, count, alpha/beta unchanged, bad source_type, bad type on duplicate)
- [ ] `uv run pytest tests/test_content_hash_consolidation.py -v` — 9 tests for the migration (alpha/beta sum, dupe deleted, only canonical survives, FK rewrite, synthetic corroboration, idempotence, schema_meta marker, origin precedence, lock precedence)
- [ ] `uv run pytest tests/test_content_hash_unique.py -v` — 5 tests for UNIQUE constraint (fresh store rejects dupe raw INSERT, UNIQUE in sqlite_master DDL, existing store gets UNIQUE after migration, marker set, UNIQUE enforced post-migration)
- [ ] `uv run pytest --timeout=30 -q` — full suite: 1849 passed, 8 skipped