### PR TITLE
fix: wire content_hash pre-check into ingest paths (#254)

### DIFF
--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -135,6 +135,20 @@ def _ingest_turn_ids(
                     session_id=session_id,
                 )
             continue
+        # Cross-source duplicate: same content already stored under a
+        # different (source, text) pair (e.g. transcript-ingest then
+        # commit-ingest of the same sentence). Record a corroboration
+        # against the canonical id and skip insert. Without this check
+        # the schema admits N rows per content_hash; see #254.
+        existing = store.get_belief_by_content_hash(out.belief.content_hash)
+        if existing is not None:
+            if not bulk:
+                store.record_corroboration(
+                    existing.id,
+                    source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
+                    session_id=session_id,
+                )
+            continue
         # v2.0 #205 parallel-write: log the classifier input before
         # materializing the belief. belief_id is deterministic on
         # (source, sentence) so derived_belief_ids is known up-front.

--- a/src/aelfrice/triple_extractor.py
+++ b/src/aelfrice/triple_extractor.py
@@ -252,6 +252,17 @@ def _resolve_or_create_belief(
             session_id=session_id,
         )
         return bid
+    # Cross-source duplicate: same phrase already stored under a
+    # different source_kind. Return the canonical id so callers wire
+    # edges to it instead of creating a parallel row. See #254.
+    cross = store.get_belief_by_content_hash(out.belief.content_hash)
+    if cross is not None:
+        store.record_corroboration(
+            cross.id,
+            source_type=CORROBORATION_SOURCE_COMMIT_INGEST,
+            session_id=session_id,
+        )
+        return cross.id
     # v2.0 #205 parallel-write: log the raw phrase before materialization.
     # source_kind=git because the commit-ingest path emits triples from
     # commit messages; source_path is unknown at this layer (callers

--- a/tests/test_cross_source_dedup.py
+++ b/tests/test_cross_source_dedup.py
@@ -1,0 +1,87 @@
+"""Cross-source dedup via content_hash pre-check (#254).
+
+belief_id is sha256(source‖text); content_hash is sha256(text). The
+same sentence ingested under two different sources used to land as
+two separate rows because the id-based dedup check missed it. The
+ingest path now consults `get_belief_by_content_hash` after the
+id-miss and records a corroboration against the canonical row
+instead of inserting a parallel one. See issue #254.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from aelfrice.ingest import ingest_turn
+from aelfrice.store import MemoryStore
+
+
+def _all_beliefs(store: MemoryStore) -> list:
+    return [store.get_belief(bid) for bid in store.list_belief_ids()]
+
+
+def test_cross_source_reingest_does_not_inflate_rows(tmp_path: Path) -> None:
+    store = MemoryStore(str(tmp_path / "t.db"))
+    try:
+        text = "The default port is 8080 for the service."
+        n1 = ingest_turn(store, text, source="source_a")
+        assert n1 == 1
+        n2 = ingest_turn(store, text, source="source_b")
+        # Same content_hash → no new belief row.
+        assert n2 == 0
+        beliefs = _all_beliefs(store)
+        hashes = {b.content_hash for b in beliefs if b is not None}
+        assert len(hashes) == 1
+        assert len(beliefs) == 1
+    finally:
+        store.close()
+
+
+def test_cross_source_reingest_records_corroboration_against_canonical(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(str(tmp_path / "t.db"))
+    try:
+        text = "The configuration directory is /etc/aelfrice."
+        ingest_turn(store, text, source="source_a")
+        beliefs = _all_beliefs(store)
+        assert len(beliefs) == 1
+        canonical_id = beliefs[0].id
+
+        ingest_turn(store, text, source="source_b")
+        ingest_turn(store, text, source="source_c")
+
+        # Two corroborations on the canonical row, no new rows.
+        assert store.count_corroborations(canonical_id) == 2
+        assert len(_all_beliefs(store)) == 1
+    finally:
+        store.close()
+
+
+def test_cross_source_canonical_id_is_first_writer(tmp_path: Path) -> None:
+    store = MemoryStore(str(tmp_path / "t.db"))
+    try:
+        text = "Cache TTL is 60 seconds by default."
+        ingest_turn(store, text, source="alpha")
+        first = _all_beliefs(store)[0]
+        ingest_turn(store, text, source="beta")
+        # Canonical id stable: still the alpha-source id.
+        beliefs = _all_beliefs(store)
+        assert len(beliefs) == 1
+        assert beliefs[0].id == first.id
+    finally:
+        store.close()
+
+
+def test_bulk_cross_source_skips_corroboration(tmp_path: Path) -> None:
+    """bulk=True suppresses corroboration on the cross-source path,
+    matching the same-source bulk semantics."""
+    store = MemoryStore(str(tmp_path / "t.db"))
+    try:
+        text = "Retries are capped at 3 by default."
+        ingest_turn(store, text, source="src_a")
+        canonical_id = _all_beliefs(store)[0].id
+        ingest_turn(store, text, source="src_b", bulk=True)
+        assert store.count_corroborations(canonical_id) == 0
+        assert len(_all_beliefs(store)) == 1
+    finally:
+        store.close()

--- a/tests/test_ingest_jsonl.py
+++ b/tests/test_ingest_jsonl.py
@@ -187,11 +187,14 @@ def test_source_label_passed_through(tmp_path: Path) -> None:
     ])
     store = MemoryStore(":memory:")
     try:
-        # Different source labels produce distinct belief ids -> two writes.
+        # Different source labels share content_hash, so the second
+        # ingest dedups against the canonical row from the first
+        # (issue #254). The first call still inserts; the second
+        # records a corroboration and inserts nothing.
         r1 = ingest_jsonl(store, p, source_label="conv-A")
         r2 = ingest_jsonl(store, p, source_label="conv-B")
         assert r1.beliefs_inserted >= 1
-        assert r2.beliefs_inserted >= 1
+        assert r2.beliefs_inserted == 0
     finally:
         store.close()
 


### PR DESCRIPTION
## Summary

Fixes the structural cause behind issue #219's 5.3× row inflation by closing the cross-source dedup gap from #254.

`belief_id = sha256(source‖text)` but `content_hash = sha256(text)`. The ingest path's `store.get_belief(bid)` check catches same-source re-ingest only — the same sentence from a different source produced a parallel belief row.

Both ingest entry points now consult `get_belief_by_content_hash` after the id miss. On hit, they record a corroboration against the canonical row and skip insert. `_resolve_or_create_belief` returns the canonical id so commit-ingest edges wire to the existing belief. `bulk=True` continues to suppress corroboration writes, matching same-source semantics.

This is the application-level (Option B) path from #254. Schema-level UNIQUE on `content_hash` (Option A) is deferred — it requires consolidation of historical duplicates (issue #219) to land first.

## Tests

- New `tests/test_cross_source_dedup.py`: 4 cases covering no-row-inflation, corroboration against canonical id, canonical-id stability across re-ingests, and bulk suppression.
- `tests/test_ingest_jsonl.py::test_source_label_passed_through` previously asserted the buggy behavior (two writes for two source labels with same content); inverted to assert the fix (second call inserts 0).
- Full suite: 1837 passed, 8 skipped.

## Test plan
- [x] New cross-source dedup tests pass
- [x] Full suite green (1837 passed)
- [x] Existing same-source corroboration coverage in `tests/test_corroborations.py` unchanged

Closes #254