### PR TITLE
fix: aelf doctor --gc-orphan-feedback for dangling feedback_history rows (#223)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -77,8 +77,10 @@ from aelfrice.derivation import DerivationInput, derive
 from aelfrice.doctor import (
     classify_orphans as _classify_orphans,
     diagnose,
+    format_orphan_feedback_report as _format_orphan_feedback_report,
     format_orphan_report as _format_orphan_report,
     format_report,
+    gc_orphan_feedback as _gc_orphan_feedback,
 )
 from aelfrice.llm_classifier import (
     ENV_API_KEY as _LLM_ENV_API_KEY,
@@ -2054,6 +2056,8 @@ def _cmd_doctor(args: argparse.Namespace, out: object) -> int:
     """
     if getattr(args, "classify_orphans", False):
         return _cmd_doctor_classify_orphans(args, out)
+    if getattr(args, "gc_orphan_feedback", False):
+        return _cmd_doctor_gc_orphan_feedback(args, out)
     scope = getattr(args, "scope", None)
     exit_code = 0
     if scope in (None, "hooks"):
@@ -2146,6 +2150,26 @@ def _cmd_doctor_classify_orphans(
         store.close()
 
     print(_format_orphan_report(orphan_report), file=out)  # type: ignore[arg-type]
+    return 0
+
+
+def _cmd_doctor_gc_orphan_feedback(
+    args: argparse.Namespace, out: object
+) -> int:
+    """Garbage-collect `feedback_history` rows whose belief_id no
+    longer resolves in `beliefs` (issue #223).
+
+    Default is dry-run (count only). With `--apply`, deletes the
+    orphan rows. Bypasses the hooks/graph checks; never touches
+    LLMs.
+    """
+    apply = bool(getattr(args, "apply", False))
+    store = _open_store()
+    try:
+        report = _gc_orphan_feedback(store, dry_run=not apply)
+    finally:
+        store.close()
+    print(_format_orphan_feedback_report(report), file=out)  # type: ignore[arg-type]
     return 0
 
 
@@ -2616,6 +2640,29 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
             "with --classify-orphans: cap the number of beliefs "
             "classified per run. No cap by default; recommended: 500 "
             "for large stores to bound per-run cost."
+        ),
+    )
+    p_doctor.add_argument(
+        "--gc-orphan-feedback",
+        dest="gc_orphan_feedback",
+        action="store_true",
+        default=False,
+        help=(
+            "find feedback_history rows whose belief_id no longer "
+            "resolves in beliefs (issue #223 residue from pre-#283 "
+            "re-ingest) and report the count. Bypasses the "
+            "hooks/graph checks. Combine with --apply to delete the "
+            "orphan rows; default is dry-run."
+        ),
+    )
+    p_doctor.add_argument(
+        "--apply",
+        dest="apply",
+        action="store_true",
+        default=False,
+        help=(
+            "with --gc-orphan-feedback: actually delete the orphan "
+            "rows (default: dry-run)."
         ),
     )
     p_doctor.set_defaults(func=_cmd_doctor)

--- a/src/aelfrice/doctor.py
+++ b/src/aelfrice/doctor.py
@@ -1029,3 +1029,69 @@ def _append_type_dist(lines: list[str], dist: dict[str, int]) -> None:
         return
     for t, n in sorted(dist.items()):
         lines.append(f"  {t}: {n}")
+
+
+# ---------------------------------------------------------------------------
+# gc-orphan-feedback pass (issue #223)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class OrphanFeedbackReport:
+    """Summary of one `gc_orphan_feedback` pass.
+
+    `orphans_found` is the number of `feedback_history` rows whose
+    `belief_id` no longer resolves in `beliefs`. `deleted` is the
+    number actually removed (zero on dry-run).
+    """
+
+    orphans_found: int = 0
+    deleted: int = 0
+    dry_run: bool = True
+
+
+def gc_orphan_feedback(
+    store: "MemoryStore",
+    *,
+    dry_run: bool = True,
+) -> OrphanFeedbackReport:
+    """Identify and (with `dry_run=False`) delete `feedback_history`
+    rows whose `belief_id` no longer resolves in `beliefs`. Issue #223.
+
+    Pre-#283 re-ingest could leave a feedback row pointing at a
+    deleted belief: the same content_hash got a fresh belief_id, the
+    old row was dropped, but feedback_history kept the dangling
+    reference. The mechanism is plugged going forward by the UNIQUE
+    `content_hash` constraint plus `insert_or_corroborate`; this
+    pass cleans the residue.
+
+    Recovery is not attempted: feedback_history stores only
+    `belief_id`, not `content_hash`, so the original target's content
+    is unrecoverable. The pass deletes rather than re-links.
+
+    `dry_run=True` (the default) counts without modifying the store.
+    """
+    report = OrphanFeedbackReport(dry_run=dry_run)
+    report.orphans_found = store.count_orphan_feedback_events()
+    if dry_run or report.orphans_found == 0:
+        return report
+    report.deleted = store.delete_orphan_feedback_events()
+    return report
+
+
+def format_orphan_feedback_report(report: OrphanFeedbackReport) -> str:
+    """Human-readable rendering of `gc_orphan_feedback` output."""
+    lines: list[str] = []
+    lines.append(
+        f"orphan feedback rows: {report.orphans_found}"
+    )
+    if report.dry_run:
+        if report.orphans_found == 0:
+            lines.append("nothing to do.")
+        else:
+            lines.append(
+                "dry-run; re-run with --apply to delete these rows."
+            )
+    else:
+        lines.append(f"deleted: {report.deleted}")
+    return "\n".join(lines)

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -1561,6 +1561,52 @@ class MemoryStore:
             return 0
         return int(row["n"])
 
+    def count_orphan_feedback_events(self) -> int:
+        """Count `feedback_history` rows whose belief_id no longer
+        exists in `beliefs` (issue #223).
+
+        Pre-#283 re-ingest could create a fresh belief_id for the same
+        content_hash and let the old row be deleted while leaving its
+        feedback_history rows behind. The UNIQUE content_hash
+        constraint and `insert_or_corroborate` plug the source going
+        forward; this counter surfaces the residue still in user DBs.
+        """
+        cur = self._conn.execute(
+            """
+            SELECT COUNT(*) AS n
+            FROM feedback_history fh
+            LEFT JOIN beliefs b ON fh.belief_id = b.id
+            WHERE b.id IS NULL
+            """
+        )
+        row = cur.fetchone()
+        if row is None:
+            return 0
+        return int(row["n"])
+
+    def delete_orphan_feedback_events(self) -> int:
+        """Delete `feedback_history` rows whose belief_id no longer
+        resolves in `beliefs`. Returns the number deleted. Issue #223.
+
+        Destructive — caller is responsible for confirmation. The audit
+        trail for the deleted rows is unrecoverable: the original
+        belief content is already gone and feedback_history stores
+        only `belief_id`, not `content_hash`.
+        """
+        cur = self._conn.execute(
+            """
+            DELETE FROM feedback_history
+            WHERE belief_id IN (
+                SELECT fh.belief_id
+                FROM feedback_history fh
+                LEFT JOIN beliefs b ON fh.belief_id = b.id
+                WHERE b.id IS NULL
+            )
+            """
+        )
+        self._conn.commit()
+        return cur.rowcount if cur.rowcount is not None else 0
+
     # --- Belief corroborations (v1.5+, #190) -----------------------------
 
     def insert_or_corroborate(

--- a/tests/test_doctor_gc_orphan_feedback.py
+++ b/tests/test_doctor_gc_orphan_feedback.py
@@ -1,0 +1,229 @@
+"""Acceptance tests for `aelf doctor --gc-orphan-feedback` (issue #223).
+
+The pre-#283 re-ingest path could leave a `feedback_history` row
+pointing at a `belief_id` that was later deleted (because a fresh
+duplicate took its place). The pass counts those rows; with
+`--apply`, deletes them.
+"""
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+import aelfrice.cli as cli_module
+from aelfrice.doctor import (
+    OrphanFeedbackReport,
+    format_orphan_feedback_report,
+    gc_orphan_feedback,
+)
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
+from aelfrice.store import MemoryStore
+
+
+def _mk(store: MemoryStore, bid: str, content: str) -> None:
+    store.insert_belief(
+        Belief(
+            id=bid,
+            content=content,
+            content_hash=f"h_{bid}",
+            alpha=1.0,
+            beta=1.0,
+            type=BELIEF_FACTUAL,
+            lock_level=LOCK_NONE,
+            locked_at=None,
+            demotion_pressure=0,
+            created_at="2026-04-26T00:00:00Z",
+            last_retrieved_at=None,
+        )
+    )
+
+
+def _seed_orphans(store: MemoryStore) -> None:
+    """One live belief with two feedback rows, plus three orphan
+    feedback rows pointing at deleted belief_ids."""
+    _mk(store, "LIVE", "still here")
+    _fb = lambda bid, v: store.insert_feedback_event(  # noqa: E731
+        bid, valence=v, source="test", created_at="2026-04-26T00:00:00Z"
+    )
+    _ = _fb("LIVE", 1.0)
+    _ = _fb("LIVE", 0.0)
+    _ = _fb("DEAD1", 1.0)
+    _ = _fb("DEAD2", 1.0)
+    _ = _fb("DEAD2", 0.0)
+
+
+# --- store helpers ------------------------------------------------------
+
+
+def test_count_orphan_feedback_events_zero_on_clean_store(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    try:
+        _mk(store, "B1", "hello")
+        _ = store.insert_feedback_event(
+            "B1", valence=1.0, source="test",
+            created_at="2026-04-26T00:00:00Z",
+        )
+        assert store.count_orphan_feedback_events() == 0
+    finally:
+        store.close()
+
+
+def test_count_orphan_feedback_events_finds_dangling(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    try:
+        _seed_orphans(store)
+        # 3 orphan rows: DEAD1 (1) + DEAD2 (2). LIVE rows must not count.
+        assert store.count_orphan_feedback_events() == 3
+    finally:
+        store.close()
+
+
+def test_delete_orphan_feedback_events_removes_only_dangling(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    try:
+        _seed_orphans(store)
+        deleted = store.delete_orphan_feedback_events()
+        assert deleted == 3
+        assert store.count_orphan_feedback_events() == 0
+        # The two rows for LIVE must remain.
+        assert store.count_feedback_events(belief_id="LIVE") == 2
+    finally:
+        store.close()
+
+
+# --- doctor function ----------------------------------------------------
+
+
+def test_gc_orphan_feedback_dry_run_counts_without_deleting(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    try:
+        _seed_orphans(store)
+        report = gc_orphan_feedback(store, dry_run=True)
+        assert report.orphans_found == 3
+        assert report.deleted == 0
+        assert report.dry_run is True
+        assert store.count_orphan_feedback_events() == 3
+    finally:
+        store.close()
+
+
+def test_gc_orphan_feedback_apply_deletes_and_reports(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    try:
+        _seed_orphans(store)
+        report = gc_orphan_feedback(store, dry_run=False)
+        assert report.orphans_found == 3
+        assert report.deleted == 3
+        assert report.dry_run is False
+        assert store.count_orphan_feedback_events() == 0
+    finally:
+        store.close()
+
+
+def test_gc_orphan_feedback_noop_on_clean_store(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    try:
+        _mk(store, "B1", "hello")
+        report = gc_orphan_feedback(store, dry_run=False)
+        assert report.orphans_found == 0
+        assert report.deleted == 0
+    finally:
+        store.close()
+
+
+# --- format ------------------------------------------------------------
+
+
+def test_format_orphan_feedback_report_dry_run() -> None:
+    out = format_orphan_feedback_report(
+        OrphanFeedbackReport(orphans_found=3, deleted=0, dry_run=True)
+    )
+    assert "orphan feedback rows: 3" in out
+    assert "--apply" in out
+
+
+def test_format_orphan_feedback_report_apply() -> None:
+    out = format_orphan_feedback_report(
+        OrphanFeedbackReport(orphans_found=3, deleted=3, dry_run=False)
+    )
+    assert "orphan feedback rows: 3" in out
+    assert "deleted: 3" in out
+
+
+def test_format_orphan_feedback_report_clean_dry_run() -> None:
+    out = format_orphan_feedback_report(
+        OrphanFeedbackReport(orphans_found=0, deleted=0, dry_run=True)
+    )
+    assert "nothing to do" in out
+
+
+# --- CLI wire-up -------------------------------------------------------
+
+
+def _run_cli_with_db(
+    monkeypatch: pytest.MonkeyPatch, db: Path, *argv: str
+) -> tuple[int, str]:
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    buf = io.StringIO()
+    code = cli_module.main(argv=list(argv), out=buf)
+    return code, buf.getvalue()
+
+
+def test_cli_doctor_gc_orphan_feedback_dry_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    store = MemoryStore(str(db))
+    try:
+        _seed_orphans(store)
+    finally:
+        store.close()
+    code, output = _run_cli_with_db(
+        monkeypatch, db, "doctor", "--gc-orphan-feedback"
+    )
+    assert code == 0
+    assert "orphan feedback rows: 3" in output
+    assert "--apply" in output
+    # No deletion under dry-run.
+    store = MemoryStore(str(db))
+    try:
+        assert store.count_orphan_feedback_events() == 3
+    finally:
+        store.close()
+
+
+def test_cli_doctor_gc_orphan_feedback_apply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    store = MemoryStore(str(db))
+    try:
+        _seed_orphans(store)
+    finally:
+        store.close()
+    code, output = _run_cli_with_db(
+        monkeypatch, db, "doctor", "--gc-orphan-feedback", "--apply"
+    )
+    assert code == 0
+    assert "deleted: 3" in output
+    store = MemoryStore(str(db))
+    try:
+        assert store.count_orphan_feedback_events() == 0
+        # Live feedback survives.
+        assert store.count_feedback_events(belief_id="LIVE") == 2
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary

Closes #223. Pre-#283 re-ingest could leave `feedback_history` rows pointing at a `belief_id` that was later deleted (a fresh duplicate took its place with a new id). The UNIQUE `content_hash` constraint and `insert_or_corroborate` plug the source going forward, but the residue still exists in user databases (issue reporter saw 100% orphan rate).

What ships:

- `store.count_orphan_feedback_events()` / `delete_orphan_feedback_events()` — direct SQL helpers.
- `doctor.gc_orphan_feedback(store, *, dry_run=True)` returning `OrphanFeedbackReport`.
- `aelf doctor --gc-orphan-feedback` flag. Dry-run by default; `--apply` deletes.

Recovery is not attempted. `feedback_history` stores only `belief_id`, not `content_hash`, so the original target's content is unrecoverable. The pass deletes rather than re-links — the only safe op.

Mirrors the `--classify-orphans` pattern from #206.

## Test plan

- [x] `uv run pytest tests/ -q` → 1865 passed, 8 skipped on 3.13.
- [x] `pytest tests/test_doctor_gc_orphan_feedback.py -q` → 11 passed (store helpers, doctor function, formatter, CLI dry-run, CLI apply).
- [x] Discretion grep on full diff → clean.

Refs #223. Source mechanism plugged by #283 / #219.