### PR TITLE
feat: rebuild diagnostic log — phase-1a write path (#288)

### DIFF
--- a/src/aelfrice/context_rebuilder.py
+++ b/src/aelfrice/context_rebuilder.py
@@ -60,10 +60,13 @@ summarize."
 """
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import sys
 import tomllib
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Final, IO, cast
 
@@ -112,6 +115,21 @@ TURN_WINDOW_KEY: Final[str] = "turn_window_n"
 TOKEN_BUDGET_KEY: Final[str] = "token_budget"
 TRIGGER_MODE_KEY: Final[str] = "trigger_mode"
 THRESHOLD_FRACTION_KEY: Final[str] = "threshold_fraction"
+
+# --- Rebuild diagnostic log (#288 phase-1a) ------------------------------
+
+REBUILD_LOG_SECTION: Final[str] = "rebuild_log"
+REBUILD_LOG_ENABLED_KEY: Final[str] = "enabled"
+REBUILD_LOG_ENV: Final[str] = "AELFRICE_REBUILD_LOG"
+REBUILD_LOG_DIRNAME: Final[str] = "rebuild_logs"
+REBUILD_LOG_MAX_BYTES: Final[int] = 5 * 1024 * 1024
+"""Per-session rebuild_log file size cap. On reach, append a final
+`{"truncated": true, ...}` row and stop writing further records to
+that file."""
+DEFAULT_REBUILD_LOG_ENABLED: Final[bool] = True
+"""Rebuild diagnostic log is default-on. Opt out via the
+`AELFRICE_REBUILD_LOG=0` env var or `[rebuild_log] enabled = false`
+in `.aelfrice.toml`."""
 
 # --- v1.4.0 trigger-mode constants (issue #141) ---------------------------
 
@@ -242,6 +260,9 @@ def rebuild_v14(
     store: MemoryStore,
     *,
     token_budget: int = DEFAULT_REBUILDER_TOKEN_BUDGET,
+    rebuild_log_path: Path | None = None,
+    rebuild_log_enabled: bool = DEFAULT_REBUILD_LOG_ENABLED,
+    session_id_for_log: str | None = None,
 ) -> str:
     """v1.4 rebuild: L0 + session-scoped + L2.5/L1 via `retrieve()`.
 
@@ -295,28 +316,132 @@ def rebuild_v14(
     used: int = sum(_estimate_belief_tokens(b) for b in locked)
     out: list[Belief] = list(locked)
     seen_hashes: set[str] = {b.content_hash for b in locked}
+    hash_to_packed_id: dict[str, str] = {b.content_hash: b.id for b in locked}
+
+    # #288 phase-1a: track per-candidate decision metadata so the
+    # rebuild_log records every belief the rebuilder considered, not
+    # just those it packed. Order: L0, then session-scoped, then L2.5/L1.
+    log_candidates: list[dict[str, object]] = []
+    n_dropped_by_dedup = 0
+    n_dropped_by_budget = 0
+    budget_exceeded_session = False
+    budget_exceeded_non_locked = False
+
+    for b in locked:
+        log_candidates.append(
+            {
+                "belief_id": b.id,
+                "rank": len(log_candidates) + 1,
+                "scores": _empty_scores(),
+                "lock_level": _belief_lock_level_for_log(b),
+                "decision": "packed",
+                "reason": None,
+            }
+        )
 
     for b in session_hits:
+        decision: str
+        reason: str | None
         if b.content_hash in seen_hashes:
-            continue
-        cost = _estimate_belief_tokens(b)
-        if used + cost > token_budget:
-            break
-        out.append(b)
-        used += cost
-        seen_hashes.add(b.content_hash)
+            decision = "dropped"
+            reason = (
+                f"content_hash_collision_with:{hash_to_packed_id[b.content_hash]}"
+            )
+            n_dropped_by_dedup += 1
+        elif budget_exceeded_session:
+            decision = "dropped"
+            reason = "budget_exceeded"
+            n_dropped_by_budget += 1
+        else:
+            cost = _estimate_belief_tokens(b)
+            if used + cost > token_budget:
+                budget_exceeded_session = True
+                decision = "dropped"
+                reason = "budget_exceeded"
+                n_dropped_by_budget += 1
+            else:
+                out.append(b)
+                used += cost
+                seen_hashes.add(b.content_hash)
+                hash_to_packed_id[b.content_hash] = b.id
+                decision = "packed"
+                reason = None
+        log_candidates.append(
+            {
+                "belief_id": b.id,
+                "rank": len(log_candidates) + 1,
+                "scores": _empty_scores(),
+                "lock_level": _belief_lock_level_for_log(b),
+                "decision": decision,
+                "reason": reason,
+            }
+        )
 
     for b in non_locked_hits:
         if b.id in session_ids:
-            continue  # already surfaced above
+            continue  # already surfaced above as a session candidate
+        decision2: str
+        reason2: str | None
         if b.content_hash in seen_hashes:
-            continue
-        cost = _estimate_belief_tokens(b)
-        if used + cost > token_budget:
-            break
-        out.append(b)
-        used += cost
-        seen_hashes.add(b.content_hash)
+            decision2 = "dropped"
+            reason2 = (
+                f"content_hash_collision_with:{hash_to_packed_id[b.content_hash]}"
+            )
+            n_dropped_by_dedup += 1
+        elif budget_exceeded_non_locked:
+            decision2 = "dropped"
+            reason2 = "budget_exceeded"
+            n_dropped_by_budget += 1
+        else:
+            cost = _estimate_belief_tokens(b)
+            if used + cost > token_budget:
+                budget_exceeded_non_locked = True
+                decision2 = "dropped"
+                reason2 = "budget_exceeded"
+                n_dropped_by_budget += 1
+            else:
+                out.append(b)
+                used += cost
+                seen_hashes.add(b.content_hash)
+                hash_to_packed_id[b.content_hash] = b.id
+                decision2 = "packed"
+                reason2 = None
+        log_candidates.append(
+            {
+                "belief_id": b.id,
+                "rank": len(log_candidates) + 1,
+                "scores": _empty_scores(),
+                "lock_level": _belief_lock_level_for_log(b),
+                "decision": decision2,
+                "reason": reason2,
+            }
+        )
+
+    if (
+        rebuild_log_enabled
+        and not _rebuild_log_disabled_via_env()
+        and rebuild_log_path is not None
+        and log_candidates
+    ):
+        n_packed = sum(
+            1 for c in log_candidates if c["decision"] == "packed"
+        )
+        total_chars_packed = sum(len(b.content) for b in out)
+        pack_summary: dict[str, int] = {
+            "n_candidates": len(log_candidates),
+            "n_packed": n_packed,
+            "n_dropped_by_floor": 0,
+            "n_dropped_by_dedup": n_dropped_by_dedup,
+            "n_dropped_by_budget": n_dropped_by_budget,
+            "total_chars_packed": total_chars_packed,
+        }
+        record = _build_rebuild_log_record(
+            recent_turns=recent_turns,
+            session_id=session_id_for_log,
+            candidates=log_candidates,
+            pack_summary=pack_summary,
+        )
+        _append_rebuild_log_record(rebuild_log_path, record)
 
     return _format_block(
         recent_turns, out, session_ids, token_budget=token_budget,
@@ -369,6 +494,7 @@ class RebuilderConfig:
     token_budget: int = DEFAULT_REBUILDER_TOKEN_BUDGET
     trigger_mode: str = DEFAULT_TRIGGER_MODE
     threshold_fraction: float = DEFAULT_THRESHOLD_FRACTION
+    rebuild_log_enabled: bool = DEFAULT_REBUILD_LOG_ENABLED
 
 
 def load_rebuilder_config(start: Path | None = None) -> RebuilderConfig:
@@ -464,11 +590,29 @@ def load_rebuilder_config(start: Path | None = None) -> RebuilderConfig:
                 frac_resolved = DEFAULT_THRESHOLD_FRACTION
             else:
                 frac_resolved = float(frac_obj)
+            log_section_obj: Any = parsed.get(REBUILD_LOG_SECTION, {})
+            log_enabled_resolved: bool = DEFAULT_REBUILD_LOG_ENABLED
+            if isinstance(log_section_obj, dict):
+                log_section = cast(dict[str, Any], log_section_obj)
+                log_enabled_obj: Any = log_section.get(
+                    REBUILD_LOG_ENABLED_KEY, DEFAULT_REBUILD_LOG_ENABLED,
+                )
+                if isinstance(log_enabled_obj, bool):
+                    log_enabled_resolved = log_enabled_obj
+                else:
+                    print(
+                        f"aelfrice rebuilder: ignoring "
+                        f"[{REBUILD_LOG_SECTION}] "
+                        f"{REBUILD_LOG_ENABLED_KEY} in {candidate} "
+                        f"(expected bool)",
+                        file=serr,
+                    )
             return RebuilderConfig(
                 turn_window_n=n_resolved,
                 token_budget=b_resolved,
                 trigger_mode=mode_resolved,
                 threshold_fraction=frac_resolved,
+                rebuild_log_enabled=log_enabled_resolved,
             )
         if current.parent == current:
             break
@@ -653,6 +797,161 @@ def _session_scoped_hits(
             continue
         out.append(b)
     return out
+
+
+# --- Rebuild diagnostic log (#288 phase-1a) -------------------------------
+
+
+def _rebuild_log_disabled_via_env() -> bool:
+    """Honour `AELFRICE_REBUILD_LOG=0` opt-out. Any other value -> not
+    disabled. Missing var -> not disabled (default-on)."""
+    val = os.environ.get(REBUILD_LOG_ENV)
+    if val is None:
+        return False
+    return val.strip() == "0"
+
+
+def _rebuild_log_dir_for_db(db_path_val: Path) -> Path:
+    """Derive the rebuild_log directory from the brain-graph DB path.
+
+    The DB lives at `<git-common-dir>/aelfrice/memory.db`; the per-
+    session JSONL files live at
+    `<git-common-dir>/aelfrice/rebuild_logs/<session_id>.jsonl`.
+    """
+    return db_path_val.parent / REBUILD_LOG_DIRNAME
+
+
+def _recent_turns_hash(recent_turns: list[RecentTurn]) -> str:
+    """SHA-256 of the concatenated recent-turn `text` fields, no
+    separator. Spec § Layer 1."""
+    h = hashlib.sha256()
+    for t in recent_turns:
+        h.update(t.text.encode("utf-8"))
+    return h.hexdigest()
+
+
+def _extracted_entities_for_log(
+    recent_turns: list[RecentTurn],
+) -> list[str]:
+    """Return the extracted entities surfaced into the retrieval query,
+    deduplicated case-insensitively. Mirrors `_query_for_recent_turns`
+    so the log records the actual entities the rebuilder saw."""
+    if not recent_turns:
+        return []
+    full_text = "\n".join(t.text for t in recent_turns if t.text)
+    if not full_text.strip():
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for ent in extract_entities(
+        full_text, max_entities=DEFAULT_QUERY_ENTITY_CAP,
+    ):
+        key = ent.lower
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(ent.raw)
+    return out
+
+
+def _belief_lock_level_for_log(b: Belief) -> str:
+    """Map the internal lock_level enum to the spec's "lock_level"
+    field. Spec uses "user" for L0 locks and "none" otherwise; the
+    internal model already uses these strings, so this is a passthrough
+    that also normalises any unexpected value to "none"."""
+    return b.lock_level if b.lock_level == LOCK_USER else "none"
+
+
+def _empty_scores() -> dict[str, float | None]:
+    """Per-belief score block. None where the field is not computed
+    in the rebuilder's current code path; the floor / reranker / final
+    composite land in the #289-#291 follow-ups under the #286 redesign
+    tree. The log shape is locked here so phase-1b operator data is
+    forward-compatible with phase-2 fixes."""
+    return {
+        "bm25": None,
+        "posterior_mean": None,
+        "reranker": None,
+        "final": None,
+    }
+
+
+def _build_rebuild_log_record(
+    recent_turns: list[RecentTurn],
+    session_id: str | None,
+    candidates: list[dict[str, object]],
+    pack_summary: dict[str, int],
+) -> dict[str, object]:
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    extracted_query = _query_for_recent_turns(recent_turns)
+    return {
+        "ts": ts,
+        "session_id": session_id,
+        "input": {
+            "recent_turns_hash": _recent_turns_hash(recent_turns),
+            "n_recent_turns": len(recent_turns),
+            "extracted_query": extracted_query,
+            "extracted_entities": _extracted_entities_for_log(recent_turns),
+            # Intent classification is not part of the v1.4 rebuild
+            # path; null until #291 query-understanding lands.
+            "extracted_intent": None,
+        },
+        "candidates": candidates,
+        "pack_summary": pack_summary,
+    }
+
+
+def _append_rebuild_log_record(
+    log_path: Path,
+    record: dict[str, object],
+    *,
+    stderr: IO[str] | None = None,
+) -> None:
+    """Append one JSON record to the per-session rebuild_log JSONL.
+
+    Fail-soft: any I/O error traces one line to stderr and never
+    raises. Enforces the 5 MB per-session cap by appending a final
+    `{"truncated": true, ...}` row when the next record would exceed
+    the cap, then refusing further writes to that file.
+    """
+    serr = stderr if stderr is not None else sys.stderr
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(
+            record, separators=(",", ":"), ensure_ascii=False,
+        ) + "\n"
+        encoded = line.encode("utf-8")
+        try:
+            current_size = log_path.stat().st_size
+        except FileNotFoundError:
+            current_size = 0
+        if current_size >= REBUILD_LOG_MAX_BYTES:
+            # Already at/past cap; nothing to write. The truncated
+            # marker was emitted on the run that crossed the cap.
+            return
+        if current_size + len(encoded) > REBUILD_LOG_MAX_BYTES:
+            marker = json.dumps(
+                {
+                    "truncated": True,
+                    "ts": datetime.now(timezone.utc).strftime(
+                        "%Y-%m-%dT%H:%M:%SZ",
+                    ),
+                    "reason": "size_cap",
+                    "cap_bytes": REBUILD_LOG_MAX_BYTES,
+                },
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ) + "\n"
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write(marker)
+            return
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(line)
+    except Exception as exc:
+        print(
+            f"aelfrice: rebuild_log write failed (non-fatal): {exc}",
+            file=serr,
+        )
 
 
 # --- Format helpers --------------------------------------------------------
@@ -938,9 +1237,23 @@ def main(
             return 0
 
         store = MemoryStore(str(p))
+        # #288 phase-1a: route the rebuild_log alongside the brain-
+        # graph DB. Disabled when the store is in-memory (no on-disk
+        # location to write to) or when the operator opted out.
+        sid_for_log = _latest_session_id(recent)
+        log_path: Path | None = None
+        if str(p) != ":memory:" and sid_for_log:
+            log_path = (
+                _rebuild_log_dir_for_db(p) / f"{sid_for_log}.jsonl"
+            )
         try:
             block = rebuild_v14(
-                recent, store, token_budget=config.token_budget,
+                recent,
+                store,
+                token_budget=config.token_budget,
+                rebuild_log_path=log_path,
+                rebuild_log_enabled=config.rebuild_log_enabled,
+                session_id_for_log=sid_for_log,
             )
         finally:
             store.close()

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -566,7 +566,11 @@ def pre_compact(
         p = db_path()
         if str(p) != ":memory:" and not p.exists():
             return 0
-        body = _rebuild_and_format(recent, budget)
+        body = _rebuild_and_format(
+            recent,
+            budget,
+            rebuild_log_enabled=config.rebuild_log_enabled,
+        )
         if body:
             sout.write(emit_pre_compact_envelope(body))
     except Exception:  # non-blocking: surface but do not fail
@@ -622,11 +626,39 @@ def _read_recent_for_pre_compact(
 
 
 def _rebuild_and_format(
-    recent: list[RecentTurn], token_budget: int
+    recent: list[RecentTurn],
+    token_budget: int,
+    *,
+    rebuild_log_enabled: bool = True,
 ) -> str:
+    """Open the store and run the v1.4 rebuild.
+
+    #288 phase-1a: also derive the per-session rebuild_log path from
+    the brain-graph DB location and plumb it into `rebuild_v14`. Log
+    writing is fail-soft inside `rebuild_v14` itself; we only decline
+    to compute a path when there's no on-disk store or no session id
+    to key the file on.
+    """
+    from aelfrice.context_rebuilder import (  # noqa: PLC0415
+        _latest_session_id,
+        _rebuild_log_dir_for_db,
+    )
+
     store = _open_store()
+    p = db_path()
+    sid = _latest_session_id(recent)
+    log_path: Path | None = None
+    if str(p) != ":memory:" and sid:
+        log_path = _rebuild_log_dir_for_db(p) / f"{sid}.jsonl"
     try:
-        return rebuild_v14(recent, store, token_budget=token_budget)
+        return rebuild_v14(
+            recent,
+            store,
+            token_budget=token_budget,
+            rebuild_log_path=log_path,
+            rebuild_log_enabled=rebuild_log_enabled,
+            session_id_for_log=sid,
+        )
     finally:
         store.close()
 

--- a/tests/test_rebuild_log.py
+++ b/tests/test_rebuild_log.py
@@ -1,0 +1,364 @@
+"""Tests for the #288 phase-1a rebuild diagnostic log.
+
+Covers schema validity (round-trip a record), 5 MB size cap, opt-out
+via env var, opt-out via .aelfrice.toml, fail-soft on I/O error, and
+the no-op when the candidate set is empty.
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.context_rebuilder import (
+    DEFAULT_REBUILDER_TOKEN_BUDGET,
+    REBUILD_LOG_ENV,
+    REBUILD_LOG_MAX_BYTES,
+    RecentTurn,
+    _append_rebuild_log_record,
+    _build_rebuild_log_record,
+    _rebuild_log_disabled_via_env,
+    load_rebuilder_config,
+    rebuild_v14,
+)
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.store import MemoryStore
+
+
+# ---- helpers -----------------------------------------------------------
+
+
+def _mk(
+    bid: str,
+    content: str,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-28T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _seed(db_path: Path, beliefs: list[Belief]) -> MemoryStore:
+    store = MemoryStore(str(db_path))
+    for b in beliefs:
+        store.insert_belief(b)
+    return store
+
+
+# ---- schema validity ---------------------------------------------------
+
+
+def test_rebuild_log_record_round_trips_required_fields() -> None:
+    """The on-disk JSON record carries every field the spec's Layer 1
+    schema names, with the right shape."""
+    turns = [
+        RecentTurn(role="user", text="hello world"),
+        RecentTurn(role="assistant", text="hi", session_id="s1"),
+    ]
+    candidates: list[dict[str, object]] = [
+        {
+            "belief_id": "abc",
+            "rank": 1,
+            "scores": {
+                "bm25": None, "posterior_mean": None,
+                "reranker": None, "final": None,
+            },
+            "lock_level": "user",
+            "decision": "packed",
+            "reason": None,
+        },
+    ]
+    pack_summary: dict[str, int] = {
+        "n_candidates": 1,
+        "n_packed": 1,
+        "n_dropped_by_floor": 0,
+        "n_dropped_by_dedup": 0,
+        "n_dropped_by_budget": 0,
+        "total_chars_packed": 11,
+    }
+    record = _build_rebuild_log_record(
+        recent_turns=turns,
+        session_id="s1",
+        candidates=candidates,
+        pack_summary=pack_summary,
+    )
+    # Round-trip via JSON to confirm it serialises with no exotic types.
+    line = json.dumps(record, separators=(",", ":"), ensure_ascii=False)
+    parsed = json.loads(line)
+
+    assert parsed["session_id"] == "s1"
+    assert isinstance(parsed["ts"], str) and parsed["ts"].endswith("Z")
+    assert parsed["input"]["n_recent_turns"] == 2
+    expected_hash = hashlib.sha256(b"hello worldhi").hexdigest()
+    assert parsed["input"]["recent_turns_hash"] == expected_hash
+    # extracted_query is whatever the rebuilder feeds retrieve(); it
+    # must be a string (possibly empty for stopword-only input).
+    assert isinstance(parsed["input"]["extracted_query"], str)
+    assert isinstance(parsed["input"]["extracted_entities"], list)
+    assert parsed["input"]["extracted_intent"] is None
+    assert parsed["candidates"] == candidates
+    assert parsed["pack_summary"] == pack_summary
+
+
+def test_rebuild_v14_writes_one_record_per_invocation(
+    tmp_path: Path,
+) -> None:
+    # L0 lock is the deterministic candidate-set source — it bypasses
+    # FTS5 indexing details that aren't the subject under test here.
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(
+            "L1", "user prefers uv over pip",
+            lock_level=LOCK_USER, locked_at="2026-04-28T00:00:00Z",
+        )],
+    )
+    log_path = tmp_path / "rebuild_logs" / "sess1.jsonl"
+    try:
+        rebuild_v14(
+            [RecentTurn(role="user", text="anything")],
+            store,
+            rebuild_log_path=log_path,
+            session_id_for_log="sess1",
+        )
+    finally:
+        store.close()
+
+    assert log_path.exists()
+    lines = [
+        ln for ln in log_path.read_text(encoding="utf-8").splitlines()
+        if ln.strip()
+    ]
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["session_id"] == "sess1"
+    assert record["pack_summary"]["n_candidates"] >= 1
+    assert record["pack_summary"]["n_packed"] >= 1
+    # Every candidate carries the locked-down score block, even
+    # though the values are null in phase-1a.
+    for cand in record["candidates"]:
+        assert set(cand["scores"].keys()) == {
+            "bm25", "posterior_mean", "reranker", "final",
+        }
+        assert cand["decision"] in ("packed", "dropped")
+
+
+def test_rebuild_v14_no_log_when_candidate_set_empty(
+    tmp_path: Path,
+) -> None:
+    """Empty store + empty turns -> no candidates -> no log row."""
+    store = _seed(tmp_path / "m.db", [])
+    log_path = tmp_path / "rebuild_logs" / "empty.jsonl"
+    try:
+        rebuild_v14(
+            [], store,
+            rebuild_log_path=log_path,
+            session_id_for_log="empty",
+        )
+    finally:
+        store.close()
+    assert not log_path.exists()
+
+
+# ---- size cap ----------------------------------------------------------
+
+
+def test_rebuild_log_appends_truncated_marker_at_cap(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "sess.jsonl"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    # Pre-fill the file to one byte under the cap so the very next
+    # record write triggers the truncation path.
+    # Pad ends with a newline so the marker appears on its own line,
+    # mirroring real JSONL contents (every record ends in \n).
+    pad = b"x" * (REBUILD_LOG_MAX_BYTES - 2) + b"\n"
+    log_path.write_bytes(pad)
+    record: dict[str, object] = {"hello": "world"}
+    _append_rebuild_log_record(log_path, record, stderr=io.StringIO())
+    # The original padding plus a truncated-marker JSON line must be
+    # the only content; the actual record must NOT have been written.
+    text = log_path.read_text(encoding="utf-8", errors="replace")
+    # Trailing line is the truncated marker.
+    last_line = text.splitlines()[-1]
+    parsed = json.loads(last_line)
+    assert parsed.get("truncated") is True
+    assert "world" not in text  # the dropped record never landed
+
+
+def test_rebuild_log_drops_writes_after_cap_reached(
+    tmp_path: Path,
+) -> None:
+    """Once a session-file is at/over the cap, no further records get
+    appended — not even another truncated marker."""
+    log_path = tmp_path / "sess.jsonl"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_bytes(b"y" * REBUILD_LOG_MAX_BYTES)
+    size_before = log_path.stat().st_size
+    _append_rebuild_log_record(
+        log_path, {"x": 1}, stderr=io.StringIO(),
+    )
+    assert log_path.stat().st_size == size_before
+
+
+# ---- opt-out -----------------------------------------------------------
+
+
+def test_rebuild_log_env_opt_out(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(REBUILD_LOG_ENV, "0")
+    assert _rebuild_log_disabled_via_env() is True
+
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(
+            "L1", "x", lock_level=LOCK_USER,
+            locked_at="2026-04-28T00:00:00Z",
+        )],
+    )
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+    try:
+        rebuild_v14(
+            [RecentTurn(role="user", text="something")],
+            store,
+            rebuild_log_path=log_path,
+            session_id_for_log="sess",
+        )
+    finally:
+        store.close()
+    assert not log_path.exists()
+
+
+def test_rebuild_log_env_other_values_do_not_disable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the literal string '0' opts out; anything else (including
+    'false'/'no') leaves the log enabled. Keeps the contract simple."""
+    for val in ("1", "false", "no", "yes", ""):
+        monkeypatch.setenv(REBUILD_LOG_ENV, val)
+        assert _rebuild_log_disabled_via_env() is False, val
+
+
+def test_rebuild_log_toml_opt_out(tmp_path: Path) -> None:
+    cfg = tmp_path / ".aelfrice.toml"
+    cfg.write_text(
+        "[rebuild_log]\nenabled = false\n",
+        encoding="utf-8",
+    )
+    config = load_rebuilder_config(start=tmp_path)
+    assert config.rebuild_log_enabled is False
+
+
+def test_rebuild_log_toml_default_on(tmp_path: Path) -> None:
+    cfg = tmp_path / ".aelfrice.toml"
+    cfg.write_text("[rebuilder]\n", encoding="utf-8")  # no log section
+    config = load_rebuilder_config(start=tmp_path)
+    assert config.rebuild_log_enabled is True
+
+
+def test_rebuild_log_toml_invalid_type_falls_back_to_default(
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / ".aelfrice.toml"
+    cfg.write_text(
+        '[rebuild_log]\nenabled = "yes"\n',  # wrong type
+        encoding="utf-8",
+    )
+    config = load_rebuilder_config(start=tmp_path)
+    assert config.rebuild_log_enabled is True
+
+
+def test_rebuild_v14_respects_rebuild_log_enabled_kwarg(
+    tmp_path: Path,
+) -> None:
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(
+            "L1", "x", lock_level=LOCK_USER,
+            locked_at="2026-04-28T00:00:00Z",
+        )],
+    )
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+    try:
+        rebuild_v14(
+            [RecentTurn(role="user", text="something")],
+            store,
+            rebuild_log_path=log_path,
+            session_id_for_log="sess",
+            rebuild_log_enabled=False,
+        )
+    finally:
+        store.close()
+    assert not log_path.exists()
+
+
+# ---- fail-soft ---------------------------------------------------------
+
+
+def test_append_rebuild_log_fail_soft_on_io_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An OSError raised by the file write is caught, traced to
+    stderr, and never propagates."""
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+
+    real_open = open
+
+    def boom(*args: object, **kwargs: object) -> object:
+        # Fail only when opening for append; let read-only opens
+        # (e.g. the size-cap stat path) continue to work via
+        # delegating to the real builtin.
+        if "a" in str(args[1] if len(args) > 1 else kwargs.get("mode", "")):
+            raise OSError("simulated disk-full")
+        return real_open(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("builtins.open", boom)
+    err = io.StringIO()
+    # No exception escapes.
+    _append_rebuild_log_record(log_path, {"x": 1}, stderr=err)
+    assert "rebuild_log write failed" in err.getvalue()
+
+
+def test_rebuild_v14_fail_soft_when_log_dir_unwritable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed log write does not break the rebuild itself."""
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(
+            "L1", "kitchen bananas", lock_level=LOCK_USER,
+            locked_at="2026-04-28T00:00:00Z",
+        )],
+    )
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+
+    def boom_mkdir(*args: object, **kwargs: object) -> None:
+        raise OSError("simulated permission denied")
+
+    monkeypatch.setattr(Path, "mkdir", boom_mkdir)
+    try:
+        block = rebuild_v14(
+            [RecentTurn(role="user", text="kitchen contents")],
+            store,
+            rebuild_log_path=log_path,
+            session_id_for_log="sess",
+        )
+    finally:
+        store.close()
+    # Block was returned despite the log failure.
+    assert "<aelfrice-rebuild>" in block
+    assert not log_path.exists()


### PR DESCRIPTION
## Summary

Implements **phase-1a** of the rebuild eval harness spec
([`docs/rebuild_eval_harness.md`](../blob/main/docs/rebuild_eval_harness.md) §
"Layer 1: per-rebuild diagnostic log"). Adds the on-disk write
path for the per-rebuild JSONL the spec defines as the cheap
ground-truth feed for #289 / #290 / #291. Strictly observational —
no ranking / floor / dedup behaviour change.

What lands:

- One JSON object per `rebuild_v14()` invocation that produces a
  non-empty candidate set, written to
  `<git-common-dir>/aelfrice/rebuild_logs/<session_id>.jsonl`.
- Schema is the spec's Layer 1 record verbatim — `input.{ts,
  recent_turns_hash, n_recent_turns, extracted_query,
  extracted_entities, extracted_intent}`, per-candidate
  `{belief_id, rank, scores, lock_level, decision, reason}`,
  `pack_summary.{n_candidates, n_packed, n_dropped_by_floor,
  n_dropped_by_dedup, n_dropped_by_budget, total_chars_packed}`.
- Score fields and the floor / dedup drop counts are written as
  `null` / `0` today. They wire up when the floor + reranker +
  final composite land under #289 / #290 / #291. Shape is locked
  here so phase-1b operator data is forward-compatible with
  phase-2.
- Default-on. Opt out with `AELFRICE_REBUILD_LOG=0` or
  `[rebuild_log] enabled = false` in `.aelfrice.toml`.
- 5 MB per-session cap; on cross, append a
  `{"truncated": true, ...}` marker and stop further writes to
  that file.
- Fail-soft on any I/O error — mirrors `hook.py:_write_telemetry`.
  Errors trace to stderr, never break the rebuild.

What's out of scope (deliberately):

- `scripts/audit_rebuild_log.py` (1c — separate optional follow-up).
- Layer 2 corpus + `scripts/eval_rebuild.py` (phase 2).
- Ranking / floor / dedup logic — those are #289 / #290 / #291,
  they consume this log, they aren't this PR.

## Test plan

- [x] `uv run pytest` (full suite, 1880 passed, 8 skipped)
- [x] new `tests/test_rebuild_log.py` covers:
  - schema round-trip (every spec field, right shape)
  - integration: one record per `rebuild_v14()` call, no record
    when candidate set is empty
  - 5 MB size cap (truncated marker on cross + no writes after cap)
  - opt-out via env var (only literal `'0'` disables)
  - opt-out via TOML + default-on + invalid-type fallback
  - fail-soft on simulated I/O error (stderr trace, rebuild block
    still returned)

Refs #288. 1c (audit script) is the natural follow-up; opening
this without `Closes` so #288 stays open through the audit-script
PR and the operator-week capture.