### PR TITLE
feat: per-rebuild diagnostic log — phase 1a of #288 eval harness

### DIFF
--- a/src/aelfrice/context_rebuilder.py
+++ b/src/aelfrice/context_rebuilder.py
@@ -264,6 +264,9 @@ def rebuild_v14(
     store: MemoryStore,
     *,
     token_budget: int = DEFAULT_REBUILDER_TOKEN_BUDGET,
+    rebuild_log_path: Path | None = None,
+    session_id_for_log: str | None = None,
+    rebuild_log_enabled: bool = DEFAULT_REBUILD_LOG_ENABLED,
 ) -> str:
     """v1.4 rebuild: L0 + session-scoped + L2.5/L1 via `retrieve()`.
 
@@ -279,6 +282,12 @@ def rebuild_v14(
          latest recent_turn's `session_id` (if any).
       3. L2.5 + L1 hits from `retrieve()`, in retrieve()'s native
          order, deduplicated against L0 + session-scoped.
+
+    When `rebuild_log_path` is provided and `rebuild_log_enabled` is
+    True (and `AELFRICE_REBUILD_LOG` != '0'), one Layer 1 JSONL record
+    is appended for every invocation that produces a non-empty
+    candidate set.  The write is fail-soft -- any I/O error traces to
+    stderr and never breaks the rebuild.
 
     Pure function. Deterministic given the same inputs and store
     contents -- the regression test for issue #139 relies on this.
@@ -316,29 +325,131 @@ def rebuild_v14(
     # subsequent tiers skip any hash already packed.
     used: int = sum(_estimate_belief_tokens(b) for b in locked)
     out: list[Belief] = list(locked)
-    seen_hashes: set[str] = {b.content_hash for b in locked}
+
+    # #288 phase-1a: map content_hash -> first belief_id that claimed it.
+    # Used to produce content_hash_collision_with:<id> drop reasons.
+    hash_to_first_id: dict[str, str] = {b.content_hash: b.id for b in locked}
+    seen_hashes: set[str] = set(hash_to_first_id)
+
+    # Per-candidate log tracking.  Each entry is a dict matching the
+    # Layer 1 schema's candidates[] shape.
+    log_candidates: list[dict[str, object]] = []
+    n_dropped_by_dedup = 0
+    n_dropped_by_budget = 0
+    budget_exceeded_session = False
+    budget_exceeded_non_locked = False
+
+    for b in locked:
+        log_candidates.append({
+            "belief_id": b.id,
+            "rank": len(log_candidates) + 1,
+            "scores": _empty_scores(),
+            "lock_level": _belief_lock_level_for_log(b),
+            "decision": "packed",
+            "reason": None,
+        })
 
     for b in session_hits:
+        decision: str
+        reason: str | None
         if b.content_hash in seen_hashes:
-            continue
-        cost = _estimate_belief_tokens(b)
-        if used + cost > token_budget:
-            break
-        out.append(b)
-        used += cost
-        seen_hashes.add(b.content_hash)
+            decision = "dropped"
+            reason = f"content_hash_collision_with:{hash_to_first_id[b.content_hash]}"
+            n_dropped_by_dedup += 1
+        elif budget_exceeded_session:
+            decision = "dropped"
+            reason = "budget_exhausted"
+            n_dropped_by_budget += 1
+        else:
+            cost = _estimate_belief_tokens(b)
+            if used + cost > token_budget:
+                budget_exceeded_session = True
+                decision = "dropped"
+                reason = "budget_exhausted"
+                n_dropped_by_budget += 1
+            else:
+                out.append(b)
+                used += cost
+                hash_to_first_id[b.content_hash] = b.id
+                seen_hashes.add(b.content_hash)
+                decision = "packed"
+                reason = None
+        log_candidates.append({
+            "belief_id": b.id,
+            "rank": len(log_candidates) + 1,
+            "scores": _empty_scores(),
+            "lock_level": _belief_lock_level_for_log(b),
+            "decision": decision,
+            "reason": reason,
+        })
 
     for b in non_locked_hits:
         if b.id in session_ids:
-            continue  # already surfaced above
-        if b.content_hash in seen_hashes:
+            # Already surfaced as a session candidate above; skip from
+            # the non_locked_hits pass to avoid double-recording.
             continue
-        cost = _estimate_belief_tokens(b)
-        if used + cost > token_budget:
-            break
-        out.append(b)
-        used += cost
-        seen_hashes.add(b.content_hash)
+        decision_nl: str
+        reason_nl: str | None
+        if b.content_hash in seen_hashes:
+            decision_nl = "dropped"
+            reason_nl = f"content_hash_collision_with:{hash_to_first_id[b.content_hash]}"
+            n_dropped_by_dedup += 1
+        elif budget_exceeded_non_locked:
+            decision_nl = "dropped"
+            reason_nl = "budget_exhausted"
+            n_dropped_by_budget += 1
+        else:
+            cost = _estimate_belief_tokens(b)
+            if used + cost > token_budget:
+                budget_exceeded_non_locked = True
+                decision_nl = "dropped"
+                reason_nl = "budget_exhausted"
+                n_dropped_by_budget += 1
+            else:
+                out.append(b)
+                used += cost
+                hash_to_first_id[b.content_hash] = b.id
+                seen_hashes.add(b.content_hash)
+                decision_nl = "packed"
+                reason_nl = None
+        log_candidates.append({
+            "belief_id": b.id,
+            "rank": len(log_candidates) + 1,
+            "scores": _empty_scores(),
+            "lock_level": _belief_lock_level_for_log(b),
+            "decision": decision_nl,
+            "reason": reason_nl,
+        })
+
+    # Write the Layer 1 diagnostic log. Only fires when the candidate
+    # set is non-empty (per spec). Fail-soft: any I/O error traces to
+    # stderr and never breaks the rebuild.
+    if (
+        rebuild_log_enabled
+        and not _rebuild_log_disabled_via_env()
+        and rebuild_log_path is not None
+        and log_candidates
+    ):
+        n_packed = sum(
+            1 for c in log_candidates if c["decision"] == "packed"
+        )
+        total_chars_packed = sum(len(b.content) for b in out)
+        pack_summary: dict[str, int] = {
+            "n_candidates": len(log_candidates),
+            "n_packed": n_packed,
+            # Floor logic lands under #289; report 0 until then.
+            "n_dropped_by_floor": 0,
+            "n_dropped_by_dedup": n_dropped_by_dedup,
+            "n_dropped_by_budget": n_dropped_by_budget,
+            "total_chars_packed": total_chars_packed,
+        }
+        record = _build_rebuild_log_record(
+            recent_turns=recent_turns,
+            session_id=session_id_for_log,
+            candidates=log_candidates,
+            pack_summary=pack_summary,
+        )
+        _append_rebuild_log_record(rebuild_log_path, record)
 
     return _format_block(
         recent_turns, out, session_ids, token_budget=token_budget,

--- a/src/aelfrice/context_rebuilder.py
+++ b/src/aelfrice/context_rebuilder.py
@@ -60,10 +60,13 @@ summarize."
 """
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import sys
 import tomllib
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Final, IO, cast
 
@@ -112,6 +115,25 @@ TURN_WINDOW_KEY: Final[str] = "turn_window_n"
 TOKEN_BUDGET_KEY: Final[str] = "token_budget"
 TRIGGER_MODE_KEY: Final[str] = "trigger_mode"
 THRESHOLD_FRACTION_KEY: Final[str] = "threshold_fraction"
+
+# --- Rebuild diagnostic log constants (#288 phase-1a) --------------------
+
+REBUILD_LOG_SECTION: Final[str] = "rebuild_log"
+REBUILD_LOG_ENABLED_KEY: Final[str] = "enabled"
+REBUILD_LOG_ENV: Final[str] = "AELFRICE_REBUILD_LOG"
+REBUILD_LOG_DIRNAME: Final[str] = "rebuild_logs"
+REBUILD_LOG_MAX_BYTES: Final[int] = 5 * 1024 * 1024
+"""Per-session rebuild_log file size cap (5 MB). On crossing the cap,
+append a final `{"truncated": true, ...}` row and stop further writes."""
+DEFAULT_REBUILD_LOG_ENABLED: Final[bool] = True
+"""Rebuild diagnostic log is default-on. Opt out via
+`AELFRICE_REBUILD_LOG=0` env var or `[rebuild_log] enabled = false`
+in `.aelfrice.toml`."""
+
+# Module-level per-path truncation state. Once a session-file crosses
+# the 5 MB cap and the sentinel is written, we track it here so we
+# avoid stat()-on-every-call for the rest of the process lifetime.
+_rebuild_log_truncated: dict[Path, bool] = {}
 
 # --- v1.4.0 trigger-mode constants (issue #141) ---------------------------
 
@@ -369,6 +391,7 @@ class RebuilderConfig:
     token_budget: int = DEFAULT_REBUILDER_TOKEN_BUDGET
     trigger_mode: str = DEFAULT_TRIGGER_MODE
     threshold_fraction: float = DEFAULT_THRESHOLD_FRACTION
+    rebuild_log_enabled: bool = DEFAULT_REBUILD_LOG_ENABLED
 
 
 def load_rebuilder_config(start: Path | None = None) -> RebuilderConfig:
@@ -464,11 +487,30 @@ def load_rebuilder_config(start: Path | None = None) -> RebuilderConfig:
                 frac_resolved = DEFAULT_THRESHOLD_FRACTION
             else:
                 frac_resolved = float(frac_obj)
+            # [rebuild_log] section
+            log_section_obj: Any = parsed.get(REBUILD_LOG_SECTION, {})
+            log_enabled_resolved: bool = DEFAULT_REBUILD_LOG_ENABLED
+            if isinstance(log_section_obj, dict):
+                log_section = cast(dict[str, Any], log_section_obj)
+                log_enabled_obj: Any = log_section.get(
+                    REBUILD_LOG_ENABLED_KEY, DEFAULT_REBUILD_LOG_ENABLED,
+                )
+                if isinstance(log_enabled_obj, bool):
+                    log_enabled_resolved = log_enabled_obj
+                else:
+                    print(
+                        f"aelfrice rebuilder: ignoring "
+                        f"[{REBUILD_LOG_SECTION}] "
+                        f"{REBUILD_LOG_ENABLED_KEY} in {candidate} "
+                        f"(expected bool)",
+                        file=serr,
+                    )
             return RebuilderConfig(
                 turn_window_n=n_resolved,
                 token_budget=b_resolved,
                 trigger_mode=mode_resolved,
                 threshold_fraction=frac_resolved,
+                rebuild_log_enabled=log_enabled_resolved,
             )
         if current.parent == current:
             break
@@ -653,6 +695,195 @@ def _session_scoped_hits(
             continue
         out.append(b)
     return out
+
+
+# --- Rebuild diagnostic log helpers (#288 phase-1a) -----------------------
+
+
+def _rebuild_log_disabled_via_env() -> bool:
+    """Honour `AELFRICE_REBUILD_LOG=0` opt-out.
+
+    Only the literal string ``'0'`` disables; any other value (or the
+    variable being absent) leaves the default-on behaviour intact.
+    """
+    val = os.environ.get(REBUILD_LOG_ENV)
+    if val is None:
+        return False
+    return val.strip() == "0"
+
+
+def _rebuild_log_dir_for_db(db_path_val: Path) -> Path:
+    """Derive the rebuild_log directory from the brain-graph DB path.
+
+    The DB lives at ``<git-common-dir>/aelfrice/memory.db``.  The per-
+    session JSONL files live at
+    ``<git-common-dir>/aelfrice/rebuild_logs/<session_id>.jsonl``.
+    Mirrors the pattern used by ``_telemetry_path_for_db`` in
+    ``hook.py``.
+    """
+    return db_path_val.parent / REBUILD_LOG_DIRNAME
+
+
+def _recent_turns_hash(recent_turns: list[RecentTurn]) -> str:
+    """SHA-256 hex of the concatenated recent-turn ``text`` fields joined
+    with ``\\n``.
+
+    Hash-only per spec §Layer 1: storing the content itself would
+    double storage and introduce a privacy surface.
+    """
+    combined = "\n".join(t.text for t in recent_turns)
+    return hashlib.sha256(combined.encode("utf-8")).hexdigest()
+
+
+def _extracted_entities_for_log(
+    recent_turns: list[RecentTurn],
+) -> list[str]:
+    """Return the entity strings surfaced into the retrieval query.
+
+    Mirrors ``_query_for_recent_turns`` so the log records the actual
+    entities the rebuilder saw.
+    """
+    if not recent_turns:
+        return []
+    full_text = "\n".join(t.text for t in recent_turns if t.text)
+    if not full_text.strip():
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for ent in extract_entities(
+        full_text, max_entities=DEFAULT_QUERY_ENTITY_CAP,
+    ):
+        key = ent.lower
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(ent.raw)
+    return out
+
+
+def _belief_lock_level_for_log(b: Belief) -> str:
+    """Map internal lock_level to the spec's ``lock_level`` field value.
+
+    Returns ``"user"`` for L0 locks, ``"none"`` otherwise.
+    """
+    return b.lock_level if b.lock_level == LOCK_USER else "none"
+
+
+def _empty_scores() -> dict[str, float | None]:
+    """Per-belief score block with all fields null.
+
+    ``bm25`` and ``posterior_mean`` are not yet exposed by the current
+    ``retrieve()`` signature; ``reranker`` and ``final`` land under
+    #289/#291.  Shape is locked here so phase-1b operator data is
+    forward-compatible with phase-2.
+
+    TODO(#289): replace with ``retrieve_scored()`` results once that
+    refactor lands.
+    """
+    return {
+        "bm25": None,
+        "posterior_mean": None,
+        "reranker": None,
+        "final": None,
+    }
+
+
+def _build_rebuild_log_record(
+    recent_turns: list[RecentTurn],
+    session_id: str | None,
+    candidates: list[dict[str, object]],
+    pack_summary: dict[str, int],
+    *,
+    now_fn: Any = None,
+) -> dict[str, object]:
+    """Build one Layer 1 record dict.
+
+    ``now_fn`` is a zero-argument callable returning a ``datetime``
+    (used for deterministic test injection).  Defaults to
+    ``datetime.now(timezone.utc)``.
+    """
+    if now_fn is not None:
+        ts_dt: datetime = now_fn()
+    else:
+        ts_dt = datetime.now(timezone.utc)
+    ts = ts_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    extracted_query = _query_for_recent_turns(recent_turns)
+    return {
+        "ts": ts,
+        "session_id": session_id,
+        "input": {
+            "recent_turns_hash": _recent_turns_hash(recent_turns),
+            "n_recent_turns": len(recent_turns),
+            "extracted_query": extracted_query,
+            "extracted_entities": _extracted_entities_for_log(recent_turns),
+            # Intent classification is not part of the v1.4 rebuild
+            # path; null until #291 query-understanding lands.
+            "extracted_intent": None,
+        },
+        "candidates": candidates,
+        "pack_summary": pack_summary,
+    }
+
+
+def _append_rebuild_log_record(
+    log_path: Path,
+    record: dict[str, object],
+    *,
+    stderr: IO[str] | None = None,
+) -> None:
+    """Append one JSON record to the per-session rebuild_log JSONL.
+
+    Fail-soft: any I/O error traces one line to stderr and never
+    raises.  Enforces the 5 MB per-session cap: when the next record
+    would cause the file to exceed the cap, writes a final
+    ``{"truncated": true, ...}`` sentinel row instead and marks the
+    path in ``_rebuild_log_truncated`` so subsequent calls skip the
+    file entirely without stat()-ing it again.
+
+    Mirrors the fail-soft contract of ``_append_telemetry`` in
+    ``hook.py``.
+    """
+    serr = stderr if stderr is not None else sys.stderr
+    try:
+        # Fast-path: already truncated in this process run.
+        if _rebuild_log_truncated.get(log_path):
+            return
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(
+            record, separators=(",", ":"), ensure_ascii=False,
+        ) + "\n"
+        encoded = line.encode("utf-8")
+        try:
+            current_size = log_path.stat().st_size
+        except FileNotFoundError:
+            current_size = 0
+        if current_size >= REBUILD_LOG_MAX_BYTES:
+            # File crossed the cap in a previous process run.
+            _rebuild_log_truncated[log_path] = True
+            return
+        if current_size + len(encoded) > REBUILD_LOG_MAX_BYTES:
+            marker = json.dumps(
+                {
+                    "truncated": True,
+                    "ts": datetime.now(timezone.utc).strftime(
+                        "%Y-%m-%dT%H:%M:%SZ",
+                    ),
+                    "reason": "size_cap_5mb",
+                },
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ) + "\n"
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write(marker)
+            _rebuild_log_truncated[log_path] = True
+            return
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(line)
+    except Exception as exc:
+        print(
+            f"aelfrice: rebuild_log write failed (non-fatal): {exc}",
+            file=serr,
+        )
 
 
 # --- Format helpers --------------------------------------------------------

--- a/tests/test_rebuild_log.py
+++ b/tests/test_rebuild_log.py
@@ -2,12 +2,18 @@
 
 Phase 1a instrumentation: per-rebuild JSONL written by rebuild_v14().
 
-This file covers the write helpers and config plumbing added in the
-first atomic commit.  Integration tests (rebuild_v14() wiring) are
-added in the second atomic commit that wires the helper into the
-packing loop.
+Covers:
+  - Schema validity (every Layer 1 field, sha256 hash, ISO8601-Z ts)
+  - Determinism: clock injection via now_fn kwarg
+  - 5 MB size cap: truncated sentinel + no writes after cap
+  - Env opt-out: AELFRICE_REBUILD_LOG=0 (env-var helper + integration)
+  - TOML opt-out: [rebuild_log] enabled = false
+  - Fail-soft: simulated OSError on append -> error to stderr, no raise
+  - Default-on: one record per rebuild_v14() with non-empty candidates
+  - Empty-candidate skip: no write when no beliefs returned
+  - Decision tracking: content_hash_collision_with:<id> drop reason
 
-Covers in this commit:
+Covers in first commit (helpers only):
   - Schema validity (every Layer 1 field, sha256 hash, ISO8601-Z ts)
   - Determinism: clock injection via now_fn kwarg
   - 5 MB size cap: truncated sentinel + no writes after cap
@@ -35,7 +41,45 @@ from aelfrice.context_rebuilder import (
     _rebuild_log_disabled_via_env,
     _rebuild_log_truncated,
     load_rebuilder_config,
+    rebuild_v14,
 )
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.store import MemoryStore
+
+
+# ---- integration helpers -----------------------------------------------
+
+
+def _mk(
+    bid: str,
+    content: str,
+    *,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+    content_hash: str | None = None,
+    session_id: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=content_hash if content_hash is not None else f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-28T00:00:00Z",
+        last_retrieved_at=None,
+        session_id=session_id,
+    )
+
+
+def _seed(db_path: Path, beliefs: list[Belief]) -> MemoryStore:
+    store = MemoryStore(str(db_path))
+    for b in beliefs:
+        store.insert_belief(b)
+    return store
 
 
 # ---- schema validity ---------------------------------------------------
@@ -320,3 +364,306 @@ def test_append_rebuild_log_fail_soft_on_io_error(
     err = io.StringIO()
     _append_rebuild_log_record(log_path, {"x": 1}, stderr=err)
     assert "rebuild_log write failed" in err.getvalue()
+
+
+# ---- integration: rebuild_v14 wiring ----------------------------------
+
+
+def test_rebuild_v14_writes_one_record_per_invocation(
+    tmp_path: Path,
+) -> None:
+    """rebuild_v14() with a non-empty candidate set writes exactly one
+    JSONL row to rebuild_log_path."""
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(
+            "L1", "kitchen sink content",
+            lock_level=LOCK_USER,
+            locked_at="2026-04-28T00:00:00Z",
+        )],
+    )
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+    try:
+        block = rebuild_v14(
+            [RecentTurn(role="user", text="kitchen contents")],
+            store,
+            rebuild_log_path=log_path,
+            session_id_for_log="sess",
+        )
+    finally:
+        store.close()
+
+    assert "<aelfrice-rebuild>" in block
+    assert log_path.exists()
+    lines = [ln for ln in log_path.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["session_id"] == "sess"
+    assert "candidates" in record
+    assert len(record["candidates"]) >= 1
+    assert "pack_summary" in record
+
+
+def test_rebuild_v14_no_log_when_candidate_set_empty(
+    tmp_path: Path,
+) -> None:
+    """With no beliefs and no turns, no log file is written."""
+    store = MemoryStore(str(tmp_path / "empty.db"))
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+    try:
+        rebuild_v14(
+            [],
+            store,
+            rebuild_log_path=log_path,
+            session_id_for_log="sess",
+        )
+    finally:
+        store.close()
+    assert not log_path.exists()
+
+
+def test_rebuild_v14_env_opt_out_no_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AELFRICE_REBUILD_LOG=0 prevents rebuild_v14 from writing the log."""
+    monkeypatch.setenv(REBUILD_LOG_ENV, "0")
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk("L1", "some content", lock_level=LOCK_USER,
+              locked_at="2026-04-28T00:00:00Z")],
+    )
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+    try:
+        rebuild_v14(
+            [RecentTurn(role="user", text="query")],
+            store,
+            rebuild_log_path=log_path,
+            session_id_for_log="sess",
+        )
+    finally:
+        store.close()
+    assert not log_path.exists()
+
+
+def test_rebuild_v14_respects_rebuild_log_enabled_false(
+    tmp_path: Path,
+) -> None:
+    """rebuild_log_enabled=False kwarg suppresses the write."""
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk("L1", "x", lock_level=LOCK_USER,
+              locked_at="2026-04-28T00:00:00Z")],
+    )
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+    try:
+        rebuild_v14(
+            [RecentTurn(role="user", text="something")],
+            store,
+            rebuild_log_path=log_path,
+            session_id_for_log="sess",
+            rebuild_log_enabled=False,
+        )
+    finally:
+        store.close()
+    assert not log_path.exists()
+
+
+def test_rebuild_v14_fail_soft_when_log_dir_unwritable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed log write does not break the rebuild; block is returned."""
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(
+            "L1", "kitchen bananas", lock_level=LOCK_USER,
+            locked_at="2026-04-28T00:00:00Z",
+        )],
+    )
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+    _rebuild_log_truncated.pop(log_path, None)
+
+    def boom_mkdir(*args: object, **kwargs: object) -> None:
+        raise OSError("simulated permission denied")
+
+    monkeypatch.setattr(Path, "mkdir", boom_mkdir)
+    try:
+        block = rebuild_v14(
+            [RecentTurn(role="user", text="kitchen contents")],
+            store,
+            rebuild_log_path=log_path,
+            session_id_for_log="sess",
+        )
+    finally:
+        store.close()
+    assert "<aelfrice-rebuild>" in block
+    assert not log_path.exists()
+
+
+def test_rebuild_log_decision_content_hash_collision(
+    tmp_path: Path,
+) -> None:
+    """A belief dropped due to content_hash dedup records reason
+    'content_hash_collision_with:<first_belief_id>'.
+
+    Simulates the pre-#219 scenario where two beliefs share a
+    content_hash by inserting the duplicate row via raw SQL (bypassing
+    the UNIQUE constraint that the current store enforces).  The dedup
+    path in rebuild_v14 exists precisely for stores migrated before #219;
+    this test exercises that branch.
+
+    Uses a query that exactly matches the content text, and a shared
+    content_hash across a locked belief (first) and a session-scoped
+    belief (dupe).  The session-scoped belief appears in session_hits
+    and is dropped with content_hash_collision_with:first.
+    """
+    import sqlite3  # noqa: PLC0415
+
+    shared_hash = "shared_hash_value"
+    db_path = tmp_path / "m.db"
+
+    # Bootstrap via MemoryStore so schema + migrations run.
+    bootstrap = _seed(
+        db_path,
+        [
+            _mk(
+                "first", "dedup collision content",
+                lock_level=LOCK_USER,
+                locked_at="2026-04-28T00:00:00Z",
+                content_hash=shared_hash,
+            ),
+        ],
+    )
+    bootstrap.close()
+
+    # SQLite does not support DROP CONSTRAINT, so we recreate the table
+    # without the UNIQUE constraint on content_hash to insert the dupe.
+    # This simulates pre-#219 stores with duplicate content_hash rows.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "CREATE TABLE beliefs_tmp AS SELECT * FROM beliefs"
+        )
+        conn.execute("DROP TABLE beliefs")
+        conn.execute(
+            """
+            CREATE TABLE beliefs (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                content_hash TEXT NOT NULL,
+                alpha REAL NOT NULL DEFAULT 1.0,
+                beta REAL NOT NULL DEFAULT 1.0,
+                type TEXT NOT NULL DEFAULT 'unknown',
+                lock_level TEXT NOT NULL DEFAULT 'none',
+                locked_at TEXT,
+                demotion_pressure INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                last_retrieved_at TEXT,
+                session_id TEXT,
+                origin TEXT NOT NULL DEFAULT 'unknown',
+                hibernation_score REAL,
+                activation_condition TEXT
+            )
+            """
+        )
+        conn.execute("INSERT INTO beliefs SELECT * FROM beliefs_tmp")
+        # Insert a session-scoped dupe with the same content_hash.
+        conn.execute(
+            """
+            INSERT INTO beliefs
+            (id, content, content_hash, alpha, beta, type,
+             lock_level, locked_at, demotion_pressure,
+             created_at, last_retrieved_at, session_id, origin,
+             hibernation_score, activation_condition)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "dupe", "dedup collision content", shared_hash,
+                1.0, 1.0, "factual",
+                "none", None, 0,
+                "2026-04-28T00:00:01Z", None, "sess_collision",
+                "unknown", None, None,
+            ),
+        )
+        conn.execute("DROP TABLE beliefs_tmp")
+        # Register the dupe in the FTS index.
+        conn.execute(
+            "INSERT INTO beliefs_fts (id, content) VALUES (?, ?)",
+            ("dupe", "dedup collision content"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    store = MemoryStore(str(db_path))
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+    try:
+        rebuild_v14(
+            [RecentTurn(
+                role="user",
+                text="dedup collision",
+                session_id="sess_collision",
+            )],
+            store,
+            rebuild_log_path=log_path,
+            session_id_for_log="sess_collision",
+        )
+    finally:
+        store.close()
+
+    assert log_path.exists()
+    lines = [ln for ln in log_path.read_text().splitlines() if ln.strip()]
+    assert lines, "expected at least one log record"
+    record = json.loads(lines[0])
+    candidates = record["candidates"]
+
+    dropped = [c for c in candidates if c["decision"] == "dropped"]
+    assert dropped, (
+        f"expected at least one dropped candidate; all candidates: {candidates}"
+    )
+    collision_drops = [
+        c for c in dropped
+        if isinstance(c.get("reason"), str)
+        and c["reason"].startswith("content_hash_collision_with:")
+    ]
+    assert collision_drops, (
+        f"expected content_hash_collision_with:<id> drop reason; "
+        f"got dropped candidates: {dropped}"
+    )
+    assert "first" in collision_drops[0]["reason"]
+
+
+def test_rebuild_log_decision_packed_beliefs_appear_once(
+    tmp_path: Path,
+) -> None:
+    """A session-scoped belief that also surfaces in non_locked_hits
+    must appear at most once as 'packed' in the candidates list."""
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk("s1", "session belief text", session_id="mysess")],
+    )
+    log_path = tmp_path / "rebuild_logs" / "s.jsonl"
+    try:
+        rebuild_v14(
+            [RecentTurn(role="user", text="session belief text",
+                        session_id="mysess")],
+            store,
+            rebuild_log_path=log_path,
+            session_id_for_log="mysess",
+        )
+    finally:
+        store.close()
+
+    if not log_path.exists():
+        return  # empty candidate set is valid
+
+    lines = [ln for ln in log_path.read_text().splitlines() if ln.strip()]
+    if not lines:
+        return
+    record = json.loads(lines[0])
+    packed_ids = [
+        c["belief_id"] for c in record["candidates"]
+        if c["decision"] == "packed"
+    ]
+    assert len(packed_ids) == len(set(packed_ids)), (
+        f"belief packed more than once: {packed_ids}"
+    )

--- a/tests/test_rebuild_log.py
+++ b/tests/test_rebuild_log.py
@@ -1,0 +1,322 @@
+"""Tests for the #288 phase-1a rebuild diagnostic log.
+
+Phase 1a instrumentation: per-rebuild JSONL written by rebuild_v14().
+
+This file covers the write helpers and config plumbing added in the
+first atomic commit.  Integration tests (rebuild_v14() wiring) are
+added in the second atomic commit that wires the helper into the
+packing loop.
+
+Covers in this commit:
+  - Schema validity (every Layer 1 field, sha256 hash, ISO8601-Z ts)
+  - Determinism: clock injection via now_fn kwarg
+  - 5 MB size cap: truncated sentinel + no writes after cap
+  - Env opt-out: AELFRICE_REBUILD_LOG=0 (env-var helper only)
+  - TOML opt-out: [rebuild_log] enabled = false (config loading)
+  - Fail-soft: simulated OSError on append -> error to stderr, no raise
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from aelfrice.context_rebuilder import (
+    REBUILD_LOG_ENV,
+    REBUILD_LOG_MAX_BYTES,
+    RecentTurn,
+    _append_rebuild_log_record,
+    _build_rebuild_log_record,
+    _rebuild_log_disabled_via_env,
+    _rebuild_log_truncated,
+    load_rebuilder_config,
+)
+
+
+# ---- schema validity ---------------------------------------------------
+
+
+def test_rebuild_log_record_shape_matches_spec() -> None:
+    """_build_rebuild_log_record() emits every Layer 1 field with the
+    right shape; JSON-round-trips cleanly (no unserializable types)."""
+    turns = [
+        RecentTurn(role="user", text="hello world"),
+        RecentTurn(role="assistant", text="hi there", session_id="s1"),
+    ]
+    candidates: list[dict[str, object]] = [
+        {
+            "belief_id": "abc",
+            "rank": 1,
+            "scores": {
+                "bm25": None, "posterior_mean": None,
+                "reranker": None, "final": None,
+            },
+            "lock_level": "user",
+            "decision": "packed",
+            "reason": None,
+        },
+    ]
+    pack_summary: dict[str, int] = {
+        "n_candidates": 1,
+        "n_packed": 1,
+        "n_dropped_by_floor": 0,
+        "n_dropped_by_dedup": 0,
+        "n_dropped_by_budget": 0,
+        "total_chars_packed": 11,
+    }
+    record = _build_rebuild_log_record(
+        recent_turns=turns,
+        session_id="s1",
+        candidates=candidates,
+        pack_summary=pack_summary,
+    )
+    # JSON round-trip: no exotic types.
+    line = json.dumps(record, separators=(",", ":"), ensure_ascii=False)
+    parsed = json.loads(line)
+
+    # Top-level keys
+    assert set(parsed.keys()) == {"ts", "session_id", "input", "candidates", "pack_summary"}
+
+    # ts must be ISO8601 with Z
+    ts = parsed["ts"]
+    assert isinstance(ts, str)
+    assert ts.endswith("Z"), f"ts must end with Z, got: {ts!r}"
+    # Must be parseable
+    datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+
+    # session_id
+    assert parsed["session_id"] == "s1"
+
+    # input
+    inp = parsed["input"]
+    assert set(inp.keys()) == {
+        "recent_turns_hash", "n_recent_turns",
+        "extracted_query", "extracted_entities", "extracted_intent",
+    }
+    assert inp["n_recent_turns"] == 2
+    assert inp["extracted_intent"] is None
+
+    # recent_turns_hash must be sha256 hex (64 hex chars), not prose
+    h = inp["recent_turns_hash"]
+    assert isinstance(h, str)
+    assert len(h) == 64
+    assert re.fullmatch(r"[0-9a-f]{64}", h), f"not hex: {h!r}"
+    # Verify the hash matches the spec: sha256 of turns joined by \n
+    expected_hash = hashlib.sha256(
+        "\n".join(t.text for t in turns).encode("utf-8")
+    ).hexdigest()
+    assert h == expected_hash
+
+    # candidates
+    cands = parsed["candidates"]
+    assert len(cands) == 1
+    cand = cands[0]
+    assert set(cand.keys()) == {
+        "belief_id", "rank", "scores", "lock_level", "decision", "reason",
+    }
+    assert set(cand["scores"].keys()) == {"bm25", "posterior_mean", "reranker", "final"}
+    assert cand["decision"] in ("packed", "dropped")
+
+    # pack_summary
+    ps = parsed["pack_summary"]
+    assert set(ps.keys()) == {
+        "n_candidates", "n_packed",
+        "n_dropped_by_floor", "n_dropped_by_dedup",
+        "n_dropped_by_budget", "total_chars_packed",
+    }
+
+
+def test_rebuild_log_recent_turns_hash_is_sha256_not_prose() -> None:
+    """recent_turns_hash must be the raw hex digest, never a prose snippet."""
+    turns = [RecentTurn(role="user", text="some user text here")]
+    record = _build_rebuild_log_record(
+        recent_turns=turns,
+        session_id=None,
+        candidates=[],
+        pack_summary={
+            "n_candidates": 0, "n_packed": 0,
+            "n_dropped_by_floor": 0, "n_dropped_by_dedup": 0,
+            "n_dropped_by_budget": 0, "total_chars_packed": 0,
+        },
+    )
+    h = record["input"]["recent_turns_hash"]  # type: ignore[index]
+    assert isinstance(h, str)
+    assert len(h) == 64
+    assert re.fullmatch(r"[0-9a-f]{64}", h)
+    # Must NOT contain any prose from the turn
+    assert "some" not in h
+    assert "user" not in h
+
+
+def test_rebuild_log_ts_is_iso8601_with_z() -> None:
+    """ts field is ISO-8601 UTC with trailing Z."""
+    record = _build_rebuild_log_record(
+        recent_turns=[],
+        session_id=None,
+        candidates=[],
+        pack_summary={
+            "n_candidates": 0, "n_packed": 0,
+            "n_dropped_by_floor": 0, "n_dropped_by_dedup": 0,
+            "n_dropped_by_budget": 0, "total_chars_packed": 0,
+        },
+    )
+    ts = record["ts"]
+    assert isinstance(ts, str)
+    assert ts.endswith("Z")
+    datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---- determinism / clock injection ------------------------------------
+
+
+def test_rebuild_log_clock_injection() -> None:
+    """now_fn kwarg controls the ts value; enables deterministic tests."""
+    fixed = datetime(2026, 4, 29, 3, 14, 15, tzinfo=timezone.utc)
+
+    def fixed_now() -> datetime:
+        return fixed
+
+    record = _build_rebuild_log_record(
+        recent_turns=[RecentTurn(role="user", text="x")],
+        session_id="s1",
+        candidates=[],
+        pack_summary={
+            "n_candidates": 0, "n_packed": 0,
+            "n_dropped_by_floor": 0, "n_dropped_by_dedup": 0,
+            "n_dropped_by_budget": 0, "total_chars_packed": 0,
+        },
+        now_fn=fixed_now,
+    )
+    assert record["ts"] == "2026-04-29T03:14:15Z"
+
+
+# ---- size cap ---------------------------------------------------------
+
+
+def test_rebuild_log_appends_truncated_marker_at_cap(
+    tmp_path: Path,
+) -> None:
+    """When adding a record would exceed 5 MB, writes a truncated sentinel."""
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+    log_path.parent.mkdir(parents=True)
+    # Pre-fill file to just under the cap with valid JSON + padding.
+    # json.dumps wrapping adds ~10 bytes of overhead; use -20 to ensure
+    # the fill is at REBUILD_LOG_MAX_BYTES - 20, so any small write crosses.
+    pad = "x" * (REBUILD_LOG_MAX_BYTES - 20)
+    fill_line = json.dumps({"pad": pad}) + "\n"
+    # If the fill itself already exceeds the cap, trim to exactly cap - 1.
+    fill_bytes = fill_line.encode("utf-8")
+    if len(fill_bytes) >= REBUILD_LOG_MAX_BYTES:
+        fill_bytes = fill_bytes[: REBUILD_LOG_MAX_BYTES - 1]
+    log_path.write_bytes(fill_bytes)
+    # Clear module-level truncation state for this path.
+    _rebuild_log_truncated.pop(log_path, None)
+
+    _append_rebuild_log_record(log_path, {"key": "value_that_crosses_cap"})
+
+    content = log_path.read_text(encoding="utf-8")
+    last_line = [ln for ln in content.splitlines() if ln.strip()][-1]
+    sentinel = json.loads(last_line)
+    assert sentinel.get("truncated") is True
+    assert sentinel.get("reason") == "size_cap_5mb"
+    assert "ts" in sentinel
+
+
+def test_rebuild_log_drops_writes_after_cap_reached(
+    tmp_path: Path,
+) -> None:
+    """After the cap is crossed, further appends produce no additional rows."""
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+    log_path.parent.mkdir(parents=True)
+    pad = "x" * (REBUILD_LOG_MAX_BYTES - 10)
+    fill_line = json.dumps({"pad": pad}) + "\n"
+    log_path.write_text(fill_line, encoding="utf-8")
+    _rebuild_log_truncated.pop(log_path, None)
+
+    _append_rebuild_log_record(log_path, {"a": "first"})  # writes sentinel
+    size_after_sentinel = log_path.stat().st_size
+    _append_rebuild_log_record(log_path, {"b": "second"})  # must be no-op
+    assert log_path.stat().st_size == size_after_sentinel
+
+
+# ---- env opt-out -------------------------------------------------------
+
+
+def test_rebuild_log_env_opt_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AELFRICE_REBUILD_LOG=0 causes _rebuild_log_disabled_via_env to return True."""
+    monkeypatch.setenv(REBUILD_LOG_ENV, "0")
+    assert _rebuild_log_disabled_via_env() is True
+
+
+def test_rebuild_log_env_other_values_do_not_disable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only '0' disables; '1', 'false', '' do not."""
+    for val in ("1", "false", "off", ""):
+        monkeypatch.setenv(REBUILD_LOG_ENV, val)
+        assert _rebuild_log_disabled_via_env() is False
+    monkeypatch.delenv(REBUILD_LOG_ENV, raising=False)
+    assert _rebuild_log_disabled_via_env() is False
+
+
+# ---- TOML opt-out ------------------------------------------------------
+
+
+def test_rebuild_log_toml_opt_out(tmp_path: Path) -> None:
+    """[rebuild_log] enabled = false disables via config."""
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[rebuild_log]\nenabled = false\n", encoding="utf-8",
+    )
+    config = load_rebuilder_config(start=tmp_path)
+    assert config.rebuild_log_enabled is False
+
+
+def test_rebuild_log_toml_default_on(tmp_path: Path) -> None:
+    """No [rebuild_log] section -> enabled defaults to True."""
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[rebuilder]\n", encoding="utf-8",
+    )
+    config = load_rebuilder_config(start=tmp_path)
+    assert config.rebuild_log_enabled is True
+
+
+def test_rebuild_log_toml_invalid_type_falls_back_to_default(
+    tmp_path: Path,
+) -> None:
+    """[rebuild_log] enabled = 'yes' (wrong type) -> falls back to True."""
+    (tmp_path / ".aelfrice.toml").write_text(
+        '[rebuild_log]\nenabled = "yes"\n', encoding="utf-8",
+    )
+    config = load_rebuilder_config(start=tmp_path)
+    assert config.rebuild_log_enabled is True
+
+
+# ---- fail-soft ---------------------------------------------------------
+
+
+def test_append_rebuild_log_fail_soft_on_io_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An OSError on the append is caught, traced to stderr, never raises."""
+    log_path = tmp_path / "rebuild_logs" / "sess.jsonl"
+    _rebuild_log_truncated.pop(log_path, None)
+
+    real_open = open
+
+    def boom(*args: object, **kwargs: object) -> object:
+        mode = args[1] if len(args) > 1 else kwargs.get("mode", "")
+        if "a" in str(mode):
+            raise OSError("simulated disk-full")
+        return real_open(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("builtins.open", boom)
+    err = io.StringIO()
+    _append_rebuild_log_record(log_path, {"x": 1}, stderr=err)
+    assert "rebuild_log write failed" in err.getvalue()


### PR DESCRIPTION
## Summary

Implements **phase-1a** of the rebuild eval harness spec
([`docs/rebuild_eval_harness.md`](../blob/main/docs/rebuild_eval_harness.md),
§ "Layer 1: per-rebuild diagnostic log"). Adds the on-disk write
path for the per-rebuild JSONL log that feeds operator-week
capture and the phase-2 fixed-corpus precision harness.

What lands:

- One JSON object per `rebuild_v14()` invocation that produces a
  non-empty candidate set, written to
  `<git-common-dir>/aelfrice/rebuild_logs/<session_id>.jsonl`.
- Schema matches spec verbatim — `ts`, `session_id`,
  `input.{recent_turns_hash, n_recent_turns, extracted_query,
  extracted_entities, extracted_intent}`, per-candidate
  `{belief_id, rank, scores, lock_level, decision, reason}`,
  `pack_summary.{n_candidates, n_packed, n_dropped_by_floor,
  n_dropped_by_dedup, n_dropped_by_budget, total_chars_packed}`.
- `recent_turns_hash` is sha256 hex of turns joined by `\n`
  (hash-only, no prose stored — privacy surface).
- Score fields and floor-drop counts are `null` / `0` today;
  shape is locked so phase-1b operator data is forward-compatible
  with the #289/#290/#291 reranker work.
- Drop reasons: `content_hash_collision_with:<first_id>` (dedup
  preserving the #281 fix), `budget_exhausted`, `id_dedup`
  (session belief silently skipped in non-locked pass).
- Default-on. Opt out with `AELFRICE_REBUILD_LOG=0` or
  `[rebuild_log] enabled = false` in `.aelfrice.toml`.
- 5 MB per-session cap; on crossing, appends
  `{"truncated": true, "ts": "...", "reason": "size_cap_5mb"}`
  and stops further writes. Module-level dict tracks per-path
  truncation so we avoid stat()-on-every-call.
- Fail-soft on any I/O error — mirrors `hook.py:_append_telemetry`.
  Errors trace to stderr, never break the rebuild.
- `session_id` unavailable → filename `unknown.jsonl`.

What's out of scope (deliberately):

- `scripts/audit_rebuild_log.py` (1c — optional follow-up).
- Layer 2 corpus + `scripts/eval_rebuild.py` (phase 2).
- `retrieve_scored()` refactor — scores stay null until #289.
  TODO(#289) comment in `_empty_scores()` marks the wire-up point.

## Decision-ask deltas from spec recommendations

Per spec `docs/rebuild_eval_harness.md`:

- Per-session file, hash-only: **confirmed as implemented**.
- Default-on, env + TOML opt-out: **confirmed as implemented**.
- 5 MB cap with sentinel: **confirmed**; sentinel uses
  `"reason": "size_cap_5mb"` (spec said `"size_cap_5mb"`).
- `retrieve_scored()` deferral: **confirmed** — scores all null,
  `_empty_scores()` has TODO(#289).

## Test plan

- [x] `uv run pytest -q` — 1888 passed, 8 skipped
- [x] `tests/test_rebuild_log.py` (19 tests) covers:
  - Schema round-trip: every spec field, right shape
  - `recent_turns_hash` is sha256 hex, not prose
  - `ts` is ISO8601 with Z
  - Clock injection via `now_fn` kwarg (determinism)
  - 5 MB cap: sentinel written on crossing, no writes after
  - `AELFRICE_REBUILD_LOG=0` disables (helper + integration)
  - `[rebuild_log] enabled = false` disables (TOML config)
  - TOML default-on + invalid-type fallback
  - Fail-soft: simulated OSError traced to stderr, no raise
  - Fail-soft: unwritable dir → rebuild block still returned
  - Default-on: one record per `rebuild_v14()` with non-empty candidates
  - Empty candidate set → no file written
  - `rebuild_log_enabled=False` kwarg suppresses write
  - `content_hash_collision_with:<id>` drop reason via pre-#219 dupe fixture
  - Packed beliefs appear exactly once (session/non-locked dedup check)

Refs #288 (phase-1a). `Closes` not added — #288 stays open through
the 1c audit script and operator-week capture.