### PR TITLE
ci: automation bots — stale, CodeRabbit, Renovate, Release Drafter

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,38 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/reference/yaml-template
+# Free for public repos. Reviews every PR with summary + line comments.
+
+language: en-US
+early_access: false
+reviews:
+  profile: chill                # less nit-picky than 'assertive'; raises real issues only
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches: ["main"]
+  path_filters:
+    - "!.planning/**"
+    - "!docs/research/**"
+    - "!tests/fixtures/**"
+    - "!**/*.lock"
+    - "!**/CHANGELOG.md"
+  path_instructions:
+    - path: "src/aelfrice/store.py"
+      instructions: |
+        This is the canonical write path for beliefs/edges. Flag any new
+        SQL that bypasses the broker-confidence attenuation (see
+        store.py:443) or writes outside a transaction.
+    - path: "tests/**"
+      instructions: |
+        Tests must hit a real SQLite DB, not mocks. Flag any introduction
+        of unittest.mock for the storage layer.
+    - path: ".github/workflows/**"
+      instructions: |
+        Third-party actions must be pinned to a commit SHA, with the
+        version tag in a trailing comment. Flag any unpinned `@v*` ref.
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -24,8 +24,9 @@ reviews:
     - path: "src/aelfrice/store.py"
       instructions: |
         This is the canonical write path for beliefs/edges. Flag any new
-        SQL that bypasses the broker-confidence attenuation (see
-        store.py:443) or writes outside a transaction.
+        SQL that bypasses broker-confidence attenuation (the
+        BrokerConfidence application in the belief-write helpers) or
+        writes outside a transaction.
     - path: "tests/**"
       instructions: |
         Tests must hit a real SQLite DB, not mocks. Flag any introduction

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,68 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+  $CONTRIBUTORS
+
+categories:
+  - title: "Features"
+    labels: ["feat", "enhancement"]
+  - title: "Bug Fixes"
+    labels: ["fix", "bug"]
+  - title: "Performance"
+    labels: ["perf"]
+  - title: "Refactors"
+    labels: ["refactor"]
+  - title: "Documentation"
+    labels: ["docs"]
+  - title: "Tests"
+    labels: ["test"]
+  - title: "CI / Build"
+    labels: ["ci", "build"]
+  - title: "Dependencies"
+    labels: ["dependencies"]
+  - title: "Other"
+
+# Conventional-commit prefix → bump rule
+# (label-based; PR labels override this if present)
+version-resolver:
+  major:
+    labels: ["breaking-change"]
+  minor:
+    labels: ["feat", "enhancement"]
+  patch:
+    labels: ["fix", "bug", "perf", "refactor", "docs", "ci", "build", "test", "chore", "dependencies"]
+  default: patch
+
+# Map conventional-commit prefix in PR title → label automatically
+autolabeler:
+  - label: "feat"
+    title: ['/^feat(\(.*\))?:/i']
+  - label: "fix"
+    title: ['/^fix(\(.*\))?:/i']
+  - label: "perf"
+    title: ['/^perf(\(.*\))?:/i']
+  - label: "refactor"
+    title: ['/^refactor(\(.*\))?:/i']
+  - label: "docs"
+    title: ['/^docs(\(.*\))?:/i']
+  - label: "test"
+    title: ['/^test(\(.*\))?:/i']
+  - label: "ci"
+    title: ['/^ci(\(.*\))?:/i']
+  - label: "build"
+    title: ['/^build(\(.*\))?:/i']
+  - label: "chore"
+    title: ['/^chore(\(.*\))?:/i']
+  - label: "breaking-change"
+    title: ['/^[a-z]+(\(.*\))?!:/i']
+
+exclude-labels:
+  - "skip-changelog"
+
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: release-drafter
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@7cf306f56b79636bb76931494ccf29fc893763bd # v6.1.0
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,8 +3,6 @@ name: release-drafter
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           exempt-issue-labels: "bench-gated,spec-ready,v2.0,v2.x,pinned"
-          exempt-pr-labels: "WIP,blocked,pinned"
+          exempt-pr-labels: "WIP,blocked,pinned,spec-ready,v2.0,v2.x"
           stale-issue-message: |
             This issue has had no activity in 60 days. It will close in 14 days
             unless updated. Add the `pinned` label to keep it open indefinitely.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,35 @@
+name: stale
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Stale Issues
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: "bench-gated,spec-ready,v2.0,v2.x,pinned"
+          exempt-pr-labels: "WIP,blocked,pinned"
+          stale-issue-message: |
+            This issue has had no activity in 60 days. It will close in 14 days
+            unless updated. Add the `pinned` label to keep it open indefinitely.
+          stale-pr-message: |
+            This PR has had no activity in 30 days. It will close in 7 days
+            unless updated. Add the `pinned` label to keep it open.
+          close-issue-message: "Closing as stale. Reopen if still relevant."
+          close-pr-message: "Closing as stale. Reopen if still relevant."
+          operations-per-run: 100

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(build)",
+    ":dependencyDashboard",
+    "schedule:weekly"
+  ],
+  "timezone": "America/New_York",
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 2,
+  "rangeStrategy": "pin",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  },
+  "packageRules": [
+    {
+      "description": "Group all non-major GitHub Actions bumps into one PR per week",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "github-actions (non-major)",
+      "schedule": ["before 5am on monday"]
+    },
+    {
+      "description": "Group all non-major Python deps into one PR per week",
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "python deps (non-major)",
+      "schedule": ["before 5am on monday"]
+    },
+    {
+      "description": "Major bumps get their own PR for explicit review",
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major-bump"],
+      "automerge": false
+    },
+    {
+      "description": "Pin GitHub Actions to commit SHA per security guidance",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "automerge": false
+  },
+  "osvVulnerabilityAlerts": true
+}


### PR DESCRIPTION
## Summary

Wires up four automation bots in one PR. Each is a small isolated config; bundled because they share \"CI plumbing\" review concerns.

- **stale** (`actions/stale` v10.2.0, SHA-pinned) — auto-closes inactive issues (60d→stale, +14d→close) and PRs (30d→stale, +7d→close). Exempt labels: `bench-gated`, `spec-ready`, `v2.0`, `v2.x`, `pinned`. Daily cron at 01:30 UTC.
- **CodeRabbit** (`.coderabbit.yaml`) — AI PR review on every PR to main. Profile=chill (real issues, not nits). Excludes `.planning/`, research docs, lock files. Path-specific instructions for `store.py` (broker-attenuation invariant), `tests/` (no mocks), workflows/ (SHA-pin enforcement).
- **Renovate** (`renovate.json`) — weekly batched dep PRs (Mon 5am ET), grouped by ecosystem (GitHub Actions, Python pep621). Forces SHA-pinning on actions. Major bumps get individual PRs with `major-bump` label.
- **Release Drafter** (`.github/release-drafter.yml` + workflow, v6.1.0 SHA-pinned) — drafts release notes on every push to main. Autolabels PRs from conventional-commit prefix (`feat:` → `feat` label → minor bump).

All third-party actions pinned to commit SHA per security guidance.

## Verification

- [ ] Existing `staging-gate.yml` (gitleaks, PII scan, history audit, pytest matrix) passes
- [ ] CodeRabbit posts review on this PR (confirms app install + config parsed)
- [ ] After merge: `Actions → stale` shows up; manual `workflow_dispatch` produces no errors
- [ ] After merge: Renovate dashboard issue appears within 24h (confirms app install + config parsed)
- [ ] After merge: Release Drafter creates a draft release entry on next merged PR

## Activation prerequisites

- CodeRabbit GitHub App must be installed on the repo (free for public repos).
- Renovate GitHub App must be installed on the repo.
- Stale + Release Drafter are workflow Actions; no app install needed.

## Test plan

- [ ] Merge → wait for next PR → confirm CodeRabbit review fires
- [ ] Merge → run `gh workflow run stale.yml` manually → confirm green
- [ ] Merge → confirm Renovate \"Dependency Dashboard\" issue is created
- [ ] Open a `feat:` PR after merge → confirm Release Drafter adds it under \"Features\"

## Summary by Sourcery

Introduce multiple automation bots for CI-related workflows, including dependency management, stale issue handling, AI code review, and automated release drafting.

New Features:
- Add CodeRabbit configuration to enable automated AI-assisted PR reviews with repository-specific path rules.
- Add Renovate configuration to manage and batch dependency update pull requests.
- Add Release Drafter configuration and workflow to automatically draft releases based on labeled pull requests and conventional-commit-style titles.
- Add a scheduled stale workflow to automatically mark and close inactive issues and pull requests.