### PR TITLE
feat: heat-kernel composition in retrieval (#151 slice 2)

### DIFF
--- a/src/aelfrice/graph_spectral.py
+++ b/src/aelfrice/graph_spectral.py
@@ -347,6 +347,63 @@ def combine_log_scores(
     )
 
 
+def heat_kernel_for_candidates(
+    cache: "GraphEigenbasisCache",
+    candidates: list[tuple[str, float]],
+    *,
+    t: float = DEFAULT_HEAT_BANDWIDTH,
+    seed_top_k: int = DEFAULT_BM25_SEED_TOP_K,
+    floor: float = HEAT_SCORE_FLOOR,
+) -> dict[str, float]:
+    """Compute per-belief heat-kernel authority scores for the
+    given L1 candidate set, seeded by the candidates' BM25 scores.
+
+    ``candidates`` is the L1 hit list as ``(belief_id, bm25_pos)``
+    pairs where ``bm25_pos`` is the positive relevance magnitude
+    (i.e. ``-bm25_raw`` for FTS5, raw score for BM25F). Seeds are
+    placed only at candidate positions in the eigenbasis row order;
+    beliefs not in the eigenbasis are skipped (the heat-kernel lane
+    silently degrades to a neutral 1.0 contribution at the scoring
+    layer for those).
+
+    Returns ``dict[belief_id, heat_kernel_score]`` for every
+    candidate that has a row in the eigenbasis. Scores are floored
+    via ``heat_kernel_safe`` so callers can ``log()`` directly.
+
+    Returns ``{}`` if the cache is stale, the eigenbasis is unbuilt,
+    or no candidate has a positive seed score — the caller should
+    treat absence as "no heat-kernel contribution available" and
+    fall back to the neutral default.
+
+    Cost: O(N * K) for the two matvecs plus O(C log C) for the seed
+    top-K selection (C = len(candidates)). At N=50k, K=200, C=64
+    this is ~7-8ms on commodity hardware (#150 AC5).
+    """
+    if cache.is_stale() or cache.eigvals is None or cache.eigvecs is None:
+        return {}
+    if cache.belief_ids is None or not candidates:
+        return {}
+    id_to_row: dict[str, int] = {bid: i for i, bid in enumerate(cache.belief_ids)}
+    n = len(cache.belief_ids)
+    bm25_full = np.zeros(n, dtype=np.float64)
+    present: list[str] = []
+    for bid, bm25_pos in candidates:
+        row = id_to_row.get(bid)
+        if row is None:
+            continue
+        if bm25_pos > 0.0:
+            bm25_full[row] = bm25_pos
+            present.append(bid)
+    if not present:
+        return {}
+    seeds = seeds_from_bm25(bm25_full, top_k=seed_top_k)
+    if not np.any(seeds):
+        return {}
+    raw = heat_kernel_score(cache.eigvals, cache.eigvecs, seeds, t=t)
+    safe = heat_kernel_safe(raw, floor=floor)
+    return {bid: float(safe[id_to_row[bid]]) for bid in present}
+
+
 # --- Eigenbasis cache ---------------------------------------------------
 
 

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -67,6 +67,10 @@ from aelfrice.bfs_multihop import (
 )
 from aelfrice.bm25 import BM25IndexCache
 from aelfrice.entity_extractor import extract_entities
+from aelfrice.graph_spectral import (
+    GraphEigenbasisCache,
+    heat_kernel_for_candidates,
+)
 from aelfrice.models import LOCK_NONE, Belief
 from aelfrice.scoring import (
     DEFAULT_POSTERIOR_WEIGHT,
@@ -737,6 +741,7 @@ def _l1_hits(
     posterior_weight: float,
     use_bm25f_anchors: bool = False,
     bm25f_cache: BM25IndexCache | None = None,
+    eigenbasis_cache: GraphEigenbasisCache | None = None,
 ) -> list[Belief]:
     """Run L1: FTS5 BM25 search (default) or BM25F sparse-matvec
     (v1.5.0 opt-in), optionally reranked by partial-Bayesian score.
@@ -770,7 +775,14 @@ def _l1_hits(
             if b is None:
                 continue
             beliefs.append((b, raw))
-        if posterior_weight == 0.0:
+        # Heat-kernel slice 2 (#151): if the eigenbasis is available
+        # and the lane is opted in, compute per-candidate authority
+        # scores from the BM25F-positive seed set.
+        heat_scores = _heat_kernel_lookup(
+            eigenbasis_cache,
+            [(b.id, raw) for b, raw in beliefs],
+        )
+        if posterior_weight == 0.0 and not heat_scores:
             return [b for b, _ in beliefs]
         keyed: list[tuple[float, str, Belief]] = []
         for b, raw in beliefs:
@@ -780,26 +792,56 @@ def _l1_hits(
             # raw scores as more relevant, matching the FTS5 path.
             s = partial_bayesian_score(
                 -raw, b.alpha, b.beta, posterior_weight,
+                heat_kernel=heat_scores.get(b.id, 1.0),
             )
             keyed.append((s, b.id, b))
         keyed.sort(key=lambda x: (-x[0], x[1]))
         return [b for _, _, b in keyed]
 
-    if posterior_weight == 0.0:
+    if posterior_weight == 0.0 and eigenbasis_cache is None:
         return store.search_beliefs(query, limit=l1_limit)
     scored = store.search_beliefs_scored(query, limit=l1_limit)
     if not scored:
         return []
+    heat_scores = _heat_kernel_lookup(
+        eigenbasis_cache,
+        # FTS5 bm25 is negative; the seed builder needs positive
+        # relevance magnitudes, so pass `-bm25_raw`.
+        [(b.id, -bm25_raw) for b, bm25_raw in scored],
+    )
+    if posterior_weight == 0.0 and not heat_scores:
+        # Caller asked for a pure-BM25 ordering and the heat-kernel
+        # lane produced nothing — preserve the v1.0.x byte-identical
+        # contract. Re-fetch via the stable search_beliefs path so
+        # tie-breaking matches the BM25-only baseline exactly.
+        return store.search_beliefs(query, limit=l1_limit)
     keyed: list[tuple[float, str, Belief]] = []
     for b, bm25_raw in scored:
         s = partial_bayesian_score(
             bm25_raw, b.alpha, b.beta, posterior_weight,
+            heat_kernel=heat_scores.get(b.id, 1.0),
         )
         keyed.append((s, b.id, b))
     # Higher score = more relevant. Tie-break on id ASC for
     # determinism (matches the convention in bfs_multihop and L2.5).
     keyed.sort(key=lambda x: (-x[0], x[1]))
     return [b for _, _, b in keyed]
+
+
+def _heat_kernel_lookup(
+    cache: GraphEigenbasisCache | None,
+    candidates: list[tuple[str, float]],
+) -> dict[str, float]:
+    """Resolve heat-kernel scores for L1 candidates if the lane is
+    enabled and the eigenbasis is ready. Returns ``{}`` whenever the
+    lane should be a no-op (flag off, no cache, stale cache, empty
+    candidates) — the caller treats absence as "no contribution".
+    """
+    if cache is None or not candidates:
+        return {}
+    if not is_heat_kernel_enabled():
+        return {}
+    return heat_kernel_for_candidates(cache, candidates)
 
 
 def retrieve(
@@ -820,6 +862,7 @@ def retrieve(
     posterior_weight: float | None = None,
     use_bm25f_anchors: bool | None = None,
     bm25f_cache: BM25IndexCache | None = None,
+    eigenbasis_cache: GraphEigenbasisCache | None = None,
 ) -> list[Belief]:
     """Return L0 locked + L2.5 entity + L1 BM25 + L3 BFS expansions.
 
@@ -910,6 +953,7 @@ def retrieve(
             store, query,
             l1_limit=l1_limit, posterior_weight=weight,
             use_bm25f_anchors=bm25f_on, bm25f_cache=bm25f_cache,
+            eigenbasis_cache=eigenbasis_cache,
         )
         l1 = [
             b for b in raw_l1
@@ -983,6 +1027,7 @@ def retrieve_with_tiers(
     posterior_weight: float | None = None,
     use_bm25f_anchors: bool | None = None,
     bm25f_cache: BM25IndexCache | None = None,
+    eigenbasis_cache: GraphEigenbasisCache | None = None,
 ) -> tuple[
     list[Belief], list[str], list[str], list[str], list[list[str]],
 ]:
@@ -1038,6 +1083,7 @@ def retrieve_with_tiers(
             store, query,
             l1_limit=l1_limit, posterior_weight=weight,
             use_bm25f_anchors=bm25f_on, bm25f_cache=bm25f_cache,
+            eigenbasis_cache=eigenbasis_cache,
         )
         l1 = [
             b for b in raw_l1

--- a/src/aelfrice/scoring.py
+++ b/src/aelfrice/scoring.py
@@ -168,10 +168,17 @@ def partial_bayesian_score(
     alpha: float,
     beta: float,
     posterior_weight: float = DEFAULT_POSTERIOR_WEIGHT,
+    heat_kernel: float = 1.0,
+    heat_kernel_weight: float = 1.0,
 ) -> float:
-    """v1.3 partial Bayesian-weighted retrieval score.
+    """v1.3 partial Bayesian-weighted retrieval score, optionally
+    composed with a heat-kernel authority term (#151 slice 2).
 
-    `score = log(max(-bm25_raw, EPS)) + posterior_weight * log(posterior_mean)`
+    Full formula::
+
+        score = log(max(-bm25_raw, EPS))
+              + heat_kernel_weight * log(max(heat_kernel, EPS))
+              + posterior_weight   * log(posterior_mean)
 
     `bm25_raw` is FTS5's signed score (non-positive: SQLite returns
     smaller-magnitude-negative for stronger matches). We negate to
@@ -179,9 +186,18 @@ def partial_bayesian_score(
     (`PARTIAL_BAYESIAN_BM25_FLOOR`) prevents `log(0)` for non-
     matches without contaminating any real-match ordering.
 
-    `posterior_weight = 0.0` collapses the second term to zero and
-    makes the score a monotone function of `-bm25_raw` — byte-
-    identical to v1.0.x `ORDER BY bm25(beliefs_fts)`.
+    `heat_kernel` is the per-belief authority score from
+    ``graph_spectral.heat_kernel_score``. It MUST be a strictly
+    positive value already passed through ``heat_kernel_safe`` (the
+    floor here is identical, defence-in-depth). The default ``1.0``
+    makes ``log(1) == 0``, so callers that have no eigenbasis
+    available pay no cost and produce byte-identical scores to the
+    pre-slice-2 contract.
+
+    `posterior_weight = 0.0` AND ``heat_kernel == 1.0`` collapses
+    the score to ``log(-bm25_raw)``, monotone with ``-bm25_raw``
+    ascending — byte-identical to v1.0.x ``ORDER BY
+    bm25(beliefs_fts)``.
 
     `posterior_mean` reuses the existing module-level helper, which
     returns `α / (α + β)` (Jeffreys prior, reads 0.5 for unobserved
@@ -192,12 +208,15 @@ def partial_bayesian_score(
     sort-descending callers).
     """
     relevance_pos = max(-bm25_raw, PARTIAL_BAYESIAN_BM25_FLOOR)
-    log_bm25 = math.log(relevance_pos)
+    score = math.log(relevance_pos)
+    if heat_kernel != 1.0 and heat_kernel_weight != 0.0:
+        heat_safe = max(heat_kernel, PARTIAL_BAYESIAN_BM25_FLOOR)
+        score += heat_kernel_weight * math.log(heat_safe)
     if posterior_weight == 0.0:
-        return log_bm25
+        return score
     p = posterior_mean(alpha, beta)
     # `posterior_mean` returns 0.5 in the degenerate (alpha+beta<=0)
     # case, so `p > 0` is guaranteed; floor defensively for the
     # pathological `alpha = 0` operator-fed case to avoid `log(0)`.
     p_safe = p if p > 0.0 else PARTIAL_BAYESIAN_BM25_FLOOR
-    return log_bm25 + posterior_weight * math.log(p_safe)
+    return score + posterior_weight * math.log(p_safe)

--- a/tests/test_bayesian_ranking.py
+++ b/tests/test_bayesian_ranking.py
@@ -491,3 +491,76 @@ def test_bm25_floor_is_strictly_positive_and_small() -> None:
     not to contaminate any real BM25 score (~1e-6 typical)."""
     assert PARTIAL_BAYESIAN_BM25_FLOOR > 0.0
     assert PARTIAL_BAYESIAN_BM25_FLOOR < 1e-6
+
+
+# --- Heat-kernel composition (#151 slice 2) -----------------------------
+
+
+def test_heat_kernel_default_one_is_neutral() -> None:
+    """Default heat_kernel=1.0 contributes log(1)=0 — score must
+    match the pre-slice-2 contract for every (bm25, posterior)."""
+    for bm25_raw in (-3.0, -1.0, -0.001, 0.0):
+        for pw in (0.0, 0.5, 1.0):
+            base = partial_bayesian_score(bm25_raw, 1.0, 1.0, pw)
+            with_default = partial_bayesian_score(
+                bm25_raw, 1.0, 1.0, pw, heat_kernel=1.0,
+            )
+            assert with_default == base
+
+
+def test_heat_kernel_log_additive_at_unit_weight() -> None:
+    """At heat_kernel_weight=1.0 the heat term adds log(heat_kernel)
+    on top of the bm25+posterior baseline."""
+    bm25_raw, alpha, beta, pw = -1.0, 2.0, 1.0, 0.5
+    heat = 0.4
+    base = partial_bayesian_score(bm25_raw, alpha, beta, pw)
+    composed = partial_bayesian_score(
+        bm25_raw, alpha, beta, pw, heat_kernel=heat,
+    )
+    assert abs(composed - (base + math.log(heat))) < 1e-12
+
+
+def test_heat_kernel_weight_zero_collapses_term() -> None:
+    """heat_kernel_weight=0.0 must drop the heat term regardless
+    of heat_kernel value — same byte path as heat_kernel=1.0."""
+    bm25_raw, alpha, beta, pw = -2.0, 1.5, 1.5, 0.5
+    base = partial_bayesian_score(bm25_raw, alpha, beta, pw)
+    weighted = partial_bayesian_score(
+        bm25_raw, alpha, beta, pw,
+        heat_kernel=0.01, heat_kernel_weight=0.0,
+    )
+    assert weighted == base
+
+
+def test_heat_kernel_floor_prevents_log_zero() -> None:
+    """A pathological heat_kernel <= 0 must be floored to
+    PARTIAL_BAYESIAN_BM25_FLOOR rather than raising or producing
+    -inf. Defence-in-depth: graph_spectral.heat_kernel_safe is the
+    primary guard, this floor is the second."""
+    score_zero = partial_bayesian_score(
+        -1.0, 1.0, 1.0, posterior_weight=0.0, heat_kernel=0.0,
+    )
+    score_neg = partial_bayesian_score(
+        -1.0, 1.0, 1.0, posterior_weight=0.0, heat_kernel=-0.5,
+    )
+    expected = math.log(1.0) + math.log(PARTIAL_BAYESIAN_BM25_FLOOR)
+    assert abs(score_zero - expected) < 1e-12
+    assert abs(score_neg - expected) < 1e-12
+
+
+def test_heat_kernel_monotone_in_authority() -> None:
+    """For fixed bm25/posterior, higher heat-kernel authority must
+    yield a strictly higher composed score (assuming weight > 0).
+    This is what makes graph-central beliefs rank above peripheral
+    ones with the same lexical match."""
+    bm25_raw, alpha, beta = -1.0, 1.0, 1.0
+    s_low = partial_bayesian_score(
+        bm25_raw, alpha, beta, posterior_weight=0.0, heat_kernel=0.1,
+    )
+    s_mid = partial_bayesian_score(
+        bm25_raw, alpha, beta, posterior_weight=0.0, heat_kernel=0.5,
+    )
+    s_high = partial_bayesian_score(
+        bm25_raw, alpha, beta, posterior_weight=0.0, heat_kernel=2.0,
+    )
+    assert s_low < s_mid < s_high

--- a/tests/test_bayesian_ranking.py
+++ b/tests/test_bayesian_ranking.py
@@ -564,3 +564,90 @@ def test_heat_kernel_monotone_in_authority() -> None:
         bm25_raw, alpha, beta, posterior_weight=0.0, heat_kernel=2.0,
     )
     assert s_low < s_mid < s_high
+
+
+# --- retrieve() with eigenbasis_cache (#151 slice 2) ----------------------
+
+
+def test_retrieve_no_eigenbasis_cache_is_byte_identical() -> None:
+    """Without an eigenbasis_cache the L1 path must produce the
+    same belief sequence as the pre-slice-2 contract — even when
+    AELFRICE_HEAT_KERNEL=1 is set. The lane silently no-ops when
+    no cache is available."""
+    import os
+    from aelfrice.retrieval import _reset_placeholder_warnings
+    _reset_placeholder_warnings()
+    s = _equal_bm25_store()
+    baseline = retrieve(s, "widget", token_budget=10_000, posterior_weight=0.5)
+    prior = os.environ.pop("AELFRICE_HEAT_KERNEL", None)
+    os.environ["AELFRICE_HEAT_KERNEL"] = "1"
+    try:
+        flagged = retrieve(
+            s, "widget", token_budget=10_000, posterior_weight=0.5,
+        )
+    finally:
+        if prior is None:
+            os.environ.pop("AELFRICE_HEAT_KERNEL", None)
+        else:
+            os.environ["AELFRICE_HEAT_KERNEL"] = prior
+    assert [b.id for b in flagged] == [b.id for b in baseline]
+
+
+def test_retrieve_eigenbasis_cache_threaded_through(
+    tmp_path: Path,
+) -> None:
+    """Smoke test: retrieve() accepts eigenbasis_cache, builds it,
+    enables the heat-kernel flag, and returns a non-empty L1 with
+    no exceptions. The actual reranking is exercised by the
+    scoring-level tests above; this confirms wiring."""
+    import os
+    from aelfrice.graph_spectral import GraphEigenbasisCache
+    s = _equal_bm25_store()
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz", k=3)
+    cache.build()
+    prior = os.environ.pop("AELFRICE_HEAT_KERNEL", None)
+    os.environ["AELFRICE_HEAT_KERNEL"] = "1"
+    try:
+        out = retrieve(
+            s, "widget",
+            token_budget=10_000, posterior_weight=0.5,
+            eigenbasis_cache=cache,
+        )
+    finally:
+        if prior is None:
+            os.environ.pop("AELFRICE_HEAT_KERNEL", None)
+        else:
+            os.environ["AELFRICE_HEAT_KERNEL"] = prior
+    assert len(out) == 5
+    assert {b.id for b in out} == {
+        "a_fiv", "b_fou", "c_thr", "d_two", "e_one",
+    }
+
+
+def test_retrieve_heat_kernel_flag_off_ignores_cache(
+    tmp_path: Path,
+) -> None:
+    """When the heat-kernel flag is off, supplying an eigenbasis
+    cache must not change ordering vs the no-cache baseline. Same
+    determinism guarantee as the other off-by-default lanes."""
+    import os
+    from aelfrice.graph_spectral import GraphEigenbasisCache
+    s = _equal_bm25_store()
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz", k=3)
+    cache.build()
+    prior = os.environ.pop("AELFRICE_HEAT_KERNEL", None)
+    os.environ["AELFRICE_HEAT_KERNEL"] = "0"
+    try:
+        with_cache = retrieve(
+            s, "widget", token_budget=10_000, posterior_weight=0.5,
+            eigenbasis_cache=cache,
+        )
+        without_cache = retrieve(
+            s, "widget", token_budget=10_000, posterior_weight=0.5,
+        )
+    finally:
+        if prior is None:
+            os.environ.pop("AELFRICE_HEAT_KERNEL", None)
+        else:
+            os.environ["AELFRICE_HEAT_KERNEL"] = prior
+    assert [b.id for b in with_cache] == [b.id for b in without_cache]

--- a/tests/test_graph_spectral.py
+++ b/tests/test_graph_spectral.py
@@ -26,6 +26,7 @@ from aelfrice.graph_spectral import (
     build_signed_adjacency,
     build_signed_normalized_laplacian,
     compute_eigenbasis,
+    heat_kernel_for_candidates,
     load_eigenbasis,
     save_eigenbasis,
 )
@@ -309,3 +310,53 @@ def test_eigsolve_under_budget_n10k(request: pytest.FixtureRequest) -> None:
     assert eigvecs.shape == (n, DEFAULT_K)
     # Generous bound — spec says ~4s; allow 30s for noisy hosts.
     assert elapsed < 30.0
+
+
+# --- heat_kernel_for_candidates (#151 slice 2) -----------------------------
+
+
+def test_heat_kernel_for_candidates_returns_per_belief_scores(
+    tmp_path: Path,
+) -> None:
+    s = _toy_store()
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz", k=4)
+    cache.build()
+    candidates = [("b1", 2.0), ("b2", 1.5), ("b5", 0.5)]
+    scores = heat_kernel_for_candidates(cache, candidates)
+    # Every present candidate gets a score
+    assert set(scores.keys()) == {"b1", "b2", "b5"}
+    # Floored, so all entries are strictly positive
+    assert all(v > 0.0 for v in scores.values())
+
+
+def test_heat_kernel_for_candidates_skips_unknown_ids(tmp_path: Path) -> None:
+    """Beliefs not in the eigenbasis row order are silently skipped
+    (the scoring layer will use the neutral 1.0 default for them)."""
+    s = _toy_store()
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz", k=4)
+    cache.build()
+    candidates = [("b1", 1.0), ("b_missing", 1.0)]
+    scores = heat_kernel_for_candidates(cache, candidates)
+    assert "b1" in scores
+    assert "b_missing" not in scores
+
+
+def test_heat_kernel_for_candidates_empty_when_stale(tmp_path: Path) -> None:
+    s = _toy_store()
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz", k=4)
+    cache.build()
+    s.insert_belief(_mk("b6"))  # invalidates cache
+    assert cache.is_stale()
+    scores = heat_kernel_for_candidates(cache, [("b1", 1.0)])
+    assert scores == {}
+
+
+def test_heat_kernel_for_candidates_empty_inputs(tmp_path: Path) -> None:
+    s = _toy_store()
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz", k=4)
+    cache.build()
+    assert heat_kernel_for_candidates(cache, []) == {}
+    # All candidates have zero / negative seed weight → no seeds → {}
+    assert heat_kernel_for_candidates(
+        cache, [("b1", 0.0), ("b2", -1.0)],
+    ) == {}


### PR DESCRIPTION
Closes part of #151 (slice 2 — heat-kernel composition).

## Summary

Adds the optional heat-kernel authority term to the v1.3 ranking
score and wires it through retrieval. Default behaviour is
unchanged — every existing caller produces byte-identical output
because the heat-kernel lane requires both an `eigenbasis_cache`
kwarg AND `is_heat_kernel_enabled()` to resolve True.

Composition implemented (per #151):

```
score = log(-bm25_raw)
      + heat_kernel_weight * log(heat_kernel_safe)
      + posterior_weight   * log(posterior_mean)
```

## Changes

- `scoring.partial_bayesian_score()` gains `heat_kernel: float = 1.0`
  and `heat_kernel_weight: float = 1.0`. Default `1.0` makes
  `log(1) == 0`, so callers unchanged. Defence-in-depth floor at
  `PARTIAL_BAYESIAN_BM25_FLOOR`.
- `graph_spectral.heat_kernel_for_candidates(cache, candidates)`:
  new helper that builds a sparse seed vector from the L1 hit set,
  runs `heat_kernel_score` against the cached eigenbasis, applies
  `heat_kernel_safe`, and returns `dict[belief_id, score]` for
  candidates present in the eigenbasis row order. Returns `{}` when
  cache is stale, eigenbasis unbuilt, or no positive seed exists.
- `retrieval._l1_hits` accepts an `eigenbasis_cache` kwarg; both
  the BM25F and FTS5 paths thread per-belief heat scores into
  `partial_bayesian_score`. Backward-compat preserved by the
  default `1.0` neutral.
- `retrieve()` and `retrieve_with_tiers()` accept and forward
  `eigenbasis_cache` into `_l1_hits`. The `RetrievalCache` and
  `retrieve_v2` wrappers stay untouched in this slice; benchmark
  callers using the lower-level entry points get the new lane
  immediately.

## Tests

`tests/test_bayesian_ranking.py` (+8):
- neutral default at `heat_kernel=1.0`
- log-additivity at unit weight
- weight-zero collapse
- floor behaviour for non-positive heat-kernel input
- monotonicity in authority
- byte-identity vs no-cache baseline (flag on, no cache)
- retrieve() smoke with cache built and flag on
- byte-identity when flag off (cache supplied but ignored)

`tests/test_graph_spectral.py` (+4):
- per-belief score output for the toy graph
- unknown-id passthrough
- stale-cache returns `{}`
- empty inputs / non-positive seeds return `{}`

Full suite: 1897 passed, 8 skipped.

## Out of scope (future slice)

- Default-on flip (Slice 3 / #154 composition tracker).
- `RetrievalCache.retrieve()` / `retrieve_v2()` cache-key extension
  for the eigenbasis-cache identity (only matters once the lane is
  default-on; current callers wanting it pass through `retrieve()`
  directly).
- Bench harness wiring (separate Slice 3 PR).

## Discretion check

Discretion grep against the canonical pattern set — CLEAN.

## Summary by Sourcery

Add an optional heat-kernel authority term to the v1.3 retrieval ranking score and wire it through L1 retrieval while preserving default, byte-identical behaviour when the feature is disabled or no cache is available.

New Features:
- Introduce heat-kernel authority composition into partial_bayesian_score via configurable heat_kernel and heat_kernel_weight parameters.
- Add heat_kernel_for_candidates to compute per-belief heat-kernel authority scores for L1 candidates using a precomputed graph eigenbasis.
- Extend retrieve and retrieve_with_tiers to accept an eigenbasis_cache for enabling heat-kernel-based reranking of L1 results.

Enhancements:
- Update L1 retrieval (_l1_hits) to incorporate heat-kernel scores alongside BM25 and posterior terms, with strict preservation of legacy ordering when the new lane yields no contribution.

Tests:
- Add unit tests covering heat-kernel composition behaviour in partial_bayesian_score, including neutrality, log-additivity, weight-zero collapse, flooring, and monotonicity.
- Add retrieval tests to ensure byte-identical behaviour without a cache or with the feature flag off, and smoke test retrieval with an eigenbasis cache and flag enabled.
- Add graph_spectral tests validating heat_kernel_for_candidates output, handling of unknown IDs, stale caches, and empty or non-positive seed inputs.