### PR TITLE
docs: mark #280 hook-hardening mitigations 1+2 as shipped

### DIFF
--- a/docs/hook_hardening.md
+++ b/docs/hook_hardening.md
@@ -2,9 +2,19 @@
 
 ## Status
 
-**Spec — proposing for ratification.** No code change in this memo.
-Implementation is roughly two PRs after ratification: framing + tag
-contract change (small) and audit-log capture (small).
+**Partially shipped.**
+
+| Layer | State | Reference |
+|---|---|---|
+| Spec memo (this doc) | Landed | PR #292 |
+| Mitigation 1 — framing-tag contract | Landed | `_FRAMING_HEADER`, `<belief id=… lock=…>` inner element in `src/aelfrice/hook.py` (`_format_hits`, `_format_baseline_hits`) |
+| Mitigation 2 — render-time belief-content escape | Landed | `_escape_for_hook_block` in `src/aelfrice/hook.py` |
+| Mitigation 3 — per-turn audit log (`hook_audit.jsonl`) | Outstanding | Tracked in this section as PR2 |
+
+The decision-asks below (lines 232-242) were tacitly ratified for
+mitigations 1+2 by the implementation landing alongside this doc. The
+mitigation-3 default-on / 10 MB / single-rotation contract remains the
+ratified shape for the outstanding PR2.
 
 ## Problem
 


### PR DESCRIPTION
## Summary

The hook-hardening spec (`docs/hook_hardening.md`, landed in #292) still reads "Status: Spec — proposing for ratification" even though mitigations 1 (framing-tag contract) and 2 (belief-content render-time escape) are already implemented in `src/aelfrice/hook.py` (`_FRAMING_HEADER`, `_escape_for_hook_block`, `<belief id=… lock=…>` inner element in `_format_hits` + `_format_baseline_hits`).

This PR replaces the status section with a per-mitigation table so future readers see what's done vs the outstanding audit-log PR2.

No code change.

## Test plan

- [x] `grep` confirms mitigations 1+2 are in `src/aelfrice/hook.py`.
- [x] Discretion grep on diff: clean.

## Summary by Sourcery

Documentation:
- Replace the generic spec status text in the hook hardening memo with a per-mitigation status table covering shipped and outstanding items.