### PR TITLE
ci: auto-rebase open PRs on main push

### DIFF
--- a/.github/workflows/auto-rebase-open-prs.yml
+++ b/.github/workflows/auto-rebase-open-prs.yml
@@ -1,0 +1,77 @@
+name: auto-rebase-open-prs
+
+# When main moves, attempt to rebase every open PR onto the new main and
+# force-push. Clean rebases land silently. Conflicts get the PR a comment
+# and a `merge-conflict` label so the author/reviewer sees it.
+#
+# This is the "auto-fresh" half of the parallel-session workflow. The other
+# half is `~/.claude/scripts/aelf-pr-open.sh`, which prevents stale-at-open.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Rebase open PRs onto main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          # JSON: [{number, headRefName, baseRefName}]
+          prs=$(gh pr list --state open --base main \
+                  --json number,headRefName,baseRefName \
+                  --jq '.[] | @base64')
+
+          for row in $prs; do
+              data=$(echo "$row" | base64 -d)
+              num=$(echo "$data"   | jq -r .number)
+              head=$(echo "$data"  | jq -r .headRefName)
+              echo "=== PR #$num: $head ==="
+
+              git fetch origin "$head" --quiet || { echo "  fetch failed, skip"; continue; }
+              git checkout -B "$head" "origin/$head"
+
+              if git merge-base --is-ancestor origin/main HEAD; then
+                  echo "  already on top of main, skip"
+                  continue
+              fi
+
+              if git rebase origin/main; then
+                  echo "  rebase clean, force-push"
+                  if git push --force-with-lease origin "$head"; then
+                      gh pr edit "$num" --remove-label merge-conflict 2>/dev/null || true
+                  else
+                      echo "  push rejected (concurrent update); will retry on next main push"
+                      git rebase --abort 2>/dev/null || true
+                  fi
+              else
+                  echo "  rebase has conflicts, flag PR"
+                  git rebase --abort
+                  gh pr edit "$num" --add-label merge-conflict 2>/dev/null || true
+                  gh pr comment "$num" --body \
+"Auto-rebase onto main failed: conflicts. Resolve locally:
+\`\`\`
+git fetch origin && git checkout $head && git rebase origin/main
+# resolve, then
+git push --force-with-lease
+\`\`\`" 2>/dev/null || true
+              fi
+          done

--- a/.github/workflows/auto-rebase-open-prs.yml
+++ b/.github/workflows/auto-rebase-open-prs.yml
@@ -16,11 +16,17 @@ permissions:
   contents: write
   pull-requests: write
 
+# Only one rebase pass at a time; queued runs collapse so we don't fight
+# ourselves with overlapping force-pushes.
+concurrency:
+  group: auto-rebase-open-prs
+  cancel-in-progress: false
+
 jobs:
   rebase:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,18 +39,28 @@ jobs:
       - name: Rebase open PRs onto main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -e
-          # JSON: [{number, headRefName, baseRefName}]
-          prs=$(gh pr list --state open --base main \
-                  --json number,headRefName,baseRefName \
+          # JSON: [{number, headRefName, baseRefName, headRepositoryOwner, isCrossRepository, labels}]
+          # --limit 1000 disables default pagination (30) so every open PR is processed.
+          prs=$(gh pr list --state open --base main --limit 1000 \
+                  --json number,headRefName,isCrossRepository,labels \
                   --jq '.[] | @base64')
 
           for row in $prs; do
               data=$(echo "$row" | base64 -d)
               num=$(echo "$data"   | jq -r .number)
               head=$(echo "$data"  | jq -r .headRefName)
-              echo "=== PR #$num: $head ==="
+              cross=$(echo "$data" | jq -r .isCrossRepository)
+              has_conflict_label=$(echo "$data" | jq -r '[.labels[].name] | index("merge-conflict") != null')
+              echo "=== PR #$num: $head (fork=$cross) ==="
+
+              # Skip fork PRs — we can't force-push to forks via GITHUB_TOKEN.
+              if [ "$cross" = "true" ]; then
+                  echo "  fork PR, skip"
+                  continue
+              fi
 
               git fetch origin "$head" --quiet || { echo "  fetch failed, skip"; continue; }
               git checkout -B "$head" "origin/$head"
@@ -66,12 +82,22 @@ jobs:
                   echo "  rebase has conflicts, flag PR"
                   git rebase --abort
                   gh pr edit "$num" --add-label merge-conflict 2>/dev/null || true
-                  gh pr comment "$num" --body \
-"Auto-rebase onto main failed: conflicts. Resolve locally:
-\`\`\`
-git fetch origin && git checkout $head && git rebase origin/main
-# resolve, then
-git push --force-with-lease
-\`\`\`" 2>/dev/null || true
+                  # Only post the explainer the first time the label is applied;
+                  # avoids spamming long-lived conflicted PRs on every main push.
+                  if [ "$has_conflict_label" = "false" ]; then
+                      body_file=$(mktemp)
+                      {
+                          echo 'Auto-rebase onto main failed: conflicts. Resolve locally:'
+                          echo '```'
+                          echo "git fetch origin && git checkout '$head' && git rebase origin/main"
+                          echo '# resolve, then'
+                          echo 'git push --force-with-lease'
+                          echo '```'
+                      } > "$body_file"
+                      gh pr comment "$num" --body-file "$body_file" 2>/dev/null || true
+                      rm -f "$body_file"
+                  else
+                      echo "  conflict label already present, skip comment"
+                  fi
               fi
           done

--- a/.github/workflows/auto-rebase-open-prs.yml
+++ b/.github/workflows/auto-rebase-open-prs.yml
@@ -4,7 +4,7 @@ name: auto-rebase-open-prs
 # force-push. Clean rebases land silently. Conflicts get the PR a comment
 # and a `merge-conflict` label so the author/reviewer sees it.
 #
-# This is the "auto-fresh" half of the parallel-session workflow. The other
+# This is the "auto-fresh" half of the multi-author PR workflow. The other
 # half is `~/.claude/scripts/aelf-pr-open.sh`, which prevents stale-at-open.
 
 on:


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/auto-rebase-open-prs.yml` fires on push to `main` and on `workflow_dispatch`.
- For each open PR with `base=main`, fetches the head branch, attempts `git rebase origin/main`, force-pushes if clean.
- Conflicts get a `merge-conflict` label and a comment with the local-recovery one-liner.

## Why
Three concurrent sessions opening PRs against main means every merge invalidates ~2 in-flight PRs. Reviewer hits "BLOCKED — needs rebase" and bounces. This eliminates the manual rebase step for the common (clean) case and makes real conflicts surface as a flag.

## Resolves
Refs #256 review thrash (5+ claim/release cycles before merge).

## Test plan
- [ ] Merge this PR. Watch the next merge-to-main; verify any other open PRs auto-rebase.
- [ ] Land a deliberately conflicting branch; verify it gets the `merge-conflict` label + comment.

## Summary by Sourcery

CI:
- Add a GitHub Actions workflow that rebases all open PRs targeting main onto the updated main branch, force-pushes clean rebases, and labels/comment flags PRs with merge conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adds automated rebasing of open PRs onto main to keep branches up to date; skips PRs already current.
  * When rebasing succeeds, updates branches automatically; when conflicts occur, labels PRs as "merge-conflict" and posts guidance on how to resolve and update the PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->