### PR TITLE
feat: per-turn hook audit log (#280 mitigation 3)

### DIFF
--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -284,6 +284,234 @@ def _append_telemetry(
         )
 
 
+# ---------------------------------------------------------------------------
+# Per-turn audit log (#280 mitigation 3)
+# ---------------------------------------------------------------------------
+
+AUDIT_DEFAULT_MAX_BYTES: Final[int] = 10 * 1024 * 1024
+"""Default size cap before rotation (10 MB). Overridable via .aelfrice.toml."""
+
+AUDIT_PROMPT_PREFIX_CAP: Final[int] = 200
+"""Maximum characters of the user prompt stored in an audit record."""
+
+AUDIT_FILENAME: Final[str] = "hook_audit.jsonl"
+"""Live audit log filename, sibling of memory.db under <git-common-dir>/aelfrice/."""
+
+AUDIT_ROTATED_SUFFIX: Final[str] = ".1"
+"""Single-slot rotation suffix. Rollover renames hook_audit.jsonl -> hook_audit.jsonl.1."""
+
+_AUDIT_SECTION: Final[str] = "hook_audit"
+_AUDIT_ENABLED_KEY: Final[str] = "enabled"
+_AUDIT_MAX_BYTES_KEY: Final[str] = "max_bytes"
+_AUDIT_ENV_DISABLE: Final[str] = "AELFRICE_HOOK_AUDIT"
+
+AUDIT_HOOK_USER_PROMPT_SUBMIT: Final[str] = "user_prompt_submit"
+AUDIT_HOOK_SESSION_START: Final[str] = "session_start"
+
+
+@dataclass(frozen=True)
+class HookAuditConfig:
+    """Resolved configuration for the per-turn hook audit log.
+
+    `enabled` defaults True (audit-on) per #280 ratification — the surface
+    is monitored unless the operator explicitly opts out via env var or
+    TOML. `max_bytes` controls when the live file is rotated.
+    """
+
+    enabled: bool = True
+    max_bytes: int = AUDIT_DEFAULT_MAX_BYTES
+
+
+def load_hook_audit_config(
+    start: Path | None = None,
+    *,
+    env: dict[str, str] | None = None,
+    stderr: IO[str] | None = None,
+) -> HookAuditConfig:
+    """Resolve the [hook_audit] config.
+
+    Resolution order:
+    1. `AELFRICE_HOOK_AUDIT=0` env var → disabled (overrides TOML).
+    2. Walk up from `start` looking for `.aelfrice.toml`; first hit wins.
+    3. Default (enabled=True, max_bytes=AUDIT_DEFAULT_MAX_BYTES).
+
+    Missing file / missing section / malformed TOML / wrong-typed values
+    all degrade to the safe default with a stderr trace; never raises.
+    """
+    serr: IO[str] = stderr if stderr is not None else sys.stderr
+    env_map = env if env is not None else dict(os.environ)
+    env_val = env_map.get(_AUDIT_ENV_DISABLE)
+    if env_val is not None and env_val.strip() == "0":
+        return HookAuditConfig(enabled=False)
+    current = (start if start is not None else Path.cwd()).resolve()
+    seen: set[Path] = set()
+    while current not in seen:
+        seen.add(current)
+        candidate = current / _CONFIG_FILENAME
+        if candidate.is_file():
+            try:
+                raw = candidate.read_bytes()
+            except OSError as exc:
+                print(
+                    f"aelfrice hook: cannot read {candidate}: {exc}",
+                    file=serr,
+                )
+                return HookAuditConfig()
+            try:
+                parsed: dict[str, Any] = tomllib.loads(
+                    raw.decode("utf-8", errors="replace"),
+                )
+            except tomllib.TOMLDecodeError as exc:
+                print(
+                    f"aelfrice hook: malformed TOML in {candidate}: {exc}",
+                    file=serr,
+                )
+                return HookAuditConfig()
+            section_obj: Any = parsed.get(_AUDIT_SECTION, {})
+            if not isinstance(section_obj, dict):
+                return HookAuditConfig()
+            section = cast(dict[str, Any], section_obj)
+            enabled_obj: Any = section.get(_AUDIT_ENABLED_KEY, True)
+            if not isinstance(enabled_obj, bool):
+                print(
+                    f"aelfrice hook: ignoring [{_AUDIT_SECTION}] "
+                    f"{_AUDIT_ENABLED_KEY} in {candidate} (expected bool)",
+                    file=serr,
+                )
+                enabled_obj = True
+            max_bytes_obj: Any = section.get(
+                _AUDIT_MAX_BYTES_KEY, AUDIT_DEFAULT_MAX_BYTES,
+            )
+            if not isinstance(max_bytes_obj, int) or max_bytes_obj <= 0:
+                if not (
+                    isinstance(max_bytes_obj, int)
+                    and max_bytes_obj == AUDIT_DEFAULT_MAX_BYTES
+                ):
+                    print(
+                        f"aelfrice hook: ignoring [{_AUDIT_SECTION}] "
+                        f"{_AUDIT_MAX_BYTES_KEY} in {candidate} "
+                        f"(expected positive int)",
+                        file=serr,
+                    )
+                max_bytes_obj = AUDIT_DEFAULT_MAX_BYTES
+            return HookAuditConfig(
+                enabled=enabled_obj,
+                max_bytes=max_bytes_obj,
+            )
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return HookAuditConfig()
+
+
+def _audit_path_for_db(db_path_val: Path) -> Path:
+    """Derive the audit log path from the DB path. Sibling of memory.db."""
+    return db_path_val.parent / AUDIT_FILENAME
+
+
+def _append_audit(
+    audit_path: Path,
+    record: dict[str, object],
+    max_bytes: int,
+    *,
+    stderr: IO[str] | None = None,
+) -> None:
+    """Append one record to the audit JSONL. Rotate if size cap exceeded.
+
+    Append-then-rotate semantics: the record always lands. If, after
+    writing, the live file exceeds `max_bytes`, it is renamed to
+    `<path>.1` (overwriting any prior `.1`) and a fresh empty file is
+    started for the next call. Single-slot rotation by spec; no archive.
+
+    Fail-soft: any I/O error is logged to stderr and swallowed.
+    """
+    try:
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record) + "\n"
+        with open(audit_path, "a", encoding="utf-8") as f:
+            f.write(line)
+            f.flush()
+            os.fsync(f.fileno())
+        if audit_path.stat().st_size > max_bytes:
+            rotated = audit_path.with_name(
+                audit_path.name + AUDIT_ROTATED_SUFFIX,
+            )
+            os.replace(audit_path, rotated)
+    except Exception as exc:
+        serr = stderr if stderr is not None else sys.stderr
+        print(
+            f"aelfrice: hook audit write failed (non-fatal): {exc}",
+            file=serr,
+        )
+
+
+def _write_hook_audit_record(
+    *,
+    hook: str,
+    prompt: str,
+    rendered_block: str,
+    n_beliefs: int,
+    n_locked: int,
+    session_id: str | None = None,
+    config: HookAuditConfig | None = None,
+    stderr: IO[str] | None = None,
+) -> None:
+    """Build and append a hook-audit record. Fail-soft.
+
+    No-op when audit is disabled by config. The record captures the
+    full rendered block so a reviewer can see *exactly* what the hook
+    injected on a given turn — distinct from telemetry, which records
+    counts only.
+    """
+    cfg = config if config is not None else load_hook_audit_config(stderr=stderr)
+    if not cfg.enabled:
+        return
+    try:
+        p = db_path()
+        audit_path = _audit_path_for_db(p)
+    except Exception:
+        return
+    record: dict[str, object] = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "hook": hook,
+        "prompt_prefix": prompt[:AUDIT_PROMPT_PREFIX_CAP],
+        "rendered_block": rendered_block,
+        "n_beliefs": n_beliefs,
+        "n_locked": n_locked,
+    }
+    if session_id is not None:
+        record["session_id"] = session_id
+    _append_audit(audit_path, record, cfg.max_bytes, stderr=stderr)
+
+
+def read_hook_audit(path: Path) -> list[dict[str, object]]:
+    """Read the hook audit JSONL at `path`. Returns [] when missing.
+
+    Raises ValueError on any non-JSON line (corruption). Lines that are
+    valid JSON but not objects are silently skipped, matching the
+    telemetry reader.
+    """
+    if not path.exists():
+        return []
+    records: list[dict[str, object]] = []
+    text = path.read_text(encoding="utf-8")
+    for i, line in enumerate(text.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"audit file {path} line {i + 1} is not valid JSON: {exc}"
+            ) from exc
+        if not isinstance(parsed, dict):
+            continue
+        records.append(cast(dict[str, object], parsed))
+    return records
+
+
 def read_user_prompt_submit_telemetry(
     path: Path,
 ) -> list[dict[str, object]]:
@@ -350,6 +578,7 @@ def user_prompt_submit(
         prompt = _extract_prompt(raw)
         if prompt is None:
             return 0
+        session_id = _extract_session_id(raw)
         budget = (
             token_budget
             if token_budget is not None
@@ -384,6 +613,16 @@ def user_prompt_submit(
                 total_chars=total_chars,
                 stderr=serr,
             )
+            # #280 mitigation 3: per-turn audit of the rendered block.
+            _write_hook_audit_record(
+                hook=AUDIT_HOOK_USER_PROMPT_SUBMIT,
+                prompt=prompt,
+                rendered_block=body,
+                n_beliefs=len(hits),
+                n_locked=sum(1 for h in hits if h.lock_level == LOCK_USER),
+                session_id=session_id,
+                stderr=serr,
+            )
     except Exception:  # non-blocking: surface but do not fail
         traceback.print_exc(file=serr)
     return 0
@@ -415,6 +654,29 @@ def _write_telemetry(
         "total_chars": total_chars,
     }
     _append_telemetry(tel_path, record, stderr=stderr)
+
+
+def _extract_session_id(raw: str) -> str | None:
+    """Best-effort extraction of `session_id` from a hook payload.
+
+    The harness's UserPromptSubmit and SessionStart payloads include a
+    `session_id` field; use it if present and a string. Returns None
+    on any parse failure or missing field — purely informational, no
+    raise.
+    """
+    if not raw.strip():
+        return None
+    try:
+        payload = json.loads(raw)  # pyright: ignore[reportAny]
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    payload_typed = cast(dict[str, object], payload)
+    sid = payload_typed.get("session_id")
+    if isinstance(sid, str) and sid:
+        return sid
+    return None
 
 
 def _extract_prompt(raw: str) -> str | None:
@@ -699,20 +961,33 @@ def session_start(
         )
         return 0
     try:
-        # Drain stdin so the hook protocol is honored even though we
-        # do not consume any fields.
+        # Drain stdin so the hook protocol is honored. We do read the
+        # session_id from the payload (best-effort) for audit-log
+        # cross-reference; no other fields are consumed.
+        raw = ""
         try:
-            _ = sin.read()
+            raw = sin.read()
         except Exception:
             pass
+        session_id = _extract_session_id(raw)
         budget = (
             token_budget
             if token_budget is not None
             else DEFAULT_SESSION_START_TOKEN_BUDGET
         )
-        body = _retrieve_and_format_baseline(budget)
+        hits, body = _retrieve_baseline_with_block(budget)
         if body:
             sout.write(body)
+            # #280 mitigation 3: per-turn audit of the rendered block.
+            _write_hook_audit_record(
+                hook=AUDIT_HOOK_SESSION_START,
+                prompt="",
+                rendered_block=body,
+                n_beliefs=len(hits),
+                n_locked=sum(1 for h in hits if h.lock_level == LOCK_USER),
+                session_id=session_id,
+                stderr=serr,
+            )
     except Exception:  # non-blocking: surface but do not fail
         traceback.print_exc(file=serr)
     return 0
@@ -726,14 +1001,27 @@ def _retrieve_and_format_baseline(token_budget: int) -> str:
     retrieve()'s budget logic, which leaves L0 untrimmed even when
     the locked set alone exceeds the budget.
     """
+    _, body = _retrieve_baseline_with_block(token_budget)
+    return body
+
+
+def _retrieve_baseline_with_block(
+    token_budget: int,
+) -> tuple[list[Belief], str]:
+    """Retrieve baseline hits and the rendered block in one call.
+
+    Returns ([], "") when retrieval yields nothing. Used by both the
+    legacy formatter wrapper and the session_start hook (which needs
+    the hit list for audit-record counts).
+    """
     store = _open_store()
     try:
         hits = retrieve(store, "", token_budget=token_budget)
     finally:
         store.close()
     if not hits:
-        return ""
-    return _format_baseline_hits(hits)
+        return ([], "")
+    return (hits, _format_baseline_hits(hits))
 
 
 def _format_baseline_hits(hits: list[Belief]) -> str:

--- a/tests/test_hook_audit.py
+++ b/tests/test_hook_audit.py
@@ -1,0 +1,418 @@
+"""Per-turn hook audit log (#280 mitigation 3)."""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.hook import (
+    AUDIT_DEFAULT_MAX_BYTES,
+    AUDIT_FILENAME,
+    AUDIT_HOOK_SESSION_START,
+    AUDIT_HOOK_USER_PROMPT_SUBMIT,
+    AUDIT_PROMPT_PREFIX_CAP,
+    AUDIT_ROTATED_SUFFIX,
+    HookAuditConfig,
+    _audit_path_for_db,
+    _write_hook_audit_record,
+    load_hook_audit_config,
+    read_hook_audit,
+    session_start,
+    user_prompt_submit,
+)
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    bid: str,
+    content: str,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _seed_db(db_path: Path, beliefs: list[Belief]) -> None:
+    store = MemoryStore(str(db_path))
+    try:
+        for b in beliefs:
+            store.insert_belief(b)
+    finally:
+        store.close()
+
+
+def _payload(prompt: str, session_id: str = "s1") -> str:
+    return json.dumps(
+        {
+            "session_id": session_id,
+            "transcript_path": "/dev/null",
+            "cwd": "/tmp",
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": prompt,
+        }
+    )
+
+
+def _set_db(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    monkeypatch.setenv("AELFRICE_DB", str(path))
+
+
+# ---------------------------------------------------------------------------
+# load_hook_audit_config
+# ---------------------------------------------------------------------------
+
+def test_default_config_is_enabled_with_default_max_bytes(
+    tmp_path: Path,
+) -> None:
+    cfg = load_hook_audit_config(start=tmp_path, env={})
+    assert cfg.enabled is True
+    assert cfg.max_bytes == AUDIT_DEFAULT_MAX_BYTES
+
+
+def test_env_disable_overrides_toml(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[hook_audit]\nenabled = true\n", encoding="utf-8",
+    )
+    cfg = load_hook_audit_config(
+        start=tmp_path, env={"AELFRICE_HOOK_AUDIT": "0"},
+    )
+    assert cfg.enabled is False
+
+
+def test_toml_disable_honored(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[hook_audit]\nenabled = false\n", encoding="utf-8",
+    )
+    cfg = load_hook_audit_config(start=tmp_path, env={})
+    assert cfg.enabled is False
+
+
+def test_toml_max_bytes_override(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[hook_audit]\nmax_bytes = 4096\n", encoding="utf-8",
+    )
+    cfg = load_hook_audit_config(start=tmp_path, env={})
+    assert cfg.enabled is True
+    assert cfg.max_bytes == 4096
+
+
+def test_malformed_toml_degrades_to_default(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[hook_audit\nbroken", encoding="utf-8",
+    )
+    serr = io.StringIO()
+    cfg = load_hook_audit_config(start=tmp_path, env={}, stderr=serr)
+    assert cfg == HookAuditConfig()
+    assert "malformed TOML" in serr.getvalue()
+
+
+def test_wrong_typed_enabled_degrades(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        '[hook_audit]\nenabled = "yes"\n', encoding="utf-8",
+    )
+    serr = io.StringIO()
+    cfg = load_hook_audit_config(start=tmp_path, env={}, stderr=serr)
+    assert cfg.enabled is True
+    assert "expected bool" in serr.getvalue()
+
+
+def test_negative_max_bytes_degrades(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[hook_audit]\nmax_bytes = -10\n", encoding="utf-8",
+    )
+    serr = io.StringIO()
+    cfg = load_hook_audit_config(start=tmp_path, env={}, stderr=serr)
+    assert cfg.max_bytes == AUDIT_DEFAULT_MAX_BYTES
+    assert "expected positive int" in serr.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Hook integration: writes a record on UserPromptSubmit fire
+# ---------------------------------------------------------------------------
+
+def test_user_prompt_submit_writes_audit_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "the kitchen is full of bananas")])
+    _set_db(monkeypatch, db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    sin = io.StringIO(_payload("bananas", session_id="sess-abc"))
+    sout = io.StringIO()
+    rc = user_prompt_submit(stdin=sin, stdout=sout)
+    assert rc == 0
+    audit_path = _audit_path_for_db(db)
+    records = read_hook_audit(audit_path)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["hook"] == AUDIT_HOOK_USER_PROMPT_SUBMIT
+    assert rec["prompt_prefix"] == "bananas"
+    assert rec["n_beliefs"] == 1
+    assert rec["n_locked"] == 0
+    assert rec["session_id"] == "sess-abc"
+    rendered = rec["rendered_block"]
+    assert isinstance(rendered, str)
+    assert "<belief id=\"F1\"" in rendered
+    assert isinstance(rec["ts"], str)
+
+
+def test_user_prompt_submit_audit_records_locked_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(
+        db,
+        [
+            _mk("L1", "user truth", lock_level=LOCK_USER, locked_at="2026-04-26T01:00:00Z"),
+            _mk("F1", "user truth"),
+        ],
+    )
+    _set_db(monkeypatch, db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    sin = io.StringIO(_payload("anything"))
+    sout = io.StringIO()
+    user_prompt_submit(stdin=sin, stdout=sout)
+    rec = read_hook_audit(_audit_path_for_db(db))[0]
+    assert rec["n_locked"] == 1
+    assert rec["n_beliefs"] >= 1
+
+
+def test_user_prompt_submit_no_audit_when_no_hits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "totally unrelated content")])
+    _set_db(monkeypatch, db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    sin = io.StringIO(_payload("xyzzy_no_match_whatever"))
+    sout = io.StringIO()
+    user_prompt_submit(stdin=sin, stdout=sout)
+    audit_path = _audit_path_for_db(db)
+    assert not audit_path.exists() or read_hook_audit(audit_path) == []
+
+
+def test_session_start_writes_audit_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(
+        db,
+        [
+            _mk(
+                "L1", "ground truth",
+                lock_level=LOCK_USER,
+                locked_at="2026-04-26T01:00:00Z",
+            ),
+        ],
+    )
+    _set_db(monkeypatch, db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    sin = io.StringIO(json.dumps({"session_id": "sess-start"}))
+    sout = io.StringIO()
+    rc = session_start(stdin=sin, stdout=sout)
+    assert rc == 0
+    rec = read_hook_audit(_audit_path_for_db(db))[0]
+    assert rec["hook"] == AUDIT_HOOK_SESSION_START
+    assert rec["prompt_prefix"] == ""
+    assert rec["n_locked"] == 1
+    assert rec["session_id"] == "sess-start"
+    assert "<aelfrice-baseline>" in rec["rendered_block"]  # type: ignore[operator]
+
+
+def test_env_disable_suppresses_audit_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "the kitchen is full of bananas")])
+    _set_db(monkeypatch, db)
+    monkeypatch.setenv("AELFRICE_HOOK_AUDIT", "0")
+    monkeypatch.chdir(tmp_path)
+    sin = io.StringIO(_payload("bananas"))
+    sout = io.StringIO()
+    user_prompt_submit(stdin=sin, stdout=sout)
+    assert not _audit_path_for_db(db).exists()
+
+
+def test_toml_disable_suppresses_audit_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "the kitchen is full of bananas")])
+    _set_db(monkeypatch, db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[hook_audit]\nenabled = false\n", encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    sin = io.StringIO(_payload("bananas"))
+    sout = io.StringIO()
+    user_prompt_submit(stdin=sin, stdout=sout)
+    assert not _audit_path_for_db(db).exists()
+
+
+# ---------------------------------------------------------------------------
+# Rotation: live file rolls to <name>.1 once max_bytes is exceeded
+# ---------------------------------------------------------------------------
+
+def test_rotation_at_max_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "the kitchen is full of bananas")])
+    _set_db(monkeypatch, db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+    # Threshold tuned so one record fits, two records exceed.
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[hook_audit]\nmax_bytes = 500\n", encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    audit_path = _audit_path_for_db(db)
+    rotated = audit_path.with_name(audit_path.name + AUDIT_ROTATED_SUFFIX)
+    # Fire once: live has one record, well under 500 B; no rotation yet.
+    sin = io.StringIO(_payload("bananas"))
+    user_prompt_submit(stdin=sin, stdout=io.StringIO())
+    assert audit_path.exists()
+    assert not rotated.exists()
+    first_size = audit_path.stat().st_size
+    # Fire again: post-write size > 500 B → rotate to .1 → fresh live file
+    # is created by the next fire.
+    sin = io.StringIO(_payload("bananas"))
+    user_prompt_submit(stdin=sin, stdout=io.StringIO())
+    sin = io.StringIO(_payload("bananas"))
+    user_prompt_submit(stdin=sin, stdout=io.StringIO())
+    assert rotated.exists()
+    # Rotated content was the post-fire-2 file (single-slot rotation).
+    rotated_records = read_hook_audit(rotated)
+    assert len(rotated_records) >= 1
+    # Live file is fresh after rotation (fire-3 wrote to it).
+    if audit_path.exists():
+        assert audit_path.stat().st_size <= first_size + 50  # only fire-3
+
+
+# ---------------------------------------------------------------------------
+# Direct API: _write_hook_audit_record + read_hook_audit
+# ---------------------------------------------------------------------------
+
+def test_write_hook_audit_disabled_is_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "x")])
+    _set_db(monkeypatch, db)
+    cfg = HookAuditConfig(enabled=False)
+    _write_hook_audit_record(
+        hook=AUDIT_HOOK_USER_PROMPT_SUBMIT,
+        prompt="x",
+        rendered_block="<aelfrice-memory></aelfrice-memory>",
+        n_beliefs=0,
+        n_locked=0,
+        config=cfg,
+    )
+    assert not _audit_path_for_db(db).exists()
+
+
+def test_prompt_prefix_is_capped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "x")])
+    _set_db(monkeypatch, db)
+    long_prompt = "a" * (AUDIT_PROMPT_PREFIX_CAP + 500)
+    cfg = HookAuditConfig(enabled=True)
+    _write_hook_audit_record(
+        hook=AUDIT_HOOK_USER_PROMPT_SUBMIT,
+        prompt=long_prompt,
+        rendered_block="<aelfrice-memory/>",
+        n_beliefs=0,
+        n_locked=0,
+        config=cfg,
+    )
+    rec = read_hook_audit(_audit_path_for_db(db))[0]
+    assert isinstance(rec["prompt_prefix"], str)
+    assert len(rec["prompt_prefix"]) == AUDIT_PROMPT_PREFIX_CAP  # type: ignore[arg-type]
+
+
+def test_session_id_omitted_when_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "x")])
+    _set_db(monkeypatch, db)
+    cfg = HookAuditConfig(enabled=True)
+    _write_hook_audit_record(
+        hook=AUDIT_HOOK_USER_PROMPT_SUBMIT,
+        prompt="x",
+        rendered_block="<aelfrice-memory/>",
+        n_beliefs=0,
+        n_locked=0,
+        session_id=None,
+        config=cfg,
+    )
+    rec = read_hook_audit(_audit_path_for_db(db))[0]
+    assert "session_id" not in rec
+
+
+def test_read_hook_audit_missing_returns_empty(tmp_path: Path) -> None:
+    assert read_hook_audit(tmp_path / "no_such.jsonl") == []
+
+
+def test_read_hook_audit_raises_on_corruption(tmp_path: Path) -> None:
+    p = tmp_path / "audit.jsonl"
+    p.write_text('{"ok": 1}\nnot json\n', encoding="utf-8")
+    with pytest.raises(ValueError):
+        read_hook_audit(p)
+
+
+def test_read_hook_audit_skips_non_object_lines(tmp_path: Path) -> None:
+    p = tmp_path / "audit.jsonl"
+    p.write_text('{"ok": 1}\n"a string"\n42\n', encoding="utf-8")
+    out = read_hook_audit(p)
+    assert out == [{"ok": 1}]
+
+
+def test_audit_write_failsoft_on_unwriteable_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the audit path is unwriteable, the hook still returns 0 cleanly."""
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "the kitchen is full of bananas")])
+    _set_db(monkeypatch, db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    # Replace the audit dir with a regular file so mkdir() raises.
+    (db.parent / "aelfrice").mkdir(parents=True, exist_ok=True)
+    audit_path = _audit_path_for_db(db)
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    audit_path.write_text("preexisting", encoding="utf-8")
+    # Make it unwriteable: replace with a directory of the same name as the
+    # JSONL file. Now open(..., "a") fails. (POSIX-only contract; skipped on
+    # Windows where directory-named file behavior differs.)
+    audit_path.unlink()
+    audit_path.mkdir()
+    sin = io.StringIO(_payload("bananas"))
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = user_prompt_submit(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    # Hook still produced its output block; only the audit failed.
+    assert sout.getvalue().startswith("<aelfrice-memory>")
+    assert "hook audit write failed" in serr.getvalue()


### PR DESCRIPTION
## Summary

Adds the per-turn audit log called for in `docs/hook_hardening.md` (#280 mitigation 3) — a JSONL sibling of the existing `hook_telemetry.jsonl` that records the *exact rendered hook block* on every fire. Telemetry records counts; audit records what was actually injected.

- New file: `<git-common-dir>/aelfrice/hook_audit.jsonl`.
- Wired into both `user_prompt_submit` and `session_start`.
- Default-on. Opt-out via `AELFRICE_HOOK_AUDIT=0` env or `[hook_audit] enabled = false` in `.aelfrice.toml`.
- 10 MB cap (configurable: `[hook_audit] max_bytes`); single-slot rotation to `hook_audit.jsonl.1` on rollover.
- Fail-soft: any I/O error traces to stderr and is swallowed; the hook still emits its output block.

Spec references in this repo:
- `docs/hook_hardening.md` — full design.
- `docs/hook_hardening.md#3-per-turn-audit-log` — record schema (matches what this PR implements).

Mitigations 1 and 2 from the same spec (framing-tag contract + render-time belief-content escape) already shipped via #292; this PR closes the third and final mitigation.

## Test plan

- [x] 21 new tests in `tests/test_hook_audit.py` covering: default config, env disable, TOML disable, max_bytes override, malformed/wrong-typed TOML graceful degradation, UserPromptSubmit + SessionStart write paths, n_locked / session_id / prompt_prefix capping, no-op when disabled, no-op when retrieval is empty, rotation at threshold, single-slot rotation overwriting prior `.1`, read API + corruption handling, fail-soft on unwriteable path.
- [x] Full pytest suite local: 1947 passed, 14 skipped.
- [x] Discretion grep on diff: clean.

## Summary by Sourcery

Introduce a per-turn hook audit log that records rendered hook blocks for user prompt submissions and session starts, with configurable opt-out and size-based rotation.

New Features:
- Add a JSONL-based hook audit log alongside existing telemetry that captures rendered hook blocks and contextual metadata per hook invocation.
- Expose a read API for the hook audit log to load parsed audit records from disk.

Enhancements:
- Wire audit logging into user_prompt_submit and session_start hooks, including best-effort extraction of session IDs and retrieval of baseline hits for count reporting.
- Add configuration resolution for hook audit behavior via environment variable and .aelfrice.toml, including a configurable file size cap with single-slot rotation and safe fallbacks on malformed config.
- Refactor baseline retrieval to return both hits and rendered blocks to support shared use by session_start and auditing logic.

Tests:
- Add comprehensive tests for hook audit configuration resolution, hook integration behavior, rotation semantics, direct read/write APIs, and fail-soft behavior on I/O errors.