### PR TITLE
chore: ignore telemetry/ runtime hook output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 *.db
 *.db-wal
 *.db-shm
+telemetry/


### PR DESCRIPTION
Adds `telemetry/` to `.gitignore`. Path holds runtime JSONL diagnostic output from the in-process search-tool hook; not part of the product surface and was showing up as untracked across worktrees.

One-line change. No code touched.

## Summary by Sourcery

Chores:
- Add telemetry/ directory to .gitignore to prevent committing runtime diagnostic output.