### PR TITLE
Feat/issue 151 heat kernel composition

### DIFF
--- a/benchmarks/posterior_ranking/ac6_50k.py
+++ b/benchmarks/posterior_ranking/ac6_50k.py
@@ -1,0 +1,145 @@
+"""AC6 perf measurement at N=50k for #151 slice 2.
+
+Builds a 50k-belief in-memory store with a sparse SUPPORTS edge graph,
+constructs the eigenbasis cache, then times retrieve() heat-off vs heat-on.
+
+Run: uv run python -m benchmarks.posterior_ranking.ac6_50k
+"""
+from __future__ import annotations
+
+import random
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+from aelfrice.graph_spectral import GraphEigenbasisCache
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief, Edge
+from aelfrice.retrieval import retrieve
+from aelfrice.store import MemoryStore
+
+N_BELIEFS = 50_000
+N_EDGES = 5_000  # ~10% density (one edge per ten beliefs)
+N_QUERIES = 30   # warmup 5, measured 25
+WARMUP = 5
+
+WORDS = [
+    "alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta",
+    "iota", "kappa", "lambda", "mu", "nu", "xi", "omicron", "pi",
+    "rho", "sigma", "tau", "upsilon", "phi", "chi", "psi", "omega",
+    "memory", "store", "belief", "vector", "graph", "kernel", "ranking",
+    "posterior", "prior", "evidence", "feedback", "weight", "score",
+]
+
+
+def _make_belief(bid: str, content: str) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=0.5,
+        beta=0.5,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-01-01T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _build_store(n: int, n_edges: int, seed: int = 0) -> MemoryStore:
+    rng = random.Random(seed)
+    store = MemoryStore(":memory:")
+    beliefs = []
+    for i in range(n):
+        words = rng.sample(WORDS, k=8)
+        beliefs.append(_make_belief(f"b{i}", " ".join(words)))
+    store.insert_beliefs(beliefs)
+
+    edges = []
+    seen: set[tuple[str, str]] = set()
+    while len(edges) < n_edges:
+        a = rng.randrange(n)
+        b = rng.randrange(n)
+        if a == b:
+            continue
+        key = (f"b{a}", f"b{b}")
+        if key in seen:
+            continue
+        seen.add(key)
+        edges.append(Edge(src=key[0], dst=key[1], type="SUPPORTS", weight=1.0))
+    store.insert_edges(edges)
+    return store
+
+
+def _time_retrieve(
+    store: MemoryStore,
+    queries: list[str],
+    *,
+    heat_kernel: bool,
+    cache: GraphEigenbasisCache | None,
+) -> list[float]:
+    times: list[float] = []
+    for i, q in enumerate(queries):
+        t0 = time.perf_counter()
+        retrieve(
+            store,
+            q,
+            l1_limit=10,
+            entity_index_enabled=False,
+            bfs_enabled=False,
+            posterior_weight=None,
+            heat_kernel_enabled=heat_kernel,
+            eigenbasis_cache=cache,
+        )
+        t1 = time.perf_counter()
+        if i >= WARMUP:
+            times.append((t1 - t0) * 1000.0)
+    return times
+
+
+def main() -> None:
+    print(f"Building store: {N_BELIEFS} beliefs, {N_EDGES} edges...")
+    t0 = time.perf_counter()
+    store = _build_store(N_BELIEFS, N_EDGES)
+    print(f"  store built in {time.perf_counter() - t0:.2f}s")
+
+    print("Building eigenbasis cache...")
+    tmp = tempfile.TemporaryDirectory(prefix="aelf_ac6_")
+    cache = GraphEigenbasisCache(store=store, path=Path(tmp.name) / "eb.npz")
+    t0 = time.perf_counter()
+    cache.build()
+    print(f"  cache built in {time.perf_counter() - t0:.2f}s")
+
+    rng = random.Random(42)
+    queries = [
+        " ".join(rng.sample(WORDS, k=3)) for _ in range(N_QUERIES)
+    ]
+
+    print(f"\nTiming retrieve() heat-off (N={N_QUERIES - WARMUP} after warmup={WARMUP})...")
+    off = _time_retrieve(store, queries, heat_kernel=False, cache=None)
+    print(f"  heat-off: median={statistics.median(off):.3f}ms "
+          f"p90={sorted(off)[int(0.9*len(off))]:.3f}ms "
+          f"max={max(off):.3f}ms")
+
+    print(f"\nTiming retrieve() heat-on...")
+    on = _time_retrieve(store, queries, heat_kernel=True, cache=cache)
+    print(f"  heat-on: median={statistics.median(on):.3f}ms "
+          f"p90={sorted(on)[int(0.9*len(on))]:.3f}ms "
+          f"max={max(on):.3f}ms")
+
+    overhead_med = statistics.median(on) - statistics.median(off)
+    print(f"\nHeat-on overhead (median): {overhead_med:+.3f}ms")
+    print(f"AC6 budget: heat-off ≤1ms, heat-on ≤10ms")
+    off_pass = statistics.median(off) <= 1.0
+    on_pass = statistics.median(on) <= 10.0
+    print(f"  heat-off pass: {off_pass}")
+    print(f"  heat-on  pass: {on_pass}")
+
+    tmp.cleanup()
+    store.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/posterior_ranking/mrr_uplift.py
+++ b/benchmarks/posterior_ranking/mrr_uplift.py
@@ -20,11 +20,13 @@ from __future__ import annotations
 
 import math
 import random
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Sequence
 
 from aelfrice.feedback import apply_feedback
+from aelfrice.graph_spectral import GraphEigenbasisCache
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
 from aelfrice.retrieval import retrieve
 from aelfrice.store import MemoryStore
@@ -97,6 +99,9 @@ def _mrr_for_belief(
     query: str,
     known_content: str,
     top_k: int = DEFAULT_TOP_K,
+    *,
+    eigenbasis_cache: GraphEigenbasisCache | None = None,
+    heat_kernel: bool = False,
 ) -> float:
     """Return 1/rank of the known belief in the retrieve() results (0 if absent)."""
     results: list[Belief] = retrieve(
@@ -106,6 +111,8 @@ def _mrr_for_belief(
         entity_index_enabled=False,
         bfs_enabled=False,
         posterior_weight=None,  # use default 0.5
+        heat_kernel_enabled=heat_kernel,
+        eigenbasis_cache=eigenbasis_cache,
     )
     for rank, belief in enumerate(results, start=1):
         if belief.content == known_content:
@@ -145,6 +152,8 @@ def run_single_seed(
     seed: int,
     top_k: int = DEFAULT_TOP_K,
     threshold: float = DEFAULT_MRR_THRESHOLD,
+    *,
+    heat_kernel: bool = False,
 ) -> MRRUpliftResult:
     """Run the 10-round MRR uplift evaluator for one seed.
 
@@ -160,18 +169,42 @@ def run_single_seed(
     if n_fixtures == 0:
         raise ValueError("fixtures must not be empty")
 
+    # Per-seed throwaway temp dir for the eigenbasis .npz files when
+    # heat_kernel is on. Cache files are rebuilt after every feedback
+    # round (store mutation invalidates them); the cleanup is handled
+    # by the TemporaryDirectory at function exit.
+    _tmp_dir = tempfile.TemporaryDirectory(prefix="aelf_pr_eb_")
+    _tmp_path = Path(_tmp_dir.name)
+
     # Build stores once; share across rounds.
-    stores_ids: list[tuple[MemoryStore, str, dict[str, object]]] = []
-    for fx in fixtures:
+    stores_ids: list[tuple[MemoryStore, str, dict[str, object], GraphEigenbasisCache | None]] = []
+    for idx, fx in enumerate(fixtures):
         store, known_id = _build_store(fx, seed)
-        stores_ids.append((store, known_id, fx))
+        cache: GraphEigenbasisCache | None = None
+        if heat_kernel:
+            cache = GraphEigenbasisCache(
+                store=store, path=_tmp_path / f"eb_{seed}_{idx}.npz",
+            )
+            cache.build()
+        stores_ids.append((store, known_id, fx, cache))
+
+    def _refresh_caches() -> None:
+        if not heat_kernel:
+            return
+        for st, _kid, _fx, cache in stores_ids:
+            if cache is not None and cache.is_stale():
+                cache.build()
 
     def _mean_mrr(round_idx: int) -> float:
         """Compute mean MRR across all fixtures for the current store state."""
         del round_idx  # round tracked externally; store state is what matters
+        _refresh_caches()
         total = 0.0
-        for st, _kid, fx in stores_ids:
-            total += _mrr_for_belief(st, str(fx["query"]), str(fx["known_belief_content"]), top_k)
+        for st, _kid, fx, cache in stores_ids:
+            total += _mrr_for_belief(
+                st, str(fx["query"]), str(fx["known_belief_content"]), top_k,
+                eigenbasis_cache=cache, heat_kernel=heat_kernel,
+            )
         return total / n_fixtures
 
     mrr_0 = _mean_mrr(0)
@@ -181,8 +214,9 @@ def run_single_seed(
     any_regression = False
 
     for _rnd in range(N_ROUNDS):
+        _refresh_caches()
         # Apply synthetic feedback to each fixture's store.
-        for st, known_id, fx in stores_ids:
+        for st, known_id, fx, cache in stores_ids:
             query = str(fx["query"])
             known_content = str(fx["known_belief_content"])
             results: list[Belief] = retrieve(
@@ -192,6 +226,8 @@ def run_single_seed(
                 entity_index_enabled=False,
                 bfs_enabled=False,
                 posterior_weight=None,
+                heat_kernel_enabled=heat_kernel,
+                eigenbasis_cache=cache,
             )
             top1 = results[0] if results else None
             if top1 is not None and top1.content == known_content:
@@ -216,8 +252,9 @@ def run_single_seed(
     passed = (uplift >= threshold) and (not any_regression)
 
     # Close stores.
-    for st, _, _ in stores_ids:
+    for st, _, _, _ in stores_ids:
         st.close()
+    _tmp_dir.cleanup()
 
     return MRRUpliftResult(
         mrr_0=mrr_0,
@@ -235,6 +272,8 @@ def run_multi_seed(
     threshold: float = DEFAULT_MRR_THRESHOLD,
     top_k: int = DEFAULT_TOP_K,
     base_seed: int = 0,
+    *,
+    heat_kernel: bool = False,
 ) -> MultiSeedReport:
     """Run the uplift evaluator across n_seeds seeds.
 
@@ -244,7 +283,10 @@ def run_multi_seed(
     results: list[MRRUpliftResult] = []
     for i in range(n_seeds):
         seed = base_seed + i
-        r = run_single_seed(fixtures, seed=seed, top_k=top_k, threshold=threshold)
+        r = run_single_seed(
+            fixtures, seed=seed, top_k=top_k, threshold=threshold,
+            heat_kernel=heat_kernel,
+        )
         results.append(r)
 
     uplifts = [r.mrr_uplift for r in results]

--- a/benchmarks/posterior_ranking/run.py
+++ b/benchmarks/posterior_ranking/run.py
@@ -15,6 +15,7 @@ The synthetic feedback stream is defined as follows:
 """
 from __future__ import annotations
 
+import tempfile
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -35,6 +36,7 @@ from benchmarks.posterior_ranking.mrr_uplift import (
     run_multi_seed,
 )
 from aelfrice.feedback import apply_feedback
+from aelfrice.graph_spectral import GraphEigenbasisCache
 from aelfrice.models import Belief
 from aelfrice.retrieval import retrieve
 
@@ -43,6 +45,8 @@ def _build_ece_observations(
     fixtures: list[dict[str, object]],
     seed: int,
     top_k: int = DEFAULT_TOP_K,
+    *,
+    heat_kernel: bool = False,
 ) -> list[dict[str, object]]:
     """Replay the synthetic feedback stream and collect ECE observations.
 
@@ -60,13 +64,25 @@ def _build_ece_observations(
     """
     observations: list[dict[str, object]] = []
 
-    for fx in fixtures:
+    _tmp_dir = tempfile.TemporaryDirectory(prefix="aelf_pr_ece_eb_")
+    _tmp_path = Path(_tmp_dir.name)
+
+    for idx, fx in enumerate(fixtures):
         store, known_id = _build_store(fx, seed)
         query = str(fx["query"])
         known_content = str(fx["known_belief_content"])
 
+        cache: GraphEigenbasisCache | None = None
+        if heat_kernel:
+            cache = GraphEigenbasisCache(
+                store=store, path=_tmp_path / f"eb_{seed}_{idx}.npz",
+            )
+            cache.build()
+
         # Round 0 is baseline (no feedback yet); include it.
         for _rnd in range(N_ROUNDS + 1):
+            if heat_kernel and cache is not None and cache.is_stale():
+                cache.build()
             results: list[Belief] = retrieve(
                 store,
                 query,
@@ -74,6 +90,8 @@ def _build_ece_observations(
                 entity_index_enabled=False,
                 bfs_enabled=False,
                 posterior_weight=None,
+                heat_kernel_enabled=heat_kernel,
+                eigenbasis_cache=cache,
             )
 
             top1 = results[0] if results else None
@@ -104,6 +122,7 @@ def _build_ece_observations(
 
         store.close()
 
+    _tmp_dir.cleanup()
     return observations
 
 
@@ -114,6 +133,8 @@ def run(
     ece_threshold: float = DEFAULT_ECE_THRESHOLD,
     top_k: int = DEFAULT_TOP_K,
     base_seed: int = 0,
+    *,
+    heat_kernel: bool = False,
 ) -> dict[str, Any]:
     """Run both MRR uplift and ECE scorers against a fixture file.
 
@@ -137,10 +158,13 @@ def run(
         threshold=mrr_threshold,
         top_k=top_k,
         base_seed=base_seed,
+        heat_kernel=heat_kernel,
     )
 
     # Collect ECE observations using seed 0 (deterministic reference).
-    observations = _build_ece_observations(fixtures, seed=base_seed, top_k=top_k)
+    observations = _build_ece_observations(
+        fixtures, seed=base_seed, top_k=top_k, heat_kernel=heat_kernel,
+    )
     ece_result: ECEResult = compute_ece_from_stores(observations, threshold=ece_threshold)
 
     overall_pass = mrr_report.passed and ece_result.passed
@@ -159,6 +183,8 @@ def run_as_dict(
     ece_threshold: float = DEFAULT_ECE_THRESHOLD,
     top_k: int = DEFAULT_TOP_K,
     base_seed: int = 0,
+    *,
+    heat_kernel: bool = False,
 ) -> dict[str, Any]:
     """Same as run() but serializes dataclasses to plain dicts for JSON output."""
     result = run(
@@ -168,6 +194,7 @@ def run_as_dict(
         ece_threshold=ece_threshold,
         top_k=top_k,
         base_seed=base_seed,
+        heat_kernel=heat_kernel,
     )
     return {
         "mrr": asdict(result["mrr"]),

--- a/docs/bayesian_ranking.md
+++ b/docs/bayesian_ranking.md
@@ -190,6 +190,52 @@ This spec ships partial. The remaining v2.0.0 work, tracked separately:
 
 These are the items #151's full claim covers. After this spec PR opens, #151 should be re-scoped to the above set, with the v1.3 posterior term itself acknowledged as shipped under #146.
 
+## Heat-kernel composition (Slice 2)
+
+Slice 2 of #151 adds a third log-additive term — a graph authority signal computed from the signed-Laplacian heat kernel `exp(-tL)`. The composed score is:
+
+```
+score(q, b) = log(BM25(q, b))
+            + heat_weight    * log(heat_kernel_safe(q, b))
+            + posterior_weight * log(posterior_mean(b))
+```
+
+where `heat_kernel_safe(q, b)` is the per-belief heat propagation seeded from the top-K BM25 hits, clamped at `HEAT_SCORE_FLOOR = 1e-9`. Default mixing weights are `heat_weight = 1.0` and `posterior_weight = 0.5` (`graph_spectral.combine_log_scores`).
+
+### Feature flag (default-OFF)
+
+The composition is gated behind `is_heat_kernel_enabled()`, which resolves with precedence env > kwarg > TOML > False:
+
+- `AELFRICE_HEAT_KERNEL=1` (env override)
+- `retrieve(..., heat_kernel_enabled=True)` (kwarg)
+- `[retrieval] use_heat_kernel = true` in `.aelfrice.toml`
+
+The flag stays default-OFF in v1.x. When the flag is OFF, the heat term is not constructed — `retrieve()` is byte-identical to the Slice 1 (BM25 + posterior) path.
+
+### Cost
+
+The dominant per-query cost is the eigenbasis matvec `eigvecs.T @ seeds` followed by `eigvecs @ filt`, which is O(N · K). At N=50k, K=200 the wall-clock is ~7-8 ms in BLAS-backed numpy on commodity hardware. With the flag OFF the per-query overhead is unmeasurable (≤ 1 ms — no spectral work happens). AC6 of #151 was renegotiated to ≤ 10 ms heat-on / ≤ 1 ms heat-off to reflect this real cost.
+
+### Graceful degrade
+
+Three graceful-degrade paths fall back byte-identically to the heat-off contract:
+
+1. No `eigenbasis_cache` passed (caller didn't construct one).
+2. `cache.is_stale()` — store mutation invalidated the cache; offline rebuild is a separate (#149) entry point.
+3. `cache.eigvals is None` — never built, or every L1 hit was inserted after the last build.
+
+In each case the rerank reverts to `partial_bayesian_score(bm25, alpha, beta, posterior_weight)`. Newly-inserted beliefs missing from `cache.belief_ids` get `HEAT_SCORE_FLOOR` for the heat term — the floor preserves rankability without invented authority signal.
+
+### Bench wedge
+
+`aelf bench posterior-residual --heat-kernel` runs the MRR + ECE harness with the flag flipped on. Each per-seed `retrieve()` gets a fresh `GraphEigenbasisCache` built against that seed's in-memory store and rebuilt on stale (the synthetic feedback stream mutates the store after every round). Without `--heat-kernel`, output is byte-identical to today.
+
+### What Slice 2 still doesn't ship
+
+- Eigenbasis offline build CLI (#149).
+- Heat-weight sweep — `heat_weight = 1.0` is the spec default, no calibration exposed yet.
+- Real-feedback retest once captured telemetry passes the corpus-size threshold.
+
 ## References
 
 - Issue [#146](https://github.com/robotrocketscience/aelfrice/issues/146) — partial Bayesian-weighted ranking, v1.3 milestone.

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -1098,6 +1098,10 @@ def _cmd_bench(args: argparse.Namespace, out: object) -> int:
         _pr_parser.add_argument(
             "--json", dest="pr_json", action="store_true",
         )
+        _pr_parser.add_argument(
+            "--heat-kernel", dest="pr_heat_kernel", action="store_true",
+            help="enable heat-kernel composition in retrieve() (slice 2 of #151)",
+        )
         _pr_ns, _ = _pr_parser.parse_known_args(args.rest)
         from pathlib import Path as _Path
         _default_fixtures = (
@@ -1115,6 +1119,7 @@ def _cmd_bench(args: argparse.Namespace, out: object) -> int:
             n_seeds=_pr_ns.pr_seeds,
             mrr_threshold=_pr_ns.pr_mrr_threshold,
             ece_threshold=_pr_ns.pr_ece_threshold,
+            heat_kernel=_pr_ns.pr_heat_kernel,
         )
 
         if _pr_ns.pr_json:

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -67,10 +67,22 @@ from aelfrice.bfs_multihop import (
 )
 from aelfrice.bm25 import BM25IndexCache
 from aelfrice.entity_extractor import extract_entities
+from aelfrice.graph_spectral import (
+    DEFAULT_BM25_SEED_TOP_K,
+    DEFAULT_HEAT_BANDWIDTH,
+    DEFAULT_HEAT_KERNEL_WEIGHT,
+    DEFAULT_POSTERIOR_LOG_WEIGHT,
+    HEAT_SCORE_FLOOR,
+    GraphEigenbasisCache,
+    combine_log_scores,
+    heat_kernel_score,
+    seeds_from_bm25,
+)
 from aelfrice.models import LOCK_NONE, Belief
 from aelfrice.scoring import (
     DEFAULT_POSTERIOR_WEIGHT,
     partial_bayesian_score,
+    posterior_mean,
 )
 from aelfrice.store import MemoryStore
 
@@ -729,6 +741,49 @@ def _l25_hits(
     return out
 
 
+def _heat_by_id(
+    cache: GraphEigenbasisCache,
+    bm25_pos_by_id: dict[str, float],
+) -> dict[str, float] | None:
+    """Run one heat-kernel propagation pass and return per-belief
+    authority scores keyed by belief id.
+
+    `cache` must already hold a non-stale eigenbasis (caller checks
+    `cache.is_stale()` and `cache.eigvals is not None`). `bm25_pos_by_id`
+    is a `{belief_id: bm25_pos}` slice of the L1 hits, where `bm25_pos`
+    is the same positive-relevance magnitude used by
+    `partial_bayesian_score` (FTS5 path passes `-bm25_raw`; BM25F path
+    passes `raw` directly).
+
+    Returns `None` when the cache rows don't intersect the L1 hit set
+    (every L1 belief was inserted after the eigenbasis build) or when
+    the seed sum is zero — caller falls back to the heat-off path. The
+    explicit None signal lets the caller short-circuit the matvec when
+    propagation is guaranteed to be a no-op.
+    """
+    import numpy as np
+
+    if cache.eigvals is None or cache.eigvecs is None or not cache.belief_ids:
+        return None
+    n = len(cache.belief_ids)
+    bm25_arr = np.zeros(n, dtype=np.float64)
+    hit_indices: list[int] = []
+    for i, bid in enumerate(cache.belief_ids):
+        v = bm25_pos_by_id.get(bid)
+        if v is not None and v > 0.0:
+            bm25_arr[i] = v
+            hit_indices.append(i)
+    if not hit_indices:
+        return None
+    seeds = seeds_from_bm25(bm25_arr, top_k=DEFAULT_BM25_SEED_TOP_K)
+    if not float(seeds.sum()) > 0.0:
+        return None
+    heat = heat_kernel_score(
+        cache.eigvals, cache.eigvecs, seeds, t=DEFAULT_HEAT_BANDWIDTH,
+    )
+    return {bid: float(heat[i]) for i, bid in enumerate(cache.belief_ids)}
+
+
 def _l1_hits(
     store: MemoryStore,
     query: str,
@@ -737,6 +792,8 @@ def _l1_hits(
     posterior_weight: float,
     use_bm25f_anchors: bool = False,
     bm25f_cache: BM25IndexCache | None = None,
+    eigenbasis_cache: GraphEigenbasisCache | None = None,
+    heat_kernel_on: bool = False,
 ) -> list[Belief]:
     """Run L1: FTS5 BM25 search (default) or BM25F sparse-matvec
     (v1.5.0 opt-in), optionally reranked by partial-Bayesian score.
@@ -754,7 +811,25 @@ def _l1_hits(
     when use_bm25f_anchors is False.
 
     `posterior_weight > 0` reranks via `partial_bayesian_score`.
+
+    `heat_kernel_on` (v1.7.0): when True AND `eigenbasis_cache` holds a
+    non-stale eigenbasis whose `belief_ids` intersect the L1 hit set,
+    the rerank uses `combine_log_scores(bm25, heat, posterior_mean)`
+    instead of `partial_bayesian_score`. Heat propagation cost is the
+    `eigvecs.T @ seeds` matvec (~7-8 ms at N=50k, K=200; see
+    docs/bayesian_ranking.md § "Heat-kernel cost"). When the cache is
+    None, stale, empty, or carries no overlap with the L1 hit ids, the
+    path degrades to `partial_bayesian_score` — byte-identical to the
+    heat-off contract. AC4 / AC8 of #151 are preserved by this fall-
+    through.
     """
+    heat_active = (
+        heat_kernel_on
+        and eigenbasis_cache is not None
+        and not eigenbasis_cache.is_stale()
+        and eigenbasis_cache.eigvals is not None
+    )
+
     if use_bm25f_anchors:
         # The cache lazy-builds the index on first call and is
         # invalidated by store mutations. The rerank below uses the
@@ -770,31 +845,68 @@ def _l1_hits(
             if b is None:
                 continue
             beliefs.append((b, raw))
-        if posterior_weight == 0.0:
+        if posterior_weight == 0.0 and not heat_active:
             return [b for b, _ in beliefs]
+        # BM25F scores are non-negative; the rerank uses `raw` as the
+        # positive-magnitude relevance signal directly (the FTS5 path
+        # has to negate first because SQLite returns smaller-negative
+        # for stronger matches; BM25F doesn't).
+        bm25_pos_by_id: dict[str, float] = {b.id: float(raw) for b, raw in beliefs}
+        heat_map = (
+            _heat_by_id(eigenbasis_cache, bm25_pos_by_id)  # type: ignore[arg-type]
+            if heat_active else None
+        )
         keyed: list[tuple[float, str, Belief]] = []
         for b, raw in beliefs:
-            # BM25F scores are non-negative; partial_bayesian_score
-            # was written for FTS5's negative bm25 convention. Pass
-            # `-raw` so the log-additive composition treats higher
-            # raw scores as more relevant, matching the FTS5 path.
-            s = partial_bayesian_score(
-                -raw, b.alpha, b.beta, posterior_weight,
-            )
+            if heat_map is not None:
+                s = combine_log_scores(
+                    bm25f=max(float(raw), 1e-9),
+                    heat=heat_map.get(b.id, HEAT_SCORE_FLOOR),
+                    posterior=posterior_mean(b.alpha, b.beta),
+                    heat_weight=DEFAULT_HEAT_KERNEL_WEIGHT,
+                    posterior_weight=(
+                        posterior_weight if posterior_weight > 0.0
+                        else DEFAULT_POSTERIOR_LOG_WEIGHT
+                    ),
+                )
+            else:
+                s = partial_bayesian_score(
+                    -raw, b.alpha, b.beta, posterior_weight,
+                )
             keyed.append((s, b.id, b))
         keyed.sort(key=lambda x: (-x[0], x[1]))
         return [b for _, _, b in keyed]
 
-    if posterior_weight == 0.0:
+    if posterior_weight == 0.0 and not heat_active:
         return store.search_beliefs(query, limit=l1_limit)
     scored = store.search_beliefs_scored(query, limit=l1_limit)
     if not scored:
         return []
+    # FTS5 path: bm25_raw is non-positive (SQLite convention). Negate
+    # to get a positive relevance magnitude, same convention used by
+    # `partial_bayesian_score` internally.
+    bm25_pos_by_id = {b.id: max(-bm25_raw, 1e-9) for b, bm25_raw in scored}
+    heat_map = (
+        _heat_by_id(eigenbasis_cache, bm25_pos_by_id)  # type: ignore[arg-type]
+        if heat_active else None
+    )
     keyed: list[tuple[float, str, Belief]] = []
     for b, bm25_raw in scored:
-        s = partial_bayesian_score(
-            bm25_raw, b.alpha, b.beta, posterior_weight,
-        )
+        if heat_map is not None:
+            s = combine_log_scores(
+                bm25f=max(-bm25_raw, 1e-9),
+                heat=heat_map.get(b.id, HEAT_SCORE_FLOOR),
+                posterior=posterior_mean(b.alpha, b.beta),
+                heat_weight=DEFAULT_HEAT_KERNEL_WEIGHT,
+                posterior_weight=(
+                    posterior_weight if posterior_weight > 0.0
+                    else DEFAULT_POSTERIOR_LOG_WEIGHT
+                ),
+            )
+        else:
+            s = partial_bayesian_score(
+                bm25_raw, b.alpha, b.beta, posterior_weight,
+            )
         keyed.append((s, b.id, b))
     # Higher score = more relevant. Tie-break on id ASC for
     # determinism (matches the convention in bfs_multihop and L2.5).
@@ -820,6 +932,8 @@ def retrieve(
     posterior_weight: float | None = None,
     use_bm25f_anchors: bool | None = None,
     bm25f_cache: BM25IndexCache | None = None,
+    heat_kernel_enabled: bool | None = None,
+    eigenbasis_cache: GraphEigenbasisCache | None = None,
 ) -> list[Belief]:
     """Return L0 locked + L2.5 entity + L1 BM25 + L3 BFS expansions.
 
@@ -864,6 +978,7 @@ def retrieve(
     bfs_on = is_bfs_enabled(bfs_enabled)
     bm25f_on = resolve_use_bm25f_anchors(use_bm25f_anchors)
     weight = resolve_posterior_weight(posterior_weight)
+    heat_on = is_heat_kernel_enabled(heat_kernel_enabled)
     # v1.5.0 #154: emit one stderr line per placeholder lane the
     # user has set True in `.aelfrice.toml`. Fail-soft, once-per-
     # process per flag.
@@ -910,6 +1025,7 @@ def retrieve(
             store, query,
             l1_limit=l1_limit, posterior_weight=weight,
             use_bm25f_anchors=bm25f_on, bm25f_cache=bm25f_cache,
+            eigenbasis_cache=eigenbasis_cache, heat_kernel_on=heat_on,
         )
         l1 = [
             b for b in raw_l1
@@ -983,6 +1099,8 @@ def retrieve_with_tiers(
     posterior_weight: float | None = None,
     use_bm25f_anchors: bool | None = None,
     bm25f_cache: BM25IndexCache | None = None,
+    heat_kernel_enabled: bool | None = None,
+    eigenbasis_cache: GraphEigenbasisCache | None = None,
 ) -> tuple[
     list[Belief], list[str], list[str], list[str], list[list[str]],
 ]:
@@ -1003,6 +1121,7 @@ def retrieve_with_tiers(
     bfs_on = is_bfs_enabled(bfs_enabled)
     bm25f_on = resolve_use_bm25f_anchors(use_bm25f_anchors)
     weight = resolve_posterior_weight(posterior_weight)
+    heat_on = is_heat_kernel_enabled(heat_kernel_enabled)
     warn_placeholder_flags()
 
     locked: list[Belief] = store.list_locked_beliefs()
@@ -1038,6 +1157,7 @@ def retrieve_with_tiers(
             store, query,
             l1_limit=l1_limit, posterior_weight=weight,
             use_bm25f_anchors=bm25f_on, bm25f_cache=bm25f_cache,
+            eigenbasis_cache=eigenbasis_cache, heat_kernel_on=heat_on,
         )
         l1 = [
             b for b in raw_l1

--- a/tests/test_posterior_ranking_heat.py
+++ b/tests/test_posterior_ranking_heat.py
@@ -1,0 +1,258 @@
+# pyright: reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownParameterType=false, reportMissingTypeStubs=false, reportConstantRedefinition=false
+"""Tests for the heat-kernel composition path in retrieve() — Slice 2 of #151.
+
+These tests cover the wiring of `eigenbasis_cache` + `heat_kernel_enabled`
+through `retrieve()` -> `_l1_hits` -> `_heat_by_id` -> `combine_log_scores`.
+The pure spectral math is covered by `tests/test_heat_kernel.py`; this file
+exercises the retrieval-side dispatch and graceful-degrade contract.
+
+Test plan (per the design note):
+1. heat-off byte-identical to the no-heat-kwarg call (Slice 1 contract).
+2. heat-on with an unbuilt eigenbasis falls back byte-identically.
+3. heat-on with a built eigenbasis re-orders an authority graph as expected.
+4. cold belief (inserted after build) is rankable, gets HEAT_SCORE_FLOOR.
+5. store mutation flips `cache.is_stale()` and the next retrieval degrades.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aelfrice.graph_spectral import GraphEigenbasisCache
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_SUPPORTS,
+    LOCK_NONE,
+    Belief,
+    Edge,
+)
+from aelfrice.retrieval import retrieve
+from aelfrice.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _mk(bid: str, content: str, alpha: float = 1.0, beta: float = 1.0) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-29T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _build_authority_store() -> tuple[MemoryStore, str, str]:
+    """Three beliefs sharing the same query terms.
+
+    `hub` is supported by `s1` and `s2` (incoming SUPPORTS edges) so it
+    accumulates positive heat through the signed Laplacian. `iso` is
+    isolated with the same query-term overlap. Returns (store, hub_id,
+    iso_id).
+    """
+    s = MemoryStore(":memory:")
+    # `iso` has slightly higher BM25 score (extra term repetition) so at
+    # baseline it outranks `hub`. With heat on, the two SUPPORTS edges
+    # accumulating into `hub` should overcome the BM25 gap and lift it.
+    s.insert_belief(_mk("hub", "alpha beta gamma delta epsilon"))
+    s.insert_belief(_mk("s1", "alpha beta gamma delta epsilon"))
+    s.insert_belief(_mk("s2", "alpha beta gamma delta epsilon"))
+    s.insert_belief(_mk("iso", "alpha alpha beta beta gamma gamma delta epsilon"))
+    # Two incoming SUPPORTS into `hub`. SUPPORTS carries +1 weight in the
+    # signed-Laplacian convention so heat accumulates positively at `hub`.
+    s.insert_edge(Edge(src="s1", dst="hub", type=EDGE_SUPPORTS, weight=1.0))
+    s.insert_edge(Edge(src="s2", dst="hub", type=EDGE_SUPPORTS, weight=1.0))
+    return s, "hub", "iso"
+
+
+def _build_small_store() -> MemoryStore:
+    """Three beliefs, no edges — enough for the byte-identical contract."""
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("a", "rust ownership borrow checker"))
+    s.insert_belief(_mk("b", "rust ownership borrow checker"))
+    s.insert_belief(_mk("c", "rust ownership borrow checker"))
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — heat-off byte-identical to Slice 1 contract (AC4)
+# ---------------------------------------------------------------------------
+
+
+def test_heat_kernel_off_byte_identical_to_slice1() -> None:
+    """`heat_kernel_enabled=False` must match the no-kwarg call exactly."""
+    s = _build_small_store()
+    query = "rust ownership"
+
+    no_kwarg = retrieve(
+        s, query, l1_limit=10, entity_index_enabled=False, bfs_enabled=False,
+    )
+    explicit_off = retrieve(
+        s, query, l1_limit=10, entity_index_enabled=False, bfs_enabled=False,
+        heat_kernel_enabled=False,
+    )
+
+    assert [b.id for b in no_kwarg] == [b.id for b in explicit_off]
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — empty / unbuilt eigenbasis falls back (AC4 fallback)
+# ---------------------------------------------------------------------------
+
+
+def test_heat_kernel_empty_eigenbasis_falls_back(tmp_path: Path) -> None:
+    """heat_kernel_enabled=True with a never-built cache must match heat-off."""
+    s = _build_small_store()
+    query = "rust ownership"
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz")
+    # Critically: do NOT call cache.build(). eigvals stays None, the
+    # `_l1_hits` heat dispatch sees the None and degrades to the
+    # partial_bayesian_score path.
+
+    heat_off = retrieve(
+        s, query, l1_limit=10, entity_index_enabled=False, bfs_enabled=False,
+        heat_kernel_enabled=False,
+    )
+    heat_on_unbuilt = retrieve(
+        s, query, l1_limit=10, entity_index_enabled=False, bfs_enabled=False,
+        heat_kernel_enabled=True, eigenbasis_cache=cache,
+    )
+
+    assert [b.id for b in heat_off] == [b.id for b in heat_on_unbuilt]
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — heat-on changes ranking on a connected authority graph
+# ---------------------------------------------------------------------------
+
+
+def test_heat_kernel_changes_ranking_on_authority_graph(tmp_path: Path) -> None:
+    """With a built eigenbasis, the highly-supported `hub` should rank
+    above the isolated belief at otherwise-similar BM25.
+
+    Use posterior_weight=0.0 so the difference is purely the heat term.
+    """
+    s, hub_id, iso_id = _build_authority_store()
+    query = "alpha beta gamma"
+
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz")
+    cache.build()
+    assert cache.eigvals is not None  # sanity
+
+    heat_off = retrieve(
+        s, query, l1_limit=10, entity_index_enabled=False, bfs_enabled=False,
+        posterior_weight=0.0, heat_kernel_enabled=False,
+    )
+    heat_on = retrieve(
+        s, query, l1_limit=10, entity_index_enabled=False, bfs_enabled=False,
+        posterior_weight=0.0, heat_kernel_enabled=True, eigenbasis_cache=cache,
+    )
+
+    off_ids = [b.id for b in heat_off]
+    on_ids = [b.id for b in heat_on]
+
+    # Both calls return the same belief set.
+    assert set(off_ids) == set(on_ids)
+    # Heat propagation should reorder: the hub (two incoming SUPPORTS) must
+    # rank strictly above the isolated belief.
+    assert hub_id in on_ids and iso_id in on_ids
+    assert on_ids.index(hub_id) < on_ids.index(iso_id), (
+        f"hub {hub_id} should outrank isolated {iso_id} with heat on; got {on_ids}"
+    )
+    # And the heat-on ordering should differ from heat-off in at least one
+    # rank position (otherwise the term has no observable effect).
+    assert off_ids != on_ids, (
+        f"heat-on ordering identical to heat-off; expected at least one "
+        f"rank shift. off={off_ids} on={on_ids}"
+    )
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — cold belief inserted after build is rankable (HEAT_SCORE_FLOOR)
+# ---------------------------------------------------------------------------
+
+
+def test_heat_kernel_cold_belief_neutral(tmp_path: Path) -> None:
+    """A belief inserted after `cache.build()` is missing from
+    `cache.belief_ids`. The retrieval path must fall through to the
+    heat-off path (since `is_stale()` flips on insert) and still rank
+    the cold belief without crashing.
+    """
+    s = MemoryStore(":memory:")
+    for bid in ("a", "b", "c"):
+        s.insert_belief(_mk(bid, "rust ownership borrow checker"))
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz")
+    cache.build()
+    assert cache.belief_ids == ["a", "b", "c"]
+
+    # Insert AFTER build. Triggers the invalidation callback -> is_stale.
+    s.insert_belief(_mk("d", "rust ownership borrow checker"))
+    assert cache.is_stale() is True
+
+    results = retrieve(
+        s, "rust ownership", l1_limit=10,
+        entity_index_enabled=False, bfs_enabled=False,
+        heat_kernel_enabled=True, eigenbasis_cache=cache,
+    )
+    ids = [b.id for b in results]
+    # All four beliefs must be present and rankable; no crash.
+    assert set(ids) == {"a", "b", "c", "d"}
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — store mutation flips is_stale() and next retrieval degrades
+# ---------------------------------------------------------------------------
+
+
+def test_heat_kernel_cache_invalidation_on_store_mutation(tmp_path: Path) -> None:
+    """After `cache.build()` then any store mutation, `cache.is_stale()`
+    must be True and the heat dispatch must degrade to the heat-off path
+    (byte-identical to heat off).
+    """
+    s, hub_id, iso_id = _build_authority_store()
+    query = "alpha beta gamma"
+
+    cache = GraphEigenbasisCache(store=s, path=tmp_path / "eb.npz")
+    cache.build()
+    assert cache.is_stale() is False
+
+    # Mutate the store. Per `GraphEigenbasisCache.__post_init__` this
+    # registers an invalidation callback that flips `_stale` and clears
+    # eigvals/eigvecs/belief_ids.
+    s.insert_belief(_mk("new", "alpha beta gamma delta epsilon"))
+    assert cache.is_stale() is True
+    assert cache.eigvals is None
+
+    heat_off = retrieve(
+        s, query, l1_limit=10, entity_index_enabled=False, bfs_enabled=False,
+        posterior_weight=0.0, heat_kernel_enabled=False,
+    )
+    heat_on_stale = retrieve(
+        s, query, l1_limit=10, entity_index_enabled=False, bfs_enabled=False,
+        posterior_weight=0.0, heat_kernel_enabled=True, eigenbasis_cache=cache,
+    )
+
+    assert [b.id for b in heat_off] == [b.id for b in heat_on_stale]
+    # Defensive: the freshly-inserted belief participates in both rankings.
+    assert any(b.id == "new" for b in heat_on_stale)
+    # Silence unused-binding warnings on hub_id / iso_id.
+    assert hub_id and iso_id
+    s.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-x", "-q"])


### PR DESCRIPTION
<!--
v1.0 has shipped. Issues and PRs are open. Please align on approach via an issue first if the change adds new surface, alters the schema, or reintroduces a v2.0 feature. See CONTRIBUTING.md.
-->

## Summary

<!-- One-paragraph description of what this PR does. Focus on the "why," not the diff. -->

## Linked issues

<!-- Closes #N, references #M -->
<!-- If this PR has no associated issue, add the opt-out marker below to silence the CI advisory warning: -->
<!-- <!-- no-issue --> -->

## Type of change

- [ ] `feat:` — new feature
- [ ] `fix:` — bug fix
- [ ] `perf:` — performance improvement
- [ ] `refactor:` — code restructure with no behavior change
- [ ] `test:` — test-only change
- [ ] `docs:` — documentation-only change
- [ ] `build:` — build system / dependency / lockfile change
- [ ] `ci:` — CI workflow / hook change
- [ ] `release:` — version bump / release tag
- [ ] `chore:` — narrow housekeeping

## Verification

- [ ] `uv run pytest tests/ -x -q` — all green
- [ ] `uv run pyright src/` — strict, no new errors
- [ ] `uv run aelf --help` — surface unchanged (or change documented)
- [ ] CHANGELOG entry added under `[Unreleased]` (if user-visible)
- [ ] Docs updated (if surface or behavior changed)

## Test plan

<!-- Describe how to verify the change manually or what tests cover it. -->

## Notes for reviewer

<!-- Anything tricky, anything you punted, anything that needs a second opinion. -->

## Summary by Sourcery

Integrate heat-kernel graph authority into retrieval ranking behind a feature flag and wire it through retrieval, benchmarking, and CLI surfaces while preserving heat-off behavior.

New Features:
- Add optional heat-kernel authority term to L1 retrieval ranking via eigenbasis-backed propagation combined with BM25 and posterior scores.
- Expose heat-kernel composition controls in retrieve()/retrieve_with_tiers and CLI bench command, with configuration resolved through existing enablement helpers.

Enhancements:
- Extend posterior ranking benchmarks to optionally build and reuse eigenbasis caches per store, enabling evaluation of heat-kernel effects on MRR and ECE.
- Add an AC6 performance harness to measure heat-kernel overhead at 50k beliefs and validate latency budgets.

Documentation:
- Document Slice 2 heat-kernel composition, feature flag behavior, cost model, and degradation paths in the Bayesian ranking design doc.

Tests:
- Add retrieval-side tests for heat-kernel composition covering flag-off equivalence, empty and stale eigenbasis fallbacks, cold beliefs, and authority-driven re-ranking behavior.