### PR TITLE
ci: skip coderabbit auto-review on docs and release PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,12 @@ reviews:
     enabled: true
     drafts: false
     base_branches: ["main"]
+    # Skip auto-review on PR types where bot review adds no signal: pure docs
+    # changes and release/version-bump PRs. Sourcery still runs on these.
+    # Manual `@coderabbitai review` always works regardless of these filters.
+    ignore_title_keywords:
+      - "docs:"
+      - "release:"
   path_filters:
     - "!.planning/**"
     - "!docs/research/**"


### PR DESCRIPTION
## Summary
- Audit of last 30 merged PRs: CodeRabbit posts **zero inline signal** on pure-docs changes and `release:` PRs.
- Filter those titles out via `reviews.auto_review.ignore_title_keywords` so CR's review budget goes to `src:`/`feat:`/`fix:`/`ci:`/`refactor:` PRs where it has caught real bugs.
- Sourcery is unaffected; manual `@coderabbitai review` still works on any PR.

## Why this and not a label allowlist
A label-based opt-in was considered first but rejected — it requires remembering to label src PRs, and forgetting silently downgrades review quality. Title-prefix filtering keys off the existing conventional-commits convention so it's automatic.

## Test plan
- [ ] Open a `docs:` PR after merge — CR should not auto-review.
- [ ] Open a `feat:` or `fix:` PR — CR should auto-review as before.
- [ ] Comment `@coderabbitai review` on a `docs:` PR — manual override should still trigger a review.

Schema reference: https://docs.coderabbit.ai/reference/yaml-template (`reviews.auto_review.ignore_title_keywords`)

## Summary by Sourcery

CI:
- Configure CodeRabbit auto-review to ignore PRs with titles starting with `docs:` or `release:` while preserving manual review triggers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automatic code review configuration to skip reviews on pull requests with titles starting with `"docs:"` or `"release:"`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->