### PR TITLE
ci: add Harden-Runner audit step to all existing workflows

### DIFF
--- a/.github/workflows/auto-rebase-open-prs.yml
+++ b/.github/workflows/auto-rebase-open-prs.yml
@@ -26,6 +26,9 @@ jobs:
   rebase:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0

--- a/.github/workflows/auto-rebase-open-prs.yml
+++ b/.github/workflows/auto-rebase-open-prs.yml
@@ -26,7 +26,7 @@ jobs:
   rebase:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         python-version: ['3.12', '3.13']
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       matrix:
         python-version: ['3.12', '3.13']
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/post-release-docs-issue.yml
+++ b/.github/workflows/post-release-docs-issue.yml
@@ -12,6 +12,9 @@ jobs:
   open-sweep-issue:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
       - name: Open docs sweep tracking issue
         env:

--- a/.github/workflows/post-release-docs-issue.yml
+++ b/.github/workflows/post-release-docs-issue.yml
@@ -12,7 +12,7 @@ jobs:
   open-sweep-issue:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # full history so --generate-notes can diff against the prior tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,6 +15,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: release-drafter/release-drafter@7cf306f56b79636bb76931494ccf29fc893763bd # v6.1.0
         with:
           config-name: release-drafter.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: release-drafter/release-drafter@7cf306f56b79636bb76931494ccf29fc893763bd # v6.1.0

--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -17,7 +17,7 @@ jobs:
   secrets-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
   pattern-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
       BASE_REF: ${{ github.event.pull_request.base.ref }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4
@@ -118,7 +118,7 @@ jobs:
   release-docs-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4
@@ -175,7 +175,7 @@ jobs:
   commit-msg-prefix:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4
@@ -222,7 +222,7 @@ jobs:
   pr-body-issue-link:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: Check PR body for issue link

--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -17,6 +17,9 @@ jobs:
   secrets-scan:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -28,6 +31,9 @@ jobs:
   pattern-scan:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
       - name: Decode patterns
         env:
@@ -71,6 +77,9 @@ jobs:
       BASE_REF: ${{ github.event.pull_request.base.ref }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -109,6 +118,9 @@ jobs:
   release-docs-check:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -163,6 +175,9 @@ jobs:
   commit-msg-prefix:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -207,6 +222,9 @@ jobs:
   pr-body-issue-link:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Check PR body for issue link
         env:
           PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: Close Stale Issues

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,6 +13,9 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Close Stale Issues
         uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:


### PR DESCRIPTION
## Summary

Adds `step-security/harden-runner@v2` (audit mode) as the first step of every job in every existing workflow. Pairs with #325 which ships the same step in newly-added workflows.

| Workflow | Jobs covered |
|---|---|
| `ci.yml` | pytest |
| `staging-gate.yml` | secrets-scan, pattern-scan, history-scan, release-docs-check, commit-msg-prefix, pr-body-issue-link |
| `publish.yml` | publish (highest value — `id-token: write` + PyPI OIDC) |
| `post-release-docs-issue.yml` | open-sweep-issue |
| `release-drafter.yml` | update_release_draft |
| `stale.yml` | stale |
| `auto-rebase-open-prs.yml` | rebase (`contents: write`, force-pushes to PRs) |

Audit mode only — no behavior change. Captures the egress baseline so a future block-mode promotion can reject unexpected outbound traffic from a compromised action.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: every workflow run shows a `harden-runner` step at the top of each job
- [ ] After ~2 weeks of normal traffic: review egress baselines at app.stepsecurity.io and consider promoting high-risk workflows (publish, auto-rebase) to block mode

## Follow-up

Promotion to block mode is deliberately deferred. Audit-only first.

## Summary by Sourcery

CI:
- Enable step-security/harden-runner@v2 in audit mode at the start of every job across all GitHub Actions workflows to baseline egress traffic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added runner hardening across CI/CD and repository workflows to strengthen execution environment; egress policy set to "audit" for the new hardening step, applied consistently before workflow actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->