### PR TITLE
docs: close out hook-hardening (#280)

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -45,6 +45,7 @@ The default retrieval mode (recall, not audit) is correctly served by latest-ser
 - **No edit.** A wrong belief is corrected by inserting a new one with a `SUPERSEDES` edge; the original stays.
 - **No graph viz.** Inspect with `sqlite3 "$(python -c 'from aelfrice.cli import db_path; print(db_path())')"`.
 - **JSONL batch ingest has no PII scrubber.** `aelf ingest-transcript --batch ~/.claude/projects/` will pull whatever you typed in chat into the local belief graph. Review before backfilling.
+- **Hook framing relies on the model honoring the trust boundary.** The `UserPromptSubmit` hook ships three structural defenses (framing tag, render-time tag-substring escape, per-turn audit log — see [hook_hardening.md](hook_hardening.md) and [PHILOSOPHY § Trust boundary at the hook surface](PHILOSOPHY.md#trust-boundary-at-the-hook-surface)). What it cannot do is force the model to verify session artifacts named in user-turn text adjacent to the block, or guarantee the model treats `<belief>`-wrapped content as data rather than instruction. A model that ignores the framing is a model-layer failure, not a hook-layer one. The `hook_audit.jsonl` log is the recovery surface — it records what was injected so a human can review after the fact.
 
 ## Out of scope
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -75,6 +75,31 @@ A user lock short-circuits decay. The function returns `(α, β)` unchanged rega
 
 Hard locks ossify, though. So locks accumulate **demotion pressure** when contradicting evidence arrives; after enough independent contradictions (default 5), the lock auto-demotes to a regular belief. Durable when stable, self-correcting when wrong.
 
+## Trust boundary at the hook surface
+
+The `UserPromptSubmit` hook injects retrieved beliefs into the model's
+input on every turn. That makes the hook a privileged channel: anything
+inside or *adjacent to* the emitted block reads as elevated, system-trusted
+context to the model.
+
+The hook layer's job is to make that trust boundary structurally legible,
+not to police what the model does on the other side of it. Three structural
+defenses ship today: a fixed framing tag (`<belief id="…" lock="…">` inside
+`<aelfrice-memory>`) tells the model the contents are *retrieved memory,
+not instructions*; a render-time escape pass neutralises any tag-substring
+that lands in stored belief content; a per-turn audit log
+(`hook_audit.jsonl`) records the exact rendered block so post-hoc forensics
+can answer "what was injected on turn N." See
+[hook_hardening.md](hook_hardening.md) for the design memo.
+
+What the hook layer cannot do, by design: enforce that the model verifies
+named session artifacts before acting, or guarantee the model treats
+escaped tag-substrings as data. Those are model-behavior contracts. They
+belong in CLAUDE.md / AGENTS.md, not in `aelfrice` Python. A model that
+chooses to act on belief content as instruction *despite* the framing tag
+is a model-layer problem; aelfrice exposes the boundary, the model honors
+it.
+
 ## Local, always
 
 Your corrections live in one SQLite file on your machine. No cloud sync, no telemetry, no API calls in the retrieval path. The cloud LLM at the other end of your prompt sees whatever aelfrice injects — that's inherent — but aelfrice limits the slice (default 2,000 tokens, scoped to the current query) rather than dumping the whole memory.

--- a/docs/hook_hardening.md
+++ b/docs/hook_hardening.md
@@ -2,19 +2,29 @@
 
 ## Status
 
-**Partially shipped.**
+**Shipped.** All three ratified mitigations have landed; #280 closes
+on this PR.
 
 | Layer | State | Reference |
 |---|---|---|
 | Spec memo (this doc) | Landed | PR #292 |
 | Mitigation 1 — framing-tag contract | Landed | `_FRAMING_HEADER`, `<belief id=… lock=…>` inner element in `src/aelfrice/hook.py` (`_format_hits`, `_format_baseline_hits`) |
 | Mitigation 2 — render-time belief-content escape | Landed | `_escape_for_hook_block` in `src/aelfrice/hook.py` |
-| Mitigation 3 — per-turn audit log (`hook_audit.jsonl`) | Outstanding | Tracked in this section as PR2 |
+| Mitigation 3 — per-turn audit log (`hook_audit.jsonl`) | Landed | PR #314 — `_write_hook_audit_record` and `[hook_audit]` config in `src/aelfrice/hook.py`; tests in `tests/test_hook_audit.py` |
 
-The decision-asks below (lines 232-242) were tacitly ratified for
-mitigations 1+2 by the implementation landing alongside this doc. The
-mitigation-3 default-on / 10 MB / single-rotation contract remains the
-ratified shape for the outstanding PR2.
+The decision-asks below (lines 240-252) were ratified for all three
+mitigations by the implementations landing in #292 and #314.
+
+The two suggestions from the original #280 body that this memo
+declined — **reference-existence check protocol** (a model-behavior
+contract, not a hook-layer one) and **hook-side allowlist for belief
+shapes** (foot-gun: any regex strict enough to block attacks would
+also drop legitimate beliefs; render-time escape is the right shape)
+— remain declined. See `Recommendation summary` below for reasoning.
+The model-behavior side of "reference-existence check" is captured
+as a residual-risk note in `LIMITATIONS.md` and a trust-boundary
+paragraph in `PHILOSOPHY.md`, per the spec's own implementation
+tracker (lines 273-276).
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Closes #280. Three docs-only changes that close out the hook-hardening campaign:

- `docs/hook_hardening.md` — status table updated. Mitigation 3 (per-turn audit log) shipped via #314; that row was still showing "Outstanding". The closing paragraph also explicitly records that the two remaining suggestions from the original #280 body (model-side reference-existence check, hook-side allowlist) are declined per this same memo's reasoning.
- `docs/PHILOSOPHY.md` — new section *Trust boundary at the hook surface*. The spec's implementation tracker (`docs/hook_hardening.md` lines 273-276) called for this paragraph alongside the residual-risk note. Frames what the hook layer can and cannot enforce so future readers don't re-litigate the declined mitigations.
- `docs/LIMITATIONS.md` — Sharp-edges entry covering the residual model-layer risk: hook framing relies on the model honoring the trust boundary; the audit log is the recovery surface.

## Why this shape

The original #280 report listed four suggested mitigations. The ratified spec memo (`docs/hook_hardening.md`, landed in #292) accepted three (framing-tag contract, render-time tag-substring escape, per-turn audit log) and explicitly declined two:

- **Reference-existence check protocol inside the model** — declined because the hook is a Python script that runs before the model thinks; it cannot enforce model verification of named session artifacts. That is a model-behavior contract and belongs in CLAUDE.md / AGENTS.md, not in `aelfrice`.
- **Hook-side allowlist for belief shapes** — declined because `belief.content` is arbitrary user / ingest text by design. Any allowlist regex strict enough to block attacks would also drop legitimate beliefs; render-time escape (mitigation 2) is the right shape.

Both declinations are on lines 103-116 of the existing spec; this PR just makes the close-out structurally legible (status table reflects ship state, residual risk noted in `LIMITATIONS.md`, trust-boundary framing in `PHILOSOPHY.md`).

## Test plan

- [x] Docs-only diff. No code under `src/` touched. No test files touched.
- [x] Discretion grep on diff: clean.

## Out of scope

Anything that would require re-opening the spec's declined-mitigation reasoning. If new evidence shows the declinations were wrong, that's a fresh spec re-ratification cycle, not a follow-up to this PR.

## Summary by Sourcery

Document the shipped state and trust boundary of the UserPromptSubmit hook and its mitigations, and record the residual model-layer risk.

Documentation:
- Update hook hardening status to mark all ratified mitigations as shipped and explicitly record declined suggestions from the original report.
- Add philosophy documentation describing the trust boundary at the hook surface and clarifying which responsibilities belong to the hook layer versus the model.
- Extend limitations documentation with a sharp-edges note on residual model-layer risk and the role of the hook audit log as the recovery surface.