### PR TITLE
build: drop tomli fallback, use stdlib tomllib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,9 +137,6 @@ DEP002 = [
 # DEP001: `benchmarks` is the in-repo top-level package imported via the
 # pytest pythonpath shim; not a PyPI dependency.
 DEP001 = ["benchmarks"]
-# DEP003: tomli is the Py 3.10 fallback for stdlib tomllib in
-# src/aelfrice/deferred_feedback.py. Drops when Py 3.10 support drops.
-DEP003 = ["tomli"]
 
 [dependency-groups]
 dev = [

--- a/src/aelfrice/deferred_feedback.py
+++ b/src/aelfrice/deferred_feedback.py
@@ -43,10 +43,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import IO, Any, Final
 
-try:
-    import tomllib
-except ImportError:  # pragma: no cover - py < 3.11 fallback path
-    import tomli as tomllib  # type: ignore[no-redef]
+import tomllib
 
 from aelfrice.store import MemoryStore
 


### PR DESCRIPTION
## Summary

Issue #330 option A. `requires-python = ">=3.12"` makes the `tomli` fallback in `src/aelfrice/deferred_feedback.py` unreachable (stdlib `tomllib` ships in 3.11+). Drop the try/except and the corresponding DEP003 allowlist entry.

## Changes

- `src/aelfrice/deferred_feedback.py:46-49` → single `import tomllib`.
- `pyproject.toml`: remove DEP003 = ["tomli"] entry under `[tool.deptry.per_rule_ignores]`.

## Verification

- Module imports clean (`from aelfrice import deferred_feedback`).
- `deptry .` shows no DEP003 hit (only unrelated pre-existing DEP001 on `longmemeval_adapter`, tracked separately under #329's sibling work).
- Targeted tests: 29 passed (`-k "deferred or implicit_feedback or grace_window"`).
- Discretion grep clean.

Closes #330.

## Summary by Sourcery

Drop the legacy tomli fallback now that the project targets Python versions with stdlib tomllib and clean up related configuration.

Enhancements:
- Simplify deferred feedback module imports to rely solely on stdlib tomllib, removing the obsolete tomli fallback.

Build:
- Remove the deptry DEP003 ignore for tomli from pyproject.toml, reflecting the removal of the tomli fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed redundant dependency configuration entry, streamlining dependency management.
  * Updated import handling to use the standard library approach, improving code simplicity and reducing external dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->