### PR TITLE
build: PEP 735 dep group for dev tooling (closes #328 dev portion)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,5 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - run: uv sync --frozen --extra dev --extra archive
+      - run: uv sync --frozen --group dev --extra archive
       - run: uv run pytest tests/ -q

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - run: uv sync --frozen --extra dev --extra archive
+      - run: uv sync --frozen --group dev --extra archive
       - name: Install mutmut
         run: uv pip install mutmut
       - name: Run mutation tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0  # full history so --generate-notes can diff against the prior tag
       - uses: astral-sh/setup-uv@v5
-      - run: uv sync --frozen --extra dev --extra archive
+      - run: uv sync --frozen --group dev --extra archive
       - run: uv run pytest tests/ -q
       - run: uv build
       - uses: actions/attest-build-provenance@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,6 @@ aelf-search-tool-hook = "aelfrice.hook_search_tool:main"
 aelf-session-start-hook = "aelfrice.hook:main_session_start"
 
 [project.optional-dependencies]
-dev = [
-    "pytest>=8.0",
-    "pytest-timeout>=2.3",
-    "pyright>=1.1.409",
-]
 mcp = [
     "fastmcp>=0.2.0",
 ]
@@ -129,13 +124,11 @@ reportMissingTypeStubs = false
 known_first_party = ["aelfrice", "benchmarks"]
 
 [tool.deptry.per_rule_ignores]
-# DEP002: declared but not imported by src/. These are dev/test/bench-only
-# but live in [project.dependencies] for now; reorganizing into PEP 735
-# groups is tracked as a follow-up issue.
+# DEP002: declared in `[project.optional-dependencies.benchmarks]` extras
+# but not imported by src/aelfrice. They are imported only by
+# `benchmarks/` adapters; the extras stay because `pip install
+# -e ".[benchmarks]"` is a documented contract (benchmarks/README.md).
 DEP002 = [
-    "pytest",
-    "pytest-timeout",
-    "pyright",
     "nltk",
     "tiktoken",
     "datasets",
@@ -150,5 +143,7 @@ DEP003 = ["tomli"]
 
 [dependency-groups]
 dev = [
+    "pytest>=8.0",
+    "pytest-timeout>=2.3",
     "pyright>=1.1.409",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -29,11 +29,6 @@ benchmarks = [
     { name = "nltk" },
     { name = "tiktoken" },
 ]
-dev = [
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-timeout" },
-]
 mcp = [
     { name = "fastmcp" },
 ]
@@ -44,6 +39,8 @@ onboard-llm = [
 [package.dev-dependencies]
 dev = [
     { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-timeout" },
 ]
 
 [package.metadata]
@@ -55,16 +52,17 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'benchmarks'", specifier = ">=0.20" },
     { name = "nltk", marker = "extra == 'benchmarks'", specifier = ">=3.9" },
     { name = "numpy", specifier = ">=2.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.409" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "scipy", specifier = ">=1.11" },
     { name = "tiktoken", marker = "extra == 'benchmarks'", specifier = ">=0.7" },
 ]
-provides-extras = ["dev", "mcp", "onboard-llm", "archive", "benchmarks"]
+provides-extras = ["mcp", "onboard-llm", "archive", "benchmarks"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pyright", specifier = ">=1.1.409" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.409" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
+]
 
 [[package]]
 name = "aiofile"


### PR DESCRIPTION
## Summary

Closes the dev portion of #328: moves `pytest`, `pytest-timeout`, `pyright` from `[project.optional-dependencies.dev]` into `[dependency-groups.dev]` (PEP 735), drops their DEP002 deptry ignores, and updates CI workflows (`ci.yml`, `mutation.yml`, `publish.yml`) to install via `--group dev` instead of `--extra dev`.

## Why

deptry was flagging dev tooling as DEP002 (declared-but-not-imported) because optional extras count as "project dependencies" from deptry's perspective. PEP 735 dependency groups don't, so the ignores can go.

## Bench portion deferred

#328 also asked to move `nltk`/`tiktoken`/`datasets`/`huggingface_hub` to a `[dependency-groups.bench]` group. Skipped: `pip install -e ".[benchmarks]"` is a documented contract (`benchmarks/README.md`), and PEP 735 dep groups are not publishable extras. Their DEP002 ignores stay; comment in `[tool.deptry.per_rule_ignores]` now explains why. Filed as a comment on #328 — the issue stays open or gets rescoped.

## Verification

- `uv lock` regenerated.
- `uv sync --frozen --group dev --extra archive` installs cleanly.
- `uvx deptry src` (CI invocation) → "Success! No dependency issues found."
- Full pytest suite: 1982 passed, 18 skipped.

Closes #328 (dev portion).

## Summary by Sourcery

Move development tooling dependencies to a PEP 735 dependency group and update CI to install from that group instead of an optional extra.

Enhancements:
- Reorganize dev tooling dependencies (pytest, pytest-timeout, pyright) from project optional extras into a PEP 735 `[dependency-groups.dev]` group.
- Clarify deptry DEP002 ignore configuration to document why benchmark extras remain and are not imported from the main src package.

CI:
- Update CI workflows to install development dependencies via `uv sync --group dev` instead of `--extra dev`.