### PR TITLE
chore: remove unused CORROBORATION_SOURCE_HOOK_INGEST

### DIFF
--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -81,7 +81,6 @@ ORIGINS: Final[frozenset[str]] = frozenset({
 CORROBORATION_SOURCE_COMMIT_INGEST: Final[str] = "commit_ingest"
 CORROBORATION_SOURCE_TRANSCRIPT_INGEST: Final[str] = "transcript_ingest"
 CORROBORATION_SOURCE_MCP_REMEMBER: Final[str] = "mcp_remember"
-CORROBORATION_SOURCE_HOOK_INGEST: Final[str] = "hook_ingest"
 # filesystem_ingest: scanner / onboard paths that read local files
 # (not git history). Distinct from transcript_ingest (conversation
 # turns) and commit_ingest (git history).
@@ -100,7 +99,6 @@ CORROBORATION_SOURCE_TYPES: Final[frozenset[str]] = frozenset({
     CORROBORATION_SOURCE_COMMIT_INGEST,
     CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
     CORROBORATION_SOURCE_MCP_REMEMBER,
-    CORROBORATION_SOURCE_HOOK_INGEST,
     CORROBORATION_SOURCE_FILESYSTEM_INGEST,
     CORROBORATION_SOURCE_CLI_REMEMBER,
     CORROBORATION_SOURCE_CONSOLIDATION_MIGRATION,

--- a/tests/test_corroborations.py
+++ b/tests/test_corroborations.py
@@ -15,7 +15,6 @@ from aelfrice.ingest import ingest_turn
 from aelfrice.models import (
     BELIEF_FACTUAL,
     CORROBORATION_SOURCE_COMMIT_INGEST,
-    CORROBORATION_SOURCE_HOOK_INGEST,
     CORROBORATION_SOURCE_MCP_REMEMBER,
     CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
     CORROBORATION_SOURCE_TYPES,
@@ -249,19 +248,17 @@ def test_different_source_types_record_distinctly() -> None:
         store.record_corroboration("b1", source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST)
         store.record_corroboration("b1", source_type=CORROBORATION_SOURCE_COMMIT_INGEST)
         store.record_corroboration("b1", source_type=CORROBORATION_SOURCE_MCP_REMEMBER)
-        store.record_corroboration("b1", source_type=CORROBORATION_SOURCE_HOOK_INGEST)
 
-        assert store.count_corroborations("b1") == 4
+        assert store.count_corroborations("b1") == 3
 
         rows = store.list_corroborations("b1")
-        assert len(rows) == 4
+        assert len(rows) == 3
         # rows are (ingested_at, source_type, session_id, source_path_hash)
         recorded_types = {r[1] for r in rows}
         assert recorded_types == {
             CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
             CORROBORATION_SOURCE_COMMIT_INGEST,
             CORROBORATION_SOURCE_MCP_REMEMBER,
-            CORROBORATION_SOURCE_HOOK_INGEST,
         }
     finally:
         store.close()
@@ -277,7 +274,6 @@ def test_source_type_enum_covers_all_variants() -> None:
         "commit_ingest",
         "transcript_ingest",
         "mcp_remember",
-        "hook_ingest",
         "filesystem_ingest",
         "cli_remember",
         "consolidation_migration",


### PR DESCRIPTION
## Summary

`CORROBORATION_SOURCE_HOOK_INGEST` (`models.py:84`, value `"hook_ingest"`) has no production caller. Git-history hooks route through `commit_ingest`; filesystem and transcript hooks use their own constants. The value was vestigial since v1.5.0.

Audited four production stores (`~/projects/aelfrice/.git/aelfrice/memory.db`, `~/projects/aelfrice-lab/.git/aelfrice/memory.db`, `~/projects/work-stuff/.git/aelfrice/memory.db`, `~/.aelfrice/memory.db`) — zero rows with `source_type='hook_ingest'`. Removing the constant is contract-clean.

Drops the constant + frozenset entry; updates `tests/test_corroborations.py` (one assertion uses three source types instead of four; enum-coverage test reflects the new set).

## Context

Surfaced while resolving #190 (closed). Pre-existing audit at last session's handoff.

## Test plan
- [x] `tests/test_corroborations.py` 18/18 passing
- [x] `tests/test_insert_or_corroborate.py` 8/8 passing
- [x] Full suite: 1979 passed, 20 skipped (one env-specific deselect for `test_serve_raises_clear_error_when_fastmcp_missing` — passes in main repo without fastmcp installed; failure is env shape, not code)
- [x] Production-store audit: zero `hook_ingest` rows

## Summary by Sourcery

Remove an unused corroboration source type and update tests accordingly.

Enhancements:
- Remove the deprecated CORROBORATION_SOURCE_HOOK_INGEST constant and its inclusion in the corroboration source set.

Tests:
- Adjust corroboration source tests to reflect the reduced set of valid source types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated corroboration source types: removed hook ingest and added commit ingest, transcript ingest, and mcp remember to the supported set.

* **Tests**
  * Updated test cases to align with changes in corroboration source type configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->