### PR TITLE
fix: drop dead `tomli` fallback (closes #330)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,9 +137,6 @@ DEP002 = [
 # DEP001: `benchmarks` is the in-repo top-level package imported via the
 # pytest pythonpath shim; not a PyPI dependency.
 DEP001 = ["benchmarks"]
-# DEP003: tomli is the Py 3.10 fallback for stdlib tomllib in
-# src/aelfrice/deferred_feedback.py. Drops when Py 3.10 support drops.
-DEP003 = ["tomli"]
 
 [dependency-groups]
 dev = [

--- a/src/aelfrice/deferred_feedback.py
+++ b/src/aelfrice/deferred_feedback.py
@@ -43,10 +43,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import IO, Any, Final
 
-try:
-    import tomllib
-except ImportError:  # pragma: no cover - py < 3.11 fallback path
-    import tomli as tomllib  # type: ignore[no-redef]
+import tomllib
 
 from aelfrice.store import MemoryStore
 


### PR DESCRIPTION
## Summary

`pyproject.toml` declares `requires-python = ">=3.12"`. Stdlib `tomllib` arrived in 3.11. The `try: import tomllib / except ImportError: import tomli` fallback in `src/aelfrice/deferred_feedback.py:46-49` is therefore unreachable code. Replace with the direct stdlib import and drop the matching DEP003 deptry ignore.

## Verification

- `uv run pytest tests/ -q` → 1982 passed, 18 skipped.
- `uvx deptry src` → "Success! No dependency issues found."
- `git grep -n tomli` → only the now-removed comment in the deptry config block; no remaining `tomli` references.

Closes #330.

## Summary by Sourcery

Remove the obsolete tomli fallback now that the project targets Python 3.12+ and clean up the corresponding dependency tooling configuration.

Enhancements:
- Simplify configuration loading by importing tomllib directly and removing the legacy tomli fallback path.

Build:
- Remove the deptry DEP003 ignore entry for tomli now that it is no longer used or required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Python version requirement to 3.11 or later. The application now uses only the built-in `tomllib` module, removing support for legacy Python compatibility fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->