### PR TITLE
build: drop dead `tomli` fallback (closes #330)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,9 +137,6 @@ DEP002 = [
 # DEP001: `benchmarks` is the in-repo top-level package imported via the
 # pytest pythonpath shim; not a PyPI dependency.
 DEP001 = ["benchmarks"]
-# DEP003: tomli is the Py 3.10 fallback for stdlib tomllib in
-# src/aelfrice/deferred_feedback.py. Drops when Py 3.10 support drops.
-DEP003 = ["tomli"]
 
 [dependency-groups]
 dev = [

--- a/src/aelfrice/deferred_feedback.py
+++ b/src/aelfrice/deferred_feedback.py
@@ -43,10 +43,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import IO, Any, Final
 
-try:
-    import tomllib
-except ImportError:  # pragma: no cover - py < 3.11 fallback path
-    import tomli as tomllib  # type: ignore[no-redef]
+import tomllib
 
 from aelfrice.store import MemoryStore
 


### PR DESCRIPTION
## Summary

Closes #330 option A. `pyproject.toml` declares `requires-python = ">=3.12"`, so the `tomli` fallback in `src/aelfrice/deferred_feedback.py:46-49` is unreachable (stdlib `tomllib` ships in 3.11+). Drop the try/except and the matching DEP003 deptry ignore.

## Why a third PR

Prior #332 and #337 had byte-identical diffs but the auto-rebase workflow rewrote both as `github-actions[bot]` (no signing key), and the branch ruleset requires signed commits. Result: neither was mergeable. This PR re-applies the same change as a freshly signed commit so it can land. Filing the auto-rebase signing strip as a separate ruleset/CI bug.

## Verification

- `uv run python -c "from aelfrice import deferred_feedback"` → import ok.
- `uvx deptry src` → "Success! No dependency issues found."
- Discretion grep clean.

Closes #330. Supersedes #332 and #337.

## Summary by Sourcery

Remove the obsolete tomli fallback now that the project requires Python 3.12+ and relies solely on the standard-library tomllib.

Enhancements:
- Simplify deferred feedback configuration by dropping dead code related to tomli fallback.

Build:
- Clean up deptry configuration by removing the unused DEP003 ignore entry for tomli.