### PR TITLE
ci: SHA-pin third-party actions in #325 bundle workflows (closes #331)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         language: [python, actions]
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4

--- a/.github/workflows/deadcode.yml
+++ b/.github/workflows/deadcode.yml
@@ -17,11 +17,11 @@ jobs:
   deptry:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -30,11 +30,11 @@ jobs:
   vulture:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -17,13 +17,13 @@ jobs:
   lychee:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4
       - name: Run lychee
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >-
             --no-progress
@@ -35,7 +35,7 @@ jobs:
           fail: false
       - name: Open issue on failure
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
         with:
           title: "link-check: broken links detected"
           content-filepath: ./lychee/out.md

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 240
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -15,8 +15,8 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@master
+      - uses: crate-ci/typos@bbaefadf97b0ec5fdc942684b647f1a6ab250274 # v1.46.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,11 +25,11 @@ jobs:
   zizmor:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
       - name: Run zizmor
         run: uvx zizmor --format sarif . > zizmor.sarif
         continue-on-error: true


### PR DESCRIPTION
## Summary

Closes #331. SHA-pin every third-party action invocation in the 6 bundle workflows added by #325. Each pinned line keeps a `# <tag>` trailing comment for human readability.

## Pins

| Action | Resolved tag | SHA |
|---|---|---|
| `crate-ci/typos` | v1.46.0 | `bbaefadf97b0ec5fdc942684b647f1a6ab250274` |
| `step-security/harden-runner` | v2.19.0 | `8d3c67de8e2fe68ef647c8db1e6a09f647780f40` |
| `astral-sh/setup-uv` | v5.4.2 | `d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86` |
| `lycheeverse/lychee-action` | v2.8.0 | `8646ba30535128ac92d33dfc9133794bfdd9b411` |
| `peter-evans/create-issue-from-file` | v5.0.1 | `e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd` |

First-party `actions/*` (checkout, upload-artifact, github/codeql-action/*) left as `@vN` per GitHub guidance.

## Anchoring

Each pin resolves to the latest release within the workflow's current major (e.g. setup-uv pinned to v5.4.2 even though v8.1.0 exists). Major bumps are a separate decision and out of scope for this sweep.

## Verification

- `crate-ci/typos@master` is gone.
- All 6 workflow YAML files parse.
- Discretion grep clean.

Closes #331.

## Summary by Sourcery

CI:
- Update six bundle workflows to replace version-tagged third-party actions with SHA-pinned references annotated with their corresponding release tags.