### PR TITLE
fix: rename merge-conflict label refs to attn:merge-conflict in flag-stale workflow

### DIFF
--- a/.github/workflows/flag-stale-open-prs.yml
+++ b/.github/workflows/flag-stale-open-prs.yml
@@ -1,7 +1,7 @@
 name: flag-stale-open-prs
 
 # When main moves, label every open PR whose branch is behind main as
-# `merge-conflict` and post a one-time rebase prompt. Authors rebase
+# `attn:merge-conflict` and post a one-time rebase prompt. Authors rebase
 # locally and force-push (preserving their signatures).
 #
 # Why not auto-rebase: the workflow runs as `github-actions[bot]`, which
@@ -55,7 +55,7 @@ jobs:
               num=$(echo "$data"   | jq -r .number)
               head=$(echo "$data"  | jq -r .headRefName)
               cross=$(echo "$data" | jq -r .isCrossRepository)
-              has_conflict_label=$(echo "$data" | jq -r '[.labels[].name] | index("merge-conflict") != null')
+              has_conflict_label=$(echo "$data" | jq -r '[.labels[].name] | index("attn:merge-conflict") != null')
               echo "=== PR #$num: $head (fork=$cross) ==="
 
               # Skip fork PRs — we don't manage their branches.
@@ -70,13 +70,13 @@ jobs:
                   echo "  already on top of main, skip"
                   # Clear stale label if the author has caught up.
                   if [ "$has_conflict_label" = "true" ]; then
-                      gh pr edit "$num" --remove-label merge-conflict 2>/dev/null || true
+                      gh pr edit "$num" --remove-label attn:merge-conflict 2>/dev/null || true
                   fi
                   continue
               fi
 
               echo "  behind main, flag for manual rebase"
-              gh pr edit "$num" --add-label merge-conflict 2>/dev/null || true
+              gh pr edit "$num" --add-label attn:merge-conflict 2>/dev/null || true
 
               # Only post the prompt the first time the label is applied;
               # avoids spamming long-lived stale PRs on every main push.


### PR DESCRIPTION
## What

Rename four `merge-conflict` label references in `.github/workflows/flag-stale-open-prs.yml` to `attn:merge-conflict`.

## Why

The bare `merge-conflict` label does not exist in this repository — `gh label list` shows only `attn:*` flags (`attn:review`, `attn:unblock`, `attn:decision`, `attn:merge-conflict`). All four `gh pr edit --add-label`/`--remove-label` calls were silent no-ops thanks to `2>/dev/null || true`.

Net effect: open PRs that fell behind `main` were never flagged, so the §3 CONFLICT path in `aelf-scan.sh` (which queries `attn:merge-conflict`) never fired automatically. The flag had to be applied by hand.

## Diff

Four sites in the workflow, plus the comment on line 4:
- L4   doc comment
- L58  `has_conflict_label` lookup
- L73  remove-label on catch-up
- L79  add-label on stale

## Verification

- `gh label list --search merge-conflict` → returns no bare label.
- `gh label list --search attn` → confirms `attn:merge-conflict` exists.
- `grep -n attn:merge-conflict .github/workflows/flag-stale-open-prs.yml` → all four sites updated.
- No other repo refs to bare `merge-conflict` outside the workflow (the two `docs/issue_priority_dag.md` hits are literal "merge conflict" prose, not labels).

## Out of scope

The forward-looking question of whether `attn:merge-conflict` is the right name long-term (vs. `attn:stale` or `attn:rebase-needed`) — keeping it aligned with the existing `attn:*` set as shipped.

## Summary by Sourcery

Bug Fixes:
- Update stale-PR workflow to use the existing `attn:merge-conflict` label instead of a non-existent `merge-conflict` label so conflicted PRs are properly flagged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the label applied to pull requests with merge conflicts from `merge-conflict` to `attn:merge-conflict` to improve consistency with project labeling conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->