### PR TITLE
feat(lifecycle): warn when multiple aelfrice installs are reachable

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -105,6 +105,7 @@ from aelfrice.lifecycle import (
     clear_cache as _clear_update_cache,
     format_update_banner as _format_update_banner,
     is_disabled as _update_check_disabled,
+    detect_reachable_installs,
     is_newer,
     maybe_check_for_update_async,
     read_cache as _read_update_cache,
@@ -1798,6 +1799,36 @@ _UPGRADE_CONTEXT_NOTE: dict[str, str] = {
 }
 
 
+_INSTALL_SITE_LABEL: dict[str, str] = {
+    "uv_tool": "uv tool",
+    "pipx": "pipx",
+    "user_local_bin": "user-local",
+}
+
+
+def _format_multi_install_warning(
+    sites: list, active_context: str
+) -> list[str]:
+    """Format a multi-install warning block, or return [] if not warranted.
+
+    `sites` is the output of `lifecycle.detect_reachable_installs()`.
+    Warning fires only when more than one distinct site is detected.
+    """
+    if len(sites) < 2:
+        return []
+    lines = ["warning: multiple aelfrice installs detected:"]
+    for site in sites:
+        marker = " (on PATH)" if site.on_path else ""
+        label = _INSTALL_SITE_LABEL.get(site.kind, site.kind)
+        lines.append(f"  - {label}: {site.path}{marker}")
+    lines.append(
+        f"upgrading the active install ({active_context}) will not change "
+        "`which aelf` if a different install is on PATH."
+    )
+    lines.append("remove the stale install before upgrading.")
+    return lines
+
+
 def _cmd_upgrade(args: argparse.Namespace, out: object) -> int:
     """Print the right upgrade command for this install context.
 
@@ -1810,6 +1841,11 @@ def _cmd_upgrade(args: argparse.Namespace, out: object) -> int:
     a yes/no answer without copy-paste material.
     """
     advice = upgrade_advice()
+    multi_warning = _format_multi_install_warning(
+        detect_reachable_installs(), advice.context
+    )
+    for line in multi_warning:
+        print(line, file=out)  # type: ignore[arg-type]
     # Force a fresh sync check unless explicitly disabled. This is the
     # one CLI surface where the user has explicitly asked about updates,
     # so we ignore the cache TTL.

--- a/src/aelfrice/lifecycle.py
+++ b/src/aelfrice/lifecycle.py
@@ -403,6 +403,112 @@ def upgrade_advice() -> UpgradeAdvice:
     )
 
 
+# --- Multi-install detection -------------------------------------------
+
+
+@dataclass(frozen=True)
+class InstallSite:
+    """A reachable aelfrice install location on disk.
+
+    `kind` is one of 'uv_tool', 'pipx', 'user_local_bin'. `path` is the
+    install root (uv_tool/pipx) or the executable path (user_local_bin).
+    `on_path` is True when this site's executable is what `aelf` resolves
+    to on PATH — i.e. the install the user gets when they type `aelf`.
+    """
+
+    kind: str
+    path: Path
+    on_path: bool
+
+
+def _which_all_aelf() -> list[Path]:
+    """Return every `aelf` executable reachable on PATH, in PATH order.
+
+    POSIX-only. We walk PATH ourselves rather than rely on `which -a`,
+    which is not portable across shells. Skips non-files and
+    non-executables.
+    """
+    seen: set[Path] = set()
+    out: list[Path] = []
+    raw = os.environ.get("PATH", "")
+    for entry in raw.split(os.pathsep):
+        if not entry:
+            continue
+        candidate = Path(entry) / "aelf"
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        if resolved in seen:
+            continue
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            seen.add(resolved)
+            out.append(candidate)
+    return out
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    """True if `child` is `parent` or a descendant. Symlink-resolved."""
+    try:
+        child_r = child.resolve()
+        parent_r = parent.resolve()
+    except OSError:
+        return False
+    try:
+        child_r.relative_to(parent_r)
+        return True
+    except ValueError:
+        return False
+
+
+def detect_reachable_installs() -> list[InstallSite]:
+    """Best-effort enumeration of aelfrice installs visible on this system.
+
+    Detection is purely filesystem + PATH inspection — no shelling out.
+    Returns an empty list on any failure (e.g. unreadable home dir).
+
+    Signals checked:
+      - ~/.local/share/uv/tools/aelfrice/  → uv_tool
+      - ~/.local/pipx/venvs/aelfrice/      → pipx
+      - any `aelf` on PATH whose resolved path is NOT under the above
+        roots                              → user_local_bin
+    """
+    sites: list[InstallSite] = []
+    try:
+        home = Path.home()
+    except (OSError, RuntimeError):
+        return sites
+
+    path_aelf_resolved: set[Path] = set()
+    for exe in _which_all_aelf():
+        try:
+            path_aelf_resolved.add(exe.resolve())
+        except OSError:
+            continue
+
+    uv_root = home / ".local" / "share" / "uv" / "tools" / PACKAGE_NAME
+    if uv_root.exists():
+        on_path = any(
+            _path_is_under(p, uv_root) for p in path_aelf_resolved
+        )
+        sites.append(InstallSite(kind="uv_tool", path=uv_root, on_path=on_path))
+
+    pipx_root = home / ".local" / "pipx" / "venvs" / PACKAGE_NAME
+    if pipx_root.exists():
+        on_path = any(
+            _path_is_under(p, pipx_root) for p in path_aelf_resolved
+        )
+        sites.append(InstallSite(kind="pipx", path=pipx_root, on_path=on_path))
+
+    known_roots = [uv_root, pipx_root]
+    for exe in path_aelf_resolved:
+        if any(_path_is_under(exe, root) for root in known_roots):
+            continue
+        sites.append(InstallSite(kind="user_local_bin", path=exe, on_path=True))
+
+    return sites
+
+
 # --- Uninstall ----------------------------------------------------------
 
 ARCHIVE_MAGIC: Final[bytes] = b"AELFENC1"  # 8 bytes, format identifier

--- a/tests/test_upgrade_ux.py
+++ b/tests/test_upgrade_ux.py
@@ -234,3 +234,128 @@ def test_upgrade_advice_routing(
     advice = lifecycle.upgrade_advice()
     assert advice.context == expected_context
     assert advice.command == expected_cmd_fragment
+
+
+# ---------------------------------------------------------------------------
+# detect_reachable_installs — multi-install warning (issue #345)
+# ---------------------------------------------------------------------------
+
+
+def _make_aelf_exe(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(0o755)
+
+
+def test_reachable_installs_empty_when_nothing_installed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setenv("PATH", str(tmp_path / "empty_bin"))
+    assert lifecycle.detect_reachable_installs() == []
+
+
+def test_reachable_installs_single_uv_tool_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    uv_root = tmp_path / ".local" / "share" / "uv" / "tools" / "aelfrice"
+    uv_root.mkdir(parents=True)
+    monkeypatch.setenv("PATH", str(tmp_path / "empty_bin"))
+    sites = lifecycle.detect_reachable_installs()
+    assert [(s.kind, s.on_path) for s in sites] == [("uv_tool", False)]
+
+
+def test_reachable_installs_uv_tool_on_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    uv_root = tmp_path / ".local" / "share" / "uv" / "tools" / "aelfrice"
+    uv_bin_dir = uv_root / "bin"
+    _make_aelf_exe(uv_bin_dir / "aelf")
+    monkeypatch.setenv("PATH", str(uv_bin_dir))
+    sites = lifecycle.detect_reachable_installs()
+    assert [(s.kind, s.on_path) for s in sites] == [("uv_tool", True)]
+
+
+def test_reachable_installs_dual_uv_tool_plus_user_local_bin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Repro from issue #318: uv-tool install + stale ~/.local/bin/aelf on PATH.
+
+    Both installs detected; the user_local_bin one is marked on_path,
+    the uv_tool one is not.
+    """
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    uv_root = tmp_path / ".local" / "share" / "uv" / "tools" / "aelfrice"
+    uv_root.mkdir(parents=True)
+    user_bin = tmp_path / ".local" / "bin"
+    _make_aelf_exe(user_bin / "aelf")
+    monkeypatch.setenv("PATH", str(user_bin))
+
+    sites = lifecycle.detect_reachable_installs()
+    by_kind = {s.kind: s for s in sites}
+    assert set(by_kind) == {"uv_tool", "user_local_bin"}
+    assert by_kind["uv_tool"].on_path is False
+    assert by_kind["user_local_bin"].on_path is True
+    assert by_kind["user_local_bin"].path == user_bin / "aelf"
+
+
+def test_reachable_installs_pipx_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    pipx_root = tmp_path / ".local" / "pipx" / "venvs" / "aelfrice"
+    pipx_root.mkdir(parents=True)
+    monkeypatch.setenv("PATH", str(tmp_path / "empty_bin"))
+    sites = lifecycle.detect_reachable_installs()
+    assert [(s.kind, s.on_path) for s in sites] == [("pipx", False)]
+
+
+def test_format_multi_install_warning_silent_when_single(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from aelfrice import cli
+
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    uv_root = tmp_path / ".local" / "share" / "uv" / "tools" / "aelfrice"
+    uv_root.mkdir(parents=True)
+    monkeypatch.setenv("PATH", str(tmp_path / "empty_bin"))
+    sites = lifecycle.detect_reachable_installs()
+    assert cli._format_multi_install_warning(sites, "uv_tool") == []
+
+
+def test_format_multi_install_warning_renders_when_multiple(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from aelfrice import cli
+
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    uv_root = tmp_path / ".local" / "share" / "uv" / "tools" / "aelfrice"
+    uv_root.mkdir(parents=True)
+    user_bin = tmp_path / ".local" / "bin"
+    _make_aelf_exe(user_bin / "aelf")
+    monkeypatch.setenv("PATH", str(user_bin))
+    sites = lifecycle.detect_reachable_installs()
+    lines = cli._format_multi_install_warning(sites, "uv_tool")
+    body = "\n".join(lines)
+    assert "warning: multiple aelfrice installs detected" in body
+    assert "uv tool:" in body
+    assert "user-local:" in body
+    assert "(on PATH)" in body
+    assert "(uv_tool)" in body
+
+
+def test_reachable_installs_path_aelf_under_uv_root_not_double_counted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An `aelf` exe living under the uv-tool root must not register as a
+    separate user_local_bin entry."""
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    uv_root = tmp_path / ".local" / "share" / "uv" / "tools" / "aelfrice"
+    uv_bin_dir = uv_root / "bin"
+    _make_aelf_exe(uv_bin_dir / "aelf")
+    monkeypatch.setenv("PATH", str(uv_bin_dir))
+    sites = lifecycle.detect_reachable_installs()
+    assert len(sites) == 1
+    assert sites[0].kind == "uv_tool"


### PR DESCRIPTION
## Summary

Closes #345. When `aelf upgrade` runs, detect every reachable aelfrice install on the system. If more than one is found, print a warning naming each site and which is on PATH before printing the upgrade command — so the user notices the shadow before re-running `aelf --version` and seeing the same stale binary.

## Behavior

```
$ aelf upgrade
warning: multiple aelfrice installs detected:
  - uv tool: /Users/me/.local/share/uv/tools/aelfrice
  - user-local: /Users/me/.local/bin/aelf (on PATH)
upgrading the active install (uv_tool) will not change `which aelf` if a different install is on PATH.
remove the stale install before upgrading.
aelfrice 1.5.1 available (installed: 1.5.0)
(installed via uv tool — use uv to upgrade)
run: uv tool upgrade aelfrice
```

Single-install case is unchanged (warning is silent).

## Detection

`lifecycle.detect_reachable_installs()` checks:

- `~/.local/share/uv/tools/aelfrice/` → `uv_tool` site
- `~/.local/pipx/venvs/aelfrice/` → `pipx` site
- any `aelf` on PATH whose resolved path is **not** under the above roots → `user_local_bin` site

`on_path` is set per site by checking whether the resolved PATH `aelf` lives under that site's root.

## Out of scope

Auto-removing stale installs (too dangerous; wrong default) and Windows path layouts. Per the issue.

## Test coverage

8 new hermetic cases under `tests/test_upgrade_ux.py`:

- empty / single-site cases (uv_tool only, pipx only, with and without PATH match)
- the #318 repro shape: uv-tool root + stale `~/.local/bin/aelf` shadowing it
- on-PATH `aelf` under the uv-tool root is not double-counted as a third site
- `_format_multi_install_warning` returns `[]` for single install, renders the warning block + `(on PATH)` marker for multi-install

Full suite: `1988 passed, 20 skipped`.

## Test plan

- [x] `uv run pytest tests/test_upgrade_ux.py tests/test_lifecycle.py`
- [x] full `uv run pytest`
- [x] discretion grep clean

## Summary by Sourcery

Detect and surface multiple reachable aelfrice installs during upgrade to warn users when a different binary on PATH may shadow the one being upgraded.

New Features:
- Add filesystem- and PATH-based detection of uv tool, pipx, and user-local aelfrice installs to identify which one is active on PATH.
- Display a multi-install warning block in `aelf upgrade` output when more than one install is reachable, including labels, paths, and PATH status.

Tests:
- Add upgrade UX tests covering empty, single-site, and multiple-site install scenarios, including shadowing and PATH resolution cases.
- Add tests ensuring the multi-install warning formatter is silent for single installs and correctly renders the warning content and markers for multiple installs.