### PR TITLE
fix(store): preserve corroborations across unique-applying migration

### DIFF
--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -1005,10 +1005,14 @@ class MemoryStore:
             )
 
             # Synthetic corroboration rows: one per duplicate consumed.
-            # Best-effort: on legacy stores where belief_corroborations
-            # has INTEGER affinity on belief_id (old schema), the FK
-            # check may reject TEXT ids. Skip gracefully so the main
-            # dedup work (belief row removal) still completes.
+            # Best-effort: log and skip on IntegrityError rather than
+            # aborting the dedup work, but do not swallow silently —
+            # #336 (silent count-signal loss) was caused by an earlier
+            # blanket `except: pass` here combined with a CASCADE-on-
+            # DROP wipe in the unique-applying migration. The cascade
+            # bug is fixed in `_maybe_apply_content_hash_unique`; this
+            # except is retained only as a guard against unforeseen
+            # legacy-schema integrity failures.
             try:
                 self._conn.executemany(
                     """
@@ -1023,12 +1027,14 @@ class MemoryStore:
                         for canon_id, _dupe_id in corroboration_rows
                     ],
                 )
-            except sqlite3.IntegrityError:
-                # Old-schema store: belief_corroborations.belief_id has
-                # INTEGER affinity; TEXT belief ids fail FK check.
-                # Corroboration rows are signal-only; skip them without
-                # aborting the dedup work.
-                pass
+            except sqlite3.IntegrityError as err:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "consolidation-migration: synthetic corroboration "
+                    "insert failed (%d rows skipped): %s",
+                    len(corroboration_rows),
+                    err,
+                )
 
             # Delete duplicate rows from beliefs and FTS.
             self._conn.execute(
@@ -1115,27 +1121,46 @@ class MemoryStore:
 
         col_list = ", ".join(col_names)
 
-        with self._conn:
-            # Drop any leftover temp table from a failed previous attempt.
-            self._conn.execute("DROP TABLE IF EXISTS beliefs_new")
-            self._conn.execute(create_sql)
-            self._conn.execute(
-                f"INSERT INTO beliefs_new ({col_list}) "
-                f"SELECT {col_list} FROM beliefs"
-            )
-            self._conn.execute("DROP TABLE beliefs")
-            self._conn.execute(
-                "ALTER TABLE beliefs_new RENAME TO beliefs"
-            )
-            # Recreate indexes that were on the original beliefs table.
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_beliefs_session "
-                "ON beliefs(session_id)"
-            )
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_beliefs_origin "
-                "ON beliefs(origin)"
-            )
+        # Disable FK enforcement around the table swap. Without this,
+        # `DROP TABLE beliefs` fires `ON DELETE CASCADE` on
+        # belief_corroborations (and any other table referencing
+        # beliefs.id), wiping rows that the dedup migration just
+        # inserted. This is the SQLite-recommended pattern for
+        # schema-mutation migrations — see
+        # https://www.sqlite.org/lang_altertable.html#otheralter
+        # ("disable foreign key constraints with PRAGMA foreign_keys=OFF").
+        # Toggling foreign_keys must happen OUTSIDE any transaction,
+        # so the swap runs in its own explicit BEGIN/COMMIT.
+        self._conn.execute("PRAGMA foreign_keys=OFF")
+        try:
+            self._conn.execute("BEGIN")
+            try:
+                # Drop any leftover temp table from a failed previous attempt.
+                self._conn.execute("DROP TABLE IF EXISTS beliefs_new")
+                self._conn.execute(create_sql)
+                self._conn.execute(
+                    f"INSERT INTO beliefs_new ({col_list}) "
+                    f"SELECT {col_list} FROM beliefs"
+                )
+                self._conn.execute("DROP TABLE beliefs")
+                self._conn.execute(
+                    "ALTER TABLE beliefs_new RENAME TO beliefs"
+                )
+                # Recreate indexes that were on the original beliefs table.
+                self._conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_beliefs_session "
+                    "ON beliefs(session_id)"
+                )
+                self._conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_beliefs_origin "
+                    "ON beliefs(origin)"
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+        finally:
+            self._conn.execute("PRAGMA foreign_keys=ON")
 
         self.set_schema_meta(
             SCHEMA_META_CONTENT_HASH_UNIQUE_APPLIED,

--- a/tests/test_content_hash_consolidation.py
+++ b/tests/test_content_hash_consolidation.py
@@ -329,3 +329,148 @@ def test_lock_level_precedence_user_wins(tmp_path: Path) -> None:
         assert canonical.lock_level == "user"
     finally:
         store.close()
+
+
+# ---------------------------------------------------------------------------
+# #336: synthetic corroborations survive the unique-applying migration
+# ---------------------------------------------------------------------------
+
+
+def _seed_duplicates_with_real_fk(path: str) -> None:
+    """Seed duplicates with the production FK on belief_corroborations.
+
+    Repros #336: the existing _seed_duplicates omits the
+    `REFERENCES beliefs(id) ON DELETE CASCADE` clause, so the cascade
+    that wipes corroborations during the unique-applying migration's
+    `DROP TABLE beliefs` never fires in tests. This helper mirrors the
+    real production legacy-store shape: `beliefs` without UNIQUE on
+    content_hash, `belief_corroborations` with the CASCADE FK.
+    """
+    con = sqlite3.connect(path)
+    con.row_factory = sqlite3.Row
+    con.execute("PRAGMA foreign_keys=ON")
+    con.executescript("""
+        CREATE TABLE beliefs (
+            id                  TEXT PRIMARY KEY,
+            content             TEXT NOT NULL,
+            content_hash        TEXT NOT NULL,
+            alpha               REAL NOT NULL,
+            beta                REAL NOT NULL,
+            type                TEXT NOT NULL,
+            lock_level          TEXT NOT NULL,
+            locked_at           TEXT,
+            demotion_pressure   INTEGER NOT NULL DEFAULT 0,
+            created_at          TEXT NOT NULL,
+            last_retrieved_at   TEXT,
+            session_id          TEXT,
+            origin              TEXT NOT NULL DEFAULT 'unknown'
+        );
+        CREATE VIRTUAL TABLE beliefs_fts
+            USING fts5(id UNINDEXED, content, tokenize='porter unicode61');
+        CREATE TABLE schema_meta (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        CREATE TABLE belief_corroborations (
+            id                INTEGER PRIMARY KEY AUTOINCREMENT,
+            belief_id         TEXT    NOT NULL
+                REFERENCES beliefs(id) ON DELETE CASCADE,
+            ingested_at       TEXT    NOT NULL,
+            source_type       TEXT    NOT NULL,
+            session_id        TEXT,
+            source_path_hash  TEXT
+        );
+    """)
+    # Two duplicate groups — one with two rows, one with three.
+    rows = [
+        ("can-A", "alpha text", "hash-A", "2026-01-01T00:00:00Z"),
+        ("dup-A1", "alpha text", "hash-A", "2026-02-01T00:00:00Z"),
+        ("can-B", "beta text", "hash-B", "2026-01-01T00:00:00Z"),
+        ("dup-B1", "beta text", "hash-B", "2026-02-01T00:00:00Z"),
+        ("dup-B2", "beta text", "hash-B", "2026-03-01T00:00:00Z"),
+    ]
+    for bid, content, ch, created in rows:
+        con.execute(
+            "INSERT INTO beliefs (id, content, content_hash, alpha, beta, "
+            "type, lock_level, demotion_pressure, created_at, origin) "
+            "VALUES (?, ?, ?, 1.0, 1.0, 'factual', 'none', 0, ?, "
+            "'agent_remembered')",
+            (bid, content, ch, created),
+        )
+        con.execute(
+            "INSERT INTO beliefs_fts (id, content) VALUES (?, ?)",
+            (bid, content),
+        )
+    con.commit()
+    con.close()
+
+
+def test_synthetic_corroboration_survives_unique_migration(
+    tmp_path: Path,
+) -> None:
+    """#336 regression: synthetic corroboration rows must survive the
+    table-swap that adds UNIQUE(content_hash) to beliefs.
+
+    Without the foreign_keys=OFF guard around the swap, `DROP TABLE
+    beliefs` fires `ON DELETE CASCADE` on belief_corroborations, wiping
+    the rows the dedup migration just inserted. Symptom in production:
+    20,470 dupes deleted, 0 consolidation_migration corroboration rows.
+    """
+    db = str(tmp_path / "mem.db")
+    _seed_duplicates_with_real_fk(db)
+    store = MemoryStore(db)
+    try:
+        # Three duplicates were consumed (1 in group A, 2 in group B).
+        cur = store._conn.execute(  # type: ignore[reportPrivateUsage]
+            "SELECT belief_id, source_type FROM belief_corroborations "
+            "WHERE source_type='consolidation_migration' "
+            "ORDER BY belief_id"
+        )
+        rows = cur.fetchall()
+        assert len(rows) == 3, (
+            f"expected 3 consolidation_migration corroborations "
+            f"(one per duplicate consumed), got {len(rows)}"
+        )
+        # All point at canonical rows; no orphans.
+        canon_ids = {r["belief_id"] for r in rows}
+        assert canon_ids == {"can-A", "can-B"}
+    finally:
+        store.close()
+
+
+def test_pre_existing_corroborations_survive_unique_migration(
+    tmp_path: Path,
+) -> None:
+    """#336 regression: pre-existing live corroboration rows on the
+    canonical belief must also survive the unique-applying migration's
+    table swap. Verifies the cascade-on-DROP wipe is fully closed, not
+    just for consolidation_migration rows."""
+    db = str(tmp_path / "mem.db")
+    _seed_duplicates_with_real_fk(db)
+    # Pre-seed live corroboration rows on the eventual canonical row,
+    # before any MemoryStore open. Mirrors a store with prior ingest
+    # history that also needs the unique migration.
+    con = sqlite3.connect(db)
+    con.execute("PRAGMA foreign_keys=ON")
+    for i in range(5):
+        con.execute(
+            "INSERT INTO belief_corroborations "
+            "(belief_id, ingested_at, source_type) "
+            "VALUES ('can-A', ?, 'cli_remember')",
+            (f"2026-04-{i + 1:02d}T00:00:00Z",),
+        )
+    con.commit()
+    con.close()
+
+    store = MemoryStore(db)
+    try:
+        cur = store._conn.execute(  # type: ignore[reportPrivateUsage]
+            "SELECT COUNT(*) AS n FROM belief_corroborations "
+            "WHERE source_type='cli_remember'"
+        )
+        n = cur.fetchone()["n"]
+        assert n == 5, (
+            f"expected 5 pre-existing cli_remember rows to survive, got {n}"
+        )
+    finally:
+        store.close()


### PR DESCRIPTION
Closes #336.

## Root cause

Two interacting bugs:

1. **Cascade-on-DROP wipe.** `_maybe_apply_content_hash_unique` swaps `beliefs` via `CREATE beliefs_new → INSERT SELECT → DROP TABLE beliefs → RENAME`. With `PRAGMA foreign_keys=ON` and `belief_corroborations.belief_id REFERENCES beliefs(id) ON DELETE CASCADE`, the `DROP TABLE beliefs` fires the cascade and deletes every row in `belief_corroborations` — including the synthetic `consolidation_migration` rows that `_maybe_consolidate_content_hash_duplicates` (which runs immediately before the unique-applying migration) had just inserted.
2. **Over-broad swallow.** The dedup pass wrapped its synthetic INSERT in `except sqlite3.IntegrityError: pass`, with a comment claiming this caught a legacy "INTEGER affinity belief_id" path. No such schema variant exists in this codebase — the table has always been created from `_SCHEMA` with TEXT affinity. The blanket pass would have masked any real failure had one fired, but on the actual production stores the synthetic INSERT succeeded; the rows were then wiped by (1).

The issue body suspected (2) and an FK-on-INSERT failure. The actual mechanism is (1) — verified by adding a diag print to the except clause and confirming it never fires while the post-state still shows zero `consolidation_migration` rows.

## Fix

Wrap the unique-applying migration's table swap in `PRAGMA foreign_keys=OFF` / `=ON`. This is the [SQLite-recommended pattern](https://www.sqlite.org/lang_altertable.html#otheralter) for table-mutation migrations. The toggle must execute outside any transaction, so the swap now uses an explicit `BEGIN`/`COMMIT` instead of `with self._conn`.

Also tighten the dedup pass's `except sqlite3.IntegrityError`: the catch is retained as a guard against unforeseen legacy-schema integrity failures, but it now `logging.warning`s with the skipped-row count instead of silent `pass`. Silent count-loss can't recur from this site even if a future schema change introduces a new integrity edge case.

## Regression coverage

Two new tests in `tests/test_content_hash_consolidation.py`:

- `test_synthetic_corroboration_survives_unique_migration` — seeds duplicates with the production-shape `belief_corroborations` schema (with the CASCADE FK that was missing from the existing helper), runs the migration, asserts the right number of `consolidation_migration` rows remain.
- `test_pre_existing_corroborations_survive_unique_migration` — same setup plus pre-seeded live `cli_remember` corroboration rows on the canonical belief; verifies they survive too. This proves the cascade-wipe path is fully closed for all corroboration types, not just the synthetic ones.

Why the existing `test_synthetic_corroboration_inserted` (already in the file) missed the bug: its `_seed_duplicates` helper creates `belief_corroborations` without the `REFERENCES beliefs(id) ON DELETE CASCADE` clause that production stores have. With no FK declared, the cascade never fires — the test's seed schema and the production schema diverged.

## Verification

- `pytest tests/test_content_hash_consolidation.py` — 11 passed (9 previous + 2 new).
- `pytest -q` — 1991 passed, 20 skipped (pre-existing skips, unrelated).
- Manual repro on a fresh tempdir store with 30 duplicates across 10 groups: pre-fix → 20 deleted, 0 corroborations; post-fix → 20 deleted, 20 corroborations.

## Out of scope

- **Recovering the lost rows on the lab store.** The duplicate beliefs that originally produced the 20,470 signal are gone; the count is unrecoverable without restoring from a pre-migration snapshot. Issue body's third "ask" (auto-flag-for-re-migration on stores with the marker set + zero synthetic rows + nonzero pre-dedup duplicate count) is deferred — the heuristic is fragile (a fresh store with no duplicates also has zero `consolidation_migration` rows and a set marker) and the recovery path requires manual intervention. Worth a separate issue if there's appetite for it.

## Summary by Sourcery

Prevent loss of corroboration rows during the content-hash uniqueness migration and improve observability of consolidation failures.

Bug Fixes:
- Ensure foreign key cascades no longer delete corroboration rows during the beliefs table swap that adds UNIQUE(content_hash).
- Preserve pre-existing corroboration records when running the content-hash deduplication and unique-constraint migrations.

Enhancements:
- Log consolidation-migration IntegrityError incidents with the number of skipped synthetic corroboration rows instead of silently swallowing them.

Tests:
- Add a regression seeding helper that mirrors the production belief_corroborations foreign key schema to reproduce the original cascade issue.
- Add tests verifying synthetic consolidation_migration corroborations and pre-existing live corroborations both survive the unique-applying migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error reporting during content deduplication: detailed warnings are now displayed instead of silently ignoring errors, making troubleshooting easier
  * Strengthened database migration process to reliably preserve data during schema updates, preventing potential data loss scenarios
  * Added regression tests to ensure deduplication and migration reliability remain stable in future releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->