### PR TITLE
feat(store): retention_class schema axis (#290 phase-1)

### DIFF
--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -52,6 +52,27 @@ LOCK_USER: Final[str] = "user"
 
 LOCK_LEVELS: Final[frozenset[str]] = frozenset({LOCK_NONE, LOCK_USER})
 
+# --- Retention class (#290) ---
+# Orthogonal axis to `type`: type describes the *form* of a claim
+# (factual / correction / preference / requirement); retention_class
+# describes its *expected lifetime* (slow-aging fact, snapshot of
+# thought, transient debugging state). Wire-format strings; do not
+# rename without a migration. `unknown` exists only for the migration
+# window — new writes always pick one of the three live values per
+# the ingest-path defaults documented at
+# `docs/belief_retention_class.md` § 2.
+RETENTION_FACT: Final[str] = "fact"
+RETENTION_SNAPSHOT: Final[str] = "snapshot"
+RETENTION_TRANSIENT: Final[str] = "transient"
+RETENTION_UNKNOWN: Final[str] = "unknown"
+
+RETENTION_CLASSES: Final[frozenset[str]] = frozenset({
+    RETENTION_FACT,
+    RETENTION_SNAPSHOT,
+    RETENTION_TRANSIENT,
+    RETENTION_UNKNOWN,
+})
+
 # --- Origin (provenance tier, v1.2+) ---
 # Wire-format strings; appear in feedback_history.source for promotion
 # events. Do not rename without a migration. Tier ordering matches
@@ -185,6 +206,7 @@ class Belief:
     corroboration_count: int = 0
     hibernation_score: float | None = None
     activation_condition: str | None = None
+    retention_class: str = RETENTION_UNKNOWN
 
 
 ANCHOR_TEXT_MAX_LEN: Final[int] = 1000

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -28,6 +28,8 @@ from aelfrice.models import (
     INGEST_SOURCE_LEGACY_UNKNOWN,
     ONBOARD_STATE_COMPLETED,
     ONBOARD_STATE_PENDING,
+    RETENTION_CLASSES,
+    RETENTION_UNKNOWN,
     Belief,
     Edge,
     FeedbackEvent,
@@ -55,7 +57,16 @@ _SCHEMA: tuple[str, ...] = (
         session_id          TEXT,
         origin              TEXT NOT NULL DEFAULT 'unknown',
         hibernation_score   REAL,
-        activation_condition TEXT
+        activation_condition TEXT,
+        -- #290: orthogonal-to-type retention axis. CHECK constraint
+        -- enforces the four-value enum on fresh stores; migrated
+        -- stores rely on the python-side RETENTION_CLASSES frozenset
+        -- for validation (ALTER TABLE ADD COLUMN can't carry the
+        -- CHECK across SQLite versions reliably). 'unknown' is the
+        -- migration default; new writes pick one of the three live
+        -- values per docs/belief_retention_class.md § 2 defaults.
+        retention_class     TEXT NOT NULL DEFAULT 'unknown'
+            CHECK (retention_class IN ('fact', 'snapshot', 'transient', 'unknown'))
     )
     """,
     """
@@ -314,6 +325,10 @@ _MIGRATIONS: tuple[str, ...] = (
     # language ratified at substrate_decision.md § Decision asks #4).
     "ALTER TABLE beliefs ADD COLUMN hibernation_score REAL",
     "ALTER TABLE beliefs ADD COLUMN activation_condition TEXT",
+    # #290 retention class. CHECK constraint omitted — ALTER TABLE
+    # ADD COLUMN with a CHECK is brittle across SQLite versions.
+    # Python-side RETENTION_CLASSES validates inserts.
+    "ALTER TABLE beliefs ADD COLUMN retention_class TEXT NOT NULL DEFAULT 'unknown'",
 )
 
 # Indexes that depend on migrated columns. Run after _MIGRATIONS so
@@ -364,6 +379,14 @@ def _escape_fts5_query(query: str) -> str:
 def _row_to_belief(row: sqlite3.Row) -> Belief:
     keys = row.keys()
     corroboration_count = int(row["corroboration_count"]) if "corroboration_count" in keys else 0
+    # retention_class column added in v1.6 (#290). Pre-migration rows
+    # don't have it — fall back to RETENTION_UNKNOWN. The store __init__
+    # runs the ALTER on open, so this branch is mainly for SELECTs that
+    # project a custom column list excluding the new column.
+    retention_class = (
+        row["retention_class"] if "retention_class" in keys
+        else RETENTION_UNKNOWN
+    )
     return Belief(
         id=row["id"],
         content=row["content"],
@@ -381,6 +404,7 @@ def _row_to_belief(row: sqlite3.Row) -> Belief:
         corroboration_count=corroboration_count,
         hibernation_score=row["hibernation_score"],
         activation_condition=row["activation_condition"],
+        retention_class=retention_class,
     )
 
 
@@ -1177,20 +1201,27 @@ class MemoryStore:
     # --- Belief CRUD ------------------------------------------------------
 
     def insert_belief(self, b: Belief) -> None:
+        if b.retention_class not in RETENTION_CLASSES:
+            raise ValueError(
+                f"invalid retention_class {b.retention_class!r}; "
+                f"must be one of {sorted(RETENTION_CLASSES)}"
+            )
         self._conn.execute(
             """
             INSERT INTO beliefs (
                 id, content, content_hash, alpha, beta, type,
                 lock_level, locked_at, demotion_pressure,
                 created_at, last_retrieved_at, session_id, origin,
-                hibernation_score, activation_condition
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                hibernation_score, activation_condition,
+                retention_class
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 b.id, b.content, b.content_hash, b.alpha, b.beta, b.type,
                 b.lock_level, b.locked_at, b.demotion_pressure,
                 b.created_at, b.last_retrieved_at, b.session_id, b.origin,
                 b.hibernation_score, b.activation_condition,
+                b.retention_class,
             ),
         )
         self._conn.execute(

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -381,7 +381,7 @@ def _row_to_belief(row: sqlite3.Row) -> Belief:
     corroboration_count = int(row["corroboration_count"]) if "corroboration_count" in keys else 0
     # retention_class column added in v1.6 (#290). Pre-migration rows
     # don't have it — fall back to RETENTION_UNKNOWN. The store __init__
-    # runs the ALTER on open, so this branch is mainly for SELECTs that
+    # runs the ALTER on open, so this branch is mainly for queries that
     # project a custom column list excluding the new column.
     retention_class = (
         row["retention_class"] if "retention_class" in keys

--- a/tests/test_retention_class.py
+++ b/tests/test_retention_class.py
@@ -1,0 +1,202 @@
+"""Tests for the #290 phase-1 retention_class schema axis.
+
+Covers:
+* default retention_class on insert is 'unknown' (the migration value)
+* explicit retention_class round-trips via insert + read
+* invalid retention_class is rejected at the python boundary
+* the SQLite CHECK constraint rejects garbage on fresh stores
+* a pre-#290 store opens cleanly: ALTER TABLE backfills 'unknown'
+  on every existing row, and reads still work
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    LOCK_NONE,
+    RETENTION_CLASSES,
+    RETENTION_FACT,
+    RETENTION_SNAPSHOT,
+    RETENTION_TRANSIENT,
+    RETENTION_UNKNOWN,
+    Belief,
+)
+from aelfrice.store import MemoryStore
+
+
+def _mk_belief(
+    bid: str = "b1",
+    *,
+    retention_class: str = RETENTION_UNKNOWN,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=f"content for {bid}",
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-05-02T00:00:00Z",
+        last_retrieved_at=None,
+        retention_class=retention_class,
+    )
+
+
+# ---- enum surface -------------------------------------------------------
+
+
+def test_retention_classes_has_four_values() -> None:
+    assert RETENTION_CLASSES == frozenset({
+        RETENTION_FACT,
+        RETENTION_SNAPSHOT,
+        RETENTION_TRANSIENT,
+        RETENTION_UNKNOWN,
+    })
+
+
+def test_belief_default_retention_class_is_unknown() -> None:
+    b = Belief(
+        id="x", content="c", content_hash="h", alpha=1.0, beta=1.0,
+        type=BELIEF_FACTUAL, lock_level=LOCK_NONE, locked_at=None,
+        demotion_pressure=0, created_at="2026-05-02T00:00:00Z",
+        last_retrieved_at=None,
+    )
+    # Default exists so callers that don't yet know about retention_class
+    # land on the migration-default value, not on something like None.
+    assert b.retention_class == RETENTION_UNKNOWN
+
+
+# ---- store round-trip ---------------------------------------------------
+
+
+def test_retention_class_round_trips_for_each_value(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    cases = {
+        "f": RETENTION_FACT,
+        "s": RETENTION_SNAPSHOT,
+        "t": RETENTION_TRANSIENT,
+        "u": RETENTION_UNKNOWN,
+    }
+    for bid, rc in cases.items():
+        store.insert_belief(_mk_belief(bid, retention_class=rc))
+    for bid, rc in cases.items():
+        b = store.get_belief(bid)
+        assert b is not None
+        assert b.retention_class == rc
+
+
+def test_invalid_retention_class_rejected_at_python_boundary(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    bad = _mk_belief("bad", retention_class="garbage")
+    with pytest.raises(ValueError, match="invalid retention_class"):
+        store.insert_belief(bad)
+
+
+def test_check_constraint_rejects_direct_sql_garbage(
+    tmp_path: Path,
+) -> None:
+    """Bypassing the python boundary still trips the CHECK on a fresh
+    store. Migrated stores don't have the CHECK (ALTER TABLE limitation)
+    — that path is covered by the python-side validator."""
+    db_path = tmp_path / "m.db"
+    MemoryStore(str(db_path))  # initialize schema with CHECK
+    raw = sqlite3.connect(str(db_path))
+    raw.execute("PRAGMA foreign_keys=ON")
+    with pytest.raises(sqlite3.IntegrityError):
+        raw.execute(
+            """
+            INSERT INTO beliefs (
+                id, content, content_hash, alpha, beta, type,
+                lock_level, locked_at, demotion_pressure,
+                created_at, last_retrieved_at, retention_class
+            ) VALUES (
+                'raw', 'c', 'h_raw', 1.0, 1.0, 'factual',
+                'none', NULL, 0, '2026-05-02T00:00:00Z', NULL,
+                'totally_invalid'
+            )
+            """
+        )
+    raw.close()
+
+
+# ---- migration path -----------------------------------------------------
+
+
+def test_pre_290_store_opens_cleanly_and_backfills_unknown(
+    tmp_path: Path,
+) -> None:
+    """Build a store WITHOUT the retention_class column (simulating a
+    pre-#290 DB), insert a row, then re-open with the current
+    MemoryStore. The ALTER TABLE in _MIGRATIONS must add the column
+    with default 'unknown' on every existing row, and reads must
+    still produce a valid Belief."""
+    db_path = tmp_path / "m.db"
+
+    raw = sqlite3.connect(str(db_path))
+    # Mirror enough of the v1.5 schema to be openable but without
+    # retention_class. Other columns the row reader needs are
+    # included explicitly.
+    raw.execute(
+        """
+        CREATE TABLE beliefs (
+            id                  TEXT PRIMARY KEY,
+            content             TEXT NOT NULL,
+            content_hash        TEXT NOT NULL UNIQUE,
+            alpha               REAL NOT NULL,
+            beta                REAL NOT NULL,
+            type                TEXT NOT NULL,
+            lock_level          TEXT NOT NULL,
+            locked_at           TEXT,
+            demotion_pressure   INTEGER NOT NULL DEFAULT 0,
+            created_at          TEXT NOT NULL,
+            last_retrieved_at   TEXT,
+            session_id          TEXT,
+            origin              TEXT NOT NULL DEFAULT 'unknown',
+            hibernation_score   REAL,
+            activation_condition TEXT
+        )
+        """
+    )
+    raw.execute(
+        """
+        INSERT INTO beliefs (
+            id, content, content_hash, alpha, beta, type,
+            lock_level, locked_at, demotion_pressure,
+            created_at, last_retrieved_at, origin
+        ) VALUES (
+            'pre', 'old content', 'h_pre', 1.0, 1.0, 'factual',
+            'none', NULL, 0, '2026-04-01T00:00:00Z', NULL, 'unknown'
+        )
+        """
+    )
+    raw.commit()
+    raw.close()
+
+    store = MemoryStore(str(db_path))
+    cur = store._conn.execute(
+        "SELECT retention_class FROM beliefs WHERE id = 'pre'"
+    )
+    row = cur.fetchone()
+    assert row is not None
+    assert row[0] == RETENTION_UNKNOWN
+
+    b = store.get_belief("pre")
+    assert b is not None
+    assert b.retention_class == RETENTION_UNKNOWN
+
+    fresh = _mk_belief("post", retention_class=RETENTION_FACT)
+    store.insert_belief(fresh)
+    got = store.get_belief("post")
+    assert got is not None
+    assert got.retention_class == RETENTION_FACT


### PR DESCRIPTION
First slice of the ratified #290 belief retention/aging design (`docs/belief_retention_class.md`). Foundational schema only — every downstream piece (ingest defaults, promotion, ranker integration) blocks on this column existing.

## What lands

- `models.py`: `RETENTION_FACT` / `SNAPSHOT` / `TRANSIENT` / `UNKNOWN` string constants, `RETENTION_CLASSES` frozenset, `retention_class: str = RETENTION_UNKNOWN` field on `Belief`.
- `store._SCHEMA`: new `beliefs.retention_class` column with `CHECK (retention_class IN ('fact', 'snapshot', 'transient', 'unknown'))` for fresh stores.
- `store._MIGRATIONS`: `ALTER TABLE beliefs ADD COLUMN retention_class TEXT NOT NULL DEFAULT 'unknown'` for pre-#290 stores. CHECK omitted from the ALTER because `ALTER TABLE ADD COLUMN` with a `CHECK` is brittle across SQLite versions; the python-side validator in `insert_belief` covers migrated stores.
- `_row_to_belief`: reads `retention_class` with a safe `RETENTION_UNKNOWN` fallback for SELECTs that project a custom column list.
- `insert_belief`: validates `retention_class` against `RETENTION_CLASSES` before write, `raise ValueError` on garbage.

## Why phase-1 only

The spec at `docs/belief_retention_class.md` calls for ingest-path defaults (transcript -> snapshot, filesystem -> fact, hook -> snapshot, CLI/MCP remember -> fact), corroboration-driven snapshot -> fact promotion, and a soft-down-weight ranker integration. Each is its own surface and its own argument. Landing the column first means follow-ups can be reviewed in isolation rather than as one 1500-LOC mega-PR.

## Tests (6 new)

- enum surface (frozenset has the four values)
- default-on-construct (`Belief(...)` without `retention_class` -> RETENTION_UNKNOWN, not None)
- round-trip for each of the four values via `insert_belief` + `get_belief`
- python-boundary rejection of garbage (`ValueError`)
- CHECK constraint rejection of direct-SQL garbage on fresh stores
- migration path: build a pre-#290 schema by hand, insert a row, reopen with current `MemoryStore`, verify ALTER backfilled `unknown` and reads still produce a valid `Belief`

Full suite: 2006 passed, 14 skipped.

## Follow-ups (not in this PR)

- Ingest-path defaults at write call sites (transcript_ingest, commit_ingest, hook ingest, CLI / MCP remember).
- Snapshot -> fact promotion via the corroboration recorder.
- Soft down-weight ranker integration + #289 floor coupling.
- One-shot heuristic backfill of existing 'unknown' rows from `source_kind`.

Tracks #290.

## Summary by Sourcery

Add belief retention_class schema axis and introduce a rebuild_log auditing CLI.

New Features:
- Add retention_class field to Belief and persist it in the beliefs table schema and migrations.
- Introduce audit_rebuild_log CLI script to summarise rebuild diagnostic JSONL logs.

Enhancements:
- Validate retention_class values at insert time and default unknown for legacy and partial rows.
- Extend belief row deserialization to tolerate stores or queries missing the retention_class column.

Tests:
- Add tests covering retention_class defaults, round-trips, validation, CHECK constraint behavior, and migration backfill.
- Add tests for audit_rebuild_log covering summarisation, drop-reason bucketing, malformed input handling, path collection, CLI behavior, and percentile calculation.