### PR TITLE
feat(hook,cli): injection log + aelf tail (#321)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2395,6 +2395,45 @@ def _cmd_session_delta(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _cmd_tail(args: argparse.Namespace, out: object) -> int:
+    """Live-tail the per-turn hook audit log (#321).
+
+    Reads `<git-common-dir>/aelfrice/hook_audit.jsonl` (the per-turn
+    record store written by UserPromptSubmit and SessionStart on every
+    fire that produces an injection block) and emits a pretty-printed
+    stream. By default follows for new records; `--no-follow` reads the
+    current contents once and exits.
+    """
+    from aelfrice.hook_tail import parse_filter, parse_since, tail_audit
+
+    filters: list[tuple[str, str]] = []
+    raw_filters: list[str] | None = getattr(args, "filter", None)
+    if raw_filters:
+        for spec in raw_filters:
+            try:
+                filters.append(parse_filter(spec))
+            except ValueError as exc:
+                print(f"aelf tail: {exc}", file=sys.stderr)
+                return 2
+    since = None
+    raw_since: str | None = getattr(args, "since", None)
+    if raw_since:
+        try:
+            since = parse_since(raw_since)
+        except ValueError as exc:
+            print(f"aelf tail: {exc}", file=sys.stderr)
+            return 2
+    follow = not bool(getattr(args, "no_follow", False))
+    include_blob = not bool(getattr(args, "no_blob", False))
+    return tail_audit(
+        filters=filters,
+        since=since,
+        include_blob=include_blob,
+        follow=follow,
+        out=out,  # type: ignore[arg-type]
+    )
+
+
 def _known_cli_subcommands() -> frozenset[str]:
     """Snapshot of the subcommands the running `aelf` parser knows.
 
@@ -3196,6 +3235,35 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         ),
     )
     p_session_delta.set_defaults(func=_cmd_session_delta)
+
+    p_tail = sub.add_parser(
+        "tail",
+        help="live-tail the per-turn hook injection audit log",
+    )
+    p_tail.add_argument(
+        "--filter", action="append", default=None, metavar="key=value",
+        help=(
+            "filter records: hook=user_prompt_submit | "
+            "hook=session_start | lane=L0 | lane=L1. Repeatable; all "
+            "filters must match (AND)."
+        ),
+    )
+    p_tail.add_argument(
+        "--since", default=None, metavar="DUR",
+        help=(
+            "backfill records from the last DUR (e.g. 30s, 5m, 2h, 1d) "
+            "before tailing live"
+        ),
+    )
+    p_tail.add_argument(
+        "--no-blob", dest="no_blob", action="store_true",
+        help="suppress per-belief snippet bodies (just header + ids)",
+    )
+    p_tail.add_argument(
+        "--no-follow", dest="no_follow", action="store_true",
+        help="dump current audit contents once and exit (no live tail)",
+    )
+    p_tail.set_defaults(func=_cmd_tail)
 
     return parser
 

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -26,6 +26,7 @@ import json
 import os
 import sys
 import tempfile
+import time
 import tomllib
 import traceback
 from dataclasses import dataclass
@@ -446,6 +447,48 @@ def _append_audit(
         )
 
 
+AUDIT_BELIEF_SNIPPET_CAP: Final[int] = 120
+"""Max chars of belief.content stored per-belief in the audit record's
+beliefs[] array. Full content is also recoverable from the rendered_block
+field; the snippet is for at-a-glance scanning in `aelf tail` output."""
+
+
+def _belief_snippet(content: str) -> str:
+    """First-line snippet capped at AUDIT_BELIEF_SNIPPET_CAP chars."""
+    head = content.split("\n", 1)[0]
+    if len(head) > AUDIT_BELIEF_SNIPPET_CAP:
+        head = head[:AUDIT_BELIEF_SNIPPET_CAP - 1] + "…"
+    return head
+
+
+def _serialize_belief_for_audit(b: "Belief") -> dict[str, object]:
+    """Project a Belief to the per-belief audit record shape (#321).
+
+    Lane mapping: locked beliefs (`lock_level == LOCK_USER`) are L0 —
+    the always-on user-asserted ground truth tier. Everything else
+    surfaced by retrieval is L1 (BM25 / L2.5 / L3 fold into one lane
+    here; downstream tiering can be re-derived from the rendered_block
+    if needed). Score is intentionally absent — `retrieve()` does not
+    propagate per-hit scores through to the hook caller, and adding
+    that plumbing was out of scope for #321.
+    """
+    locked = b.lock_level == LOCK_USER
+    alpha = float(b.alpha)
+    beta = float(b.beta)
+    denom = alpha + beta
+    posterior_mean = (alpha / denom) if denom > 0 else 0.0
+    return {
+        "id": b.id,
+        "lane": "L0" if locked else "L1",
+        "locked": locked,
+        "content_hash": b.content_hash,
+        "alpha": alpha,
+        "beta": beta,
+        "posterior_mean": posterior_mean,
+        "snippet": _belief_snippet(b.content),
+    }
+
+
 def _write_hook_audit_record(
     *,
     hook: str,
@@ -454,6 +497,8 @@ def _write_hook_audit_record(
     n_beliefs: int,
     n_locked: int,
     session_id: str | None = None,
+    beliefs: list["Belief"] | None = None,
+    latency_ms: int | None = None,
     config: HookAuditConfig | None = None,
     stderr: IO[str] | None = None,
 ) -> None:
@@ -463,6 +508,13 @@ def _write_hook_audit_record(
     full rendered block so a reviewer can see *exactly* what the hook
     injected on a given turn — distinct from telemetry, which records
     counts only.
+
+    #321 additive fields (all optional for backward compatibility):
+    `beliefs` — per-hit structured data (id/lane/locked/content_hash/
+    alpha/beta/posterior_mean/snippet); `latency_ms` — wall-clock around
+    retrieve+format; `tokens` — derived from `rendered_block` via the
+    same 4-chars-per-token estimator retrieval uses for budgeting.
+    Older readers ignore unknown fields.
     """
     cfg = config if config is not None else load_hook_audit_config(stderr=stderr)
     if not cfg.enabled:
@@ -479,10 +531,26 @@ def _write_hook_audit_record(
         "rendered_block": rendered_block,
         "n_beliefs": n_beliefs,
         "n_locked": n_locked,
+        "tokens": _audit_tokens_from_block(rendered_block),
     }
     if session_id is not None:
         record["session_id"] = session_id
+    if beliefs is not None:
+        record["beliefs"] = [_serialize_belief_for_audit(b) for b in beliefs]
+    if latency_ms is not None:
+        record["latency_ms"] = int(latency_ms)
     _append_audit(audit_path, record, cfg.max_bytes, stderr=stderr)
+
+
+def _audit_tokens_from_block(block: str) -> int:
+    """Estimate tokens in the rendered block.
+
+    Uses the same 4-chars-per-token estimator as
+    `aelfrice.retrieval._estimate_tokens` to keep audit-side counts
+    comparable with the budgeter that produced the block.
+    """
+    chars_per_token = 4.0
+    return int((len(block) + chars_per_token - 1) // chars_per_token)
 
 
 def read_hook_audit(path: Path) -> list[dict[str, object]]:
@@ -585,6 +653,7 @@ def user_prompt_submit(
             else DEFAULT_HOOK_TOKEN_BUDGET
         )
         config = load_user_prompt_submit_config(stderr=serr)
+        retrieve_start = time.monotonic()
         hits = _retrieve(prompt, budget)
         if hits:
             # AC1 telemetry: record pre-collapse counts.
@@ -602,6 +671,7 @@ def user_prompt_submit(
             # total_chars measured post-collapse (what is actually injected).
             total_chars = sum(len(h.content) for h in hits)
             body = _format_hits(hits)
+            latency_ms = int((time.monotonic() - retrieve_start) * 1000)
             sout.write(body)
             # AC1: append telemetry record for fires that produce a block.
             _write_telemetry(
@@ -614,6 +684,7 @@ def user_prompt_submit(
                 stderr=serr,
             )
             # #280 mitigation 3: per-turn audit of the rendered block.
+            # #321 additive fields: beliefs[], latency_ms, tokens.
             _write_hook_audit_record(
                 hook=AUDIT_HOOK_USER_PROMPT_SUBMIT,
                 prompt=prompt,
@@ -621,6 +692,8 @@ def user_prompt_submit(
                 n_beliefs=len(hits),
                 n_locked=sum(1 for h in hits if h.lock_level == LOCK_USER),
                 session_id=session_id,
+                beliefs=hits,
+                latency_ms=latency_ms,
                 stderr=serr,
             )
     except Exception:  # non-blocking: surface but do not fail
@@ -975,10 +1048,13 @@ def session_start(
             if token_budget is not None
             else DEFAULT_SESSION_START_TOKEN_BUDGET
         )
+        retrieve_start = time.monotonic()
         hits, body = _retrieve_baseline_with_block(budget)
         if body:
+            latency_ms = int((time.monotonic() - retrieve_start) * 1000)
             sout.write(body)
             # #280 mitigation 3: per-turn audit of the rendered block.
+            # #321 additive fields: beliefs[], latency_ms, tokens.
             _write_hook_audit_record(
                 hook=AUDIT_HOOK_SESSION_START,
                 prompt="",
@@ -986,6 +1062,8 @@ def session_start(
                 n_beliefs=len(hits),
                 n_locked=sum(1 for h in hits if h.lock_level == LOCK_USER),
                 session_id=session_id,
+                beliefs=hits,
+                latency_ms=latency_ms,
                 stderr=serr,
             )
     except Exception:  # non-blocking: surface but do not fail

--- a/src/aelfrice/hook_tail.py
+++ b/src/aelfrice/hook_tail.py
@@ -75,7 +75,7 @@ def parse_since(spec: str) -> timedelta:
     m = _SINCE_RE.match(spec)
     if m is None:
         raise ValueError(
-            f"--since must look like Ns / Nm / Nh / Nd (got {spec!r})"
+            f"--since must look like 30s / 5m / 2h / 1d (got {spec!r})"
         )
     n = int(m.group("n"))
     unit = m.group("unit")

--- a/src/aelfrice/hook_tail.py
+++ b/src/aelfrice/hook_tail.py
@@ -1,0 +1,336 @@
+"""Reader + pretty-printer for the per-turn hook audit log (#321).
+
+`aelf tail` is the live observability primitive over `hook_audit.jsonl`
+(the per-turn audit log shipped in #280 mitigation 3, extended in #321
+with `beliefs[]`, `latency_ms`, and `tokens` fields).
+
+Why this layer is separate from `hook.py`: the writer side runs inside
+the UserPromptSubmit / SessionStart hook process and must stay
+import-cheap (every Claude Code prompt pays its import cost). The
+reader side is interactive and only loads when the operator runs
+`aelf tail`. Splitting keeps hook startup unburdened by formatting
+helpers and reduces the surface area that the hook's non-blocking
+contract has to defend.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import IO, Final, Iterable
+
+from aelfrice.hook import (
+    AUDIT_FILENAME,
+    AUDIT_ROTATED_SUFFIX,
+    _audit_path_for_db,
+)
+
+
+_FILTER_KEYS: Final[frozenset[str]] = frozenset({"hook", "lane"})
+"""Keys accepted by --filter. `hook` matches the record-level value;
+`lane` matches at least one belief in the record's beliefs[] array."""
+
+_SINCE_RE: Final[re.Pattern[str]] = re.compile(
+    r"^\s*(?P<n>\d+)\s*(?P<unit>[smhd])\s*$"
+)
+"""Relative `--since` durations: `30s`, `5m`, `2h`, `1d`."""
+
+_TAIL_POLL_INTERVAL: Final[float] = 0.25
+"""Seconds between follow-mode polls when no new lines arrive."""
+
+
+def parse_filter(spec: str) -> tuple[str, str]:
+    """Parse a single `--filter key=value` argument.
+
+    Raises ValueError if the spec is malformed or the key is unknown.
+    Caller catches and reports; the CLI converts ValueError to an
+    error exit.
+    """
+    if "=" not in spec:
+        raise ValueError(
+            f"--filter must look like key=value (got {spec!r})"
+        )
+    key, _, value = spec.partition("=")
+    key = key.strip()
+    value = value.strip()
+    if key not in _FILTER_KEYS:
+        raise ValueError(
+            f"--filter key {key!r} not recognized "
+            f"(supported: {sorted(_FILTER_KEYS)})"
+        )
+    if not value:
+        raise ValueError(f"--filter {key}= has no value")
+    return key, value
+
+
+def parse_since(spec: str) -> timedelta:
+    """Parse a `--since` relative duration like `5m` or `2h`.
+
+    Returns a `timedelta`. Raises ValueError on malformed input.
+    """
+    m = _SINCE_RE.match(spec)
+    if m is None:
+        raise ValueError(
+            f"--since must look like Ns / Nm / Nh / Nd (got {spec!r})"
+        )
+    n = int(m.group("n"))
+    unit = m.group("unit")
+    if unit == "s":
+        return timedelta(seconds=n)
+    if unit == "m":
+        return timedelta(minutes=n)
+    if unit == "h":
+        return timedelta(hours=n)
+    return timedelta(days=n)
+
+
+def _parse_record_ts(record: dict[str, object]) -> datetime | None:
+    """Best-effort parse of the `ts` field. Returns None if missing
+    or unparseable."""
+    raw = record.get("ts")
+    if not isinstance(raw, str):
+        return None
+    try:
+        # Audit writes `%Y-%m-%dT%H:%M:%SZ` — Python's fromisoformat
+        # in 3.11+ accepts trailing Z directly.
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def record_matches_filters(
+    record: dict[str, object], filters: list[tuple[str, str]]
+) -> bool:
+    """Return True iff the record matches all (key, value) filters.
+
+    `hook=...` matches `record["hook"]` exactly. `lane=...` matches
+    iff at least one entry in `record["beliefs"]` has the given lane.
+    Records missing the queried field never match — the filter is
+    falsifying, not best-effort.
+    """
+    for key, value in filters:
+        if key == "hook":
+            if record.get("hook") != value:
+                return False
+            continue
+        if key == "lane":
+            beliefs = record.get("beliefs")
+            if not isinstance(beliefs, list):
+                return False
+            hit = False
+            for b in beliefs:
+                if isinstance(b, dict) and b.get("lane") == value:
+                    hit = True
+                    break
+            if not hit:
+                return False
+    return True
+
+
+def format_record(
+    record: dict[str, object], *, include_blob: bool = True,
+) -> str:
+    """Render one audit record as multi-line text suitable for tail output.
+
+    Header line: `<HH:MM:SS>  <hook>  <tokens>tok  <latency>ms  L0×N L1×M`.
+    Then one indented line per belief from `beliefs[]` (when present).
+    `include_blob=False` suppresses the per-belief snippet bodies and
+    leaves just the header line + per-belief identifiers.
+    """
+    ts = record.get("ts", "?")
+    short_ts = _short_ts(ts if isinstance(ts, str) else "?")
+    hook = str(record.get("hook", "?"))
+    tokens = record.get("tokens")
+    latency_ms = record.get("latency_ms")
+    beliefs_obj = record.get("beliefs")
+    beliefs: list[dict[str, object]] = []
+    if isinstance(beliefs_obj, list):
+        beliefs = [b for b in beliefs_obj if isinstance(b, dict)]
+    n_l0 = sum(1 for b in beliefs if b.get("lane") == "L0")
+    n_l1 = sum(1 for b in beliefs if b.get("lane") == "L1")
+    parts: list[str] = [short_ts, hook]
+    if isinstance(tokens, int):
+        parts.append(f"{tokens} tok")
+    if isinstance(latency_ms, int):
+        parts.append(f"{latency_ms} ms")
+    parts.append(f"L0×{n_l0} L1×{n_l1}")
+    lines = ["  ".join(parts)]
+    for b in beliefs:
+        lane = str(b.get("lane", "??"))
+        bid = str(b.get("id", "?"))
+        bid_short = bid[:8] if len(bid) > 8 else bid
+        locked_mark = " locked" if b.get("locked") is True else ""
+        if include_blob:
+            snippet = str(b.get("snippet", ""))
+            lines.append(
+                f"  [{lane}{locked_mark:7s}] {bid_short}  {snippet}"
+            )
+        else:
+            lines.append(f"  [{lane}{locked_mark:7s}] {bid_short}")
+    return "\n".join(lines)
+
+
+def _short_ts(ts: str) -> str:
+    """Compact `HH:MM:SS` from a full ISO timestamp; passthrough on fail."""
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return ts
+    return dt.strftime("%H:%M:%S")
+
+
+def _read_records(
+    path: Path, *, since_cutoff: datetime | None,
+) -> list[dict[str, object]]:
+    """Read all valid JSON-object records from `path`, optionally
+    filtered to records at or after `since_cutoff`. Lines that fail to
+    parse as JSON objects are silently skipped — `aelf tail` is a
+    diagnostic, not an integrity tool, and a single corrupt line should
+    not abort a live tail. (`read_hook_audit` in hook.py raises on
+    corruption; that's the contract for batch consumers.)
+    """
+    if not path.exists():
+        return []
+    out: list[dict[str, object]] = []
+    text = path.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        if since_cutoff is not None:
+            ts = _parse_record_ts(parsed)
+            if ts is None or ts < since_cutoff:
+                continue
+        out.append(parsed)
+    return out
+
+
+def _emit_records(
+    records: Iterable[dict[str, object]],
+    filters: list[tuple[str, str]],
+    *,
+    include_blob: bool,
+    out: IO[str],
+) -> None:
+    """Format and write each record that matches all filters."""
+    for rec in records:
+        if not record_matches_filters(rec, filters):
+            continue
+        out.write(format_record(rec, include_blob=include_blob))
+        out.write("\n\n")
+        out.flush()
+
+
+def tail_audit(
+    *,
+    audit_path: Path | None = None,
+    filters: list[tuple[str, str]] | None = None,
+    since: timedelta | None = None,
+    include_blob: bool = True,
+    follow: bool = True,
+    out: IO[str] | None = None,
+    poll_interval: float = _TAIL_POLL_INTERVAL,
+    max_iters: int | None = None,
+) -> int:
+    """Read (and optionally follow) the audit log; emit pretty records.
+
+    Backfill semantics: when `since` is set, replay matching records
+    from both the rotated `<path>.1` (oldest) and the live file (newest)
+    in order. Without `since`, follow mode starts at end-of-file and
+    only emits new records as they land.
+
+    `follow=True` (default) keeps tailing forever, polling for new
+    lines and detecting rotation by inode change. `follow=False` reads
+    once and returns — useful for tests and one-shot dumps.
+
+    `max_iters` caps the follow loop's poll cycles. Tests pass a small
+    integer so the loop returns deterministically; production callers
+    leave it None for an infinite tail.
+    """
+    sink: IO[str] = out if out is not None else sys.stdout
+    flt = filters if filters is not None else []
+    if audit_path is None:
+        from aelfrice.cli import db_path
+        audit_path = _audit_path_for_db(db_path())
+    rotated = audit_path.with_name(audit_path.name + AUDIT_ROTATED_SUFFIX)
+
+    cutoff: datetime | None = None
+    if since is not None:
+        cutoff = datetime.now(timezone.utc) - since
+
+    # Backfill: if --since given, read rotated then live. Otherwise (and
+    # in follow mode) skip backfill — start at end-of-file so a fresh
+    # `aelf tail` doesn't dump the entire history on every invocation.
+    if cutoff is not None:
+        backfill: list[dict[str, object]] = []
+        backfill.extend(_read_records(rotated, since_cutoff=cutoff))
+        backfill.extend(_read_records(audit_path, since_cutoff=cutoff))
+        _emit_records(backfill, flt, include_blob=include_blob, out=sink)
+
+    if not follow:
+        if cutoff is None:
+            # One-shot, no --since: dump everything currently in the
+            # live file. Tests rely on this path.
+            records = _read_records(audit_path, since_cutoff=None)
+            _emit_records(records, flt, include_blob=include_blob, out=sink)
+        return 0
+
+    # Follow mode: open the live file at end-of-file and stream new
+    # lines. Detect rotation by ino change (st_ino flips when
+    # _append_audit renames live → .1 and the next write recreates a
+    # fresh inode).
+    pos = 0
+    last_ino: int | None = None
+    if audit_path.exists():
+        pos = audit_path.stat().st_size
+        last_ino = audit_path.stat().st_ino
+
+    iters = 0
+    while True:
+        if max_iters is not None and iters >= max_iters:
+            return 0
+        iters += 1
+
+        if not audit_path.exists():
+            time.sleep(poll_interval)
+            continue
+
+        st = audit_path.stat()
+        if last_ino is not None and st.st_ino != last_ino:
+            # Rotation detected: live file was renamed to .1 and a new
+            # one was created. Reset position to read from the start.
+            pos = 0
+        last_ino = st.st_ino
+
+        if st.st_size <= pos:
+            time.sleep(poll_interval)
+            continue
+
+        with audit_path.open("r", encoding="utf-8") as f:
+            f.seek(pos)
+            new_text = f.read()
+            pos = f.tell()
+
+        new_records: list[dict[str, object]] = []
+        for line in new_text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            new_records.append(parsed)
+        _emit_records(new_records, flt, include_blob=include_blob, out=sink)

--- a/src/aelfrice/hook_tail.py
+++ b/src/aelfrice/hook_tail.py
@@ -6,11 +6,11 @@ with `beliefs[]`, `latency_ms`, and `tokens` fields).
 
 Why this layer is separate from `hook.py`: the writer side runs inside
 the UserPromptSubmit / SessionStart hook process and must stay
-import-cheap (every Claude Code prompt pays its import cost). The
-reader side is interactive and only loads when the operator runs
-`aelf tail`. Splitting keeps hook startup unburdened by formatting
-helpers and reduces the surface area that the hook's non-blocking
-contract has to defend.
+import-cheap (every host-prompt fire pays the import cost). The reader
+side is interactive and only loads when the operator runs `aelf tail`.
+Splitting keeps hook startup unburdened by formatting helpers and
+reduces the surface area that the hook's non-blocking contract has to
+defend.
 """
 from __future__ import annotations
 

--- a/src/aelfrice/slash_commands/tail.md
+++ b/src/aelfrice/slash_commands/tail.md
@@ -1,0 +1,18 @@
+---
+name: aelf:tail
+description: Live-tail the per-turn hook injection audit log; pretty-print what the UserPromptSubmit and SessionStart hooks injected on each fire.
+argument-hint: (optional) --filter hook=user_prompt_submit | --filter lane=L0 | --since 5m | --no-blob | --no-follow
+allowed-tools:
+  - Bash
+---
+<objective>
+Stream the per-turn hook audit log so the operator can see exactly
+which beliefs each UserPromptSubmit / SessionStart fire injected — id,
+lane (L0 locked / L1 retrieved), token count, latency, and a snippet.
+By default tails forever; pass `--no-follow` for a one-shot dump.
+</objective>
+
+<process>
+Run: `uv run aelf tail $ARGUMENTS`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/tests/test_hook_audit.py
+++ b/tests/test_hook_audit.py
@@ -280,9 +280,11 @@ def test_rotation_at_max_bytes(
     _seed_db(db, [_mk("F1", "the kitchen is full of bananas")])
     _set_db(monkeypatch, db)
     monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
-    # Threshold tuned so one record fits, two records exceed.
+    # Threshold tuned so one record fits, two records exceed. Bumped
+    # from 500 → 1000 when #321 added beliefs[]/latency_ms/tokens fields
+    # to the audit record schema (one fire is now ~650B, two ~1300B).
     (tmp_path / ".aelfrice.toml").write_text(
-        "[hook_audit]\nmax_bytes = 500\n", encoding="utf-8",
+        "[hook_audit]\nmax_bytes = 1000\n", encoding="utf-8",
     )
     monkeypatch.chdir(tmp_path)
     audit_path = _audit_path_for_db(db)

--- a/tests/test_hook_tail.py
+++ b/tests/test_hook_tail.py
@@ -1,0 +1,552 @@
+"""Tests for `aelf tail` (#321) — reader/pretty-printer over hook_audit.jsonl.
+
+Covers:
+  - filter parser (valid / invalid / unknown key)
+  - since parser (s/m/h/d, malformed)
+  - record_matches_filters (hook + lane semantics, missing field falsifies)
+  - format_record (header + per-belief lines, --no-blob)
+  - tail_audit one-shot (--no-follow) over a seeded file
+  - tail_audit follow mode picks up new lines
+  - tail_audit follow mode survives rotation (inode flip)
+  - tail_audit --since backfills both rotated and live
+  - end-to-end: hook fires write, `aelf tail --no-follow` reads them
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from aelfrice.hook import (
+    AUDIT_FILENAME,
+    AUDIT_ROTATED_SUFFIX,
+    _audit_path_for_db,
+    _write_hook_audit_record,
+)
+from aelfrice.hook_tail import (
+    format_record,
+    parse_filter,
+    parse_since,
+    record_matches_filters,
+    tail_audit,
+)
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _mk(
+    bid: str,
+    content: str,
+    lock_level: str = LOCK_NONE,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=2.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=("2026-04-26T00:00:00Z" if lock_level == LOCK_USER else None),
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _seed_db(db_path: Path, beliefs: list[Belief]) -> None:
+    store = MemoryStore(str(db_path))
+    try:
+        for b in beliefs:
+            store.insert_belief(b)
+    finally:
+        store.close()
+
+
+def _write_record(
+    audit_path: Path,
+    *,
+    hook: str = "user_prompt_submit",
+    beliefs: list[Belief] | None = None,
+    rendered_block: str = "<aelfrice-memory>...</aelfrice-memory>\n",
+    latency_ms: int = 12,
+    ts: str | None = None,
+) -> None:
+    """Write one audit record by calling `_write_hook_audit_record`. The
+    ts override is only used for `--since` tests; default ts is now()."""
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    # Monkey the global db_path lookup by temporarily setting AELFRICE_DB
+    # to the parent so _audit_path_for_db lands at the right place.
+    bs = beliefs or []
+    n_locked = sum(1 for b in bs if b.lock_level == LOCK_USER)
+    # Going through the live writer keeps schema in sync with production.
+    db = audit_path.parent / "memory.db"
+    os.environ["AELFRICE_DB"] = str(db)
+    _write_hook_audit_record(
+        hook=hook,
+        prompt="bananas",
+        rendered_block=rendered_block,
+        n_beliefs=len(bs),
+        n_locked=n_locked,
+        session_id="sid",
+        beliefs=bs,
+        latency_ms=latency_ms,
+    )
+    if ts is not None:
+        # Patch the most-recent record's ts in place. Used by --since
+        # tests that need an artificially-old record.
+        lines = audit_path.read_text(encoding="utf-8").splitlines()
+        last = json.loads(lines[-1])
+        last["ts"] = ts
+        lines[-1] = json.dumps(last)
+        audit_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# parse_filter
+# ---------------------------------------------------------------------------
+
+
+def test_parse_filter_valid_hook() -> None:
+    assert parse_filter("hook=user_prompt_submit") == (
+        "hook", "user_prompt_submit",
+    )
+
+
+def test_parse_filter_valid_lane() -> None:
+    assert parse_filter("lane=L0") == ("lane", "L0")
+
+
+def test_parse_filter_strips_whitespace() -> None:
+    assert parse_filter("  hook = session_start  ") == (
+        "hook", "session_start",
+    )
+
+
+def test_parse_filter_no_equals_raises() -> None:
+    with pytest.raises(ValueError, match="key=value"):
+        parse_filter("hook")
+
+
+def test_parse_filter_unknown_key_raises() -> None:
+    with pytest.raises(ValueError, match="not recognized"):
+        parse_filter("score=0.5")
+
+
+def test_parse_filter_empty_value_raises() -> None:
+    with pytest.raises(ValueError, match="no value"):
+        parse_filter("hook=")
+
+
+# ---------------------------------------------------------------------------
+# parse_since
+# ---------------------------------------------------------------------------
+
+
+def test_parse_since_seconds() -> None:
+    assert parse_since("30s") == timedelta(seconds=30)
+
+
+def test_parse_since_minutes() -> None:
+    assert parse_since("5m") == timedelta(minutes=5)
+
+
+def test_parse_since_hours() -> None:
+    assert parse_since("2h") == timedelta(hours=2)
+
+
+def test_parse_since_days() -> None:
+    assert parse_since("1d") == timedelta(days=1)
+
+
+def test_parse_since_malformed_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_since("five-minutes")
+
+
+def test_parse_since_missing_unit_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_since("30")
+
+
+# ---------------------------------------------------------------------------
+# record_matches_filters
+# ---------------------------------------------------------------------------
+
+
+def test_filter_hook_match() -> None:
+    rec = {"hook": "user_prompt_submit"}
+    assert record_matches_filters(rec, [("hook", "user_prompt_submit")])
+    assert not record_matches_filters(rec, [("hook", "session_start")])
+
+
+def test_filter_lane_match_when_belief_present() -> None:
+    rec = {
+        "hook": "user_prompt_submit",
+        "beliefs": [{"lane": "L0"}, {"lane": "L1"}],
+    }
+    assert record_matches_filters(rec, [("lane", "L0")])
+    assert record_matches_filters(rec, [("lane", "L1")])
+    assert not record_matches_filters(rec, [("lane", "L2")])
+
+
+def test_filter_lane_no_beliefs_field_falsifies() -> None:
+    rec = {"hook": "user_prompt_submit"}
+    assert not record_matches_filters(rec, [("lane", "L0")])
+
+
+def test_filter_compound_AND() -> None:
+    rec = {
+        "hook": "session_start",
+        "beliefs": [{"lane": "L0"}],
+    }
+    assert record_matches_filters(
+        rec, [("hook", "session_start"), ("lane", "L0")],
+    )
+    assert not record_matches_filters(
+        rec, [("hook", "session_start"), ("lane", "L1")],
+    )
+
+
+# ---------------------------------------------------------------------------
+# format_record
+# ---------------------------------------------------------------------------
+
+
+def test_format_record_header_and_per_belief_lines() -> None:
+    rec = {
+        "ts": "2026-05-02T14:22:11Z",
+        "hook": "user_prompt_submit",
+        "tokens": 412,
+        "latency_ms": 18,
+        "beliefs": [
+            {
+                "id": "ab96e9d3501b1c14",
+                "lane": "L0",
+                "locked": True,
+                "snippet": "Content sourced from somewhere",
+            },
+            {
+                "id": "032197a1cccccccc",
+                "lane": "L1",
+                "locked": False,
+                "snippet": "BM25 hit body",
+            },
+        ],
+    }
+    text = format_record(rec, include_blob=True)
+    lines = text.splitlines()
+    # Header carries hook, tokens, latency, lane counts.
+    assert "user_prompt_submit" in lines[0]
+    assert "412 tok" in lines[0]
+    assert "18 ms" in lines[0]
+    assert "L0×1 L1×1" in lines[0]
+    # Per-belief lines: short id, lane, snippet.
+    assert any("ab96e9d3" in line and "L0" in line for line in lines[1:])
+    assert any("locked" in line for line in lines[1:])
+    assert any("BM25 hit body" in line for line in lines[1:])
+
+
+def test_format_record_no_blob_omits_snippets() -> None:
+    rec = {
+        "ts": "2026-05-02T14:22:11Z",
+        "hook": "user_prompt_submit",
+        "tokens": 100,
+        "latency_ms": 5,
+        "beliefs": [
+            {
+                "id": "abc",
+                "lane": "L0",
+                "locked": True,
+                "snippet": "secret content body",
+            },
+        ],
+    }
+    text = format_record(rec, include_blob=False)
+    assert "secret content body" not in text
+    assert "abc" in text  # id still shown
+    assert "L0" in text
+
+
+def test_format_record_handles_missing_optional_fields() -> None:
+    """Backward-compatible: pre-#321 records lack beliefs/tokens/latency."""
+    rec = {
+        "ts": "2026-05-02T14:22:11Z",
+        "hook": "user_prompt_submit",
+        "n_beliefs": 0,
+        "n_locked": 0,
+    }
+    text = format_record(rec, include_blob=True)
+    # Header still emits without crashing.
+    assert "user_prompt_submit" in text
+    # No "tok" / "ms" tokens since fields are missing.
+    assert "tok" not in text
+    assert " ms" not in text
+
+
+# ---------------------------------------------------------------------------
+# tail_audit one-shot (no follow)
+# ---------------------------------------------------------------------------
+
+
+def test_tail_no_follow_dumps_current_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "alpha")])
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    audit_path = _audit_path_for_db(db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+
+    _write_record(audit_path, beliefs=[_mk("B1", "first")])
+    _write_record(audit_path, beliefs=[_mk("B2", "second")])
+
+    out = io.StringIO()
+    rc = tail_audit(
+        audit_path=audit_path, follow=False, out=out,
+    )
+    assert rc == 0
+    text = out.getvalue()
+    assert "B1" in text
+    assert "B2" in text
+
+
+def test_tail_no_follow_filter_hook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "alpha")])
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    audit_path = _audit_path_for_db(db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+
+    _write_record(audit_path, hook="user_prompt_submit",
+                  beliefs=[_mk("X1", "ups body")])
+    _write_record(audit_path, hook="session_start",
+                  beliefs=[_mk("X2", "ss body")])
+
+    out = io.StringIO()
+    tail_audit(
+        audit_path=audit_path,
+        filters=[("hook", "session_start")],
+        follow=False,
+        out=out,
+    )
+    text = out.getvalue()
+    assert "X2" in text
+    assert "X1" not in text
+
+
+def test_tail_no_follow_filter_lane(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "alpha")])
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    audit_path = _audit_path_for_db(db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+
+    _write_record(
+        audit_path,
+        beliefs=[_mk("L1ONLY", "unlocked", lock_level=LOCK_NONE)],
+    )
+    _write_record(
+        audit_path,
+        beliefs=[_mk("L0HIT", "locked one", lock_level=LOCK_USER)],
+    )
+
+    out = io.StringIO()
+    tail_audit(
+        audit_path=audit_path,
+        filters=[("lane", "L0")],
+        follow=False,
+        out=out,
+    )
+    text = out.getvalue()
+    assert "L0HIT" in text
+    assert "L1ONLY" not in text
+
+
+# ---------------------------------------------------------------------------
+# tail_audit follow mode
+# ---------------------------------------------------------------------------
+
+
+def test_tail_follow_emits_new_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Seed one record, then run tail_audit in follow mode in a thread.
+    Write two more records and assert they show up in the output."""
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "alpha")])
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    audit_path = _audit_path_for_db(db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+
+    _write_record(audit_path, beliefs=[_mk("OLD", "before tail")])
+
+    out = io.StringIO()
+
+    def _run() -> None:
+        tail_audit(
+            audit_path=audit_path, follow=True, out=out,
+            poll_interval=0.02, max_iters=80,
+        )
+
+    th = threading.Thread(target=_run)
+    th.start()
+    time.sleep(0.05)  # let tail_audit reach end-of-file
+    _write_record(audit_path, beliefs=[_mk("NEW1", "after tail")])
+    time.sleep(0.05)
+    _write_record(audit_path, beliefs=[_mk("NEW2", "even later")])
+    th.join(timeout=4.0)
+    text = out.getvalue()
+    # OLD was already in the file when tail started → should NOT show.
+    assert "OLD" not in text
+    assert "NEW1" in text
+    assert "NEW2" in text
+
+
+def test_tail_follow_survives_rotation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simulate a rotation: rename live → .1 mid-tail, recreate live,
+    write a new record. The follower must pick it up."""
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "alpha")])
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    audit_path = _audit_path_for_db(db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+
+    _write_record(audit_path, beliefs=[_mk("PRE", "pre-rotation")])
+
+    out = io.StringIO()
+
+    def _run() -> None:
+        tail_audit(
+            audit_path=audit_path, follow=True, out=out,
+            poll_interval=0.02, max_iters=120,
+        )
+
+    th = threading.Thread(target=_run)
+    th.start()
+    time.sleep(0.05)
+
+    # Rotate: rename live to .1, then write a fresh live record.
+    rotated = audit_path.with_name(audit_path.name + AUDIT_ROTATED_SUFFIX)
+    os.replace(audit_path, rotated)
+    _write_record(audit_path, beliefs=[_mk("POSTROT", "after rotation")])
+    th.join(timeout=4.0)
+    text = out.getvalue()
+    assert "POSTROT" in text
+
+
+# ---------------------------------------------------------------------------
+# tail_audit --since
+# ---------------------------------------------------------------------------
+
+
+def test_tail_since_backfills_recent_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "alpha")])
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    audit_path = _audit_path_for_db(db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+
+    # An old record (10 hours ago) and a fresh one.
+    old_ts = (
+        datetime.now(timezone.utc) - timedelta(hours=10)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    _write_record(
+        audit_path, beliefs=[_mk("ANCIENT", "old")], ts=old_ts,
+    )
+    _write_record(
+        audit_path, beliefs=[_mk("RECENT", "new")],
+    )
+
+    out = io.StringIO()
+    tail_audit(
+        audit_path=audit_path, since=timedelta(minutes=30),
+        follow=False, out=out,
+    )
+    text = out.getvalue()
+    assert "RECENT" in text
+    assert "ANCIENT" not in text
+
+
+def test_tail_since_reads_rotated_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--since` should backfill from .1 (rotated) AND live."""
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("F1", "alpha")])
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    audit_path = _audit_path_for_db(db)
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+
+    # Put one record in .1 (rotated), one in live, both within window.
+    _write_record(audit_path, beliefs=[_mk("ROT", "in rotated")])
+    rotated = audit_path.with_name(audit_path.name + AUDIT_ROTATED_SUFFIX)
+    os.replace(audit_path, rotated)
+    _write_record(audit_path, beliefs=[_mk("LIVE", "in live")])
+
+    out = io.StringIO()
+    tail_audit(
+        audit_path=audit_path, since=timedelta(hours=1),
+        follow=False, out=out,
+    )
+    text = out.getvalue()
+    assert "ROT" in text
+    assert "LIVE" in text
+
+
+# ---------------------------------------------------------------------------
+# end-to-end: hook fire → tail reads
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_hook_fire_then_tail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real hook fire must produce a record that `aelf tail` renders."""
+    from aelfrice.hook import user_prompt_submit
+
+    db = tmp_path / "memory.db"
+    _seed_db(db, [_mk("HIT", "the kitchen is full of bananas")])
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+    audit_path = _audit_path_for_db(db)
+
+    payload = json.dumps({
+        "session_id": "S",
+        "transcript_path": "/dev/null",
+        "cwd": "/tmp",
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "bananas",
+    })
+    rc = user_prompt_submit(stdin=io.StringIO(payload), stdout=io.StringIO())
+    assert rc == 0
+
+    out = io.StringIO()
+    rc = tail_audit(audit_path=audit_path, follow=False, out=out)
+    assert rc == 0
+    text = out.getvalue()
+    # Header lane counts derived from beliefs[].
+    assert "L1×1" in text
+    assert "user_prompt_submit" in text
+    # Per-belief snippet visible.
+    assert "kitchen is full of bananas" in text
+    assert "HIT" in text

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -32,6 +32,7 @@ EXPECTED_COMMANDS = (
     "upgrade",
     "uninstall",
     "rebuild",
+    "tail",
 )
 
 


### PR DESCRIPTION
Closes #321.

## Approach

Per the [pre-implementation comment](https://github.com/robotrocketscience/aelfrice/issues/321#issuecomment-4364482154), this PR takes path **(a)**: extend the existing `hook_audit.jsonl` (shipped in #280 mitigation 3) rather than ship a parallel `injections.ndjson`. The rationale and three-path breakdown is in the issue thread; the user picked (a).

Net result is a single audit log on the file system — same path, same rotation, same writer entry-points — with additive structured fields and a new reader CLI.

## Schema additions to `hook_audit.jsonl`

All additive and optional, so older readers keep working unchanged:

| Field | Type | Source |
|---|---|---|
| `beliefs` | `list[{id, lane, locked, content_hash, alpha, beta, posterior_mean, snippet}]` | per-hit projection of the rendered belief list |
| `latency_ms` | `int` | wall-clock around retrieve+format span |
| `tokens` | `int` | rendered_block sized via the same 4-chars-per-token estimator retrieval uses for budgeting |

`lane` is derived from `lock_level` (`LOCK_USER` → `"L0"`, else `"L1"`). Per-hit BM25 / ranking scores are intentionally **not** included — `retrieve()` does not propagate per-hit scores through to the hook caller, and adding that plumbing was out of scope for #321 (replay harness over historical logs is explicitly out-of-scope in the issue body too). `posterior_mean` is computed from the belief's `alpha`/`beta` so the user can still see Bayesian confidence at a glance.

`snippet` is the first line of `belief.content` capped at 120 chars; the full `rendered_block` is still on the record (existing field), so nothing is lost — the snippet is for at-a-glance scanning in `aelf tail` output.

## `aelf tail`

```
$ aelf tail --help
usage: aelf tail [-h] [--filter key=value] [--since DUR] [--no-blob] [--no-follow]

  --filter key=value  hook=<name> | lane=L0 | lane=L1. Repeatable, AND-joined.
  --since DUR         30s | 5m | 2h | 1d — backfill rotated + live before tailing
  --no-blob           suppress per-belief snippet bodies (header + ids only)
  --no-follow         dump current contents once and exit
```

Header line: `<HH:MM:SS>  <hook>  <tokens> tok  <latency> ms  L0×N L1×M`. Then one indented line per belief from `beliefs[]`.

Default behaviour (no `--since`, follow): start at end-of-file and stream new records. Rotation is detected via inode change so tail survives a single-slot rotation. Filter semantics are falsifying (records missing the queried field never match) so the count of matched records is well-defined.

The reader lives in a new `aelfrice.hook_tail` module — splitting it from `aelfrice.hook` keeps the hook write path import-cheap (every `UserPromptSubmit` fire pays its import cost).

## Tests

- 27 new tests in `tests/test_hook_tail.py` covering: filter parser (valid / unknown key / missing value), `--since` parser (s/m/h/d, malformed), `record_matches_filters` (hook + lane semantics + AND), `format_record` (header + per-belief + `--no-blob` + missing-optional-fields back-compat), one-shot tail, follow mode (new-line pickup + rotation survival), `--since` (rotated + live backfill), and an end-to-end hook-fire-then-tail integration test.
- `tests/test_hook_audit.py::test_rotation_at_max_bytes` threshold bumped 500 → 1000 to accommodate the larger record (~650B per fire vs. ~250B previously).
- `tests/test_slash_commands.py` updated: added `tail` to `EXPECTED_COMMANDS`. New `slash_commands/tail.md`.
- `pytest -q` → 2013 passed, 14 skipped (pre-existing skips, unrelated).

## Out of scope (deferred)

- Per-hit BM25 score plumbing through `retrieve()` → audit record.
- `aelf statusline-inject` (Optional, separate commit per issue body).
- Replay harness over historical logs.

## Discretion

Reserved-vocab grep over the full diff is empty.

## Summary by Sourcery

Extend hook injection auditing with richer per-belief metadata and add a CLI subcommand to live-tail and inspect these audit logs.

New Features:
- Add per-belief audit metadata (beliefs list, token estimates, latency) to hook audit records for UserPromptSubmit and SessionStart hooks.
- Introduce the `aelf tail` CLI subcommand and backing `hook_tail` module to pretty-print and live-tail hook audit logs with filtering and time-based backfill.
- Define a new slash command `aelf:tail` to expose the tail functionality via slash commands.

Enhancements:
- Estimate and persist token counts for rendered hook injection blocks using the existing 4-chars-per-token heuristic.
- Capture and record end-to-end retrieval+format latency for each hook fire in the audit log.
- Serialize beliefs into a compact, lane-annotated snippet form to support quick scanning in tail output.
- Adjust hook audit rotation threshold in tests to account for larger audit records produced by the new schema additions.

Documentation:
- Document the `aelf tail` slash command usage, arguments, and behavior.

Tests:
- Add comprehensive tests for the new hook_tail module, including filter and since parsing, matching semantics, formatting, follow mode, rotation handling, and end-to-end hook-to-tail flows.
- Update existing tests to reflect the new tail subcommand and increased audit record size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `aelf tail` CLI command for live-tailing hook injection audit logs with optional record filtering, time-window filtering, and output control options (`--no-follow` for one-shot mode, `--no-blob` to exclude content snippets).
  * Enhanced audit logs to include per-turn latency measurements and token counts.

* **Documentation**
  * Added reference documentation for the `aelf tail` command.

* **Tests**
  * Added comprehensive test coverage for tail functionality and audit logging enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->