### PR TITLE
feat(retention): wire per-ingest-source defaults (#290 phase-2)

### DIFF
--- a/src/aelfrice/derivation.py
+++ b/src/aelfrice/derivation.py
@@ -28,6 +28,7 @@ from aelfrice.models import (
     ORIGIN_USER_STATED,
     Belief,
     Edge,
+    retention_class_for_source,
 )
 
 _BELIEF_ID_HEX_LEN: Final[int] = 16
@@ -192,6 +193,7 @@ def derive(inp: DerivationInput) -> DerivationOutput:
             last_retrieved_at=None,
             session_id=inp.session_id,
             origin=ORIGIN_USER_STATED,
+            retention_class=retention_class_for_source(inp.source_kind),
         )
         return DerivationOutput(belief=belief, edges=[])
 
@@ -213,6 +215,7 @@ def derive(inp: DerivationInput) -> DerivationOutput:
             last_retrieved_at=None,
             session_id=inp.session_id,
             origin=ORIGIN_AGENT_INFERRED,
+            retention_class=retention_class_for_source(inp.source_kind),
         )
         return DerivationOutput(belief=belief, edges=[])
 
@@ -239,6 +242,7 @@ def derive(inp: DerivationInput) -> DerivationOutput:
             last_retrieved_at=None,
             session_id=inp.session_id,
             origin=ORIGIN_AGENT_INFERRED,
+            retention_class=retention_class_for_source(inp.source_kind),
         )
         return DerivationOutput(belief=belief, edges=[])
 
@@ -265,5 +269,6 @@ def derive(inp: DerivationInput) -> DerivationOutput:
         last_retrieved_at=None,
         session_id=inp.session_id,
         origin=ORIGIN_AGENT_INFERRED,
+        retention_class=retention_class_for_source(inp.source_kind),
     )
     return DerivationOutput(belief=belief, edges=[])

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -73,6 +73,33 @@ RETENTION_CLASSES: Final[frozenset[str]] = frozenset({
     RETENTION_UNKNOWN,
 })
 
+# Per-ingest-source defaults from docs/belief_retention_class.md § 2.
+# `transient` is never a default — it is operator-supplied only,
+# reserved for a future `aelf remember --transient` flag.
+# Sources outside this table fall back to RETENTION_UNKNOWN; use
+# retention_class_for_source() rather than reading directly.
+_RETENTION_DEFAULT_BY_SOURCE: Final[dict[str, str]] = {
+    "filesystem": RETENTION_FACT,
+    "git": RETENTION_FACT,
+    "python_ast": RETENTION_FACT,
+    "mcp_remember": RETENTION_FACT,
+    "cli_remember": RETENTION_FACT,
+    "feedback_loop_synthesis": RETENTION_SNAPSHOT,
+    "legacy_unknown": RETENTION_UNKNOWN,
+}
+
+
+def retention_class_for_source(source_kind: str) -> str:
+    """Return the default retention_class for a given ingest source_kind.
+
+    Phase-2 wiring for #290: every ingest path that constructs a Belief
+    asks here rather than hard-coding a value, so the spec table stays
+    the single source of truth. Unknown source_kinds (e.g. test
+    fixtures, future ingest paths not yet ratified) fall back to
+    RETENTION_UNKNOWN — safer than guessing.
+    """
+    return _RETENTION_DEFAULT_BY_SOURCE.get(source_kind, RETENTION_UNKNOWN)
+
 # --- Origin (provenance tier, v1.2+) ---
 # Wire-format strings; appear in feedback_history.source for promotion
 # events. Do not rename without a migration. Tier ordering matches

--- a/src/aelfrice/scanner.py
+++ b/src/aelfrice/scanner.py
@@ -32,6 +32,7 @@ from aelfrice.models import (
     INGEST_SOURCE_FILESYSTEM,
     LOCK_NONE,
     Belief,
+    retention_class_for_source,
 )
 from aelfrice.noise_filter import NoiseConfig, is_noise
 from aelfrice.store import MemoryStore
@@ -260,6 +261,9 @@ def scan_repo(
                     created_at=created_at,
                     last_retrieved_at=None,
                     origin=route.origin,
+                    retention_class=retention_class_for_source(
+                        INGEST_SOURCE_FILESYSTEM,
+                    ),
                 ),
                 source_type=CORROBORATION_SOURCE_FILESYSTEM_INGEST,
             )

--- a/tests/test_retention_class_defaults.py
+++ b/tests/test_retention_class_defaults.py
@@ -1,0 +1,102 @@
+"""Tests for #290 phase-2: per-ingest-source retention_class defaults.
+
+Covers the spec table at docs/belief_retention_class.md § 2 and its
+wiring through derivation.derive() and scanner.
+
+Phase-1 (PR #351) shipped the column + python validator. Phase-2
+(this PR) ratifies the per-source defaults so live ingest paths stop
+landing every new belief as `unknown`.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aelfrice.derivation import DerivationInput, derive
+from aelfrice.models import (
+    INGEST_SOURCE_CLI_REMEMBER,
+    INGEST_SOURCE_FEEDBACK_LOOP_SYNTHESIS,
+    INGEST_SOURCE_FILESYSTEM,
+    INGEST_SOURCE_GIT,
+    INGEST_SOURCE_LEGACY_UNKNOWN,
+    INGEST_SOURCE_MCP_REMEMBER,
+    INGEST_SOURCE_PYTHON_AST,
+    RETENTION_FACT,
+    RETENTION_SNAPSHOT,
+    RETENTION_UNKNOWN,
+    retention_class_for_source,
+)
+
+
+# ---- helper surface -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source_kind,expected",
+    [
+        (INGEST_SOURCE_FILESYSTEM, RETENTION_FACT),
+        (INGEST_SOURCE_GIT, RETENTION_FACT),
+        (INGEST_SOURCE_PYTHON_AST, RETENTION_FACT),
+        (INGEST_SOURCE_MCP_REMEMBER, RETENTION_FACT),
+        (INGEST_SOURCE_CLI_REMEMBER, RETENTION_FACT),
+        (INGEST_SOURCE_FEEDBACK_LOOP_SYNTHESIS, RETENTION_SNAPSHOT),
+        (INGEST_SOURCE_LEGACY_UNKNOWN, RETENTION_UNKNOWN),
+    ],
+)
+def test_retention_class_for_source_table(
+    source_kind: str, expected: str
+) -> None:
+    assert retention_class_for_source(source_kind) == expected
+
+
+def test_unknown_source_kind_falls_back_to_unknown() -> None:
+    # Future / test-only / not-yet-ratified source labels must not
+    # silently become 'fact' — that would lie about provenance.
+    assert retention_class_for_source("not-a-real-source") == RETENTION_UNKNOWN
+
+
+def test_no_source_defaults_to_transient() -> None:
+    # The spec is explicit: `transient` is operator-supplied only,
+    # never assigned by default. Guard against accidental reintroduction.
+    for value in {retention_class_for_source(s) for s in [
+        INGEST_SOURCE_FILESYSTEM,
+        INGEST_SOURCE_GIT,
+        INGEST_SOURCE_PYTHON_AST,
+        INGEST_SOURCE_MCP_REMEMBER,
+        INGEST_SOURCE_CLI_REMEMBER,
+        INGEST_SOURCE_FEEDBACK_LOOP_SYNTHESIS,
+        INGEST_SOURCE_LEGACY_UNKNOWN,
+    ]}:
+        assert value != "transient"
+
+
+# ---- derive() wiring ----------------------------------------------------
+
+
+def test_derive_cli_remember_belief_is_fact() -> None:
+    out = derive(DerivationInput(
+        raw_text="A real fact the operator wants preserved.",
+        source_kind=INGEST_SOURCE_CLI_REMEMBER,
+        ts="2026-05-02T00:00:00Z",
+    ))
+    assert out.belief is not None
+    assert out.belief.retention_class == RETENTION_FACT
+
+
+def test_derive_mcp_remember_belief_is_fact() -> None:
+    out = derive(DerivationInput(
+        raw_text="MCP-written fact.",
+        source_kind=INGEST_SOURCE_MCP_REMEMBER,
+        ts="2026-05-02T00:00:00Z",
+    ))
+    assert out.belief is not None
+    assert out.belief.retention_class == RETENTION_FACT
+
+
+def test_derive_git_commit_belief_is_fact() -> None:
+    out = derive(DerivationInput(
+        raw_text="alice fixed bug",
+        source_kind=INGEST_SOURCE_GIT,
+        ts="2026-05-02T00:00:00Z",
+    ))
+    assert out.belief is not None
+    assert out.belief.retention_class == RETENTION_FACT


### PR DESCRIPTION
Phase-2 of #290. Phase-1 (PR #351) added the `retention_class` column +
python validator; every new belief landed as `unknown` because no live
ingest path actually picked a value. This wires the spec table at
`docs/belief_retention_class.md` § 2 into `derive()` and `scanner` so
production writes stop defaulting to the migration sentinel.

## What lands

- `models.retention_class_for_source(source_kind)` helper backed by a
  small dict mapping each `INGEST_SOURCE_*` constant to its spec value.
  Unknown source kinds fall back to `RETENTION_UNKNOWN` (safer than
  guessing `fact` for an unratified path).
- `derivation.derive`: every `Belief()` construction (lock/remember,
  triple/git, override-classified, regex-classified) sets
  `retention_class` from `inp.source_kind` via the helper.
- `scanner.scan_repo`: the direct `Belief()` construction now sets
  `retention_class=retention_class_for_source(INGEST_SOURCE_FILESYSTEM)`.

`transient` remains never-assigned-by-default per spec; reserved for a
future operator-supplied `aelf remember --transient` flag.

## Resulting mapping (per spec § 2)

| Source                      | retention_class |
|-----------------------------|-----------------|
| filesystem                  | fact            |
| git                         | fact            |
| python_ast                  | fact            |
| mcp_remember                | fact            |
| cli_remember                | fact            |
| feedback_loop_synthesis     | snapshot        |
| legacy_unknown              | unknown         |
| (any unrecognized)          | unknown         |

## Tests (12 new)

- parametrized table check covering every defined `INGEST_SOURCE_*`
- unknown / future source kind falls back to `unknown`
- `transient` is never produced as a default — regression guard
- `derive()` round-trip for `cli_remember`, `mcp_remember`, `git` —
  confirms the wiring actually reaches the constructed `Belief`

Full suite: 2051 passed, 20 skipped.

## Out of scope (followups)

- `transcript_ingest` / `hook_ingest` defaults — those paths don't go
  through `INGEST_SOURCE_KINDS` today; addressed when those source
  kinds get added to the v2.0 ingest_log enum.
- Snapshot -> fact promotion via the corroboration recorder.
- Aging-multiplier ranker integration (#289 floor coupling).
- One-shot heuristic backfill of existing `unknown` rows from
  `source_kind`.

Tracks #290.

## Summary by Sourcery

Wire ingest source kinds to retention_class defaults so new beliefs derive their retention classification from a single shared mapping instead of defaulting to unknown.

New Features:
- Introduce a central retention_class_for_source helper that maps ingest source kinds to their default retention_class values per the documented spec.

Bug Fixes:
- Ensure beliefs created via derivation and repository scanning receive the correct non-unknown retention_class by default instead of the migration sentinel.

Enhancements:
- Apply the retention_class_for_source mapping across all Belief construction paths in derive() and scanner to keep retention behavior consistent and spec-driven.

Tests:
- Add tests covering the per-source retention_class mapping, unknown-source fallback behavior, guarding against transient as a default, and verifying derive() propagates the expected retention_class for key ingest sources.