### PR TITLE
test(e2e): tests/e2e/ skeleton + scenario 1 (#334 step 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - run: uv sync --frozen --group dev --extra archive
-      - run: uv run pytest tests/ -q
+      - run: uv run pytest tests/ --ignore=tests/e2e -q

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,11 +29,13 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.13'
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           case "${{ matrix.install-method }}" in
             uv-tool)   bin="$HOME/.local/bin/aelf" ;;
-            pipx)      bin="$HOME/.local/bin/aelf" ;;
+            pipx)      bin="$(pipx environment --value PIPX_BIN_DIR)/aelf" ;;
             venv-pip)  bin="$PWD/.e2e-venv/bin/aelf" ;;
           esac
           test -x "$bin" || { echo "::error::aelf binary not found at $bin"; exit 1; }

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,60 @@
+name: E2E
+
+# End-to-end suite (#334). Step-1 trigger: PR opt-in via the `e2e` label
+# only. Step-4 of the rollout flips this to also run on push to main and
+# adds the `attn:e2e-failure` issue-opening step. See umbrella issue.
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    if: contains(github.event.pull_request.labels.*.name, 'e2e')
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    strategy:
+      fail-fast: false
+      matrix:
+        install-method: [uv-tool, pipx, venv-pip]
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Install pipx
+        if: matrix.install-method == 'pipx'
+        run: python -m pip install --user pipx
+      - name: Install via ${{ matrix.install-method }}
+        run: ./tests/e2e/install-${{ matrix.install-method }}.sh
+      - name: Locate installed aelf
+        id: locate
+        run: |
+          case "${{ matrix.install-method }}" in
+            uv-tool)   bin="$HOME/.local/bin/aelf" ;;
+            pipx)      bin="$HOME/.local/bin/aelf" ;;
+            venv-pip)  bin="$PWD/.e2e-venv/bin/aelf" ;;
+          esac
+          test -x "$bin" || { echo "::error::aelf binary not found at $bin"; exit 1; }
+          echo "bin=$bin" >> "$GITHUB_OUTPUT"
+      - name: Run e2e suite against installed binary
+        env:
+          AELFRICE_E2E_BIN: ${{ steps.locate.outputs.bin }}
+        run: |
+          uv sync --frozen --group dev
+          uv run pytest tests/e2e/ -q --maxfail=3

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,148 @@
+"""E2E test fixtures (#334).
+
+Boundary rule: e2e tests invoke the binary as installed (subprocess),
+never via in-process imports. Fixtures here are deliberately minimal —
+each test owns its own ephemeral DB and (where needed) its own
+synthetic git project. No mocks for store, store init, or schema.
+
+`installed_aelf` resolves which `aelf` to run:
+    AELFRICE_E2E_BIN env var > shutil.which('aelf') > 'uv run aelf'.
+
+CI sets AELFRICE_E2E_BIN per install-method matrix leg
+(see .github/workflows/e2e.yml). Locally the fallback to `uv run aelf`
+keeps the suite runnable without an explicit install step.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def ephemeral_db(tmp_path: Path) -> Path:
+    """Per-test SQLite path. Set AELFRICE_DB to this in subprocess env."""
+    return tmp_path / "aelf.sqlite3"
+
+
+@pytest.fixture
+def installed_aelf() -> Sequence[str]:
+    """Argv prefix for invoking `aelf`. Tuple of strings; tests append args."""
+    explicit = os.environ.get("AELFRICE_E2E_BIN")
+    if explicit:
+        return (explicit,)
+    on_path = shutil.which("aelf")
+    if on_path:
+        return (on_path,)
+    # Local fallback for `pytest tests/e2e/` without an explicit install.
+    return ("uv", "run", "aelf")
+
+
+@pytest.fixture
+def aelf_run(
+    installed_aelf: Sequence[str],
+    ephemeral_db: Path,
+) -> Iterator[
+    "callable[..., subprocess.CompletedProcess[str]]"  # type: ignore[name-defined]
+]:
+    """Run `aelf <args>` with AELFRICE_DB pinned to the ephemeral DB.
+
+    Returns a callable so tests can capture stdout/stderr and exit code.
+    Inherits the parent environment (PATH etc.) and overlays AELFRICE_DB.
+    """
+
+    def _run(
+        *args: str,
+        cwd: Path | None = None,
+        check: bool = True,
+        timeout: float = 60.0,
+        extra_env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["AELFRICE_DB"] = str(ephemeral_db)
+        if extra_env:
+            env.update(extra_env)
+        return subprocess.run(  # noqa: S603 — argv list, not shell
+            [*installed_aelf, *args],
+            cwd=str(cwd) if cwd else None,
+            env=env,
+            check=check,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    yield _run
+
+
+@pytest.fixture
+def tiny_project(tmp_path: Path) -> Path:
+    """Public-safe synthetic git repo with a handful of distinctive commits.
+
+    Deliberately not a snapshot of any real project. Content is generated
+    inline so the fixture has no on-disk dependencies and no
+    directory-of-origin concerns.
+    """
+    proj = tmp_path / "tiny-project"
+    proj.mkdir()
+
+    files: dict[str, str] = {
+        "README.md": textwrap.dedent(
+            """
+            # tiny-project
+
+            Synthetic fixture for aelfrice e2e tests. The phrase
+            `quokka calibration knob` is a deliberate distinctive
+            token that search tests look for.
+            """
+        ).strip()
+        + "\n",
+        "src/widgets.py": textwrap.dedent(
+            '''
+            """Widgets module — distinctive token: aardvark-counter."""
+
+
+            def make_widget(label: str) -> dict[str, str]:
+                """Construct a labeled widget."""
+                return {"label": label, "kind": "widget"}
+            '''
+        ).lstrip(),
+        "docs/notes.md": "Calibrating the quokka knob requires three turns.\n",
+    }
+
+    for relpath, body in files.items():
+        path = proj / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+
+    git_env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "tiny-project",
+        "GIT_AUTHOR_EMAIL": "tiny@example.invalid",
+        "GIT_COMMITTER_NAME": "tiny-project",
+        "GIT_COMMITTER_EMAIL": "tiny@example.invalid",
+    }
+
+    def git(*args: str) -> None:
+        subprocess.run(  # noqa: S603
+            ["git", *args],  # noqa: S607
+            cwd=proj,
+            env=git_env,
+            check=True,
+            capture_output=True,
+        )
+
+    git("init", "-q", "-b", "main")
+    git("add", "README.md")
+    git("commit", "-q", "-m", "init: tiny-project README")
+    git("add", "src/widgets.py")
+    git("commit", "-q", "-m", "feat: add widgets module")
+    git("add", "docs/notes.md")
+    git("commit", "-q", "-m", "docs: note quokka calibration cadence")
+
+    return proj

--- a/tests/e2e/install-pipx.sh
+++ b/tests/e2e/install-pipx.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Install the working tree via pipx. Single dumb line per spec.
+# Used by the e2e workflow's `pipx` matrix leg (#334).
+set -euo pipefail
+pipx install --force .

--- a/tests/e2e/install-uv-tool.sh
+++ b/tests/e2e/install-uv-tool.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Install the working tree as an isolated uv-tool. Single dumb line per spec.
+# Used by the e2e workflow's `uv-tool` matrix leg (#334).
+set -euo pipefail
+uv tool install --force .

--- a/tests/e2e/install-venv-pip.sh
+++ b/tests/e2e/install-venv-pip.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Install the working tree into a fresh venv via pip. Single dumb line per
+# spec; the venv's bin/ is exported on PATH by the workflow step.
+# Used by the e2e workflow's `venv-pip` matrix leg (#334).
+set -euo pipefail
+python -m venv .e2e-venv
+.e2e-venv/bin/pip install --quiet --upgrade pip
+.e2e-venv/bin/pip install --quiet .

--- a/tests/e2e/test_install_onboard_search.py
+++ b/tests/e2e/test_install_onboard_search.py
@@ -1,0 +1,81 @@
+"""E2E scenario #1 (#334): install -> onboard -> search returns hits.
+
+Catches: install-time wiring drift, search-path drift, onboard
+candidate-emit JSON contract drift. Failure here means the binary
+on PATH cannot complete the most basic ingest-then-retrieve loop.
+
+Distinct from in-process tests because every step runs through the
+real `aelf` argv entry point and a real SQLite file.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+
+pytestmark = pytest.mark.timeout(120)
+
+
+def test_aelf_version_prints(
+    aelf_run: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    """The installed binary responds to --version. Smoke check for matrix."""
+    result = aelf_run("--version")
+    assert result.returncode == 0
+    # Version string format is `aelfrice X.Y.Z` — match prefix only so the
+    # test isn't coupled to the live version number.
+    assert result.stdout.strip(), "expected non-empty version output"
+
+
+def test_onboard_emit_candidates_returns_distinctive_token(
+    aelf_run: Callable[..., subprocess.CompletedProcess[str]],
+    tiny_project: Path,
+) -> None:
+    """`aelf onboard --emit-candidates` extracts text from the fixture.
+
+    The synthetic repo seeds a distinctive token ("quokka calibration") in
+    README and docs. If candidate emission is wired correctly the token
+    appears in the JSON sentences[] payload printed to stdout.
+    """
+    result = aelf_run(
+        "onboard",
+        "--emit-candidates",
+        str(tiny_project),
+        timeout=90.0,
+    )
+    assert result.returncode == 0, (
+        f"onboard --emit-candidates exited {result.returncode}; "
+        f"stderr: {result.stderr!r}"
+    )
+    payload = json.loads(result.stdout)
+    assert "session_id" in payload
+    assert "sentences" in payload
+    sentences = payload["sentences"]
+    assert isinstance(sentences, list)
+    joined = " ".join(
+        s if isinstance(s, str) else json.dumps(s) for s in sentences
+    ).lower()
+    assert "quokka" in joined, (
+        f"expected distinctive token 'quokka' in candidate sentences; "
+        f"got first 5: {sentences[:5]!r}"
+    )
+
+
+def test_search_runs_against_empty_store(
+    aelf_run: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    """`aelf search` against a fresh store completes cleanly with 0 hits.
+
+    Guards the search-path init story: store auto-creates, FTS5 index is
+    queryable, exit code is 0 even with no matches. (Catches the class
+    of regression where a missing migration leaves FTS5 unbuilt.)
+    """
+    result = aelf_run("search", "quokka", check=False)
+    assert result.returncode == 0, (
+        f"empty-store search exited {result.returncode}; "
+        f"stderr: {result.stderr!r}"
+    )


### PR DESCRIPTION
Step 1 of #334's rollout: land the `tests/e2e/` skeleton + scenario #1
behind a CI job that runs only on PR with the `e2e` label, so we can
verify wall time and the install-method matrix before flipping the
`if:` to also run on push to `main` (step 4).

## What lands

- `tests/e2e/conftest.py` — three fixtures:
  - `ephemeral_db` (per-test SQLite under `tmp_path`)
  - `installed_aelf` (argv prefix; resolves `AELFRICE_E2E_BIN` >
    `shutil.which('aelf')` > `uv run aelf` so the suite runs in CI
    *and* locally without an explicit install step)
  - `aelf_run` (callable that pins `AELFRICE_DB` and captures output)
  - `tiny_project` (synthetic three-commit git repo with a
    distinctive token; generated inline — no on-disk fixture data,
    no directory-of-origin concerns)
- `tests/e2e/test_install_onboard_search.py` — three test cases:
  - `--version` smoke check (binary on PATH, importable)
  - `onboard --emit-candidates` against `tiny_project` finds the
    distinctive token in the JSON `sentences[]` payload
  - `search` against an empty store exits 0 (catches the missing-
    migration / FTS5-unbuilt regression class)
- `tests/e2e/install-{uv-tool,pipx,venv-pip}.sh` — three single-line
  shell scripts, one per matrix leg, per spec ("keep them dumb").
- `.github/workflows/e2e.yml` — new workflow:
  - PR-label opt-in only this round (`contains(... labels.*.name, 'e2e')`)
  - Matrix `install-method = [uv-tool, pipx, venv-pip]`
  - `fail-fast: false` so legs don't mask each other
  - 8 min timeout per spec hard cap
  - harden-runner audit egress, pinned actions
- `.github/workflows/ci.yml` — `pytest` now uses
  `--ignore=tests/e2e` so the unit job stays in-process and doesn't
  trip over the e2e suite (which expects the matrix install step to
  set `AELFRICE_E2E_BIN`).

## Local verification

```
$ uv run pytest tests/e2e/ -q
3 passed in 1.51s

$ uv run pytest tests/ --ignore=tests/e2e -q
2051 passed, 20 skipped in 43.84s
```

## What's deliberately *not* in this PR

Subsequent rollout steps (each a separate atomic PR referencing the
umbrella):

- step 2: scenarios #3 (`source_type` discrimination) + #2 (hook
  round-trip) — the load-bearing ones, deferred so the matrix
  trigger gets validated on a smaller surface first.
- step 3: scenario #5 (migration) + the synthetic v1.4 snapshot
  fixture (option (a) per spec).
- step 4: flip `if:` to also run on `push: main` and add the
  `attn:e2e-failure` issue-opening step on failure.
- step 5: `docs/testing-strategy.md` companion doc.
- step 6: 30-day flake review, then promote to required-on-PR.

## Verifying the PR-label trigger

After merging this PR, the next PR that wants e2e coverage adds the
`e2e` label and the workflow runs. Until then it is dormant — zero
CI cost on the existing PR queue.

Tracks #334.

## Summary by Sourcery

Introduce an end-to-end testing skeleton and initial scenario, and wire it into a label-gated CI workflow while isolating it from the existing unit test job.

New Features:
- Add an e2e test suite with fixtures and a tiny synthetic git project to exercise the installed aelf binary via subprocess.
- Add the first e2e scenario covering version output, onboarding candidate emission, and search behavior against an empty store.

Enhancements:
- Exclude the e2e tests from the standard pytest run in the main CI workflow to keep unit tests focused and fast.

CI:
- Add a new GitHub Actions workflow that runs the e2e test matrix for different install methods when PRs are labeled with 'e2e'.
- Add simple install scripts per install method (uv-tool, pipx, venv-pip) used by the e2e CI matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test suite validating version reporting, project onboarding, and search behavior across multiple install methods.
  * Introduced fixtures and helpers to run the CLI against ephemeral projects and databases.

* **Chores**
  * CI updated to run end-to-end tests in a dedicated workflow and exclude them from the primary test run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->