### PR TITLE
feat(doctor): aelf doctor --promote-retention (#290 phase-3)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -79,8 +79,10 @@ from aelfrice.doctor import (
     diagnose,
     format_orphan_feedback_report as _format_orphan_feedback_report,
     format_orphan_report as _format_orphan_report,
+    format_promotion_report as _format_promotion_report,
     format_report,
     gc_orphan_feedback as _gc_orphan_feedback,
+    promote_retention as _promote_retention,
 )
 from aelfrice.llm_classifier import (
     ENV_API_KEY as _LLM_ENV_API_KEY,
@@ -2129,6 +2131,8 @@ def _cmd_doctor(args: argparse.Namespace, out: object) -> int:
         return _cmd_doctor_classify_orphans(args, out)
     if getattr(args, "gc_orphan_feedback", False):
         return _cmd_doctor_gc_orphan_feedback(args, out)
+    if getattr(args, "promote_retention", False):
+        return _cmd_doctor_promote_retention(args, out)
     if getattr(args, "replay", False):
         return _cmd_doctor_replay(args, out)
     scope = getattr(args, "scope", None)
@@ -2275,6 +2279,33 @@ def _cmd_doctor_gc_orphan_feedback(
     finally:
         store.close()
     print(_format_orphan_feedback_report(report), file=out)  # type: ignore[arg-type]
+    return 0
+
+
+def _cmd_doctor_promote_retention(
+    args: argparse.Namespace, out: object
+) -> int:
+    """Promote snapshot beliefs to ``fact`` once corroborated enough
+    (issue #290 phase-3).
+
+    A snapshot is promoted when corroborated >= 3 times across >= 2
+    distinct sessions with no inbound CONTRADICTS edge. See
+    docs/belief_retention_class.md §4.
+
+    Opt-in by design (mirrors --classify-orphans from #206). Use
+    --dry-run to count candidates without mutating; --max N to cap
+    promotions per run. Bypasses the hooks/graph checks.
+    """
+    dry_run = bool(getattr(args, "dry_run", False))
+    max_n_raw = getattr(args, "max", None)
+    max_n: int | None = int(max_n_raw) if max_n_raw is not None else None
+
+    store = _open_store()
+    try:
+        report = _promote_retention(store, dry_run=dry_run, max_n=max_n)
+    finally:
+        store.close()
+    print(_format_promotion_report(report), file=out)  # type: ignore[arg-type]
     return 0
 
 
@@ -2832,7 +2863,9 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         default=False,
         help=(
             "with --classify-orphans: print orphan count and "
-            "before-distribution without making LLM calls or DB writes."
+            "before-distribution without making LLM calls or DB writes. "
+            "with --promote-retention: count promotable snapshots "
+            "without writing."
         ),
     )
     p_doctor.add_argument(
@@ -2844,7 +2877,22 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help=(
             "with --classify-orphans: cap the number of beliefs "
             "classified per run. No cap by default; recommended: 500 "
-            "for large stores to bound per-run cost."
+            "for large stores to bound per-run cost. "
+            "with --promote-retention: cap the number of beliefs "
+            "promoted per run."
+        ),
+    )
+    p_doctor.add_argument(
+        "--promote-retention",
+        dest="promote_retention",
+        action="store_true",
+        default=False,
+        help=(
+            "promote snapshot beliefs to 'fact' once corroborated >= 3 "
+            "times across >= 2 distinct sessions with no inbound "
+            "CONTRADICTS edge (issue #290 phase-3). Bypasses the "
+            "hooks/graph checks. Combine with --dry-run to count "
+            "candidates without writing."
         ),
     )
     p_doctor.add_argument(

--- a/src/aelfrice/doctor.py
+++ b/src/aelfrice/doctor.py
@@ -1095,3 +1095,107 @@ def format_orphan_feedback_report(report: OrphanFeedbackReport) -> str:
     else:
         lines.append(f"deleted: {report.deleted}")
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# promote-retention pass (issue #290 phase-3)
+# ---------------------------------------------------------------------------
+
+# Promotion thresholds from docs/belief_retention_class.md §4.
+# A snapshot belief is promoted to ``fact`` once it has been
+# corroborated at least N times across at least M distinct sessions
+# with no inbound CONTRADICTS edge. Constants are module-level so
+# tests can reference the canonical values.
+PROMOTE_RETENTION_MIN_CORROBORATIONS: Final[int] = 3
+PROMOTE_RETENTION_MIN_SESSIONS: Final[int] = 2
+
+# Wire-format source string for the synthetic feedback_history row
+# written on promotion. Operators auditing feedback_history grep on
+# this; do not rename without a migration.
+FEEDBACK_SOURCE_RETENTION_PROMOTION: Final[str] = "retention_promotion"
+
+
+@dataclass
+class PromotionRunReport:
+    """Summary of one `promote_retention` pass.
+
+    `candidates_found` is the count of snapshot beliefs meeting the
+    corroboration / distinct-session / no-CONTRADICTS rule, before
+    `max_n` is applied. `promoted` is the number actually flipped to
+    `fact`. `dry_run` flags whether DB writes occurred.
+    """
+
+    candidates_found: int = 0
+    promoted: int = 0
+    dry_run: bool = False
+
+
+def promote_retention(
+    store: "MemoryStore",
+    *,
+    dry_run: bool = False,
+    max_n: int | None = None,
+    min_corroborations: int = PROMOTE_RETENTION_MIN_CORROBORATIONS,
+    min_sessions: int = PROMOTE_RETENTION_MIN_SESSIONS,
+) -> PromotionRunReport:
+    """Promote snapshot beliefs to ``fact`` once corroborated enough.
+
+    Per docs/belief_retention_class.md §4 a snapshot is promoted when
+    it has been re-asserted ``min_corroborations`` times across
+    ``min_sessions`` distinct sessions with no inbound CONTRADICTS
+    edge. Promotion writes two things per belief:
+
+      1. ``UPDATE beliefs SET retention_class = 'fact'`` via
+         ``store.set_retention_class``.
+      2. A synthetic ``feedback_history`` row with
+         ``source = 'retention_promotion'`` and ``valence = 0.0``.
+         The neutral valence keeps the Bayesian alpha/beta untouched;
+         the row exists for audit trail only.
+
+    ``dry_run=True`` returns the candidate count without mutating.
+    ``max_n`` caps how many candidates are promoted per run.
+    """
+    from datetime import datetime, timezone
+
+    report = PromotionRunReport(dry_run=dry_run)
+    candidates = store.find_promotable_snapshots(
+        min_corroborations=min_corroborations,
+        min_sessions=min_sessions,
+    )
+    report.candidates_found = len(candidates)
+
+    if dry_run or not candidates:
+        return report
+
+    to_promote = candidates[:max_n] if max_n is not None else candidates
+    ts = datetime.now(timezone.utc).isoformat()
+    for belief in to_promote:
+        store.set_retention_class(belief.id, "fact")
+        store.insert_feedback_event(
+            belief.id,
+            valence=0.0,
+            source=FEEDBACK_SOURCE_RETENTION_PROMOTION,
+            created_at=ts,
+        )
+        report.promoted += 1
+    return report
+
+
+def format_promotion_report(report: PromotionRunReport) -> str:
+    """Render a `PromotionRunReport` for the CLI."""
+    lines: list[str] = []
+    prefix = "[dry-run] " if report.dry_run else ""
+    lines.append(
+        f"{prefix}promote-retention: {report.candidates_found} "
+        f"snapshot(s) eligible for promotion"
+    )
+    if report.dry_run:
+        if report.candidates_found == 0:
+            lines.append("nothing to do.")
+        else:
+            lines.append(
+                "dry-run; re-run without --dry-run to promote these beliefs."
+            )
+    else:
+        lines.append(f"  promoted: {report.promoted}")
+    return "\n".join(lines)

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -2112,6 +2112,75 @@ class MemoryStore:
         )
         return [_row_to_belief(r) for r in cur.fetchall()]
 
+    def find_promotable_snapshots(
+        self, *, min_corroborations: int = 3, min_sessions: int = 2,
+        max_n: int | None = None,
+    ) -> list[Belief]:
+        """Return snapshot beliefs eligible for promotion to ``fact``.
+
+        Per docs/belief_retention_class.md §4 the promotion rule is:
+
+          retention_class = 'snapshot'
+          AND COUNT(corroborations) >= min_corroborations
+          AND COUNT(DISTINCT corroborations.session_id) >= min_sessions
+          AND no inbound CONTRADICTS edge targets the belief
+
+        ``session_id`` may be NULL on legacy corroboration rows (#192 T3
+        backfill not yet landed). NULLs are excluded from the distinct
+        count rather than treated as a single anonymous session — that
+        avoids letting one un-attributed re-ingest masquerade as
+        cross-session reuse.
+
+        ``max_n`` caps the result set; the SQL does the limiting so a
+        large store doesn't materialize the full candidate list.
+        """
+        limit_clause = f"LIMIT {int(max_n)}" if max_n is not None else ""
+        cur = self._conn.execute(
+            f"""
+            SELECT b.* FROM beliefs b
+            JOIN (
+                SELECT belief_id,
+                       COUNT(*) AS n_corr,
+                       COUNT(DISTINCT session_id) AS n_sess
+                FROM belief_corroborations
+                GROUP BY belief_id
+            ) bc ON bc.belief_id = b.id
+            WHERE b.retention_class = 'snapshot'
+              AND bc.n_corr >= ?
+              AND bc.n_sess >= ?
+              AND NOT EXISTS (
+                  SELECT 1 FROM edges e
+                  WHERE e.dst = b.id AND e.type = 'CONTRADICTS'
+              )
+            ORDER BY b.created_at ASC
+            {limit_clause}
+            """,
+            (int(min_corroborations), int(min_sessions)),
+        )
+        return [_row_to_belief(r) for r in cur.fetchall()]
+
+    def set_retention_class(self, belief_id: str, retention_class: str) -> None:
+        """Targeted update of a belief's ``retention_class``.
+
+        Phase-3 promotion writes through this rather than ``update_belief``
+        because ``update_belief`` rewrites the full row (including FTS5 +
+        entity index) and does not currently carry ``retention_class`` in
+        its UPDATE clause. A focused setter avoids the broader surgery
+        and keeps the write atomic.
+        """
+        if retention_class not in RETENTION_CLASSES:
+            raise ValueError(
+                f"Unknown retention_class {retention_class!r}. "
+                f"Must be one of {sorted(RETENTION_CLASSES)}"
+            )
+        self._conn.execute(
+            "UPDATE beliefs SET retention_class = ? WHERE id = ?",
+            (retention_class, belief_id),
+        )
+        self._bump_belief_version(belief_id)
+        self._conn.commit()
+        self._fire_invalidation()
+
     def count_beliefs_by_type(self) -> dict[str, int]:
         """Return a mapping of belief type → count across all beliefs."""
         cur = self._conn.execute(

--- a/tests/test_doctor_promote_retention.py
+++ b/tests/test_doctor_promote_retention.py
@@ -1,0 +1,331 @@
+"""Tests for `aelf doctor --promote-retention` (issue #290 phase-3).
+
+Covers:
+* find_promotable_snapshots query: respects N>=3 corroborations,
+  M>=2 distinct sessions, retention_class='snapshot' filter, and the
+  inbound-CONTRADICTS-edge exclusion.
+* promote_retention() flips retention_class to 'fact', writes a
+  synthetic feedback_history row with source='retention_promotion'
+  and valence=0.0, and respects dry_run / max_n.
+* set_retention_class store helper updates the row and rejects
+  unknown class names.
+* CLI wiring: --promote-retention --dry-run prints the candidate
+  count without mutating; --promote-retention writes through.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+from pathlib import Path
+
+import pytest
+
+import aelfrice.cli as cli_module
+from aelfrice.doctor import (
+    FEEDBACK_SOURCE_RETENTION_PROMOTION,
+    PROMOTE_RETENTION_MIN_CORROBORATIONS,
+    PROMOTE_RETENTION_MIN_SESSIONS,
+    PromotionRunReport,
+    format_promotion_report,
+    promote_retention,
+)
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CONTRADICTS,
+    LOCK_NONE,
+    RETENTION_FACT,
+    RETENTION_SNAPSHOT,
+    Belief,
+    Edge,
+)
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    store: MemoryStore,
+    bid: str,
+    *,
+    retention_class: str = RETENTION_SNAPSHOT,
+) -> Belief:
+    b = Belief(
+        id=bid,
+        content=f"content for {bid}",
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+        retention_class=retention_class,
+    )
+    store.insert_belief(b)
+    return b
+
+
+def _corr(
+    store: MemoryStore, belief_id: str, *, session: str | None
+) -> None:
+    store.record_corroboration(
+        belief_id,
+        source_type="filesystem_ingest",
+        session_id=session,
+    )
+
+
+# --- thresholds are spec-anchored ---------------------------------------
+
+
+def test_promotion_thresholds_match_spec() -> None:
+    """docs/belief_retention_class.md §4 nails N=3, M=2."""
+    assert PROMOTE_RETENTION_MIN_CORROBORATIONS == 3
+    assert PROMOTE_RETENTION_MIN_SESSIONS == 2
+
+
+# --- find_promotable_snapshots query ------------------------------------
+
+
+def test_promotable_requires_three_corroborations(tmp_path: Path) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    _mk(store, "b1")
+    _corr(store, "b1", session="s1")
+    _corr(store, "b1", session="s2")
+    # Only N=2; below the threshold.
+    assert store.find_promotable_snapshots() == []
+
+
+def test_promotable_requires_two_distinct_sessions(tmp_path: Path) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    _mk(store, "b1")
+    _corr(store, "b1", session="s1")
+    _corr(store, "b1", session="s1")
+    _corr(store, "b1", session="s1")
+    # N=3 but M=1; not promotable.
+    assert store.find_promotable_snapshots() == []
+
+
+def test_promotable_excludes_null_sessions_from_distinct_count(
+    tmp_path: Path,
+) -> None:
+    """Pre-#192-T3 corroborations may have session_id=NULL. NULL must
+    not count as a distinct session, otherwise one un-attributed
+    re-ingest could masquerade as cross-session reuse."""
+    store = MemoryStore(str(tmp_path / "m.db"))
+    _mk(store, "b1")
+    _corr(store, "b1", session="s1")
+    _corr(store, "b1", session=None)
+    _corr(store, "b1", session=None)
+    # COUNT(DISTINCT session_id) drops NULLs → distinct == 1 → not promotable.
+    assert store.find_promotable_snapshots() == []
+
+
+def test_promotable_only_returns_snapshot_class(tmp_path: Path) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    _mk(store, "b_fact", retention_class=RETENTION_FACT)
+    _corr(store, "b_fact", session="s1")
+    _corr(store, "b_fact", session="s2")
+    _corr(store, "b_fact", session="s3")
+    # Already a fact; promotion is a no-op for non-snapshots.
+    assert store.find_promotable_snapshots() == []
+
+
+def test_promotable_excludes_beliefs_with_inbound_contradicts(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    _mk(store, "b1")
+    _mk(store, "b2", retention_class=RETENTION_FACT)
+    _corr(store, "b1", session="s1")
+    _corr(store, "b1", session="s2")
+    _corr(store, "b1", session="s3")
+    store.insert_edge(
+        Edge(src="b2", dst="b1", type=EDGE_CONTRADICTS, weight=1.0)
+    )
+    assert store.find_promotable_snapshots() == []
+
+
+def test_promotable_returns_qualifying_belief(tmp_path: Path) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    _mk(store, "b1")
+    _corr(store, "b1", session="s1")
+    _corr(store, "b1", session="s2")
+    _corr(store, "b1", session="s3")
+    promotable = store.find_promotable_snapshots()
+    assert [b.id for b in promotable] == ["b1"]
+
+
+# --- set_retention_class --------------------------------------------------
+
+
+def test_set_retention_class_updates_row(tmp_path: Path) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    _mk(store, "b1")
+    store.set_retention_class("b1", RETENTION_FACT)
+    refreshed = store.get_belief("b1")
+    assert refreshed is not None
+    assert refreshed.retention_class == RETENTION_FACT
+
+
+def test_set_retention_class_rejects_unknown_value(tmp_path: Path) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    _mk(store, "b1")
+    with pytest.raises(ValueError):
+        store.set_retention_class("b1", "garbage")
+
+
+# --- promote_retention end-to-end ---------------------------------------
+
+
+def _seed_one_promotable(store: MemoryStore, bid: str = "b1") -> None:
+    _mk(store, bid)
+    _corr(store, bid, session="s1")
+    _corr(store, bid, session="s2")
+    _corr(store, bid, session="s3")
+
+
+def test_promote_retention_dry_run_does_not_mutate(tmp_path: Path) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    _seed_one_promotable(store)
+    report = promote_retention(store, dry_run=True)
+    assert report.candidates_found == 1
+    assert report.promoted == 0
+    assert report.dry_run is True
+    # Belief still snapshot.
+    refreshed = store.get_belief("b1")
+    assert refreshed is not None
+    assert refreshed.retention_class == RETENTION_SNAPSHOT
+    # No synthetic feedback row written.
+    events = store.list_feedback_events(belief_id="b1")
+    assert all(
+        e.source != FEEDBACK_SOURCE_RETENTION_PROMOTION for e in events
+    )
+
+
+def test_promote_retention_flips_class_and_records_feedback(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    _seed_one_promotable(store)
+    report = promote_retention(store, dry_run=False)
+    assert report.candidates_found == 1
+    assert report.promoted == 1
+
+    refreshed = store.get_belief("b1")
+    assert refreshed is not None
+    assert refreshed.retention_class == RETENTION_FACT
+    # Bayesian prior must be untouched (valence=0.0 contract).
+    assert refreshed.alpha == 1.0
+    assert refreshed.beta == 1.0
+
+    events = store.list_feedback_events(belief_id="b1")
+    matching = [
+        e for e in events if e.source == FEEDBACK_SOURCE_RETENTION_PROMOTION
+    ]
+    assert len(matching) == 1
+    assert matching[0].valence == 0.0
+
+
+def test_promote_retention_respects_max_n(tmp_path: Path) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    _seed_one_promotable(store, "b1")
+    _seed_one_promotable(store, "b2")
+    report = promote_retention(store, dry_run=False, max_n=1)
+    assert report.candidates_found == 2
+    assert report.promoted == 1
+
+
+def test_promote_retention_no_candidates_is_noop(tmp_path: Path) -> None:
+    store = MemoryStore(str(tmp_path / "m.db"))
+    _mk(store, "b1")  # snapshot, no corroborations
+    report = promote_retention(store, dry_run=False)
+    assert report.candidates_found == 0
+    assert report.promoted == 0
+
+
+# --- format helper -------------------------------------------------------
+
+
+def test_format_promotion_report_dry_run() -> None:
+    text = format_promotion_report(
+        PromotionRunReport(candidates_found=2, promoted=0, dry_run=True)
+    )
+    assert "[dry-run]" in text
+    assert "2 snapshot" in text
+
+
+def test_format_promotion_report_applied() -> None:
+    text = format_promotion_report(
+        PromotionRunReport(candidates_found=2, promoted=2, dry_run=False)
+    )
+    assert "promoted: 2" in text
+
+
+# --- CLI wiring ----------------------------------------------------------
+
+
+def _doctor_args(**overrides: object) -> argparse.Namespace:
+    base = dict(
+        scope=None,
+        user_settings=None,
+        project_root=None,
+        hook_failures_log=None,
+        classify_orphans=False,
+        gc_orphan_feedback=False,
+        promote_retention=False,
+        replay=False,
+        apply=False,
+        dry_run=False,
+        max=None,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_cli_promote_retention_dry_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "m.db"
+    store = MemoryStore(str(db))
+    _seed_one_promotable(store)
+    store.close()
+
+    monkeypatch.setattr(
+        cli_module, "_open_store", lambda: MemoryStore(str(db))
+    )
+    out = io.StringIO()
+    args = _doctor_args(promote_retention=True, dry_run=True)
+    rc = cli_module._cmd_doctor(args, out)
+    assert rc == 0
+    assert "[dry-run]" in out.getvalue()
+    # Belief unchanged.
+    s2 = MemoryStore(str(db))
+    refreshed = s2.get_belief("b1")
+    s2.close()
+    assert refreshed is not None
+    assert refreshed.retention_class == RETENTION_SNAPSHOT
+
+
+def test_cli_promote_retention_applies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "m.db"
+    store = MemoryStore(str(db))
+    _seed_one_promotable(store)
+    store.close()
+
+    monkeypatch.setattr(
+        cli_module, "_open_store", lambda: MemoryStore(str(db))
+    )
+    out = io.StringIO()
+    args = _doctor_args(promote_retention=True)
+    rc = cli_module._cmd_doctor(args, out)
+    assert rc == 0
+    assert "promoted: 1" in out.getvalue()
+
+    s2 = MemoryStore(str(db))
+    refreshed = s2.get_belief("b1")
+    s2.close()
+    assert refreshed is not None
+    assert refreshed.retention_class == RETENTION_FACT


### PR DESCRIPTION
## Summary

Issue #290 phase-3 — the **promotion lane**. Implements
`aelf doctor --promote-retention` per
[docs/belief_retention_class.md §4](docs/belief_retention_class.md).

A snapshot belief is promoted to `fact` when:
- corroboration count >= 3, AND
- distinct sessions >= 2 (NULL `session_id` rows excluded), AND
- no inbound `CONTRADICTS` edge.

Each promotion writes a synthetic `feedback_history` row with
`source='retention_promotion'` and `valence=0.0`. The neutral valence
keeps the Bayesian prior untouched while leaving an audit trail.

Phase-1 (schema axis) and phase-2 (per-ingest defaults) are already
merged; this is the third and final implementation PR for #290.

## Test plan

- [x] `tests/test_doctor_promote_retention.py` — 17 new tests covering
  the SQL filter (N/M thresholds, NULL-session exclusion, snapshot-only,
  CONTRADICTS exclusion), the doctor pass (dry-run, mutation,
  feedback row, max_n cap), `set_retention_class` validation, and
  CLI wiring (dry-run vs apply).
- [x] No regressions in adjacent suites (`test_retention_class*`,
  `test_doctor*`, `test_corroborations`, `test_auditor`).
- [ ] Operator: run `aelf doctor --promote-retention --dry-run` on a
  live store after merge to confirm candidate count is sane before
  enabling write-through.

## Notes

- Thresholds (`PROMOTE_RETENTION_MIN_CORROBORATIONS=3`,
  `PROMOTE_RETENTION_MIN_SESSIONS=2`) are exposed as module-level
  constants. A follow-up calibration PR (post-#288 operator-week of
  logs) can swap them without rippling through tests.
- `update_belief()` does not currently carry `retention_class` in its
  UPDATE clause; rather than expand its surgery here, this PR adds a
  focused `set_retention_class()` setter. Aligning `update_belief()`
  is left for a separate cleanup.

## Summary by Sourcery

Add a doctor subcommand to promote sufficiently corroborated snapshot beliefs to facts and record audit feedback events.

New Features:
- Introduce promote_retention doctor pass that upgrades eligible snapshot beliefs to fact based on corroboration and session thresholds while supporting dry-run and per-run caps.
- Expose a CLI flag aelf doctor --promote-retention with --dry-run and --max options to run the promotion lane on a store.

Enhancements:
- Add store helpers to find promotable snapshot beliefs, update retention_class safely, and format promotion run reports.

Tests:
- Add comprehensive tests covering promotion eligibility SQL, retention_class setter validation, promotion behavior (dry-run, max_n, feedback events), and CLI wiring for the new doctor subcommand.