### PR TITLE
feat: session_id propagation through scanner / onboard / mcp ingest paths (#192)

### DIFF
--- a/src/aelfrice/classification.py
+++ b/src/aelfrice/classification.py
@@ -503,6 +503,7 @@ def accept_classifications(
             source_kind=INGEST_SOURCE_FILESYSTEM,
             source_path=source,
             ts=timestamp,
+            session_id=session_id,
             override_belief_type=c.belief_type,
         ))
         # override_belief_type always produces a belief (persist=True
@@ -518,6 +519,7 @@ def accept_classifications(
             source_path=source,
             raw_text=text,
             derived_belief_ids=[bid],
+            session_id=session_id,
             ts=timestamp,
         )
         _, was_inserted = store.insert_or_corroborate(

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -199,12 +199,18 @@ def tool_search(
     }
 
 
-def tool_lock(store: MemoryStore, *, statement: str) -> dict[str, Any]:
+def tool_lock(
+    store: MemoryStore,
+    *,
+    statement: str,
+    session_id: str | None = None,
+) -> dict[str, Any]:
     now = _utc_now_iso()
     out = derive(DerivationInput(
         raw_text=statement,
         source_kind=INGEST_SOURCE_MCP_REMEMBER,
         ts=now,
+        session_id=session_id,
     ))
     # mcp_remember always produces a belief.
     assert out.belief is not None

--- a/src/aelfrice/scanner.py
+++ b/src/aelfrice/scanner.py
@@ -142,6 +142,19 @@ class LLMRoute:
     audit_source: str | None = None
 
 
+def _derive_scan_session_id(root: Path, timestamp: str) -> str:
+    """Synthetic session_id for filesystem scans.
+
+    Stable across two scans of the same tree at the same timestamp; the
+    timestamp differs per invocation so each scan run gets its own id.
+    Mirrors `hook_commit_ingest._derive_session_id` in shape (16-hex
+    sha256 prefix) so downstream consumers can treat all session_id
+    values uniformly.
+    """
+    raw = f"scan:{root}:{timestamp}".encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
 def scan_repo(
     store: MemoryStore,
     root: Path,
@@ -149,6 +162,7 @@ def scan_repo(
     *,
     noise_config: NoiseConfig | None = None,
     llm_router: LLMRouter | None = None,
+    session_id: str | None = None,
 ) -> ScanResult:
     """Run all three extractors on `root`, classify each candidate, and
     insert persistable results as Beliefs in the store.
@@ -179,6 +193,9 @@ def scan_repo(
     input tree + clock supplied via `now`.
     """
     timestamp = now if now is not None else _utc_now_iso()
+    sid = session_id if session_id is not None else _derive_scan_session_id(
+        root, timestamp,
+    )
     cfg: NoiseConfig = (
         noise_config
         if noise_config is not None
@@ -245,6 +262,7 @@ def scan_repo(
                 source_path=candidate.source,
                 raw_text=candidate.text,
                 derived_belief_ids=[belief_id],
+                session_id=sid,
                 ts=created_at,
             )
             _, was_inserted = store.insert_or_corroborate(
@@ -260,6 +278,7 @@ def scan_repo(
                     demotion_pressure=0,
                     created_at=created_at,
                     last_retrieved_at=None,
+                    session_id=sid,
                     origin=route.origin,
                     retention_class=retention_class_for_source(
                         INGEST_SOURCE_FILESYSTEM,
@@ -284,6 +303,7 @@ def scan_repo(
                 source_kind=INGEST_SOURCE_FILESYSTEM,
                 source_path=candidate.source,
                 ts=created_at,
+                session_id=sid,
             ))
             if out.belief is None:
                 skipped_non_persisting += 1
@@ -297,6 +317,7 @@ def scan_repo(
                 source_path=candidate.source,
                 raw_text=candidate.text,
                 derived_belief_ids=[belief_id],
+                session_id=sid,
                 ts=created_at,
             )
             _, was_inserted = store.insert_or_corroborate(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -133,6 +133,19 @@ def test_lock_creates_new_belief(store: MemoryStore) -> None:
     assert inserted.lock_level == LOCK_USER
 
 
+def test_lock_propagates_session_id_to_new_belief(store: MemoryStore) -> None:
+    """tool_lock with explicit session_id tags the inserted belief (#192)."""
+    out = tool_lock(
+        store,
+        statement="we always sign commits with ssh",
+        session_id="mcp-host-session-123",
+    )
+    assert out["action"] == "locked"
+    inserted = store.get_belief(out["id"])
+    assert inserted is not None
+    assert inserted.session_id == "mcp-host-session-123"
+
+
 def test_lock_upgrades_existing_unlocked_belief(store: MemoryStore) -> None:
     first = tool_lock(store, statement="claude is my friend")
     bid = first["id"]

--- a/tests/test_onboard_handshake.py
+++ b/tests/test_onboard_handshake.py
@@ -314,3 +314,26 @@ def _derive_id_for_sentence(text: str, source: str) -> str:
     """Mirror classification._derive_belief_id for the precomputed-id test."""
     import hashlib
     return hashlib.sha256(f"{source}\x00{text}".encode("utf-8")).hexdigest()[:16]
+
+
+# --- session_id propagation (#192) -------------------------------------
+
+
+def test_accept_classifications_tags_beliefs_with_session_id(
+    store: MemoryStore, tmp_path: Path
+) -> None:
+    """Beliefs inserted via accept_classifications carry the onboard session_id."""
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    cls = [
+        HostClassification(index=s.index, belief_type=BELIEF_FACTUAL, persist=True)
+        for s in result.sentences
+    ]
+    outcome = accept_classifications(
+        store, result.session_id, cls, now="2026-04-26T01:00:00Z"
+    )
+    assert outcome.inserted > 0
+    for bid in store.list_belief_ids():
+        b = store.get_belief(bid)
+        assert b is not None
+        assert b.session_id == result.session_id

--- a/tests/test_scanner_scan_repo.py
+++ b/tests/test_scanner_scan_repo.py
@@ -265,3 +265,50 @@ def test_inserted_belief_demotion_pressure_zero(tmp_path: Path) -> None:
     scan_repo(s, tmp_path)
     b = s.search_beliefs("regex")[0]
     assert b.demotion_pressure == 0
+
+
+# --- session_id propagation (#192) -------------------------------------
+
+
+def test_scan_repo_tags_beliefs_with_synthetic_session_id(tmp_path: Path) -> None:
+    """Every belief inserted by scan_repo carries a non-null session_id."""
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    s = MemoryStore(":memory:")
+    scan_repo(s, tmp_path)
+    rows = s.search_beliefs("regex")
+    assert rows, "scan_repo did not insert any belief from the fixture"
+    for b in rows:
+        assert b.session_id is not None and b.session_id != ""
+
+
+def test_scan_repo_explicit_session_id_propagates(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    s = MemoryStore(":memory:")
+    scan_repo(s, tmp_path, session_id="explicit-test-sid")
+    rows = s.search_beliefs("regex")
+    assert rows
+    for b in rows:
+        assert b.session_id == "explicit-test-sid"
+
+
+def test_scan_repo_synthetic_id_stable_for_same_root_and_now(
+    tmp_path: Path,
+) -> None:
+    """Two scans of the same tree at the same `now` produce the same sid."""
+    (tmp_path / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    s1 = MemoryStore(":memory:")
+    s2 = MemoryStore(":memory:")
+    scan_repo(s1, tmp_path, now="2026-05-02T00:00:00+00:00")
+    scan_repo(s2, tmp_path, now="2026-05-02T00:00:00+00:00")
+    sid1 = s1.search_beliefs("regex")[0].session_id
+    sid2 = s2.search_beliefs("regex")[0].session_id
+    assert sid1 is not None and sid1 == sid2


### PR DESCRIPTION
## Summary
Closes phantom-prereqs T3 (#192) producer-side gap. Three filesystem/MCP entry points dropped `session_id` before reaching the store; this PR plumbs it through.

- **`scanner.scan_repo`** — accepts optional `session_id`; derives synthetic `sha256("scan:<root>:<timestamp>")[:16]` when absent. Mirrors `hook_commit_ingest._derive_session_id` shape so consumers handle all sids uniformly. Threaded through both LLM-classify and regex paths plus their `record_ingest` calls.
- **`classification.accept_classifications`** — had `session_id` in scope but dropped it on the `DerivationInput`/`record_ingest` calls. One-line pass-through.
- **`mcp_server.tool_lock`** — now accepts optional `session_id`; backwards-compatible.

## Verification
- Full pytest suite: 2051 passed, 20 skipped.
- New tests: synthetic id non-null + stable, explicit id propagates, onboard session id flows to beliefs, MCP lock tags belief.
- Sanity gate (in-memory scan): `sid_rate = 1.000` on every belief inserted by `scan_repo` post-fix (vs 0.000 from the regex path pre-fix). Gate ≥ 0.80 met.

## Scope notes
- Producers explicitly *out of scope*: `migrate.py` (mechanical row copy — preserves source sid), `benchmark.py` / `doctor.py` (test/diagnostic, not user-facing), `store.insert_or_corroborate` re-assertion path (preserves the new Belief's sid).
- The `transcript_logger.py` and `ingest_jsonl` paths already correctly extract/propagate `session_id` from JSONL rows; no change needed there.

## Test plan
- [x] `uv run pytest -x -q` — 2051 passed
- [x] Manual: `scan_repo` on a fixture tree → all inserted beliefs carry non-null `session_id`
- [x] Discretion grep clean (no `~/.claude/`-derived content in diff)

## Summary by Sourcery

Propagate session_id through filesystem scanning, onboarding classification acceptance, and MCP locking paths so all newly inserted beliefs are consistently tagged.

New Features:
- Allow scan_repo to accept or synthesize a session_id for all beliefs and ingest records created during a filesystem scan.
- Allow the MCP tool_lock endpoint to accept an optional session_id and attach it to the created belief.

Bug Fixes:
- Ensure accept_classifications propagates the existing session_id into derivation and ingest records so onboarded beliefs retain their session context.

Tests:
- Add scanner tests verifying synthetic session_id presence, explicit session_id propagation, and stability of derived session_ids for identical scan inputs.
- Add onboarding test ensuring accept_classifications tags all inserted beliefs with the onboard session_id.
- Add MCP server test confirming tool_lock propagates the provided session_id to the locked belief.