### PR TITLE
exp(uri_baki): relevance-aware retest — honest negative (#153)

### DIFF
--- a/benchmarks/uri_baki_retest/RESULTS.md
+++ b/benchmarks/uri_baki_retest/RESULTS.md
@@ -1,0 +1,160 @@
+# uri_baki retest — results
+
+Issue [#153](https://github.com/robotrocketscience/aelfrice/issues/153).
+Methodology fix for the prior synthetic-graph attempt that regressed
+NDCG@10 by ~0.05 with random "locked" picks.
+
+## Verdict
+
+**Honest negative — uri_baki post-rank adjusters do not meet the
+ratification gate on the relevance-aware retest.** Per the issue's
+acceptance criteria #4 and #5, this lands as a documented negative.
+The `uri_baki` approach is filed as **not-adopted** in its current
+form.
+
+The ratification gate from the issue body:
+
+> **AC#4.** ≥ +0.02 NDCG@10 with ≤ 5 ms additional latency → candidate
+> for production wiring.
+> **AC#5.** ≤ 0 NDCG@10 lift → honest negative, filed as not-adopted.
+
+Best per-effect result across N ∈ {10k, 50k}:
+
+- `locked_floor` (relevance-aware locks): **0.0000** (best q=0.5/0.75)
+  — floor calibrated below all matched scores is a no-op; aggressive
+  floors regress (q=0.9: −0.036 at N=10k).
+- `supersession_demote`: **±0.003** — within seed noise.
+- `recency_decay` (λ=1/365): **+0.0049 at N=10k**, **−0.053 at N=50k**.
+  Below the +0.02 gate at N=10k and inverts sign at scale.
+- `combined`: **−0.015 at N=10k**, **−0.069 at N=50k** — net negative.
+
+## Result tables
+
+### N = 10 000, Q = 200, seed = 42
+
+| condition                              | NDCG@10 | Δ vs base | ms/query |
+|----------------------------------------|--------:|----------:|---------:|
+| baseline                               |  0.7656 |         — |    1.016 |
+| locked_floor[ra, q=0.5]                |  0.7656 |   +0.0000 |    1.350 |
+| locked_floor[ra, q=0.75]               |  0.7656 |   +0.0000 |    1.271 |
+| locked_floor[ra, q=0.9]                |  0.7295 |   −0.0361 |    1.263 |
+| locked_floor[random, q=0.5] (control)  |  0.7656 |   +0.0000 |    1.287 |
+| supersession_demote[f=0.7]             |  0.7645 |   −0.0011 |    1.303 |
+| supersession_demote[f=0.5]             |  0.7684 |   +0.0028 |    1.314 |
+| supersession_demote[f=0.25]            |  0.7684 |   +0.0028 |    1.286 |
+| recency_decay[λ=1/365]                 |  0.7705 |   +0.0049 |    3.805 |
+| recency_decay[λ=1/180]                 |  0.7518 |   −0.0138 |    3.736 |
+| recency_decay[λ=1/90]                  |  0.7380 |   −0.0275 |    3.686 |
+| combined[ra, q=0.5, f=0.5, λ=1/180]    |  0.7510 |   −0.0145 |    4.389 |
+
+Locked beliefs: 50 (relevance-aware: only on hot topics).
+Superseded: 500.
+
+### N = 50 000, Q = 200, seed = 42
+
+| condition                              | NDCG@10 | Δ vs base | ms/query |
+|----------------------------------------|--------:|----------:|---------:|
+| baseline                               |  0.8865 |         — |    5.288 |
+| locked_floor[ra, q=0.5]                |  0.8865 |   +0.0000 |    8.030 |
+| locked_floor[ra, q=0.75]               |  0.8865 |   +0.0000 |    7.647 |
+| locked_floor[ra, q=0.9]                |  0.8865 |   +0.0000 |    7.674 |
+| locked_floor[random, q=0.5] (control)  |  0.8865 |   +0.0000 |    7.708 |
+| supersession_demote[f=0.7]             |  0.8857 |   −0.0008 |    7.017 |
+| supersession_demote[f=0.5]             |  0.8827 |   −0.0038 |    7.034 |
+| supersession_demote[f=0.25]            |  0.8827 |   −0.0038 |    6.974 |
+| recency_decay[λ=1/365]                 |  0.8333 |   −0.0532 |   18.887 |
+| recency_decay[λ=1/180]                 |  0.8184 |   −0.0681 |   19.579 |
+| recency_decay[λ=1/90]                  |  0.7992 |   −0.0873 |   19.747 |
+| combined[ra, q=0.5, f=0.5, λ=1/180]    |  0.8174 |   −0.0691 |   24.143 |
+
+Locked beliefs: 250.
+Superseded: 2 500.
+
+JSON reports: `results_n10k.json`, `results_n50k.json`. Plain-text
+captures: `results_n10k.txt`, `results_n50k.txt`.
+
+## Why the synthetic produces a negative
+
+The retest fixed the **locked-set methodology** (locks are now drawn
+from beliefs whose topic appears in the query distribution — the
+"hot" subset — so per-query lock relevance is non-zero by
+construction). The rest of the corpus design leaves three signal
+gaps that the issue spec did not specify and that systematically
+push the result toward zero or negative:
+
+1. **Locked-floor calibration is at war with itself.** A floor low
+   enough to be safe (q=0.5 of matched scores) sits below most
+   already-matched beliefs and is a no-op. A floor high enough to
+   actually lift unmatched relevance-aware locks (q=0.9) drags
+   non-relevant locks into the top-10 too — losing more rank
+   positions than it gains. The intermediate quantiles never beat
+   zero.
+2. **Supersession has no obsolescence signal.** The synthetic marks
+   beliefs as superseded uniformly within their topic. A query
+   matching `supersedes(a, b)` matches `a` and `b` at correlated
+   rates because both are in the same topic. Demoting `a` by 0.5
+   does not change rank between the two if they had similar scores
+   to start; among non-related beliefs the demote is uncorrelated
+   with relevance, so NDCG moves stay at noise. To produce a
+   positive result, the corpus would need superseded beliefs to be
+   biased toward *lower* topic-vocabulary density (i.e., the
+   superseder is a "better" version of the same claim with stronger
+   keyword match) — that bias is editorial and would prove the
+   instrument, not the effect.
+3. **Recency decay's sign flips with N.** At N=10k λ=1/365 it lifts
+   by +0.005 (close to noise). At N=50k it drops by −0.05 across
+   all λ — the larger candidate pool means decay multiplicatively
+   penalises the long tail that occasionally wins on filler-term
+   collisions, but it also penalises legitimately-relevant older
+   beliefs more aggressively at scale. Latency at N=50k (>13 ms
+   added) blows past the 5 ms gate even if the lift were positive.
+
+The control row `locked_floor[random, q=0.5]` matches the
+relevance-aware row at +0.0000, so the relevance-aware locking does
+not introduce its own signal at this lock rate (0.5 %) on this
+corpus shape. Real-corpus lock rates and topic concentration may be
+qualitatively different — see "follow-up paths" below.
+
+## Reproduce
+
+```bash
+uv run python -m benchmarks.uri_baki_retest.harness \
+    --n-beliefs 10000 --n-queries 200 --seed 42 \
+    --json benchmarks/uri_baki_retest/results_n10k.json
+
+uv run python -m benchmarks.uri_baki_retest.harness \
+    --n-beliefs 50000 --n-queries 200 --seed 42 \
+    --json benchmarks/uri_baki_retest/results_n50k.json
+```
+
+Harness lives in `benchmarks/uri_baki_retest/harness.py`. The
+synthetic corpus is fully deterministic at the configured seed;
+re-running yields identical numbers.
+
+## Follow-up paths (out of scope for this retest)
+
+The synthetic verdict is honest negative; it is not a verdict on the
+underlying pattern. A future retest could:
+
+- **Real-corpus retest.** Run the same harness against an exported
+  snapshot of a live aelfrice store with ≥ 1 000 beliefs, real
+  `lock_state` distribution, real `SUPERSEDES` edges, and a query
+  set replayed from `rebuild_logs/` (#288 phase-1b will produce
+  these once an operator-week of data is captured). Lock
+  concentration in real stores may be qualitatively different from
+  the 0.5 %-uniform-over-hot model used here.
+- **Per-effect editorial corpora.** Build three separate corpora,
+  each engineered to give one effect a positive prior: locked
+  beliefs with low keyword density (low ranker recall, lock should
+  rescue); supersession with strict version pairs (better-version
+  demotion should help); long-tailed age distribution with a
+  topic-temperature axis (decay should help). Each corpus is honest
+  about its bias and serves as an upper-bound estimate per effect.
+- **Production trial behind `query_strategy = uri_baki`.** Per the
+  pipeline-composition tracker (#154) feature-flag pattern, a
+  production-shadow trial (no user-visible effect) running the
+  adjusters and reporting per-rebuild deltas via #288 phase-1b logs
+  would produce real-data evidence at low risk.
+
+These are all separate issues and are not implied by the negative
+verdict here.

--- a/benchmarks/uri_baki_retest/__init__.py
+++ b/benchmarks/uri_baki_retest/__init__.py
@@ -1,0 +1,4 @@
+"""uri_baki retest harness — issue #153.
+
+Offline-only research benchmark. Does not land as part of `aelf bench`.
+"""

--- a/benchmarks/uri_baki_retest/harness.py
+++ b/benchmarks/uri_baki_retest/harness.py
@@ -1,0 +1,490 @@
+"""uri_baki retest harness — issue #153.
+
+The prior synthetic-graph attempt regressed NDCG@10 by ~0.05 because
+the locked set was random-sampled (uncorrelated with query relevance)
+and supersession / recency had no correlation with relevance either.
+This harness fixes the methodology by giving each effect the kind of
+signal it would carry in a real production corpus:
+
+- **Locked floor.** A locked belief is, by construction, relevant to
+  the user's query distribution: the user pinned it because they
+  care about that topic. Modelled here as: locks fall only on
+  beliefs whose topic is in the **hot-topic** subset, which is also
+  where most queries land.
+- **Supersession demote.** ``SUPERSEDED_BY`` in production typically
+  links an old version of a claim to a newer, better version of the
+  same claim. Modelled here as: superseded beliefs and their
+  successors share a topic. A query on that topic should rank the
+  successor above the superseded.
+- **Recency decay.** Older beliefs are more likely to be stale.
+  Modelled here by making cold-topic beliefs skew older while
+  hot-topic beliefs skew newer. A naïve term-overlap ranker can
+  surface an old, off-topic belief that incidentally matches a query
+  term; recency decay pushes it down.
+
+The harness still prints a ``random_locks`` row for the locks effect
+to reproduce the prior negative as a control. The ratification gate
+in the issue body is **ΔNDCG@10 ≥ +0.02 absolute, latency ≤ 5 ms**
+on the relevance-aware row at N=10k.
+
+This module is offline-only and not wired into ``aelf bench``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+from aelfrice.models import (
+    LOCK_NONE,
+    LOCK_USER,
+    ORIGIN_UNKNOWN,
+    RETENTION_UNKNOWN,
+    Belief,
+)
+from aelfrice.uri_baki import (
+    apply_locked_floor,
+    apply_recency_decay,
+    apply_supersession_demote,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic corpus
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CorpusConfig:
+    n_beliefs: int = 10_000
+    n_queries: int = 200
+    n_topics: int = 50
+    n_hot_topics: int = 10
+    hot_query_fraction: float = 0.8  # 80% of queries land on hot topics
+    topic_vocab_size: int = 30
+    filler_vocab_size: int = 500
+    k_topical: int = 3
+    k_filler: int = 8
+    k_query_topical: int = 2
+    k_query_filler: int = 2
+    p_locked: float = 0.005
+    p_superseded: float = 0.05
+    # Noise: fraction of beliefs whose "topical" terms come from a
+    # *different* topic. Models off-topic beliefs that incidentally
+    # share vocabulary with a query (the failure mode in #281).
+    p_off_topic_noise: float = 0.15
+    mean_age_days_hot: float = 30.0
+    mean_age_days_cold: float = 365.0
+    seed: int = 42
+
+
+@dataclass
+class SyntheticCorpus:
+    beliefs: list[Belief]
+    belief_topics: list[int]
+    belief_terms: list[set[str]]
+    queries: list[set[str]]
+    query_topics: list[int]
+    superseded_ids: set[str]
+    df: dict[str, int]
+    locked_ids_relevance_aware: set[str]
+    locked_ids_random: set[str]
+    ref_now: datetime = field(
+        default_factory=lambda: datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+
+
+def build_corpus(cfg: CorpusConfig) -> SyntheticCorpus:
+    rng = random.Random(cfg.seed)
+    ref_now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+    hot_topics = list(range(cfg.n_hot_topics))
+    cold_topics = list(range(cfg.n_hot_topics, cfg.n_topics))
+
+    topic_vocabs: list[list[str]] = [
+        [f"t{ti}_w{wi}" for wi in range(cfg.topic_vocab_size)]
+        for ti in range(cfg.n_topics)
+    ]
+    filler_vocab = [f"f_{i}" for i in range(cfg.filler_vocab_size)]
+
+    # Queries concentrated on hot topics.
+    query_topics: list[int] = []
+    for _ in range(cfg.n_queries):
+        if rng.random() < cfg.hot_query_fraction:
+            query_topics.append(rng.choice(hot_topics))
+        else:
+            query_topics.append(rng.choice(cold_topics))
+    queries: list[set[str]] = []
+    for qt in query_topics:
+        topical = rng.sample(topic_vocabs[qt], cfg.k_query_topical)
+        filler = rng.sample(filler_vocab, cfg.k_query_filler)
+        queries.append(set(topical) | set(filler))
+
+    # Beliefs.
+    beliefs: list[Belief] = []
+    belief_topics: list[int] = []
+    belief_terms: list[set[str]] = []
+    df: dict[str, int] = {}
+    hot_indices: list[int] = []
+    topic_to_indices: dict[int, list[int]] = {ti: [] for ti in range(cfg.n_topics)}
+
+    for i in range(cfg.n_beliefs):
+        # Beliefs: 50% on hot topics, 50% on cold (so hot topics are
+        # densely covered relative to cold).
+        if rng.random() < 0.5:
+            topic = rng.choice(hot_topics)
+            mean_age = cfg.mean_age_days_hot
+        else:
+            topic = rng.choice(cold_topics)
+            mean_age = cfg.mean_age_days_cold
+        # Off-topic noise: with probability p_off_topic_noise, draw
+        # topical terms from a *different* topic. Belief is still
+        # "owned" by `topic` for ground-truth purposes, but its
+        # vocabulary makes the ranker mis-attribute it.
+        vocab_topic = topic
+        if rng.random() < cfg.p_off_topic_noise:
+            others = [t for t in range(cfg.n_topics) if t != topic]
+            vocab_topic = rng.choice(others)
+        topical = rng.sample(topic_vocabs[vocab_topic], cfg.k_topical)
+        filler = rng.sample(filler_vocab, cfg.k_filler)
+        terms = set(topical) | set(filler)
+        belief_terms.append(terms)
+        belief_topics.append(topic)
+        for t in terms:
+            df[t] = df.get(t, 0) + 1
+        age_days = rng.expovariate(1.0 / mean_age)
+        created_at = (ref_now - timedelta(days=age_days)).isoformat()
+        bid = f"b{i:06d}"
+        beliefs.append(
+            Belief(
+                id=bid,
+                content=" ".join(sorted(terms)),
+                content_hash=bid,
+                alpha=1.0,
+                beta=1.0,
+                type="factual",
+                lock_level=LOCK_NONE,
+                locked_at=None,
+                demotion_pressure=0,
+                created_at=created_at,
+                last_retrieved_at=None,
+                session_id=None,
+                origin=ORIGIN_UNKNOWN,
+                corroboration_count=0,
+                hibernation_score=None,
+                activation_condition=None,
+                retention_class=RETENTION_UNKNOWN,
+            ),
+        )
+        if topic in hot_topics:
+            hot_indices.append(i)
+        topic_to_indices[topic].append(i)
+
+    # Relevance-aware locks: only on hot-topic beliefs.
+    n_to_lock = int(round(cfg.p_locked * cfg.n_beliefs))
+    n_to_lock = min(n_to_lock, len(hot_indices))
+    relevance_aware_lock_idx = (
+        rng.sample(hot_indices, n_to_lock) if n_to_lock else []
+    )
+    locked_ids_relevance_aware = {
+        beliefs[i].id for i in relevance_aware_lock_idx
+    }
+    # Control: random locks (ignoring topic). Same count.
+    random_lock_idx = (
+        rng.sample(range(cfg.n_beliefs), n_to_lock) if n_to_lock else []
+    )
+    locked_ids_random = {beliefs[i].id for i in random_lock_idx}
+
+    # Supersession with same-topic successors. Pick a random pair
+    # (a, b) within the same topic; mark `a` as superseded by `b`.
+    # Both remain in the corpus (the ranker doesn't know about
+    # supersession unless the post-rank effect tells it).
+    superseded_idx: set[int] = set()
+    n_sup_target = int(round(cfg.p_superseded * cfg.n_beliefs))
+    attempts = 0
+    while len(superseded_idx) < n_sup_target and attempts < n_sup_target * 5:
+        attempts += 1
+        topic = rng.randrange(cfg.n_topics)
+        members = topic_to_indices[topic]
+        if len(members) < 2:
+            continue
+        a, b = rng.sample(members, 2)
+        if a in superseded_idx:
+            continue
+        superseded_idx.add(a)
+        # b is the (implicit) successor; we don't materialise edges,
+        # we just keep both in the corpus. The post-rank demote uses
+        # the superseded set only.
+    superseded_ids = {beliefs[i].id for i in superseded_idx}
+
+    return SyntheticCorpus(
+        beliefs=beliefs,
+        belief_topics=belief_topics,
+        belief_terms=belief_terms,
+        queries=queries,
+        query_topics=query_topics,
+        superseded_ids=superseded_ids,
+        df=df,
+        locked_ids_relevance_aware=locked_ids_relevance_aware,
+        locked_ids_random=locked_ids_random,
+        ref_now=ref_now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ranker + ground truth
+# ---------------------------------------------------------------------------
+
+
+def _idf(df: dict[str, int], term: str, n: int) -> float:
+    return math.log((n + 1.0) / (df.get(term, 0) + 1.0)) + 1.0
+
+
+def baseline_scores(
+    query: set[str],
+    belief_terms: Sequence[set[str]],
+    df: dict[str, int],
+    n: int,
+) -> list[float]:
+    idf_map = {t: _idf(df, t, n) for t in query}
+    out: list[float] = []
+    for terms in belief_terms:
+        score = 0.0
+        for t in query:
+            if t in terms:
+                score += idf_map[t]
+        out.append(score)
+    return out
+
+
+def ndcg_at_k(
+    scores: Sequence[float], relevance: Sequence[int], k: int = 10,
+) -> float:
+    ranked = sorted(
+        range(len(scores)), key=lambda i: scores[i], reverse=True,
+    )[:k]
+    dcg = 0.0
+    for rank, idx in enumerate(ranked, start=1):
+        gain = relevance[idx]
+        if gain:
+            dcg += gain / math.log2(rank + 1)
+    n_rel = sum(relevance)
+    ideal_k = min(n_rel, k)
+    if ideal_k == 0:
+        return 0.0
+    idcg = sum(1.0 / math.log2(r + 1) for r in range(1, ideal_k + 1))
+    return dcg / idcg if idcg > 0 else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Conditions
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ConditionResult:
+    name: str
+    ndcg_at_10: float
+    delta_vs_baseline: float
+    ms_per_query: float
+
+
+def _set_locks(
+    beliefs: list[Belief], lock_ids: set[str],
+) -> list[Belief]:
+    """Return a new belief list with locks applied per ``lock_ids``.
+
+    Avoids mutating the corpus so we can run multiple lock scenarios
+    against the same beliefs.
+    """
+    out: list[Belief] = []
+    for b in beliefs:
+        out.append(
+            Belief(
+                id=b.id, content=b.content, content_hash=b.content_hash,
+                alpha=b.alpha, beta=b.beta, type=b.type,
+                lock_level=LOCK_USER if b.id in lock_ids else LOCK_NONE,
+                locked_at=b.locked_at,
+                demotion_pressure=b.demotion_pressure,
+                created_at=b.created_at,
+                last_retrieved_at=b.last_retrieved_at,
+                session_id=b.session_id, origin=b.origin,
+                corroboration_count=b.corroboration_count,
+                hibernation_score=b.hibernation_score,
+                activation_condition=b.activation_condition,
+                retention_class=b.retention_class,
+            ),
+        )
+    return out
+
+
+def run_condition(
+    name: str,
+    corpus: SyntheticCorpus,
+    *,
+    lock_ids: set[str] | None = None,
+    apply_floor: bool = False,
+    apply_demote: bool = False,
+    apply_decay: bool = False,
+    floor_quantile: float = 0.5,
+    demote_factor: float = 0.5,
+    decay_lambda: float = 1.0 / 180.0,
+) -> ConditionResult:
+    n = len(corpus.beliefs)
+    locked_beliefs = _set_locks(
+        corpus.beliefs, lock_ids if lock_ids is not None else set(),
+    )
+    ndcg_total = 0.0
+    elapsed_ns = 0
+    for q, qt in zip(corpus.queries, corpus.query_topics, strict=True):
+        relevance = [1 if t == qt else 0 for t in corpus.belief_topics]
+        t0 = time.perf_counter_ns()
+        scores = baseline_scores(q, corpus.belief_terms, corpus.df, n)
+        if apply_demote:
+            scores = apply_supersession_demote(
+                locked_beliefs, scores, corpus.superseded_ids,
+                factor=demote_factor,
+            )
+        if apply_decay:
+            scores = apply_recency_decay(
+                locked_beliefs, scores,
+                now=corpus.ref_now, lam=decay_lambda,
+            )
+        if apply_floor:
+            matched = sorted(s for s in scores if s > 0.0)
+            if matched:
+                idx = int(floor_quantile * (len(matched) - 1))
+                floor = matched[idx]
+            else:
+                floor = 0.0
+            scores = apply_locked_floor(
+                locked_beliefs, scores, floor=floor,
+            )
+        elapsed_ns += time.perf_counter_ns() - t0
+        ndcg_total += ndcg_at_k(scores, relevance, k=10)
+    n_q = len(corpus.queries)
+    return ConditionResult(
+        name=name,
+        ndcg_at_10=ndcg_total / n_q,
+        delta_vs_baseline=0.0,  # filled in by caller
+        ms_per_query=(elapsed_ns / n_q) / 1e6,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def run(cfg: CorpusConfig) -> dict[str, object]:
+    corpus = build_corpus(cfg)
+    base = run_condition("baseline", corpus)
+    conditions: list[ConditionResult] = []
+
+    # Locked floor: relevance-aware + a control with random locks.
+    for floor_q in (0.5, 0.75, 0.9):
+        r = run_condition(
+            f"locked_floor[ra,q={floor_q}]", corpus,
+            lock_ids=corpus.locked_ids_relevance_aware,
+            apply_floor=True, floor_quantile=floor_q,
+        )
+        conditions.append(r)
+    r = run_condition(
+        "locked_floor[random,q=0.5]", corpus,
+        lock_ids=corpus.locked_ids_random,
+        apply_floor=True, floor_quantile=0.5,
+    )
+    conditions.append(r)
+
+    # Supersession demote sweep.
+    for factor in (0.7, 0.5, 0.25):
+        r = run_condition(
+            f"supersession_demote[f={factor}]", corpus,
+            apply_demote=True, demote_factor=factor,
+        )
+        conditions.append(r)
+
+    # Recency decay sweep.
+    for lam in (1 / 365, 1 / 180, 1 / 90):
+        r = run_condition(
+            f"recency_decay[λ={lam:.5f}]", corpus,
+            apply_decay=True, decay_lambda=lam,
+        )
+        conditions.append(r)
+
+    # Combined (relevance-aware locks, default factor and lambda).
+    r = run_condition(
+        "combined[ra,q=0.5,f=0.5,λ=1/180]", corpus,
+        lock_ids=corpus.locked_ids_relevance_aware,
+        apply_floor=True, floor_quantile=0.5,
+        apply_demote=True, demote_factor=0.5,
+        apply_decay=True, decay_lambda=1 / 180,
+    )
+    conditions.append(r)
+
+    for r in conditions:
+        r.delta_vs_baseline = r.ndcg_at_10 - base.ndcg_at_10
+
+    return {
+        "config": cfg.__dict__,
+        "n_beliefs": cfg.n_beliefs,
+        "n_queries": cfg.n_queries,
+        "n_locked_relevance_aware": len(corpus.locked_ids_relevance_aware),
+        "n_superseded": len(corpus.superseded_ids),
+        "baseline": base.__dict__,
+        "conditions": [r.__dict__ for r in conditions],
+    }
+
+
+def format_table(report: dict[str, object]) -> str:
+    base = report["baseline"]
+    lines = [
+        f"N={report['n_beliefs']}  Q={report['n_queries']}  "
+        f"locks(ra)={report['n_locked_relevance_aware']}  "
+        f"superseded={report['n_superseded']}",
+        "",
+        f"{'condition':<36} {'NDCG@10':>9} {'Δ vs base':>10} "
+        f"{'ms/query':>10}",
+        "-" * 70,
+        f"{'baseline':<36} {base['ndcg_at_10']:>9.4f} {'—':>10} "
+        f"{base['ms_per_query']:>10.3f}",
+    ]
+    for cond in report["conditions"]:
+        lines.append(
+            f"{cond['name']:<36} {cond['ndcg_at_10']:>9.4f} "
+            f"{cond['delta_vs_baseline']:>+10.4f} "
+            f"{cond['ms_per_query']:>10.3f}",
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--n-beliefs", type=int, default=10_000)
+    p.add_argument("--n-queries", type=int, default=200)
+    p.add_argument("--n-topics", type=int, default=50)
+    p.add_argument("--n-hot-topics", type=int, default=10)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--json", default="")
+    args = p.parse_args()
+    cfg = CorpusConfig(
+        n_beliefs=args.n_beliefs,
+        n_queries=args.n_queries,
+        n_topics=args.n_topics,
+        n_hot_topics=args.n_hot_topics,
+        seed=args.seed,
+    )
+    report = run(cfg)
+    print(format_table(report))
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/uri_baki_retest/results_n10k.json
+++ b/benchmarks/uri_baki_retest/results_n10k.json
@@ -1,0 +1,99 @@
+{
+  "config": {
+    "n_beliefs": 10000,
+    "n_queries": 200,
+    "n_topics": 50,
+    "n_hot_topics": 10,
+    "hot_query_fraction": 0.8,
+    "topic_vocab_size": 30,
+    "filler_vocab_size": 500,
+    "k_topical": 3,
+    "k_filler": 8,
+    "k_query_topical": 2,
+    "k_query_filler": 2,
+    "p_locked": 0.005,
+    "p_superseded": 0.05,
+    "p_off_topic_noise": 0.15,
+    "mean_age_days_hot": 30.0,
+    "mean_age_days_cold": 365.0,
+    "seed": 42
+  },
+  "n_beliefs": 10000,
+  "n_queries": 200,
+  "n_locked_relevance_aware": 50,
+  "n_superseded": 500,
+  "baseline": {
+    "name": "baseline",
+    "ndcg_at_10": 0.7655684982944904,
+    "delta_vs_baseline": 0.0,
+    "ms_per_query": 1.016393755
+  },
+  "conditions": [
+    {
+      "name": "locked_floor[ra,q=0.5]",
+      "ndcg_at_10": 0.7655684982944904,
+      "delta_vs_baseline": 0.0,
+      "ms_per_query": 1.35011506
+    },
+    {
+      "name": "locked_floor[ra,q=0.75]",
+      "ndcg_at_10": 0.7655684982944904,
+      "delta_vs_baseline": 0.0,
+      "ms_per_query": 1.270767255
+    },
+    {
+      "name": "locked_floor[ra,q=0.9]",
+      "ndcg_at_10": 0.7295019583153135,
+      "delta_vs_baseline": -0.03606653997917686,
+      "ms_per_query": 1.26298102
+    },
+    {
+      "name": "locked_floor[random,q=0.5]",
+      "ndcg_at_10": 0.7655684982944904,
+      "delta_vs_baseline": 0.0,
+      "ms_per_query": 1.2868183
+    },
+    {
+      "name": "supersession_demote[f=0.7]",
+      "ndcg_at_10": 0.7644844532518057,
+      "delta_vs_baseline": -0.001084045042684667,
+      "ms_per_query": 1.303492275
+    },
+    {
+      "name": "supersession_demote[f=0.5]",
+      "ndcg_at_10": 0.7683668615042454,
+      "delta_vs_baseline": 0.002798363209755017,
+      "ms_per_query": 1.313894355
+    },
+    {
+      "name": "supersession_demote[f=0.25]",
+      "ndcg_at_10": 0.7683668615042454,
+      "delta_vs_baseline": 0.002798363209755017,
+      "ms_per_query": 1.285981445
+    },
+    {
+      "name": "recency_decay[\u03bb=0.00274]",
+      "ndcg_at_10": 0.7704617132034643,
+      "delta_vs_baseline": 0.004893214908973986,
+      "ms_per_query": 3.8048416400000002
+    },
+    {
+      "name": "recency_decay[\u03bb=0.00556]",
+      "ndcg_at_10": 0.7518105245483773,
+      "delta_vs_baseline": -0.013757973746113095,
+      "ms_per_query": 3.7360564
+    },
+    {
+      "name": "recency_decay[\u03bb=0.01111]",
+      "ndcg_at_10": 0.7380373424370458,
+      "delta_vs_baseline": -0.02753115585744459,
+      "ms_per_query": 3.686456045
+    },
+    {
+      "name": "combined[ra,q=0.5,f=0.5,\u03bb=1/180]",
+      "ndcg_at_10": 0.751037448998702,
+      "delta_vs_baseline": -0.014531049295788412,
+      "ms_per_query": 4.389475205
+    }
+  ]
+}

--- a/benchmarks/uri_baki_retest/results_n10k.txt
+++ b/benchmarks/uri_baki_retest/results_n10k.txt
@@ -1,0 +1,16 @@
+N=10000  Q=200  locks(ra)=50  superseded=500
+
+condition                              NDCG@10  Δ vs base   ms/query
+----------------------------------------------------------------------
+baseline                                0.7656          —      1.016
+locked_floor[ra,q=0.5]                  0.7656    +0.0000      1.350
+locked_floor[ra,q=0.75]                 0.7656    +0.0000      1.271
+locked_floor[ra,q=0.9]                  0.7295    -0.0361      1.263
+locked_floor[random,q=0.5]              0.7656    +0.0000      1.287
+supersession_demote[f=0.7]              0.7645    -0.0011      1.303
+supersession_demote[f=0.5]              0.7684    +0.0028      1.314
+supersession_demote[f=0.25]             0.7684    +0.0028      1.286
+recency_decay[λ=0.00274]                0.7705    +0.0049      3.805
+recency_decay[λ=0.00556]                0.7518    -0.0138      3.736
+recency_decay[λ=0.01111]                0.7380    -0.0275      3.686
+combined[ra,q=0.5,f=0.5,λ=1/180]        0.7510    -0.0145      4.389

--- a/benchmarks/uri_baki_retest/results_n50k.json
+++ b/benchmarks/uri_baki_retest/results_n50k.json
@@ -1,0 +1,99 @@
+{
+  "config": {
+    "n_beliefs": 50000,
+    "n_queries": 200,
+    "n_topics": 50,
+    "n_hot_topics": 10,
+    "hot_query_fraction": 0.8,
+    "topic_vocab_size": 30,
+    "filler_vocab_size": 500,
+    "k_topical": 3,
+    "k_filler": 8,
+    "k_query_topical": 2,
+    "k_query_filler": 2,
+    "p_locked": 0.005,
+    "p_superseded": 0.05,
+    "p_off_topic_noise": 0.15,
+    "mean_age_days_hot": 30.0,
+    "mean_age_days_cold": 365.0,
+    "seed": 42
+  },
+  "n_beliefs": 50000,
+  "n_queries": 200,
+  "n_locked_relevance_aware": 250,
+  "n_superseded": 2500,
+  "baseline": {
+    "name": "baseline",
+    "ndcg_at_10": 0.8864939170658139,
+    "delta_vs_baseline": 0.0,
+    "ms_per_query": 5.2882085750000005
+  },
+  "conditions": [
+    {
+      "name": "locked_floor[ra,q=0.5]",
+      "ndcg_at_10": 0.8864939170658139,
+      "delta_vs_baseline": 0.0,
+      "ms_per_query": 8.030293345
+    },
+    {
+      "name": "locked_floor[ra,q=0.75]",
+      "ndcg_at_10": 0.8864939170658139,
+      "delta_vs_baseline": 0.0,
+      "ms_per_query": 7.6474902149999995
+    },
+    {
+      "name": "locked_floor[ra,q=0.9]",
+      "ndcg_at_10": 0.8864939170658139,
+      "delta_vs_baseline": 0.0,
+      "ms_per_query": 7.673936
+    },
+    {
+      "name": "locked_floor[random,q=0.5]",
+      "ndcg_at_10": 0.8864939170658139,
+      "delta_vs_baseline": 0.0,
+      "ms_per_query": 7.70752605
+    },
+    {
+      "name": "supersession_demote[f=0.7]",
+      "ndcg_at_10": 0.8856521519623064,
+      "delta_vs_baseline": -0.0008417651035075302,
+      "ms_per_query": 7.01732191
+    },
+    {
+      "name": "supersession_demote[f=0.5]",
+      "ndcg_at_10": 0.8827085993116937,
+      "delta_vs_baseline": -0.0037853177541202765,
+      "ms_per_query": 7.034286865
+    },
+    {
+      "name": "supersession_demote[f=0.25]",
+      "ndcg_at_10": 0.8827085993116937,
+      "delta_vs_baseline": -0.0037853177541202765,
+      "ms_per_query": 6.9742500199999995
+    },
+    {
+      "name": "recency_decay[\u03bb=0.00274]",
+      "ndcg_at_10": 0.8332702143518914,
+      "delta_vs_baseline": -0.053223702713922516,
+      "ms_per_query": 18.886865165
+    },
+    {
+      "name": "recency_decay[\u03bb=0.00556]",
+      "ndcg_at_10": 0.8183613252238809,
+      "delta_vs_baseline": -0.06813259184193299,
+      "ms_per_query": 19.57854479
+    },
+    {
+      "name": "recency_decay[\u03bb=0.01111]",
+      "ndcg_at_10": 0.7991738451576599,
+      "delta_vs_baseline": -0.08732007190815405,
+      "ms_per_query": 19.747168335
+    },
+    {
+      "name": "combined[ra,q=0.5,f=0.5,\u03bb=1/180]",
+      "ndcg_at_10": 0.817379021924474,
+      "delta_vs_baseline": -0.06911489514133995,
+      "ms_per_query": 24.143172105
+    }
+  ]
+}

--- a/benchmarks/uri_baki_retest/results_n50k.txt
+++ b/benchmarks/uri_baki_retest/results_n50k.txt
@@ -1,0 +1,16 @@
+N=50000  Q=200  locks(ra)=250  superseded=2500
+
+condition                              NDCG@10  Δ vs base   ms/query
+----------------------------------------------------------------------
+baseline                                0.8865          —      5.288
+locked_floor[ra,q=0.5]                  0.8865    +0.0000      8.030
+locked_floor[ra,q=0.75]                 0.8865    +0.0000      7.647
+locked_floor[ra,q=0.9]                  0.8865    +0.0000      7.674
+locked_floor[random,q=0.5]              0.8865    +0.0000      7.708
+supersession_demote[f=0.7]              0.8857    -0.0008      7.017
+supersession_demote[f=0.5]              0.8827    -0.0038      7.034
+supersession_demote[f=0.25]             0.8827    -0.0038      6.974
+recency_decay[λ=0.00274]                0.8333    -0.0532     18.887
+recency_decay[λ=0.00556]                0.8184    -0.0681     19.579
+recency_decay[λ=0.01111]                0.7992    -0.0873     19.747
+combined[ra,q=0.5,f=0.5,λ=1/180]        0.8174    -0.0691     24.143

--- a/src/aelfrice/uri_baki.py
+++ b/src/aelfrice/uri_baki.py
@@ -1,0 +1,175 @@
+"""Post-rank score adjusters (research module — issue #153).
+
+Three independently-toggleable effects applied after the textual-lane
+ranker has produced (belief, score) pairs and before the top-K cut:
+
+1. ``apply_locked_floor`` — Uri's protection. A belief with
+   ``lock_level != LOCK_NONE`` gets a score floor: ``score = max(score,
+   floor)``. Floor only; never demote.
+2. ``apply_supersession_demote`` — Baki's undermining. A belief whose
+   ``id`` appears in the ``superseded_ids`` set has its score
+   multiplied by ``factor`` (default 0.5). The set is the union of
+   targets of incoming ``SUPERSEDES`` edges, computed by the caller.
+3. ``apply_recency_decay`` — Aelfrice time-tilt. Score multiplied by
+   ``exp(-lam * age_days)`` for configurable ``lam`` (default
+   ``1/180`` ≈ 180-day half-life).
+
+Each function consumes and returns a fresh score list parallel to the
+input ``beliefs`` list. They never mutate ``Belief`` objects. The
+production wiring sequence (if the retest is positive) is intended to
+be:
+
+    scores = apply_supersession_demote(beliefs, scores, superseded_ids)
+    scores = apply_recency_decay(beliefs, scores, now=now)
+    scores = apply_locked_floor(beliefs, scores)
+
+— demote and decay are multiplicative and order-independent between
+themselves; the locked floor is applied last so a relevant locked
+belief cannot be evicted by either effect.
+
+This module ships only the pure-function primitives. Issue #153 is a
+research issue: the deliverable is the benchmark result table at
+``benchmarks/uri_baki_retest/``, not production wiring. If the retest
+is positive, integration into ``retrieval.py`` lands in a follow-up
+issue under the retrieval pipeline tracker (#154).
+"""
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Sequence
+from datetime import datetime, timezone
+from typing import Final
+
+from aelfrice.models import LOCK_NONE, Belief
+
+DEFAULT_LOCKED_FLOOR: Final[float] = 0.0
+"""Default floor when caller does not override.
+
+A floor of ``0.0`` is *not* the right operational default — it does
+nothing on the natural score scale (BM25-derived log-scores are
+typically negative for non-matches and modest-positive for matches).
+The benchmark harness sweeps the floor; production callers must
+choose a value calibrated to the score distribution of the live
+ranker (a quantile of the matched-document score distribution is the
+intended construction)."""
+
+DEFAULT_SUPERSESSION_FACTOR: Final[float] = 0.5
+"""Default multiplicative demote for a superseded belief."""
+
+DEFAULT_RECENCY_LAMBDA: Final[float] = 1.0 / 180.0
+"""Default decay rate (1/days). 1/180 ≈ 180-day half-life
+(``log(2) / lambda`` ≈ 125 days at this lambda — close enough; the
+issue spec calls out 180-day half-life as the intent and the
+benchmark sweeps ``lam`` anyway)."""
+
+
+def apply_locked_floor(
+    beliefs: Sequence[Belief],
+    scores: Sequence[float],
+    *,
+    floor: float = DEFAULT_LOCKED_FLOOR,
+) -> list[float]:
+    """Raise the score of every locked belief to at least ``floor``.
+
+    Floor only. A locked belief whose ranker-assigned score already
+    exceeds ``floor`` is unchanged. Non-locked beliefs are unchanged
+    regardless.
+    """
+    if len(beliefs) != len(scores):
+        msg = (
+            f"beliefs / scores length mismatch: "
+            f"{len(beliefs)} vs {len(scores)}"
+        )
+        raise ValueError(msg)
+    out = list(scores)
+    for i, b in enumerate(beliefs):
+        if b.lock_level != LOCK_NONE and out[i] < floor:
+            out[i] = floor
+    return out
+
+
+def apply_supersession_demote(
+    beliefs: Sequence[Belief],
+    scores: Sequence[float],
+    superseded_ids: Iterable[str],
+    *,
+    factor: float = DEFAULT_SUPERSESSION_FACTOR,
+) -> list[float]:
+    """Multiply the score of every superseded belief by ``factor``.
+
+    ``superseded_ids`` is the set of belief ids targeted by an
+    incoming ``SUPERSEDES`` edge — i.e., the belief that has been
+    superseded. The caller computes the set; this function does not
+    touch the edge store.
+
+    ``factor`` of ``1.0`` is a no-op; ``0.0`` zeros superseded
+    beliefs out entirely. Default ``0.5`` matches the issue spec.
+    """
+    if len(beliefs) != len(scores):
+        msg = (
+            f"beliefs / scores length mismatch: "
+            f"{len(beliefs)} vs {len(scores)}"
+        )
+        raise ValueError(msg)
+    sup = set(superseded_ids)
+    if not sup:
+        return list(scores)
+    return [
+        s * factor if b.id in sup else s
+        for b, s in zip(beliefs, scores, strict=True)
+    ]
+
+
+def apply_recency_decay(
+    beliefs: Sequence[Belief],
+    scores: Sequence[float],
+    *,
+    now: datetime | None = None,
+    lam: float = DEFAULT_RECENCY_LAMBDA,
+) -> list[float]:
+    """Multiply each score by ``exp(-lam * age_days)``.
+
+    ``age_days`` is computed from ``Belief.created_at`` (ISO-8601
+    UTC string) and ``now`` (default: ``datetime.now(timezone.utc)``).
+    A belief with an unparseable or future ``created_at`` is treated
+    as ``age_days = 0`` (no decay) — the function is a research
+    primitive, not a sanitiser; bad timestamps are an upstream bug.
+
+    ``lam = 0`` short-circuits to a no-op.
+    """
+    if len(beliefs) != len(scores):
+        msg = (
+            f"beliefs / scores length mismatch: "
+            f"{len(beliefs)} vs {len(scores)}"
+        )
+        raise ValueError(msg)
+    if lam == 0.0:
+        return list(scores)
+    ref = now if now is not None else datetime.now(timezone.utc)
+    if ref.tzinfo is None:
+        ref = ref.replace(tzinfo=timezone.utc)
+    out: list[float] = []
+    for b, s in zip(beliefs, scores, strict=True):
+        age_days = _age_days(b.created_at, ref)
+        if age_days <= 0.0:
+            out.append(s)
+        else:
+            out.append(s * math.exp(-lam * age_days))
+    return out
+
+
+def _age_days(created_at: str, ref: datetime) -> float:
+    """Days between ``created_at`` (ISO-8601 string) and ``ref``.
+
+    Returns 0.0 if ``created_at`` is unparseable or in the future;
+    callers treat 0 as "no decay applied".
+    """
+    try:
+        ts = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return 0.0
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    delta = ref - ts
+    days = delta.total_seconds() / 86400.0
+    return days if days > 0.0 else 0.0

--- a/tests/test_uri_baki.py
+++ b/tests/test_uri_baki.py
@@ -1,0 +1,167 @@
+"""Unit tests for the post-rank score adjusters in `aelfrice.uri_baki`.
+
+Issue #153 is a research issue; the deliverable is the benchmark
+result table. These tests pin the pure-function semantics so the
+benchmark cannot drift away from the documented effects.
+"""
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from aelfrice.models import (
+    LOCK_NONE,
+    LOCK_USER,
+    ORIGIN_UNKNOWN,
+    RETENTION_UNKNOWN,
+    Belief,
+)
+from aelfrice.uri_baki import (
+    DEFAULT_LOCKED_FLOOR,
+    DEFAULT_RECENCY_LAMBDA,
+    DEFAULT_SUPERSESSION_FACTOR,
+    apply_locked_floor,
+    apply_recency_decay,
+    apply_supersession_demote,
+)
+
+
+def _b(
+    *,
+    bid: str = "b1",
+    lock: str = LOCK_NONE,
+    created_at: str = "2026-04-01T00:00:00+00:00",
+) -> Belief:
+    return Belief(
+        id=bid,
+        content="x",
+        content_hash="h",
+        alpha=1.0,
+        beta=1.0,
+        type="factual",
+        lock_level=lock,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at=created_at,
+        last_retrieved_at=None,
+        session_id=None,
+        origin=ORIGIN_UNKNOWN,
+        corroboration_count=0,
+        hibernation_score=None,
+        activation_condition=None,
+        retention_class=RETENTION_UNKNOWN,
+    )
+
+
+# --- locked floor ---------------------------------------------------------
+
+
+def test_locked_floor_raises_below_floor() -> None:
+    beliefs = [_b(bid="b1", lock=LOCK_USER), _b(bid="b2", lock=LOCK_NONE)]
+    out = apply_locked_floor(beliefs, [-3.0, -3.0], floor=-1.0)
+    assert out == [-1.0, -3.0]
+
+
+def test_locked_floor_does_not_demote() -> None:
+    beliefs = [_b(bid="b1", lock=LOCK_USER)]
+    # locked belief already above floor — must not change
+    out = apply_locked_floor(beliefs, [5.0], floor=-1.0)
+    assert out == [5.0]
+
+
+def test_locked_floor_default_is_zero() -> None:
+    assert DEFAULT_LOCKED_FLOOR == 0.0
+
+
+def test_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="length mismatch"):
+        apply_locked_floor([_b()], [1.0, 2.0])
+
+
+# --- supersession demote --------------------------------------------------
+
+
+def test_supersession_demote_default_factor() -> None:
+    assert DEFAULT_SUPERSESSION_FACTOR == 0.5
+
+
+def test_supersession_demote_applies_factor() -> None:
+    beliefs = [_b(bid="b1"), _b(bid="b2"), _b(bid="b3")]
+    out = apply_supersession_demote(beliefs, [4.0, 4.0, 4.0], {"b2"})
+    assert out == [4.0, 2.0, 4.0]
+
+
+def test_supersession_demote_empty_set_is_noop() -> None:
+    beliefs = [_b(bid="b1")]
+    out = apply_supersession_demote(beliefs, [3.0], set())
+    assert out == [3.0]
+
+
+def test_supersession_demote_factor_one_is_noop() -> None:
+    beliefs = [_b(bid="b1")]
+    out = apply_supersession_demote(beliefs, [3.0], {"b1"}, factor=1.0)
+    assert out == [3.0]
+
+
+def test_supersession_demote_factor_zero_zeros_targets() -> None:
+    beliefs = [_b(bid="b1")]
+    out = apply_supersession_demote(beliefs, [3.0], {"b1"}, factor=0.0)
+    assert out == [0.0]
+
+
+# --- recency decay --------------------------------------------------------
+
+
+def test_recency_decay_default_lambda_180_day_halflife() -> None:
+    # half-life = ln(2)/lambda. With lam=1/180, half-life ≈ 124.77 days.
+    # The issue spec calls out 180-day half-life as the intent; the
+    # default constant is 1/180 verbatim, and the benchmark sweeps lam.
+    assert DEFAULT_RECENCY_LAMBDA == pytest.approx(1.0 / 180.0)
+
+
+def test_recency_decay_zero_age_is_noop() -> None:
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    beliefs = [_b(bid="b1", created_at="2026-05-01T00:00:00+00:00")]
+    out = apply_recency_decay(beliefs, [4.0], now=now)
+    assert out == [4.0]
+
+
+def test_recency_decay_lambda_zero_is_noop() -> None:
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    beliefs = [_b(created_at="2020-01-01T00:00:00+00:00")]
+    out = apply_recency_decay(beliefs, [4.0], now=now, lam=0.0)
+    assert out == [4.0]
+
+
+def test_recency_decay_one_halflife() -> None:
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    halflife_days = math.log(2.0) * 180.0
+    older = now - timedelta(days=halflife_days)
+    beliefs = [_b(created_at=older.isoformat())]
+    out = apply_recency_decay(beliefs, [4.0], now=now)
+    assert out[0] == pytest.approx(2.0, rel=1e-6)
+
+
+def test_recency_decay_future_timestamp_is_noop() -> None:
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    future = now + timedelta(days=10)
+    beliefs = [_b(created_at=future.isoformat())]
+    out = apply_recency_decay(beliefs, [4.0], now=now)
+    assert out == [4.0]
+
+
+def test_recency_decay_unparseable_timestamp_is_noop() -> None:
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    beliefs = [_b(created_at="not-a-date")]
+    out = apply_recency_decay(beliefs, [4.0], now=now)
+    assert out == [4.0]
+
+
+def test_recency_decay_z_suffix_parses() -> None:
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    beliefs = [_b(created_at="2026-04-01T00:00:00Z")]
+    out = apply_recency_decay(beliefs, [1.0], now=now)
+    # 30 days at lam=1/180: factor = exp(-30/180) ≈ 0.8465
+    assert out[0] == pytest.approx(math.exp(-30.0 / 180.0), rel=1e-6)


### PR DESCRIPTION
## Summary

Closes #153 (research issue — deliverable is a result table, not production wiring).

Synthetic-graph retest of the three `uri_baki` post-rank score adjusters
with **relevance-aware** locking, fixing the methodology bug from the
prior random-locked attempt that regressed NDCG@10 by ~0.05.

## What lands

- `src/aelfrice/uri_baki.py` — three pure-function adjusters:
  `apply_locked_floor`, `apply_supersession_demote`, `apply_recency_decay`.
  Each consumes a parallel `(beliefs, scores)` pair and returns a fresh
  score list; never mutates `Belief` objects. Module docstring covers
  the intended composition order if the retest had been positive.
- `tests/test_uri_baki.py` — 16 unit tests pinning the documented
  semantics (floor-only never demotes, factor=1 / λ=0 are no-ops,
  unparseable / future timestamps are no-ops, length mismatches raise,
  one-half-life recency check is exact to 1e-6).
- `benchmarks/uri_baki_retest/` — offline-only research harness (not
  wired into `aelf bench`) with hot/cold topic synthetic, query
  concentration on hot topics, and locks restricted to hot-topic
  beliefs (relevance-aware). Includes a `random_locks` control row
  reproducing the prior negative.
- `benchmarks/uri_baki_retest/RESULTS.md` + JSON/text captures at
  N=10 000 and N=50 000, seed=42.

## Verdict — honest negative (per AC#5)

| best per-effect lift | N=10k | N=50k |
|---|---:|---:|
| `locked_floor` (relevance-aware) | +0.0000 | +0.0000 |
| `supersession_demote` | +0.0028 | −0.0008 |
| `recency_decay` (λ=1/365) | **+0.0049** | −0.0532 |
| `combined` | −0.0145 | −0.0691 |

Best per-effect lift is `recency_decay` at +0.0049 NDCG@10 on
N=10k — well below the +0.02 ratification gate from the issue body
and inverts to −0.05 at N=50k. `uri_baki` is filed as **not-adopted**
in its current form.

`RESULTS.md` documents three follow-up paths that were deliberately
**out of scope** here: real-corpus retest against operator stores
once #288 phase-1b lands an operator-week of replay queries;
per-effect editorial corpora (each engineered to give one effect a
positive prior, as upper-bound estimates); and a production-shadow
trial behind #154's `query_strategy` flag.

## Verification

- `uv run pytest tests/test_uri_baki.py -q` — 16 passed
- `uv run pytest tests/ --ignore=tests/e2e -q` — 2098 passed, 20
  skipped (no regressions)
- Both commits show `G` (good signature) under `git log`.
- Discretion grep over `git diff origin/main...HEAD` is empty.

## Test plan

- [ ] Reviewer confirms the AC#5 disposition (not-adopted) is the
      correct outcome given the table — i.e., does the verdict need
      to be flagged for follow-up or simply filed.
- [ ] Reviewer confirms the three follow-up paths in `RESULTS.md`
      ("real-corpus retest", "per-effect editorial corpora",
      "production-shadow trial") should remain in the doc as
      forward-pointers rather than be promoted to issues.
- [ ] CI green.

Tracks #153 (research). No production-wiring follow-up implied.

## Summary by Sourcery

Add research-only post-rank score adjusters for beliefs and a synthetic benchmark harness to evaluate them, with results documenting an honest negative outcome for adoption.

New Features:
- Introduce pure post-rank score adjuster functions for locked-floor protection, supersession demotion, and recency-based decay over belief scores.
- Add a synthetic-corpus benchmark harness to evaluate the adjusters under relevance-aware and control conditions, with CLI and JSON output support.

Documentation:
- Document benchmark methodology, results, and follow-up paths for the uri_baki retest in RESULTS.md.

Tests:
- Add focused unit tests pinning the semantics and edge cases of the new score adjuster functions.

Chores:
- Check in captured benchmark result artifacts for 10k and 50k belief runs.