### PR TITLE
feat(rebuild): relevance floor + silent-when-empty (#364)

### DIFF
--- a/src/aelfrice/context_rebuilder.py
+++ b/src/aelfrice/context_rebuilder.py
@@ -73,6 +73,7 @@ from typing import Any, Final, IO, cast
 from aelfrice.entity_extractor import extract_entities
 from aelfrice.models import LOCK_USER, Belief
 from aelfrice.retrieval import retrieve
+from aelfrice.scoring import posterior_mean
 from aelfrice.store import MemoryStore
 from aelfrice.triple_extractor import extract_triples
 
@@ -130,6 +131,31 @@ DEFAULT_REBUILD_LOG_ENABLED: Final[bool] = True
 """Rebuild diagnostic log is default-on. Opt out via the
 `AELFRICE_REBUILD_LOG=0` env var or `[rebuild_log] enabled = false`
 in `.aelfrice.toml`."""
+
+# --- Relevance floor (#289 / #364) ---------------------------------------
+
+REBUILD_FLOOR_SECTION: Final[str] = "rebuild_floor"
+REBUILD_FLOOR_SESSION_KEY: Final[str] = "session"
+REBUILD_FLOOR_L1_KEY: Final[str] = "l1"
+
+DEFAULT_FLOOR_SESSION: Final[float] = 0.10
+"""Soft floor for session-scoped (L2) hits. Beliefs from the current
+session have a high prior of relevance; reject only on near-zero
+composite scores. Placeholder per `docs/relevance_floor.md` §4 — the
+production value lands in a follow-up after #288 phase-1b
+calibration. Operator-tunable via `[rebuild_floor] session`."""
+
+DEFAULT_FLOOR_L1: Final[float] = 0.40
+"""Hard floor for L1 BM25 / L2.5 entity hits. Most candidates that
+fall below this composite score are off-topic for the recent-turn
+query. Placeholder per `docs/relevance_floor.md` §4. Operator-tunable
+via `[rebuild_floor] l1`."""
+
+FLOOR_SCORED_QUERY_LIMIT: Final[int] = 200
+"""Cap on `search_beliefs_scored()` rows pulled to derive bm25_raw
+for the floor's composite score. Generous enough to cover the
+retrieve()-returned candidate set in normal operation; bounded so a
+pathological store cannot turn the floor into an O(N) scan."""
 
 # --- v1.4.0 trigger-mode constants (issue #141) ---------------------------
 
@@ -263,6 +289,8 @@ def rebuild_v14(
     rebuild_log_path: Path | None = None,
     rebuild_log_enabled: bool = DEFAULT_REBUILD_LOG_ENABLED,
     session_id_for_log: str | None = None,
+    floor_session: float = 0.0,
+    floor_l1: float = 0.0,
 ) -> str:
     """v1.4 rebuild: L0 + session-scoped + L2.5/L1 via `retrieve()`.
 
@@ -282,6 +310,22 @@ def rebuild_v14(
     Pure function. Deterministic given the same inputs and store
     contents -- the regression test for issue #139 relies on this.
     Empty recent_turns: returns L0 only, block is still well-formed.
+
+    v1.7 (#289 / #364): per-lane relevance floor. L0 locked always
+    packs (no floor). Session-scoped (L2) packs above `floor_session`.
+    L1 / L2.5 packs above `floor_l1`. When all hits are floored out
+    AND no locks exist the function returns the empty string —
+    `rebuild_v14`'s "I don't know — say nothing" path. See
+    `docs/relevance_floor.md` for the composite-score formula and
+    the rationale for the split.
+
+    The function-signature defaults are `floor_session=0.0,
+    floor_l1=0.0` — backwards-compatible no-floor behavior for
+    direct callers. The production hook path threads the
+    placeholder values (`DEFAULT_FLOOR_SESSION`,
+    `DEFAULT_FLOOR_L1`) from `RebuilderConfig`, so operators get
+    the floor end-to-end while existing tests and ad-hoc callers
+    are unaffected.
     """
     locked: list[Belief] = store.list_locked_beliefs()
     locked_ids: set[str] = {b.id for b in locked}
@@ -307,6 +351,19 @@ def rebuild_v14(
     )
     session_ids: set[str] = {b.id for b in session_hits}
 
+    # v1.7 (#289 / #364): per-lane composite-score floor. Pull bm25_raw
+    # for every candidate via one extra FTS5 call; off-FTS5 candidates
+    # (entity-only, BFS, session-only) score with bm25_normalized=1.0
+    # so the floor decision rests on posterior_mean alone for them.
+    bm25_lookup: dict[str, float] = _bm25_lookup_for_query(store, query)
+
+    def _score_for(b: Belief) -> tuple[float, float | None]:
+        bm25_raw = bm25_lookup.get(b.id)
+        return (
+            floor_composite_score(bm25_raw, b.alpha, b.beta),
+            bm25_raw,
+        )
+
     # Pack, accounting tokens. L0 always survives.
     # Output-level content_hash dedup (#281): different belief_ids can
     # share a content_hash (re-ingest before #219, multi-source ingest,
@@ -324,6 +381,7 @@ def rebuild_v14(
     log_candidates: list[dict[str, object]] = []
     n_dropped_by_dedup = 0
     n_dropped_by_budget = 0
+    n_dropped_by_floor = 0
     budget_exceeded_session = False
     budget_exceeded_non_locked = False
 
@@ -342,12 +400,19 @@ def rebuild_v14(
     for b in session_hits:
         decision: str
         reason: str | None
+        composite, bm25_raw = _score_for(b)
         if b.content_hash in seen_hashes:
             decision = "dropped"
             reason = (
                 f"content_hash_collision_with:{hash_to_packed_id[b.content_hash]}"
             )
             n_dropped_by_dedup += 1
+        elif composite < floor_session:
+            decision = "dropped"
+            reason = (
+                f"below_floor_session:{composite:.4f}<{floor_session:.4f}"
+            )
+            n_dropped_by_floor += 1
         elif budget_exceeded_session:
             decision = "dropped"
             reason = "budget_exceeded"
@@ -370,7 +435,12 @@ def rebuild_v14(
             {
                 "belief_id": b.id,
                 "rank": len(log_candidates) + 1,
-                "scores": _empty_scores(),
+                "scores": {
+                    "bm25": bm25_raw,
+                    "posterior_mean": posterior_mean(b.alpha, b.beta),
+                    "reranker": None,
+                    "final": composite,
+                },
                 "lock_level": _belief_lock_level_for_log(b),
                 "decision": decision,
                 "reason": reason,
@@ -382,12 +452,17 @@ def rebuild_v14(
             continue  # already surfaced above as a session candidate
         decision2: str
         reason2: str | None
+        composite2, bm25_raw2 = _score_for(b)
         if b.content_hash in seen_hashes:
             decision2 = "dropped"
             reason2 = (
                 f"content_hash_collision_with:{hash_to_packed_id[b.content_hash]}"
             )
             n_dropped_by_dedup += 1
+        elif composite2 < floor_l1:
+            decision2 = "dropped"
+            reason2 = f"below_floor_l1:{composite2:.4f}<{floor_l1:.4f}"
+            n_dropped_by_floor += 1
         elif budget_exceeded_non_locked:
             decision2 = "dropped"
             reason2 = "budget_exceeded"
@@ -410,7 +485,12 @@ def rebuild_v14(
             {
                 "belief_id": b.id,
                 "rank": len(log_candidates) + 1,
-                "scores": _empty_scores(),
+                "scores": {
+                    "bm25": bm25_raw2,
+                    "posterior_mean": posterior_mean(b.alpha, b.beta),
+                    "reranker": None,
+                    "final": composite2,
+                },
                 "lock_level": _belief_lock_level_for_log(b),
                 "decision": decision2,
                 "reason": reason2,
@@ -430,7 +510,7 @@ def rebuild_v14(
         pack_summary: dict[str, int] = {
             "n_candidates": len(log_candidates),
             "n_packed": n_packed,
-            "n_dropped_by_floor": 0,
+            "n_dropped_by_floor": n_dropped_by_floor,
             "n_dropped_by_dedup": n_dropped_by_dedup,
             "n_dropped_by_budget": n_dropped_by_budget,
             "total_chars_packed": total_chars_packed,
@@ -442,6 +522,15 @@ def rebuild_v14(
             pack_summary=pack_summary,
         )
         _append_rebuild_log_record(rebuild_log_path, record)
+
+    # v1.7 (#289 / #364) silent path: when no candidate cleared any
+    # lane (no L0 locks, no above-floor session/L1), return "" so
+    # downstream callers do not inject an empty memory block. The
+    # PreCompact hook's `if body:` guard already drops the envelope
+    # on falsy output (hook.py L966), so empty input -> no
+    # additionalContext written.
+    if not out:
+        return ""
 
     return _format_block(
         recent_turns, out, session_ids, token_budget=token_budget,
@@ -495,6 +584,14 @@ class RebuilderConfig:
     trigger_mode: str = DEFAULT_TRIGGER_MODE
     threshold_fraction: float = DEFAULT_THRESHOLD_FRACTION
     rebuild_log_enabled: bool = DEFAULT_REBUILD_LOG_ENABLED
+    floor_session: float = DEFAULT_FLOOR_SESSION
+    """v1.7 (#289 / #364) placeholder — operator-tunable via
+    `[rebuild_floor] session` in .aelfrice.toml. Calibration lands
+    in a follow-up after #288 phase-1b."""
+    floor_l1: float = DEFAULT_FLOOR_L1
+    """v1.7 (#289 / #364) placeholder — operator-tunable via
+    `[rebuild_floor] l1` in .aelfrice.toml. Calibration lands
+    in a follow-up after #288 phase-1b."""
 
 
 def load_rebuilder_config(start: Path | None = None) -> RebuilderConfig:
@@ -607,12 +704,53 @@ def load_rebuilder_config(start: Path | None = None) -> RebuilderConfig:
                         f"(expected bool)",
                         file=serr,
                     )
+            floor_section_obj: Any = parsed.get(REBUILD_FLOOR_SECTION, {})
+            floor_session_resolved: float = DEFAULT_FLOOR_SESSION
+            floor_l1_resolved: float = DEFAULT_FLOOR_L1
+            if isinstance(floor_section_obj, dict):
+                floor_section = cast(dict[str, Any], floor_section_obj)
+                fs_obj: Any = floor_section.get(
+                    REBUILD_FLOOR_SESSION_KEY, DEFAULT_FLOOR_SESSION,
+                )
+                fl_obj: Any = floor_section.get(
+                    REBUILD_FLOOR_L1_KEY, DEFAULT_FLOOR_L1,
+                )
+                if (
+                    isinstance(fs_obj, bool)
+                    or not isinstance(fs_obj, (int, float))
+                    or float(fs_obj) < 0.0
+                ):
+                    print(
+                        f"aelfrice rebuilder: ignoring "
+                        f"[{REBUILD_FLOOR_SECTION}] "
+                        f"{REBUILD_FLOOR_SESSION_KEY} in {candidate} "
+                        f"(expected non-negative number)",
+                        file=serr,
+                    )
+                else:
+                    floor_session_resolved = float(fs_obj)
+                if (
+                    isinstance(fl_obj, bool)
+                    or not isinstance(fl_obj, (int, float))
+                    or float(fl_obj) < 0.0
+                ):
+                    print(
+                        f"aelfrice rebuilder: ignoring "
+                        f"[{REBUILD_FLOOR_SECTION}] "
+                        f"{REBUILD_FLOOR_L1_KEY} in {candidate} "
+                        f"(expected non-negative number)",
+                        file=serr,
+                    )
+                else:
+                    floor_l1_resolved = float(fl_obj)
             return RebuilderConfig(
                 turn_window_n=n_resolved,
                 token_budget=b_resolved,
                 trigger_mode=mode_resolved,
                 threshold_fraction=frac_resolved,
                 rebuild_log_enabled=log_enabled_resolved,
+                floor_session=floor_session_resolved,
+                floor_l1=floor_l1_resolved,
             )
         if current.parent == current:
             break
@@ -860,6 +998,67 @@ def _belief_lock_level_for_log(b: Belief) -> str:
     internal model already uses these strings, so this is a passthrough
     that also normalises any unexpected value to "none"."""
     return b.lock_level if b.lock_level == LOCK_USER else "none"
+
+
+def floor_composite_score(
+    bm25_raw: float | None, alpha: float, beta: float,
+) -> float:
+    """Composite floor score: `bm25_normalized * (0.5 + 0.5 * posterior_mean)`.
+
+    `bm25_raw` is SQLite's signed FTS5 score (smaller = better, ≤ 0
+    in normal cases). It is converted to `bm25_normalized` ∈ [0, 1]
+    via `min(-bm25_raw, 1.0) / 1.0` style clamping. `None` means the
+    candidate is not in the FTS5 hit set (e.g. L2.5 entity-only or
+    L3 BFS expansion); the floor gives such candidates the
+    benefit-of-doubt `bm25_normalized = 1.0` so the decision rests
+    on `posterior_mean`. Locked beliefs bypass the floor entirely;
+    callers should not call this for them.
+
+    Composite formula and clamp behavior pinned by
+    `docs/relevance_floor.md` §1. Coefficient 0.5/0.5 is the
+    placeholder split; tuning lands post-#288.
+    """
+    if bm25_raw is None:
+        bm25_normalized = 1.0
+    else:
+        # SQLite FTS5 returns a non-positive score; flip sign and
+        # clamp to [0, 1] against a unit baseline. Above-baseline
+        # raw scores saturate at 1.0 — the floor is about whether
+        # there is a signal at all, not how strong it is.
+        signed = -float(bm25_raw)
+        if signed <= 0.0:
+            bm25_normalized = 0.0
+        elif signed >= 1.0:
+            bm25_normalized = 1.0
+        else:
+            bm25_normalized = signed
+    pm = posterior_mean(alpha, beta)
+    return bm25_normalized * (0.5 + 0.5 * pm)
+
+
+def _bm25_lookup_for_query(
+    store: MemoryStore, query: str,
+) -> dict[str, float]:
+    """Return `{belief_id: bm25_raw}` for the query.
+
+    Used to score floor candidates against the same BM25 raw values
+    SQLite would return inside `retrieve()`. Off-FTS5 candidates
+    (entity index, BFS expansion, session-scoped) are absent from
+    the dict — callers should treat absence as "no FTS5 signal" and
+    pass `None` to `floor_composite_score`.
+
+    Empty / whitespace-only query: returns `{}`.
+    """
+    if not query or not query.strip():
+        return {}
+    try:
+        scored = store.search_beliefs_scored(
+            query, limit=FLOOR_SCORED_QUERY_LIMIT,
+        )
+    except Exception:  # pyright: ignore[reportBroadException]
+        # Floor must never block rebuild on a transient store error.
+        return {}
+    return {b.id: bm25_raw for b, bm25_raw in scored}
 
 
 def _empty_scores() -> dict[str, float | None]:

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -962,6 +962,8 @@ def pre_compact(
             recent,
             budget,
             rebuild_log_enabled=config.rebuild_log_enabled,
+            floor_session=config.floor_session,
+            floor_l1=config.floor_l1,
         )
         if body:
             sout.write(emit_pre_compact_envelope(body))
@@ -1022,6 +1024,8 @@ def _rebuild_and_format(
     token_budget: int,
     *,
     rebuild_log_enabled: bool = True,
+    floor_session: float = 0.0,
+    floor_l1: float = 0.0,
 ) -> str:
     """Open the store and run the v1.4 rebuild.
 
@@ -1050,6 +1054,8 @@ def _rebuild_and_format(
             rebuild_log_path=log_path,
             rebuild_log_enabled=rebuild_log_enabled,
             session_id_for_log=sid,
+            floor_session=floor_session,
+            floor_l1=floor_l1,
         )
     finally:
         store.close()

--- a/tests/test_hook_pre_compact.py
+++ b/tests/test_hook_pre_compact.py
@@ -80,8 +80,13 @@ def _aelfrice_log(cwd: Path, lines: list[dict[str, object]]) -> Path:
     # tests exercise the auto-fire path, so opt them into "threshold".
     cfg = cwd / ".aelfrice.toml"
     if not cfg.exists():
+        # Disable v1.7 (#364) relevance floor in tests by default;
+        # tests that exercise floor behavior set their own thresholds
+        # via this knob. Keeps pre-floor pre-compact tests valid
+        # without an audit of every weak-overlap query.
         cfg.write_text(
-            '[rebuilder]\ntrigger_mode = "threshold"\n',
+            '[rebuilder]\ntrigger_mode = "threshold"\n'
+            "[rebuild_floor]\nsession = 0.0\nl1 = 0.0\n",
             encoding="utf-8",
         )
     return p
@@ -168,7 +173,18 @@ def test_pre_compact_prefers_aelfrice_log(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     db = tmp_path / "memory.db"
-    _seed_db(db, [_mk("F1", "kitchen has bananas")])
+    # v1.7 (#364) post-floor contract: rebuild_v14 returns "" when no
+    # candidate survives the floor and there are no locks. The fixture
+    # belief F1 is intentionally unrelated to the recent turn (FTS5 is
+    # not populated for in-memory inserts in this test path), so we
+    # lock it to exercise the L0-always-packs guarantee. The test's
+    # assertion is "the rebuild path picked the aelfrice log over the
+    # alternate transcript path", not "weak BM25 hit packs".
+    _seed_db(
+        db,
+        [_mk("F1", "kitchen contents",
+             lock_level=LOCK_USER, locked_at="2026-04-26T00:00:00Z")],
+    )
     _set_db(monkeypatch, db)
     cwd = tmp_path / "repo"
     (cwd / ".git").mkdir(parents=True)
@@ -197,13 +213,23 @@ def test_pre_compact_falls_back_to_claude_transcript(
 ) -> None:
     """No .git anywhere -> use transcript_path."""
     db = tmp_path / "memory.db"
-    _seed_db(db, [_mk("F1", "kitchen has bananas")])
+    # See test_pre_compact_prefers_aelfrice_log for the L0-lock rationale
+    # post v1.7 (#364) floor.
+    _seed_db(
+        db,
+        [_mk("F1", "kitchen check fixture",
+             lock_level=LOCK_USER, locked_at="2026-04-26T00:00:00Z")],
+    )
     _set_db(monkeypatch, db)
     no_git = tmp_path / "no_git"
     no_git.mkdir()
-    # v1.4 default trigger_mode is "manual"; opt into auto-fire.
+    # v1.4 default trigger_mode is "manual"; opt into auto-fire. Floor
+    # disabled so this test's assertion ("kitchen check" appears in
+    # rebuild output) is not gated on FTS5 indexing of the fixture.
     (no_git / ".aelfrice.toml").write_text(
-        '[rebuilder]\ntrigger_mode = "threshold"\n', encoding="utf-8",
+        '[rebuilder]\ntrigger_mode = "threshold"\n'
+        "[rebuild_floor]\nsession = 0.0\nl1 = 0.0\n",
+        encoding="utf-8",
     )
     transcript = tmp_path / "claude.jsonl"
     _claude_transcript(transcript, [
@@ -226,7 +252,15 @@ def test_pre_compact_writes_rebuild_block_with_hits(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     db = tmp_path / "memory.db"
-    _seed_db(db, [_mk("F1", "kitchen has bananas")])
+    # v1.7 (#364) post-floor contract: lock the fixture so the L0
+    # always-pack lane keeps the block emitted regardless of FTS5
+    # state. The assertion target is the block's structural tags,
+    # not retrieval quality.
+    _seed_db(
+        db,
+        [_mk("F1", "kitchen has bananas",
+             lock_level=LOCK_USER, locked_at="2026-04-26T00:00:00Z")],
+    )
     _set_db(monkeypatch, db)
     cwd = tmp_path / "repo"
     (cwd / ".git").mkdir(parents=True)

--- a/tests/test_relevance_floor.py
+++ b/tests/test_relevance_floor.py
@@ -1,0 +1,327 @@
+"""Unit tests for the v1.7 (#289 / #364) relevance floor.
+
+Covers:
+  - composite-score formula determinism + clamp behavior
+  - L0 always-pack guarantee (no floor on locked beliefs)
+  - L1 hard-floor behavior (above-floor packs, below-floor drops)
+  - all-floored-out + no-locks => empty rebuild block ("")
+  - `[rebuild_floor]` config override resolves and validates
+  - rebuild_log `n_dropped_by_floor` accounting matches drops
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aelfrice.context_rebuilder import (
+    DEFAULT_FLOOR_L1,
+    DEFAULT_FLOOR_SESSION,
+    RecentTurn,
+    floor_composite_score,
+    load_rebuilder_config,
+    rebuild_v14,
+)
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    bid: str,
+    content: str,
+    *,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _seed(db_path: Path, beliefs: list[Belief]) -> MemoryStore:
+    store = MemoryStore(str(db_path))
+    for b in beliefs:
+        store.insert_belief(b)
+    return store
+
+
+# --- composite-score formula --------------------------------------------
+
+
+def test_composite_zero_bm25_yields_zero() -> None:
+    """`bm25_raw=0` (no FTS5 signal) zeroes the composite. Posterior
+    cannot rescue a belief that did not match any query token."""
+    assert floor_composite_score(0.0, 1.0, 1.0) == 0.0
+
+
+def test_composite_strong_bm25_neutral_posterior_is_three_quarters() -> None:
+    """bm25_raw <= -1 saturates `bm25_normalized = 1.0`; with
+    `posterior_mean = 0.5` the composite is `1.0 * (0.5 + 0.25) = 0.75`."""
+    assert abs(floor_composite_score(-1.5, 1.0, 1.0) - 0.75) < 1e-9
+
+
+def test_composite_high_posterior_lifts_score() -> None:
+    """`posterior_mean = 1.0` (alpha >> beta) drives the composite to
+    `bm25_normalized * 1.0`, the upper bound."""
+    composite = floor_composite_score(-1.0, 100.0, 0.5)
+    assert composite > 0.99
+
+
+def test_composite_off_fts5_candidate_uses_unit_bm25() -> None:
+    """Entity-only / BFS / session-only candidates pass `bm25_raw=None`
+    and get `bm25_normalized = 1.0`. Floor decision rests on
+    posterior alone for those candidates."""
+    none_composite = floor_composite_score(None, 1.0, 1.0)
+    saturated_composite = floor_composite_score(-1.5, 1.0, 1.0)
+    assert none_composite == saturated_composite
+
+
+def test_composite_is_deterministic() -> None:
+    """Same inputs -> same composite, every call. The floor decision
+    must not jitter run-to-run for the same store snapshot."""
+    args = (-0.42, 3.0, 2.0)
+    a = floor_composite_score(*args)
+    b = floor_composite_score(*args)
+    c = floor_composite_score(*args)
+    assert a == b == c
+
+
+# --- L0 always packs ----------------------------------------------------
+
+
+def test_locked_belief_packs_under_aggressive_floor(tmp_path: Path) -> None:
+    """An L0 lock with no query-overlap survives even an absurdly
+    high floor. L0 bypasses the floor by contract."""
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(
+            "L1",
+            "completely unrelated locked truth",
+            lock_level=LOCK_USER,
+            locked_at="2026-04-26T00:00:00Z",
+        )],
+    )
+    try:
+        block = rebuild_v14(
+            [RecentTurn(role="user", text="totally different topic")],
+            store,
+            floor_session=10.0,
+            floor_l1=10.0,
+        )
+    finally:
+        store.close()
+    assert "completely unrelated locked truth" in block
+
+
+# --- empty path ---------------------------------------------------------
+
+
+def test_empty_when_all_hits_floored_and_no_locks(tmp_path: Path) -> None:
+    """No locks + every candidate below the floor -> rebuild_v14
+    returns the empty string."""
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk("F1", "kitchen has bananas")],
+    )
+    try:
+        block = rebuild_v14(
+            [RecentTurn(role="user", text="kitchen contents")],
+            store,
+            floor_session=10.0,
+            floor_l1=10.0,
+        )
+    finally:
+        store.close()
+    assert block == ""
+
+
+def test_empty_path_default_zero_floor_packs_normally(tmp_path: Path) -> None:
+    """Backwards-compatible default: `floor_session=0.0, floor_l1=0.0`
+    gates nothing — direct callers see the v1.6 packing behavior."""
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(
+            "L1",
+            "kitchen has bananas",
+            lock_level=LOCK_USER,
+            locked_at="2026-04-26T00:00:00Z",
+        )],
+    )
+    try:
+        block = rebuild_v14(
+            [RecentTurn(role="user", text="kitchen contents")],
+            store,
+        )
+    finally:
+        store.close()
+    assert block != ""
+    assert "kitchen has bananas" in block
+
+
+# --- config loader ------------------------------------------------------
+
+
+def test_default_floor_constants_match_spec() -> None:
+    """Pin the placeholder values to `docs/relevance_floor.md` §4.
+    A change to either trips this test so a follow-up calibration
+    PR cannot slip past review unnoticed."""
+    assert DEFAULT_FLOOR_SESSION == 0.10
+    assert DEFAULT_FLOOR_L1 == 0.40
+
+
+def test_config_override_resolves_floor_values(tmp_path: Path) -> None:
+    """`[rebuild_floor]` block overrides defaults; resolved cfg has
+    operator-tuned values."""
+    (tmp_path / ".aelfrice.toml").write_text(
+        '[rebuild_floor]\nsession = 0.25\nl1 = 0.55\n',
+        encoding="utf-8",
+    )
+    cfg = load_rebuilder_config(tmp_path)
+    assert cfg.floor_session == 0.25
+    assert cfg.floor_l1 == 0.55
+
+
+def test_config_negative_floor_falls_back_to_default(tmp_path: Path) -> None:
+    """Out-of-range values degrade silently to defaults; never raise."""
+    (tmp_path / ".aelfrice.toml").write_text(
+        '[rebuild_floor]\nsession = -1.0\nl1 = -0.5\n',
+        encoding="utf-8",
+    )
+    cfg = load_rebuilder_config(tmp_path)
+    assert cfg.floor_session == DEFAULT_FLOOR_SESSION
+    assert cfg.floor_l1 == DEFAULT_FLOOR_L1
+
+
+def test_config_zero_floor_is_valid_explicit_opt_out(tmp_path: Path) -> None:
+    """`0.0` is a valid operator-tunable value (full opt-out of floor),
+    distinct from the placeholder defaults."""
+    (tmp_path / ".aelfrice.toml").write_text(
+        '[rebuild_floor]\nsession = 0.0\nl1 = 0.0\n',
+        encoding="utf-8",
+    )
+    cfg = load_rebuilder_config(tmp_path)
+    assert cfg.floor_session == 0.0
+    assert cfg.floor_l1 == 0.0
+
+
+# --- rebuild_log accounting --------------------------------------------
+
+
+def test_rebuild_log_records_floor_drops(tmp_path: Path) -> None:
+    """`pack_summary.n_dropped_by_floor` matches the count of dropped
+    candidates whose `reason` starts with `below_floor_`."""
+    store = _seed(
+        tmp_path / "m.db",
+        [
+            _mk(
+                "L1",
+                "anchor lock for the rebuild path",
+                lock_level=LOCK_USER,
+                locked_at="2026-04-26T00:00:00Z",
+            ),
+            _mk("F1", "weak match content"),
+        ],
+    )
+    log_path = tmp_path / "rebuild.jsonl"
+    try:
+        block = rebuild_v14(
+            [RecentTurn(
+                role="user",
+                text="weak match content query",
+                session_id="sess-x",
+            )],
+            store,
+            rebuild_log_path=log_path,
+            rebuild_log_enabled=True,
+            session_id_for_log="sess-x",
+            floor_session=10.0,
+            floor_l1=10.0,
+        )
+    finally:
+        store.close()
+    # Block is non-empty — the L0 lock packed under any floor.
+    assert block
+    raw = log_path.read_text(encoding="utf-8")
+    record = json.loads(raw.strip().splitlines()[-1])
+    summary = record["pack_summary"]
+    n_floor = summary["n_dropped_by_floor"]
+    candidate_floor = sum(
+        1
+        for c in record["candidates"]
+        if isinstance(c.get("reason"), str)
+        and c["reason"].startswith("below_floor_")
+    )
+    # Invariant: n_dropped_by_floor matches the count of candidates
+    # whose reason starts with `below_floor_`. (We don't pin a specific
+    # `>= 1` here because retrieve()'s candidate set in this in-process
+    # path can vary; the invariant is the load-bearing claim.)
+    assert n_floor == candidate_floor
+
+
+def test_session_scoped_belief_floored_increments_count(tmp_path: Path) -> None:
+    """Pin a guaranteed floor drop: a session-scoped belief that the
+    rebuilder always considers gets dropped under an aggressive floor,
+    and the rebuild_log records that drop in `n_dropped_by_floor`.
+    """
+    sid = "sess-floor-pin"
+    # Inject a belief tagged with the session_id so `_session_scoped_hits`
+    # picks it up unconditionally — independent of FTS5 / retrieve().
+    store = MemoryStore(str(tmp_path / "m.db"))
+    try:
+        store.insert_belief(_mk(
+            "L1",
+            "anchor lock to keep block non-empty",
+            lock_level=LOCK_USER,
+            locked_at="2026-04-26T00:00:00Z",
+        ))
+        # Insert via raw SQL so we can pin session_id (insert_belief
+        # respects it but the helper doesn't take it).
+        store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+            "UPDATE beliefs SET session_id = ? WHERE id = ?",
+            (None, "L1"),  # locked belief stays unsessioned
+        )
+        store.insert_belief(_mk("S1", "session scoped low posterior"))
+        store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+            "UPDATE beliefs SET session_id = ?, alpha = ?, beta = ? "
+            "WHERE id = ?",
+            (sid, 0.01, 100.0, "S1"),  # posterior_mean ~ 0.0001
+        )
+        store._conn.commit()  # pyright: ignore[reportPrivateUsage]
+
+        log_path = tmp_path / "rebuild.jsonl"
+        block = rebuild_v14(
+            [RecentTurn(role="user", text="any topic", session_id=sid)],
+            store,
+            rebuild_log_path=log_path,
+            rebuild_log_enabled=True,
+            session_id_for_log=sid,
+            # Off-FTS5 candidate with bm25=None gets bm25_normalized=1.0;
+            # composite = 1.0 * (0.5 + 0.5 * pm). With pm ~ 1e-4, composite
+            # ~ 0.5. Floor 0.75 drops it; floor_l1=0.0 doesn't gate L1.
+            floor_session=0.75,
+            floor_l1=0.0,
+        )
+    finally:
+        store.close()
+    assert block  # L0 lock kept it non-empty
+    raw = log_path.read_text(encoding="utf-8")
+    record = json.loads(raw.strip().splitlines()[-1])
+    summary = record["pack_summary"]
+    assert summary["n_dropped_by_floor"] >= 1
+    s1_candidate = next(
+        c for c in record["candidates"] if c["belief_id"] == "S1"
+    )
+    assert s1_candidate["decision"] == "dropped"
+    assert isinstance(s1_candidate["reason"], str)
+    assert s1_candidate["reason"].startswith("below_floor_session")


### PR DESCRIPTION
## Summary

Implements the ratified #289 spec (`docs/relevance_floor.md`) for the relevance floor + silent-when-empty contract on `rebuild_v14()`.

- **Composite score**: `bm25_normalized * (0.5 + 0.5 * posterior_mean)`, with `bm25_normalized` clamped to `[0, 1]` and off-FTS5 candidates (entity / BFS / session-only) given `bm25_normalized = 1.0` so the decision rests on posterior alone for them.
- **Three-tier floor**: L0 always packs (no floor); L2 session-scoped uses `floor_session`; L1 / L2.5 use `floor_l1`.
- **Empty path**: `rebuild_v14()` returns `""` when no candidate clears any lane. The existing `if body:` guard at `hook.py:967` already drops the precompact `additionalContext` envelope on falsy output, so the silent path lands end-to-end with no further hook changes.
- **Config**: new `[rebuild_floor] session/l1` block, mirrors the existing `rebuilder` / `rebuild_log` loader pattern. Placeholder defaults `DEFAULT_FLOOR_SESSION = 0.10` and `DEFAULT_FLOOR_L1 = 0.40` per spec §4. Calibration lands in a follow-up after #288 phase-1b operator-week.
- **Diagnostic log**: per-candidate scores (bm25, posterior_mean, final composite) now flow into rebuild_log; `pack_summary.n_dropped_by_floor` reflects actual drops so the eval harness can grade the floor's effect retrospectively.

## API back-compat

`rebuild_v14`'s function-signature defaults are `floor=0.0` (no-floor) so direct callers and tests are unaffected. The production hook path (`hook.py:_rebuild_and_format`) threads the placeholder values from `RebuilderConfig`. `test_hook_pre_compact` fixtures lock the seeded belief so the L0-always-packs lane keeps the rebuild block emitted — matching the new contract that empty hits = empty rebuild.

## Out of scope (follow-ups)

- `hook_search.py` `last_retrieved_at` stamp gating on floor survivors (spec §3). That's a separate retrieve-time refactor against the UserPromptSubmit path; will land as its own PR.
- Calibration of T values from #288 phase-1b logs (operator-week pending).

## Test plan

- [x] `uv run pytest tests/ --timeout=30 -q` — 2115 passed (was 2101 + 14 new), 20 skipped
- [x] `ruff check src/aelfrice/context_rebuilder.py src/aelfrice/hook.py tests/test_relevance_floor.py tests/test_hook_pre_compact.py` — clean
- [x] Discretion check — clean
- [x] New `tests/test_relevance_floor.py` covers: composite formula determinism + clamps + off-FTS5 handling, L0 always packs under aggressive floor, all-floored-no-locks → `""`, default-zero opt-out, config override + negative-value fallback + zero-as-explicit-opt-out, rebuild_log accounting matches per-candidate `below_floor_*` reasons, session-lane drop pinned with low-posterior fixture
- [ ] CI green

## Summary by Sourcery

Introduce a configurable relevance floor and silent-when-empty behavior to the v1.7 context rebuilder, and plumb it through the hook path while extending logging and tests.

New Features:
- Add per-lane relevance floor to rebuild_v14(), using a composite score over BM25 and posterior to decide which session and L1/L2.5 candidates to pack.
- Allow rebuild_v14() to return an empty string when all non-locked candidates fall below the floor and no locks exist, signaling "no useful context".
- Expose floor thresholds via a new [rebuild_floor] config section with separate session and L1 values and sensible defaults.

Enhancements:
- Record per-candidate composite scores and BM25 values in rebuild logs and track the number of candidates dropped by the relevance floor.
- Thread floor configuration from RebuilderConfig through the hook pre_compact path into rebuild_v14(), preserving backwards-compatible zero-floor defaults for direct callers.
- Add utilities for computing composite floor scores and looking up BM25 values for a query without impacting rebuild reliability.

Tests:
- Add comprehensive unit tests covering composite score behavior, floor configuration loading and validation, L0 always-pack semantics, empty-output behavior, and rebuild_log accounting for floor drops.
- Update pre-compact hook tests to default floor thresholds to zero and adjust fixtures to align with the new floor and L0 lock behavior.