### PR TITLE
feat(query_understanding): R1 entity-expand + R3 IDF-clip modules (#291 PR-1)

### DIFF
--- a/src/aelfrice/query_understanding/__init__.py
+++ b/src/aelfrice/query_understanding/__init__.py
@@ -1,0 +1,39 @@
+"""Query understanding stack for the rebuilder (R1 + R3, #291).
+
+Two deterministic transforms a caller stacks before BM25:
+
+1. R1 entity expansion (`expand_with_capitalised_entities`)
+2. R3 IDF clip with per-store quantile thresholds
+   (`clip_with_quantile_thresholds`, `compute_idf_quantile_thresholds`)
+
+PR-1 lands the modules + per-store IDF-quantile helper + unit tests.
+The context-rebuilder integration lands in PR-2 behind the
+`query_strategy = "legacy-bm25"` setting (#291 rollout step 2).
+
+The synthetic-tuned IDF constants (1.5, 2.5) from the lab R3.5
+campaign do not transfer to live stores (live IDF medians 7.5-9.5
+versus synthetic 2.85). Per-store quantiles are the architectural
+fix and are computed by `compute_idf_quantile_thresholds` over the
+live BM25 IDF distribution.
+"""
+from aelfrice.query_understanding.entity_expand import (
+    DEFAULT_QF_MULTIPLIER,
+    expand_with_capitalised_entities,
+)
+from aelfrice.query_understanding.idf_clip import (
+    DEFAULT_BOOST_QF,
+    DEFAULT_HIGH_QUANTILE,
+    DEFAULT_LOW_QUANTILE,
+    clip_with_quantile_thresholds,
+    compute_idf_quantile_thresholds,
+)
+
+__all__ = [
+    "DEFAULT_BOOST_QF",
+    "DEFAULT_HIGH_QUANTILE",
+    "DEFAULT_LOW_QUANTILE",
+    "DEFAULT_QF_MULTIPLIER",
+    "clip_with_quantile_thresholds",
+    "compute_idf_quantile_thresholds",
+    "expand_with_capitalised_entities",
+]

--- a/src/aelfrice/query_understanding/entity_expand.py
+++ b/src/aelfrice/query_understanding/entity_expand.py
@@ -1,0 +1,59 @@
+"""R1 entity-expansion query rewriter (#291).
+
+Detects capitalised tokens in the raw query, lowercases them, and
+appends them to the BM25 term list. Each detected entity is emitted
+`qf_multiplier` times. The BM25 integer-qf contract represents 2x
+weight as a duplicated term -- fractional qf is not encodable.
+
+The lab R1 round measured this exact rule (capitalised token detect
+-> lowercase -> append at 2x qf) at +0.104 P@10 on the synthetic v2
+corpus (ENTITY_POOL=12). Magnitude on live stores is unknown until
+the #288 phase-1b retest -- the rule is carried as written.
+
+Pure regex over the raw query string. Deterministic; no I/O; no
+store coupling. Sub-microsecond per call.
+"""
+from __future__ import annotations
+
+import re
+from typing import Final
+
+# Capitalised-token rule: an uppercase letter followed by at least one
+# lowercase letter, then any mix of letters or digits. The two-character
+# minimum avoids matching the sentence pronoun "I" while still catching
+# short product names like "Go" or "Qt".
+_CAPITALISED: Final[re.Pattern[str]] = re.compile(r"\b[A-Z][a-z][a-zA-Z0-9]*\b")
+
+# 2x is the value the lab R1 round measured. The integer-qf BM25
+# contract cannot encode fractional weights, so "boost X" means
+# "emit X copies of the term".
+DEFAULT_QF_MULTIPLIER: Final[int] = 2
+
+
+def expand_with_capitalised_entities(
+    raw_query: str,
+    base_terms: list[str],
+    *,
+    qf_multiplier: int = DEFAULT_QF_MULTIPLIER,
+) -> list[str]:
+    """Return `base_terms` with capitalised-entity expansions appended.
+
+    Detects capitalised tokens in `raw_query` (left-to-right match
+    order), lowercases each, and appends `qf_multiplier` copies to
+    a new list following `base_terms`. `base_terms` is not mutated.
+
+    Entities that already appear in `base_terms` are still appended;
+    the duplication is the boost mechanism in the integer-qf BM25
+    contract.
+
+    `qf_multiplier=1` reduces to "append once" (no boost). Values
+    below 1 raise `ValueError`.
+    """
+    if qf_multiplier < 1:
+        raise ValueError(f"qf_multiplier must be >= 1, got {qf_multiplier}")
+    expansions: list[str] = []
+    for match in _CAPITALISED.finditer(raw_query):
+        token = match.group(0).lower()
+        for _ in range(qf_multiplier):
+            expansions.append(token)
+    return list(base_terms) + expansions

--- a/src/aelfrice/query_understanding/idf_clip.py
+++ b/src/aelfrice/query_understanding/idf_clip.py
@@ -1,0 +1,116 @@
+"""R3 IDF-clip query rewriter with per-store quantile thresholds (#291).
+
+Two deterministic transforms over a BM25 term list:
+
+1. `compute_idf_quantile_thresholds(idf, low_q, high_q)` -- derive
+   per-store low/high IDF cutoffs from the live IDF distribution.
+   The synthetic-tuned (1.5, 2.5) constants from the lab R3.5 audit
+   do **not** transfer; live store IDF medians sit at 7.5-9.5
+   versus the synthetic 2.85, so absolute constants are inert at
+   live scale (R5 prereq survey, #291). Per-store quantiles are
+   the architectural fix.
+
+2. `clip_with_quantile_thresholds(terms, vocabulary, idf, low,
+   high, *, boost_qf)` -- drop terms whose IDF is strictly below
+   `low_threshold`; duplicate (`boost_qf` total copies) terms whose
+   IDF is strictly above `high_threshold`. Terms absent from
+   `vocabulary` (i.e. unseen by BM25) pass through unchanged --
+   they will simply not score, but downstream callers may want
+   their slot preserved.
+
+The two transforms are factored apart so the per-store quantile
+computation can be cached on `BeliefStore` (PR-1 follow-up: PR-2
+wires the cache surface) independent of any individual query.
+"""
+from __future__ import annotations
+
+from typing import Final
+
+import numpy as np
+
+# 25th / 75th percentile of the live IDF distribution as the default
+# low / high cutoffs. These are deliberately liberal -- the lab R5
+# survey showed live IDF distributions are heavy-tailed enough that
+# tighter quantiles (e.g. 0.1 / 0.9) would drop too aggressively.
+# The values are runtime-tunable; the defaults are the ratified
+# starting point pending real-corpus calibration via #288 phase-1b.
+DEFAULT_LOW_QUANTILE: Final[float] = 0.25
+DEFAULT_HIGH_QUANTILE: Final[float] = 0.75
+
+# 2x to mirror the R1 boost convention (integer-qf BM25 cannot encode
+# fractional weights; "boost N" means "emit N copies").
+DEFAULT_BOOST_QF: Final[int] = 2
+
+
+def compute_idf_quantile_thresholds(
+    idf: np.ndarray,
+    low_quantile: float = DEFAULT_LOW_QUANTILE,
+    high_quantile: float = DEFAULT_HIGH_QUANTILE,
+) -> tuple[float, float]:
+    """Return (low_threshold, high_threshold) IDF cutoffs.
+
+    `idf` is the per-vocabulary-term IDF vector from a `BM25Index`.
+    Quantiles are computed on that vector directly. An empty
+    vector returns `(0.0, 0.0)` as a safe noop -- callers will then
+    drop nothing and boost nothing.
+
+    Both quantile arguments must satisfy
+    `0.0 <= low_quantile < high_quantile <= 1.0`. `low == high` is
+    rejected because it produces a degenerate clip (everything in
+    "mid band", nothing dropped or boosted).
+    """
+    if not (0.0 <= low_quantile < high_quantile <= 1.0):
+        raise ValueError(
+            f"need 0 <= low ({low_quantile}) < high ({high_quantile}) <= 1"
+        )
+    if idf.size == 0:
+        return (0.0, 0.0)
+    low_t = float(np.quantile(idf, low_quantile))
+    high_t = float(np.quantile(idf, high_quantile))
+    return (low_t, high_t)
+
+
+def clip_with_quantile_thresholds(
+    terms: list[str],
+    vocabulary: dict[str, int],
+    idf: np.ndarray,
+    low_threshold: float,
+    high_threshold: float,
+    *,
+    boost_qf: int = DEFAULT_BOOST_QF,
+) -> list[str]:
+    """Return `terms` with low-IDF dropped and high-IDF boosted.
+
+    For each term in input order:
+
+    - If absent from `vocabulary`: pass through unchanged.
+    - Else read its IDF from `idf[vocabulary[term]]`.
+        - IDF strictly less than `low_threshold`: drop.
+        - IDF strictly greater than `high_threshold`: emit
+          `boost_qf` copies.
+        - Otherwise (within the [low, high] band, inclusive): emit
+          once.
+
+    `boost_qf` must be >= 1 (1 disables the boost). Out-of-vocab
+    terms are kept because the vocabulary may be a strict subset of
+    the global term space (e.g. an ephemeral `BM25Index` over a
+    per-rebuild belief subset); dropping silently would be
+    surprising.
+    """
+    if boost_qf < 1:
+        raise ValueError(f"boost_qf must be >= 1, got {boost_qf}")
+    out: list[str] = []
+    for term in terms:
+        idx = vocabulary.get(term)
+        if idx is None:
+            out.append(term)
+            continue
+        term_idf = float(idf[idx])
+        if term_idf < low_threshold:
+            continue
+        if term_idf > high_threshold:
+            for _ in range(boost_qf):
+                out.append(term)
+        else:
+            out.append(term)
+    return out

--- a/tests/test_query_understanding.py
+++ b/tests/test_query_understanding.py
@@ -1,0 +1,253 @@
+"""Unit tests for the R1+R3 query understanding stack (#291 PR-1)."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from aelfrice.query_understanding import (
+    clip_with_quantile_thresholds,
+    compute_idf_quantile_thresholds,
+    expand_with_capitalised_entities,
+)
+
+
+# --- R1 entity expansion ----------------------------------------------------
+
+def test_r1_expand_appends_lowercased_capitalised_at_2x():
+    out = expand_with_capitalised_entities(
+        raw_query="why does the Rebuilder use Bayesian inference",
+        base_terms=["why", "does", "the", "rebuilder", "use", "bayesian", "inference"],
+    )
+    assert out[:7] == ["why", "does", "the", "rebuilder", "use", "bayesian", "inference"]
+    assert out[7:] == ["rebuilder", "rebuilder", "bayesian", "bayesian"]
+
+
+def test_r1_expand_preserves_match_order():
+    out = expand_with_capitalised_entities(
+        raw_query="Zebra Apple Mango",
+        base_terms=[],
+    )
+    assert out == ["zebra", "zebra", "apple", "apple", "mango", "mango"]
+
+
+def test_r1_expand_qf_multiplier_one_is_no_boost():
+    out = expand_with_capitalised_entities(
+        raw_query="Foo bar Baz",
+        base_terms=["x"],
+        qf_multiplier=1,
+    )
+    assert out == ["x", "foo", "baz"]
+
+
+def test_r1_expand_no_capitalised_returns_base():
+    out = expand_with_capitalised_entities(
+        raw_query="all lowercase here",
+        base_terms=["all", "lowercase", "here"],
+    )
+    assert out == ["all", "lowercase", "here"]
+
+
+def test_r1_expand_empty_query():
+    out = expand_with_capitalised_entities(raw_query="", base_terms=["a"])
+    assert out == ["a"]
+
+
+def test_r1_expand_skips_single_letter_capital():
+    # Sentence pronoun "I" is a single uppercase character with no
+    # trailing lowercase -- the pattern must not match it.
+    out = expand_with_capitalised_entities(
+        raw_query="I see Foo",
+        base_terms=[],
+    )
+    assert out == ["foo", "foo"]
+
+
+def test_r1_expand_does_not_mutate_base_terms():
+    base = ["one", "two"]
+    _ = expand_with_capitalised_entities("Foo", base)
+    assert base == ["one", "two"]
+
+
+def test_r1_expand_rejects_invalid_qf():
+    with pytest.raises(ValueError):
+        expand_with_capitalised_entities("Foo", [], qf_multiplier=0)
+    with pytest.raises(ValueError):
+        expand_with_capitalised_entities("Foo", [], qf_multiplier=-1)
+
+
+def test_r1_expand_handles_camelcase_as_single_token():
+    out = expand_with_capitalised_entities(
+        raw_query="The MemoryStore loads BeliefRows",
+        base_terms=[],
+    )
+    # "The" matches the rule too -- the campaign relies on R3's IDF
+    # clip (downstream) to drop high-frequency words like "the".
+    # CamelCase tokens collapse to a single lowercased entity each.
+    assert out == [
+        "the", "the",
+        "memorystore", "memorystore",
+        "beliefrows", "beliefrows",
+    ]
+
+
+# --- R3 quantile threshold computation --------------------------------------
+
+def test_quantiles_basic():
+    idf = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    low, high = compute_idf_quantile_thresholds(idf, 0.25, 0.75)
+    assert low == 2.0
+    assert high == 4.0
+
+
+def test_quantiles_default_is_25_75():
+    idf = np.arange(101, dtype=float)
+    low, high = compute_idf_quantile_thresholds(idf)
+    assert low == 25.0
+    assert high == 75.0
+
+
+def test_quantiles_empty_idf_returns_zero_zero():
+    low, high = compute_idf_quantile_thresholds(np.array([]))
+    assert (low, high) == (0.0, 0.0)
+
+
+def test_quantiles_single_element_idf():
+    low, high = compute_idf_quantile_thresholds(np.array([3.5]))
+    assert low == 3.5
+    assert high == 3.5
+
+
+def test_quantiles_reject_swapped_args():
+    with pytest.raises(ValueError):
+        compute_idf_quantile_thresholds(np.array([1.0]), 0.9, 0.1)
+
+
+def test_quantiles_reject_equal_args():
+    with pytest.raises(ValueError):
+        compute_idf_quantile_thresholds(np.array([1.0]), 0.5, 0.5)
+
+
+def test_quantiles_reject_out_of_range_args():
+    with pytest.raises(ValueError):
+        compute_idf_quantile_thresholds(np.array([1.0]), -0.1, 0.5)
+    with pytest.raises(ValueError):
+        compute_idf_quantile_thresholds(np.array([1.0]), 0.5, 1.1)
+
+
+# --- R3 clip ----------------------------------------------------------------
+
+def test_clip_drops_low_keeps_mid_boosts_high():
+    vocab = {"low": 0, "mid": 1, "high": 2}
+    idf = np.array([0.5, 2.0, 5.0])
+    out = clip_with_quantile_thresholds(
+        terms=["low", "mid", "high"],
+        vocabulary=vocab,
+        idf=idf,
+        low_threshold=1.0,
+        high_threshold=4.0,
+    )
+    assert out == ["mid", "high", "high"]
+
+
+def test_clip_passes_through_oov_terms():
+    vocab = {"in": 0}
+    idf = np.array([3.0])
+    out = clip_with_quantile_thresholds(
+        terms=["in", "outofvocab", "in"],
+        vocabulary=vocab,
+        idf=idf,
+        low_threshold=1.0,
+        high_threshold=5.0,
+    )
+    assert out == ["in", "outofvocab", "in"]
+
+
+def test_clip_boost_qf_three_emits_three_copies():
+    vocab = {"rare": 0}
+    idf = np.array([10.0])
+    out = clip_with_quantile_thresholds(
+        terms=["rare"],
+        vocabulary=vocab,
+        idf=idf,
+        low_threshold=1.0,
+        high_threshold=2.0,
+        boost_qf=3,
+    )
+    assert out == ["rare", "rare", "rare"]
+
+
+def test_clip_boundary_idf_exactly_at_threshold_keeps_once():
+    # Strict < and > -- IDF exactly at threshold falls in the mid band.
+    vocab = {"a": 0, "b": 1}
+    idf = np.array([1.0, 5.0])
+    out = clip_with_quantile_thresholds(
+        terms=["a", "b"],
+        vocabulary=vocab,
+        idf=idf,
+        low_threshold=1.0,
+        high_threshold=5.0,
+    )
+    assert out == ["a", "b"]
+
+
+def test_clip_reject_invalid_boost_qf():
+    with pytest.raises(ValueError):
+        clip_with_quantile_thresholds(
+            terms=[],
+            vocabulary={},
+            idf=np.array([]),
+            low_threshold=0.0,
+            high_threshold=1.0,
+            boost_qf=0,
+        )
+
+
+def test_clip_empty_terms():
+    out = clip_with_quantile_thresholds(
+        terms=[],
+        vocabulary={"x": 0},
+        idf=np.array([1.0]),
+        low_threshold=0.5,
+        high_threshold=2.0,
+    )
+    assert out == []
+
+
+def test_clip_repeated_low_term_dropped_each_time():
+    vocab = {"the": 0, "rare": 1}
+    idf = np.array([0.1, 9.0])
+    out = clip_with_quantile_thresholds(
+        terms=["the", "rare", "the", "the"],
+        vocabulary=vocab,
+        idf=idf,
+        low_threshold=0.5,
+        high_threshold=5.0,
+    )
+    assert out == ["rare", "rare"]
+
+
+# --- Composition smoke (R1 then R3) -----------------------------------------
+
+def test_r1_then_r3_pipeline_smoke():
+    """End-to-end shape check: R1 expand -> R3 clip preserves the
+    documented stack ordering. Real bench numbers come from PR-2
+    integration; this is a wiring smoke check only."""
+    raw = "Foo bar Baz quux"
+    base = ["foo", "bar", "baz", "quux"]
+    after_r1 = expand_with_capitalised_entities(raw, base)
+    assert after_r1 == ["foo", "bar", "baz", "quux", "foo", "foo", "baz", "baz"]
+
+    vocab = {"foo": 0, "bar": 1, "baz": 2, "quux": 3}
+    idf = np.array([2.0, 0.1, 5.0, 1.0])
+    after_r3 = clip_with_quantile_thresholds(
+        after_r1, vocab, idf, low_threshold=0.5, high_threshold=4.0,
+    )
+    # "bar" -- IDF 0.1 < 0.5 -> dropped (every occurrence).
+    # "baz" -- 3 occurrences in after_r1 (1 base + 2 from R1 boost),
+    #          IDF 5.0 > 4.0 -> each emitted boost_qf=2 times = 6.
+    # "foo" -- 3 occurrences (1 base + 2 R1), IDF 2.0 mid-band = 3.
+    # "quux" -- 1 occurrence (lowercase in raw, no R1 boost), mid = 1.
+    assert "bar" not in after_r3
+    assert after_r3.count("baz") == 6
+    assert after_r3.count("foo") == 3
+    assert after_r3.count("quux") == 1


### PR DESCRIPTION
First of four atomic PRs implementing the ratified scope of #291 (R1 + R3 query-understanding stack).

## What

New `aelfrice.query_understanding` package with two pure transforms and a per-store quantile helper:

- `expand_with_capitalised_entities(raw_query, base_terms, *, qf_multiplier=2)` — R1: detect capitalised tokens, lowercase, append `qf_multiplier` copies. Pure regex; sub-microsecond.
- `compute_idf_quantile_thresholds(idf, low_q=0.25, high_q=0.75)` — derive per-store low/high IDF cutoffs from a `BM25Index.idf` vector. Replaces the synthetic-tuned (1.5, 2.5) constants from the lab R3.5 audit, which are inert at live IDF medians of 7.5–9.5 (R5 prereq survey, #291 body).
- `clip_with_quantile_thresholds(terms, vocabulary, idf, low, high, *, boost_qf=2)` — R3: drop terms with IDF strictly below `low`, duplicate (`boost_qf` copies) terms strictly above `high`, mid-band emits once.

24 unit tests covering both transforms, edge cases (empty vectors, OOV terms, boundary IDF, invalid args), and one R1→R3 composition smoke test.

## What this PR does **not** change

No call site is touched. `context_rebuilder.py`, `retrieval.py`, `bm25.py`, and `store.py` are unchanged. The integration behind `query_strategy = "legacy-bm25"` lands in PR-2 (#291 rollout step 2).

## Verification

- `uv run pytest tests/test_query_understanding.py -q` → 24 passed.
- `uv run pytest tests/ --ignore=tests/regression --ignore=tests/bench_gate --ignore=tests/e2e -q` → 2067 passed, 14 skipped (no regression).
- Discretion grep over `git diff github/main...HEAD`: clean.
- Commit SSH-signed.

## Why per-store quantiles, not synthetic constants

The lab R5 survey (see #291 body, "Calibration evidence") found live store IDF medians at 7.5–9.5 vs the synthetic 2.85. The R3.5 tuned constants (1.5, 2.5) sit far below the live distribution; the boost rule would fire on essentially every term, which is operationally a noop. Per-store quantiles derived from the live IDF distribution are the architectural fix and are the only design that survives the synthetic→live shape divergence.

## Closes / refs

- Implements step 1 of the four-PR rollout in #291.
- Bench gates from #291 ("ΔP@10 ≥ +0.05 real corpus", etc.) are verified at PR-3 (the default flip), not here.

## Test plan

- [x] Unit tests pass locally on Python 3.13.
- [ ] CI staging-gate green.
- [ ] CodeQL / vulture / deptry / typos green.

## Summary by Sourcery

Introduce a new query_understanding package providing R1 entity expansion and R3 IDF clipping building blocks, along with tests, without wiring them into existing query pipelines yet.

New Features:
- Add an R1 entity-expansion helper that detects capitalised tokens in raw queries, lowercases them, and appends boosted copies to the BM25 term list.
- Add an R3 IDF clipping helper that derives per-store low/high IDF thresholds from BM25 IDF quantiles and rewrites term lists by dropping low-IDF and boosting high-IDF terms.

Tests:
- Add unit test coverage for entity expansion, IDF quantile threshold computation, IDF-based clipping behavior, error handling, and an end-to-end R1→R3 composition smoke test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced query understanding stack with entity expansion capabilities that recognize and process capitalized tokens in search queries.
* Added IDF-based term filtering and boosting mechanisms to optimize search term quality and relevance.

## Tests
* Added comprehensive test suite validating query understanding functionality and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->