### PR TITLE
feat(rebuild): query_strategy setting routes legacy vs R1+R3 stack (#291 PR-2)

### DIFF
--- a/src/aelfrice/context_rebuilder.py
+++ b/src/aelfrice/context_rebuilder.py
@@ -72,6 +72,14 @@ from typing import Any, Final, IO, cast
 
 from aelfrice.entity_extractor import extract_entities
 from aelfrice.models import LOCK_USER, Belief
+from aelfrice.query_understanding import (
+    DEFAULT_STRATEGY as DEFAULT_QUERY_STRATEGY,
+)
+from aelfrice.query_understanding import (
+    LEGACY_STRATEGY,
+    VALID_STRATEGIES,
+    transform_query,
+)
 from aelfrice.retrieval import retrieve
 from aelfrice.scoring import posterior_mean
 from aelfrice.store import MemoryStore
@@ -116,6 +124,7 @@ TURN_WINDOW_KEY: Final[str] = "turn_window_n"
 TOKEN_BUDGET_KEY: Final[str] = "token_budget"
 TRIGGER_MODE_KEY: Final[str] = "trigger_mode"
 THRESHOLD_FRACTION_KEY: Final[str] = "threshold_fraction"
+QUERY_STRATEGY_KEY: Final[str] = "query_strategy"
 
 # --- Rebuild diagnostic log (#288 phase-1a) ------------------------------
 
@@ -291,6 +300,7 @@ def rebuild_v14(
     session_id_for_log: str | None = None,
     floor_session: float = 0.0,
     floor_l1: float = 0.0,
+    query_strategy: str = LEGACY_STRATEGY,
 ) -> str:
     """v1.4 rebuild: L0 + session-scoped + L2.5/L1 via `retrieve()`.
 
@@ -326,13 +336,21 @@ def rebuild_v14(
     `DEFAULT_FLOOR_L1`) from `RebuilderConfig`, so operators get
     the floor end-to-end while existing tests and ad-hoc callers
     are unaffected.
+
+    v1.7 (#291 PR-2): `query_strategy` selects the query rewriter.
+    Default `legacy-bm25` is byte-identical to the v1.4 path.
+    `stack-r1-r3` opts into the ratified R1 entity-expansion + R3
+    per-store IDF-clip stack from `aelfrice.query_understanding`.
+    The default flip lands in PR-3 after a clean #288 phase-1b
+    operator-week.
     """
     locked: list[Belief] = store.list_locked_beliefs()
     locked_ids: set[str] = {b.id for b in locked}
 
     sid = _latest_session_id(recent_turns)
 
-    query = _query_for_recent_turns(recent_turns)
+    raw_query = _query_for_recent_turns(recent_turns)
+    query = transform_query(raw_query, store, query_strategy)
 
     # retrieve() returns L0 + L2.5 + L1 in that order. We already
     # have L0 from list_locked_beliefs(); we'll rebuild the
@@ -592,6 +610,12 @@ class RebuilderConfig:
     """v1.7 (#289 / #364) placeholder — operator-tunable via
     `[rebuild_floor] l1` in .aelfrice.toml. Calibration lands
     in a follow-up after #288 phase-1b."""
+    query_strategy: str = DEFAULT_QUERY_STRATEGY
+    """v1.7 (#291 PR-2) opt-in for the R1+R3 query-understanding
+    stack. `legacy-bm25` (default) is byte-identical to v1.4.
+    `stack-r1-r3` opts in. Operator-tunable via
+    `[rebuilder] query_strategy` in .aelfrice.toml. Default flip
+    lands in PR-3 after a clean #288 phase-1b operator-week."""
 
 
 def load_rebuilder_config(start: Path | None = None) -> RebuilderConfig:
@@ -743,6 +767,22 @@ def load_rebuilder_config(start: Path | None = None) -> RebuilderConfig:
                     )
                 else:
                     floor_l1_resolved = float(fl_obj)
+            qs_obj: Any = section.get(
+                QUERY_STRATEGY_KEY, DEFAULT_QUERY_STRATEGY,
+            )
+            if (
+                not isinstance(qs_obj, str)
+                or qs_obj not in VALID_STRATEGIES
+            ):
+                print(
+                    f"aelfrice rebuilder: ignoring [{REBUILDER_SECTION}] "
+                    f"{QUERY_STRATEGY_KEY} in {candidate} "
+                    f"(expected one of {sorted(VALID_STRATEGIES)})",
+                    file=serr,
+                )
+                qs_resolved = DEFAULT_QUERY_STRATEGY
+            else:
+                qs_resolved = qs_obj
             return RebuilderConfig(
                 turn_window_n=n_resolved,
                 token_budget=b_resolved,
@@ -751,6 +791,7 @@ def load_rebuilder_config(start: Path | None = None) -> RebuilderConfig:
                 rebuild_log_enabled=log_enabled_resolved,
                 floor_session=floor_session_resolved,
                 floor_l1=floor_l1_resolved,
+                query_strategy=qs_resolved,
             )
         if current.parent == current:
             break

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -964,6 +964,7 @@ def pre_compact(
             rebuild_log_enabled=config.rebuild_log_enabled,
             floor_session=config.floor_session,
             floor_l1=config.floor_l1,
+            query_strategy=config.query_strategy,
         )
         if body:
             sout.write(emit_pre_compact_envelope(body))
@@ -1026,6 +1027,7 @@ def _rebuild_and_format(
     rebuild_log_enabled: bool = True,
     floor_session: float = 0.0,
     floor_l1: float = 0.0,
+    query_strategy: str = "legacy-bm25",
 ) -> str:
     """Open the store and run the v1.4 rebuild.
 
@@ -1056,6 +1058,7 @@ def _rebuild_and_format(
             session_id_for_log=sid,
             floor_session=floor_session,
             floor_l1=floor_l1,
+            query_strategy=query_strategy,
         )
     finally:
         store.close()

--- a/src/aelfrice/query_understanding/__init__.py
+++ b/src/aelfrice/query_understanding/__init__.py
@@ -1,14 +1,20 @@
 """Query understanding stack for the rebuilder (R1 + R3, #291).
 
-Two deterministic transforms a caller stacks before BM25:
+Three deterministic transforms a caller stacks before BM25:
 
 1. R1 entity expansion (`expand_with_capitalised_entities`)
 2. R3 IDF clip with per-store quantile thresholds
    (`clip_with_quantile_thresholds`, `compute_idf_quantile_thresholds`)
+3. PR-2 wiring: `transform_query(raw_query, store, strategy)`
+   dispatches between `legacy-bm25` (default) and `stack-r1-r3`.
+   The per-store BM25Index + quantile cache lives in
+   `store_cache.get_bm25_and_quantiles`.
 
-PR-1 lands the modules + per-store IDF-quantile helper + unit tests.
-The context-rebuilder integration lands in PR-2 behind the
-`query_strategy = "legacy-bm25"` setting (#291 rollout step 2).
+PR-1 landed the rewriters + per-store quantile helper + unit tests.
+PR-2 lands the dispatcher + cache + rebuilder/hook plumbing behind
+the `query_strategy = "legacy-bm25"` setting (default unchanged).
+The default flip to `stack-r1-r3` lands in PR-3 after a clean
+#288 phase-1b operator-week.
 
 The synthetic-tuned IDF constants (1.5, 2.5) from the lab R3.5
 campaign do not transfer to live stores (live IDF medians 7.5-9.5
@@ -27,13 +33,31 @@ from aelfrice.query_understanding.idf_clip import (
     clip_with_quantile_thresholds,
     compute_idf_quantile_thresholds,
 )
+from aelfrice.query_understanding.store_cache import (
+    get_bm25_and_quantiles,
+    invalidate,
+)
+from aelfrice.query_understanding.strategy import (
+    DEFAULT_STRATEGY,
+    LEGACY_STRATEGY,
+    STACK_R1_R3_STRATEGY,
+    VALID_STRATEGIES,
+    transform_query,
+)
 
 __all__ = [
     "DEFAULT_BOOST_QF",
     "DEFAULT_HIGH_QUANTILE",
     "DEFAULT_LOW_QUANTILE",
     "DEFAULT_QF_MULTIPLIER",
+    "DEFAULT_STRATEGY",
+    "LEGACY_STRATEGY",
+    "STACK_R1_R3_STRATEGY",
+    "VALID_STRATEGIES",
     "clip_with_quantile_thresholds",
     "compute_idf_quantile_thresholds",
     "expand_with_capitalised_entities",
+    "get_bm25_and_quantiles",
+    "invalidate",
+    "transform_query",
 ]

--- a/src/aelfrice/query_understanding/store_cache.py
+++ b/src/aelfrice/query_understanding/store_cache.py
@@ -1,0 +1,87 @@
+"""Per-store BM25Index + IDF-quantile cache for the R3 IDF-clip path.
+
+The R3 IDF-clip query rewriter needs a per-store IDF distribution to
+derive its low/high cutoffs (#291 ratified scope; synthetic-tuned
+constants do not transfer to live stores). Building a `BM25Index`
+on every rebuild would be wasteful -- live stores have ~1.6k beliefs
+median (lab R5 survey), and the index is deterministic given store
+contents.
+
+This module owns a process-wide cache keyed by store identity. The
+first call to `get_bm25_and_quantiles(store)` builds a `BM25Index`
+from the store, computes the IDF-quantile thresholds, and stores
+both. Subsequent calls return the cached tuple.
+
+Invalidation is wired through `MemoryStore.add_invalidation_callback`
+(the existing pattern that the retrieval cache + materialised views
+use) so any belief / edge mutation drops the stale cache entry. The
+cache is a `WeakKeyDictionary`; entries also drop when the store
+object is garbage-collected.
+"""
+from __future__ import annotations
+
+import weakref
+
+from aelfrice.bm25 import BM25Index
+from aelfrice.query_understanding.idf_clip import (
+    DEFAULT_HIGH_QUANTILE,
+    DEFAULT_LOW_QUANTILE,
+    compute_idf_quantile_thresholds,
+)
+from aelfrice.store import MemoryStore
+
+_CacheValue = tuple[BM25Index, tuple[float, float]]
+_cache: weakref.WeakKeyDictionary[MemoryStore, _CacheValue] = (
+    weakref.WeakKeyDictionary()
+)
+# Tracks which stores already had an invalidation callback registered,
+# so `get_bm25_and_quantiles` does not double-register on every call.
+_callback_registered: weakref.WeakSet[MemoryStore] = weakref.WeakSet()
+
+
+def get_bm25_and_quantiles(
+    store: MemoryStore,
+    *,
+    low_quantile: float = DEFAULT_LOW_QUANTILE,
+    high_quantile: float = DEFAULT_HIGH_QUANTILE,
+) -> _CacheValue:
+    """Return cached `(BM25Index, (low_t, high_t))` for `store`.
+
+    First call: builds a `BM25Index` from `store`, computes IDF
+    quantile thresholds, registers a one-time invalidation callback
+    on the store, and caches the tuple. Subsequent calls return the
+    cached tuple in O(1) until the next store mutation (or until the
+    store is garbage-collected).
+
+    Quantile arguments must satisfy
+    `0.0 <= low_quantile < high_quantile <= 1.0` (delegated to
+    `compute_idf_quantile_thresholds`).
+    """
+    cached = _cache.get(store)
+    if cached is not None:
+        return cached
+    index = BM25Index.build(store)
+    thresholds = compute_idf_quantile_thresholds(
+        index.idf, low_quantile, high_quantile,
+    )
+    value: _CacheValue = (index, thresholds)
+    _cache[store] = value
+    if store not in _callback_registered:
+        store.add_invalidation_callback(lambda s=store: invalidate(s))
+        _callback_registered.add(store)
+    return value
+
+
+def invalidate(store: MemoryStore) -> None:
+    """Drop the cached entry for `store` if any.
+
+    Called automatically via `MemoryStore`'s invalidation-callback
+    chain on belief / edge mutation; can also be called directly
+    in tests.
+    """
+    _cache.pop(store, None)
+
+
+def _cache_size_for_test() -> int:
+    """Test-only: number of live cache entries."""
+    return len(_cache)

--- a/src/aelfrice/query_understanding/strategy.py
+++ b/src/aelfrice/query_understanding/strategy.py
@@ -1,0 +1,76 @@
+"""Query-strategy dispatcher: legacy-bm25 (default) vs stack-r1-r3.
+
+The rebuilder calls `transform_query(raw_query, store, strategy)` to
+produce the final query string fed to `retrieve()`. Two strategies
+exist at v1.7 (#291):
+
+* `legacy-bm25` -- the v1.4-era query string is passed through
+  unchanged. Default until #291 PR-3 flips after a clean
+  #288 phase-1b operator-week.
+* `stack-r1-r3` -- the ratified R1+R3 stack: capitalised-token
+  entity expansion, then per-store IDF-quantile clipping, against
+  the cached `BM25Index` for the store. Returns the rewritten term
+  list joined with spaces (FTS5 MATCH consumes the whitespace-
+  separated form; duplicated terms boost their effective query
+  frequency the same way the lab campaign measured).
+
+This module owns no state; the per-store BM25Index + quantile cache
+lives in `query_understanding.store_cache`.
+"""
+from __future__ import annotations
+
+from typing import Final
+
+from aelfrice.bm25 import tokenize
+from aelfrice.query_understanding.entity_expand import (
+    expand_with_capitalised_entities,
+)
+from aelfrice.query_understanding.idf_clip import (
+    clip_with_quantile_thresholds,
+)
+from aelfrice.query_understanding.store_cache import (
+    get_bm25_and_quantiles,
+)
+from aelfrice.store import MemoryStore
+
+LEGACY_STRATEGY: Final[str] = "legacy-bm25"
+STACK_R1_R3_STRATEGY: Final[str] = "stack-r1-r3"
+VALID_STRATEGIES: Final[frozenset[str]] = frozenset(
+    {LEGACY_STRATEGY, STACK_R1_R3_STRATEGY},
+)
+DEFAULT_STRATEGY: Final[str] = LEGACY_STRATEGY
+
+
+def transform_query(
+    raw_query: str,
+    store: MemoryStore,
+    strategy: str = DEFAULT_STRATEGY,
+) -> str:
+    """Return a possibly-rewritten query string per `strategy`.
+
+    `legacy-bm25`: returns `raw_query` unchanged.
+
+    `stack-r1-r3`: tokenises `raw_query`, applies R1 entity
+    expansion, then R3 IDF-clip against the cached per-store BM25
+    IDF distribution, and returns the resulting term list joined
+    by whitespace. Empty / whitespace-only input returns `""` for
+    any strategy.
+
+    Unknown `strategy` raises `ValueError`.
+    """
+    if strategy not in VALID_STRATEGIES:
+        raise ValueError(
+            f"unknown query_strategy: {strategy!r} "
+            f"(valid: {sorted(VALID_STRATEGIES)})"
+        )
+    if not raw_query.strip():
+        return ""
+    if strategy == LEGACY_STRATEGY:
+        return raw_query
+    base_terms = tokenize(raw_query)
+    expanded = expand_with_capitalised_entities(raw_query, base_terms)
+    index, (low_t, high_t) = get_bm25_and_quantiles(store)
+    clipped = clip_with_quantile_thresholds(
+        expanded, index.vocabulary, index.idf, low_t, high_t,
+    )
+    return " ".join(clipped)

--- a/tests/test_query_strategy.py
+++ b/tests/test_query_strategy.py
@@ -1,0 +1,315 @@
+"""Unit tests for the v1.7 (#291 PR-2) query-strategy dispatcher,
+per-store BM25 + IDF-quantile cache, and rebuilder/hook plumbing.
+
+Covers:
+  - `transform_query` legacy passthrough (default, byte-identical)
+  - `transform_query` stack-r1-r3 path applies R1 + R3 against the
+    store's own IDF distribution
+  - Unknown strategy raises
+  - `store_cache.get_bm25_and_quantiles` is cached per store and
+    invalidates on belief mutation via the existing callback chain
+  - `RebuilderConfig.query_strategy` parses + validates from
+    `[rebuilder] query_strategy` in `.aelfrice.toml`
+  - `rebuild_v14(query_strategy=...)` produces the same result as
+    `legacy-bm25` when no opt-in is requested (no behavior change at
+    default), and routes through the stack on opt-in.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aelfrice.context_rebuilder import (
+    RebuilderConfig,
+    RecentTurn,
+    load_rebuilder_config,
+    rebuild_v14,
+)
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.query_understanding import (
+    DEFAULT_STRATEGY,
+    LEGACY_STRATEGY,
+    STACK_R1_R3_STRATEGY,
+    VALID_STRATEGIES,
+    transform_query,
+)
+from aelfrice.query_understanding.store_cache import (
+    _cache_size_for_test,
+    get_bm25_and_quantiles,
+    invalidate,
+)
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    bid: str,
+    content: str,
+    *,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _seed(db_path: Path, beliefs: list[Belief]) -> MemoryStore:
+    store = MemoryStore(str(db_path))
+    for b in beliefs:
+        store.insert_belief(b)
+    return store
+
+
+# --- transform_query --------------------------------------------------------
+
+
+def test_transform_legacy_returns_query_unchanged(tmp_path: Path) -> None:
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk("a", "rebuilder bayesian inference")],
+    )
+    try:
+        out = transform_query("Why does the Rebuilder use Bayesian inference",
+                              store, LEGACY_STRATEGY)
+        assert out == "Why does the Rebuilder use Bayesian inference"
+    finally:
+        store.close()
+
+
+def test_transform_default_is_legacy() -> None:
+    assert DEFAULT_STRATEGY == LEGACY_STRATEGY
+
+
+def test_transform_stack_lowercases_capitalised(tmp_path: Path) -> None:
+    """The stack tokenises and lowercases capitalised tokens via R1.
+    IDF-clip may then drop or boost them depending on the per-store
+    distribution; what we assert here is the lower-case + non-empty
+    behaviour, not numerical lift (graded by the bench harness)."""
+    # Seed with content where "Foo" is rare relative to filler vocab,
+    # so that "foo" is high-IDF and survives the R3 clip.
+    beliefs = [
+        _mk(f"f{i:03d}", f"common fillerword{i % 5} commonword another")
+        for i in range(30)
+    ]
+    beliefs.append(_mk("rare", "foo special-rare-marker"))
+    store = _seed(tmp_path / "m.db", beliefs)
+    try:
+        out = transform_query("Foo", store, STACK_R1_R3_STRATEGY)
+        # Stack output is space-joined lowercased tokens. "Foo" must
+        # not appear with its original capitalisation.
+        assert "Foo" not in out
+        # And the stack must have produced some non-empty output --
+        # "foo" is in vocabulary so R3 either keeps or boosts it.
+        assert out.strip() != ""
+    finally:
+        store.close()
+
+
+def test_transform_empty_query_returns_empty(tmp_path: Path) -> None:
+    store = _seed(tmp_path / "m.db", [_mk("a", "x")])
+    try:
+        assert transform_query("", store, LEGACY_STRATEGY) == ""
+        assert transform_query("   ", store, STACK_R1_R3_STRATEGY) == ""
+    finally:
+        store.close()
+
+
+def test_transform_unknown_strategy_raises(tmp_path: Path) -> None:
+    store = _seed(tmp_path / "m.db", [_mk("a", "x")])
+    try:
+        with pytest.raises(ValueError, match="unknown query_strategy"):
+            transform_query("foo", store, "bogus-strategy")
+    finally:
+        store.close()
+
+
+def test_valid_strategies_set_is_exactly_two() -> None:
+    assert VALID_STRATEGIES == frozenset({LEGACY_STRATEGY, STACK_R1_R3_STRATEGY})
+
+
+# --- store_cache ------------------------------------------------------------
+
+
+def test_cache_returns_same_object_on_second_call(tmp_path: Path) -> None:
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(f"b{i}", f"alpha beta gamma {i}") for i in range(10)],
+    )
+    try:
+        first = get_bm25_and_quantiles(store)
+        second = get_bm25_and_quantiles(store)
+        # Identity check: the cache returns the exact same tuple,
+        # so the BM25Index is built once.
+        assert first is second
+    finally:
+        store.close()
+
+
+def test_cache_invalidates_on_belief_mutation(tmp_path: Path) -> None:
+    store = _seed(tmp_path / "m.db", [_mk("a", "alpha")])
+    try:
+        first = get_bm25_and_quantiles(store)
+        # Insert a new belief; the invalidation callback chain should
+        # drop the cached entry.
+        store.insert_belief(_mk("b", "beta gamma delta"))
+        second = get_bm25_and_quantiles(store)
+        assert first is not second
+        # And the new index sees the new vocabulary.
+        new_index, _ = second
+        assert "delta" in new_index.vocabulary
+    finally:
+        store.close()
+
+
+def test_cache_invalidate_helper_drops_entry(tmp_path: Path) -> None:
+    store = _seed(tmp_path / "m.db", [_mk("a", "x")])
+    try:
+        get_bm25_and_quantiles(store)
+        size_before = _cache_size_for_test()
+        invalidate(store)
+        assert _cache_size_for_test() == size_before - 1
+    finally:
+        store.close()
+
+
+def test_cache_quantile_args_passed_through(tmp_path: Path) -> None:
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(f"b{i}", "alpha beta gamma delta epsilon") for i in range(5)],
+    )
+    try:
+        invalidate(store)  # ensure fresh build with our quantile args
+        _, (low_t, high_t) = get_bm25_and_quantiles(
+            store, low_quantile=0.1, high_quantile=0.9,
+        )
+        assert low_t <= high_t
+    finally:
+        store.close()
+
+
+# --- RebuilderConfig --------------------------------------------------------
+
+
+def test_config_default_query_strategy_is_legacy() -> None:
+    cfg = RebuilderConfig()
+    assert cfg.query_strategy == LEGACY_STRATEGY
+
+
+def test_config_loads_query_strategy_override(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        '[rebuilder]\nquery_strategy = "stack-r1-r3"\n'
+    )
+    cfg = load_rebuilder_config(tmp_path)
+    assert cfg.query_strategy == STACK_R1_R3_STRATEGY
+
+
+def test_config_invalid_query_strategy_falls_back_to_default(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        '[rebuilder]\nquery_strategy = "nonsense"\n'
+    )
+    cfg = load_rebuilder_config(tmp_path)
+    assert cfg.query_strategy == LEGACY_STRATEGY
+    err = capsys.readouterr().err
+    assert "query_strategy" in err
+    assert "nonsense" not in err  # don't echo the bad value verbatim
+
+
+def test_config_non_string_query_strategy_falls_back(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        '[rebuilder]\nquery_strategy = 42\n'
+    )
+    cfg = load_rebuilder_config(tmp_path)
+    assert cfg.query_strategy == LEGACY_STRATEGY
+    assert "query_strategy" in capsys.readouterr().err
+
+
+def test_config_explicit_legacy_value_loads(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        '[rebuilder]\nquery_strategy = "legacy-bm25"\n'
+    )
+    cfg = load_rebuilder_config(tmp_path)
+    assert cfg.query_strategy == LEGACY_STRATEGY
+
+
+# --- rebuild_v14 plumbing ---------------------------------------------------
+
+
+def test_rebuild_default_query_strategy_is_legacy(tmp_path: Path) -> None:
+    """Calling rebuild_v14 with no `query_strategy` argument is
+    byte-identical to calling it with `query_strategy='legacy-bm25'`.
+    Default must not change behavior."""
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(
+            "a", "rebuilder uses bayesian posterior",
+            lock_level=LOCK_USER, locked_at="2026-04-26T00:00:00Z",
+        )],
+    )
+    try:
+        turns = [RecentTurn(role="user", text="Tell me about the Rebuilder")]
+        without_arg = rebuild_v14(turns, store)
+        with_legacy = rebuild_v14(turns, store, query_strategy=LEGACY_STRATEGY)
+        assert without_arg == with_legacy
+    finally:
+        store.close()
+
+
+def test_rebuild_stack_strategy_returns_block(tmp_path: Path) -> None:
+    """Smoke-check that the stack strategy runs end-to-end without
+    raising and produces a well-formed rebuild block when there is a
+    locked belief in the store. The numerical lift is graded by the
+    bench harness (#288), not by this unit test."""
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(
+            "a", "rebuilder uses bayesian posterior",
+            lock_level=LOCK_USER, locked_at="2026-04-26T00:00:00Z",
+        )],
+    )
+    try:
+        turns = [RecentTurn(role="user", text="Tell me about the Rebuilder")]
+        out = rebuild_v14(turns, store, query_strategy=STACK_R1_R3_STRATEGY)
+        # L0 locked always packs; the block must contain the belief id.
+        assert "<aelfrice-rebuild>" in out
+        assert "id=\"a\"" in out
+    finally:
+        store.close()
+
+
+def test_rebuild_stack_strategy_empty_turns_returns_locked_only(
+    tmp_path: Path,
+) -> None:
+    """Empty recent_turns + stack strategy: the query is empty, the
+    stack short-circuits, retrieve sees an empty query, and only L0
+    locked beliefs pack -- same as legacy."""
+    store = _seed(
+        tmp_path / "m.db",
+        [_mk(
+            "a", "rebuilder uses bayesian posterior",
+            lock_level=LOCK_USER, locked_at="2026-04-26T00:00:00Z",
+        )],
+    )
+    try:
+        without_arg = rebuild_v14([], store)
+        stacked = rebuild_v14([], store, query_strategy=STACK_R1_R3_STRATEGY)
+        # Both paths return the same locked-only block on empty input.
+        assert without_arg == stacked
+    finally:
+        store.close()


### PR DESCRIPTION
Second of four atomic PRs implementing the ratified scope of #291 (R1 + R3 query-understanding stack). Stacked on PR #368 (PR-1, merged).

## What

Wires the `query_understanding` package from PR-1 into the context rebuilder behind a new `[rebuilder] query_strategy` setting that defaults to `"legacy-bm25"` — byte-identical to the v1.4 path.

- `query_understanding.strategy.transform_query(raw_query, store, strategy)` — dispatcher: legacy passthrough or R1 entity-expand + R3 IDF-clip.
- `query_understanding.store_cache.get_bm25_and_quantiles(store)` — process-wide `WeakKeyDictionary` keyed by store identity, with a one-time invalidation callback registered via the existing `MemoryStore.add_invalidation_callback` chain so belief / edge mutations drop the stale cache entry.
- `RebuilderConfig.query_strategy` — parses + validates from `[rebuilder] query_strategy`; unknown values fall back to the default with a stderr trace (matches the existing `trigger_mode` / floor convention).
- `rebuild_v14(query_strategy=...)` — threads through `transform_query` before `retrieve()`. Default `legacy-bm25` is a no-op against the v1.4 path.
- `hook._rebuild_and_format` — plumbs `config.query_strategy` through.

## What this PR does **not** change

Default behavior is unchanged. `query_strategy` is operator opt-in via `.aelfrice.toml`:

```toml
[rebuilder]
query_strategy = "stack-r1-r3"
```

The default flip (`stack-r1-r3` becomes default) lands in **PR-3** after a clean #288 phase-1b operator-week (per #291 rollout step 3).

## Per-store cache invariants

- **Built lazily.** First `get_bm25_and_quantiles(store)` builds a `BM25Index` and computes IDF-quantile thresholds; subsequent calls are O(1) until the next mutation.
- **Invalidation via the existing callback chain.** A one-time `MemoryStore.add_invalidation_callback` registration drops the cached entry on any `_fire_invalidation()` (belief insert, edge insert, etc.). Same pattern as `RetrievalCache`.
- **GC safety.** `WeakKeyDictionary` clears entries when the store object is garbage-collected; the matching `WeakSet` for callback-registered stores does the same.

## Verification

- `uv run pytest tests/test_query_strategy.py -q` → 18 passed.
- `uv run pytest tests/ --ignore=tests/regression --ignore=tests/bench_gate --ignore=tests/e2e -q` → **2099 passed**, 14 skipped (no regression vs main).
- Discretion grep over `git diff github/main...HEAD`: clean.
- Commit SSH-signed.

## Default-vs-strategy parity check

`test_rebuild_default_query_strategy_is_legacy` asserts `rebuild_v14(turns, store)` and `rebuild_v14(turns, store, query_strategy="legacy-bm25")` produce byte-identical output. This is the no-behavior-change guarantee for PR-2.

## Closes / refs

- Implements step 2 of the four-PR rollout in #291.
- Stacked on #368 (PR-1, merged).
- Bench gates from #291 ("ΔP@10 ≥ +0.05 real corpus", etc.) are graded by the bench harness when the operator opts in via the setting; PR-3 flips the default after a clean operator-week.

## Test plan

- [x] Unit tests pass on Python 3.13.
- [x] Wider test suite green; no regression.
- [ ] CI staging-gate green.
- [ ] CodeQL / vulture / deptry / typos green.

## Summary by Sourcery

Add a configurable query strategy for the context rebuilder that can route between the existing legacy BM25 path and the new R1+R3 query-understanding stack, while keeping the default behavior unchanged.

New Features:
- Introduce a query strategy dispatcher that selects between legacy BM25 queries and the R1+R3 query-understanding stack.
- Add a per-store BM25 index and IDF-quantile cache to support the R3 IDF-clipping query rewrite.
- Expose a `[rebuilder] query_strategy` configuration option that controls which query strategy the rebuilder uses.

Enhancements:
- Wire the query-understanding stack into the v1.4 context rebuilder and hook layer without changing default behavior.

Tests:
- Add unit tests covering the query-strategy dispatcher, the per-store cache behavior, configuration parsing, and rebuild plumbing consistency.