### PR TITLE
docs(v2-reentry-queue): point H1 row at split issue #374

### DIFF
--- a/docs/V2_REENTRY_QUEUE.md
+++ b/docs/V2_REENTRY_QUEUE.md
@@ -25,7 +25,7 @@ Each row references its public spec memo and the GitHub issue that tracks re-ent
 - **Gate:** ≥3pp improvement on a classification-accuracy or onboard-quality `aelf bench` number, **and** a PRIVACY.md rewrite documenting per-provider trust surface and consent gate.
 - **Why deferred:** privacy regression (outbound to *N* providers vs. 1), determinism regression (non-deterministic by construction), *N×* per-onboard token cost, no published evidence that cross-model consensus measurably improves classification quality. Substrate-decision (#196 Option B) removed the strongest historical justification.
 
-### Directive detection (enforcement H1) — issue #199 sub-track
+### Directive detection (enforcement H1) — issue #374
 
 - **Spec:** [`docs/v2_enforcement.md`](v2_enforcement.md) § H1
 - **Disposition:** defer to v2.x. (H3 selective injection ships at v2.0; H2 compliance audit is dropped, not deferred.)


### PR DESCRIPTION
## What

One-line update to `docs/V2_REENTRY_QUEUE.md` H1 row: change "issue #199 sub-track" → "issue #374".

## Why

#199 was the enforcement-triad umbrella. Per ratified spec [`docs/v2_enforcement.md`](https://github.com/robotrocketscience/aelfrice/blob/main/docs/v2_enforcement.md) (PR #257):

- **H3** selective injection → split to #373 (`spec-ready`, `v2.0`).
- **H1** directive detection → split to #374 (`spec-ready`, `bench-gated`, deferred).
- **H2** compliance audit → dropped (`wontfix`), no issue.

#199 closed as the umbrella resolves into the splits. The queue's H1 row was pointing at the now-closed umbrella; this PR points it at the live deferral issue (#374) so the audit trail stays correct.

## Verify

- `grep -n '199 sub-track\|#374' docs/V2_REENTRY_QUEUE.md` → only the new `#374` line should appear.
- Spec memo at `docs/v2_enforcement.md` (unchanged) is the source of truth for the disposition.

Tracks: #199, #373, #374.

## Summary by Sourcery

Documentation:
- Adjust V2 re-entry queue documentation to link the directive detection (enforcement H1) row to issue #374 instead of the closed umbrella issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal tracking references and documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->