### PR TITLE
feat(directive_detection): bench gate + candidate detector for #374 H1

### DIFF
--- a/src/aelfrice/directive_detector.py
+++ b/src/aelfrice/directive_detector.py
@@ -1,0 +1,114 @@
+"""Directive detection — H1 split of #199 (#374).
+
+Candidate regex detector against which the bench gate is evaluated.
+
+Per spec [`docs/v2_enforcement.md` § H1](../docs/v2_enforcement.md#h1-directive-detection--defer-to-v2x-with-benchmark-gate),
+H1 (`process_directive`, TODO lifecycle, escalation) does not start until a
+labeled corpus shows ≥80% precision and ≥60% recall on 200 coding prompts.
+This module provides the detector under test. It does not auto-create
+beliefs, build the TODO lifecycle, or wire into the rebuild path; that work
+is gated on this gate passing.
+
+Shape:
+
+    detect_directive(text: str) -> bool
+
+True when the text reads as an imperative directive the user intends as a
+durable rule. False for questions, hedged statements, and reported speech.
+
+The verb bank below is the spec's "29 imperatives" reconstructed from the
+ratification text (issue #374, `docs/v2_enforcement.md` § H1). The exact
+membership is tunable; the gate scores whatever detector is in this module.
+"""
+from __future__ import annotations
+
+import re
+
+# 29 imperative / deontic markers. Order is irrelevant — alternation in a
+# single regex with word boundaries.
+_IMPERATIVE_VERBS: tuple[str, ...] = (
+    "never",
+    "always",
+    "must",
+    "must not",
+    "do not",
+    "don't",
+    "should",
+    "should not",
+    "shouldn't",
+    "shall",
+    "ensure",
+    "require",
+    "required",
+    "requires",
+    "avoid",
+    "prefer",
+    "only",
+    "before",
+    "after",
+    "unless",
+    "whenever",
+    "need to",
+    "needs to",
+    "cannot",
+    "can't",
+    "won't",
+    "forbidden",
+    "mandatory",
+    "prohibited",
+)
+
+# Build a single alternation regex. Sort by length desc so multi-word
+# phrases match before their single-word prefixes.
+_VERB_PATTERN = re.compile(
+    r"\b(?:" + "|".join(re.escape(v) for v in sorted(_IMPERATIVE_VERBS, key=len, reverse=True)) + r")\b",
+    re.IGNORECASE,
+)
+
+# Hedge markers — when present, the imperative reads as opinion or
+# uncertainty rather than a directive.
+_HEDGE_PATTERN = re.compile(
+    r"\b(?:maybe|perhaps|probably|might|i think|i guess|i wonder|not sure|"
+    r"kinda|sort of|sometimes|occasionally|in theory)\b",
+    re.IGNORECASE,
+)
+
+# Reported-speech / conditional-narration markers. A clause like
+# "I never push to main when I'm tired" describes habit, not rule.
+_NARRATION_PATTERN = re.compile(
+    r"\bi\s+(?:never|always|don't|do not|won't|cannot|can't|must|should)\b"
+    r"(?:\s+\w+){1,8}\s+(?:when|while|if|because|since)\b",
+    re.IGNORECASE,
+)
+
+# Wh-question leaders (always interrogative). Aux-verb leaders (do/does/can/...)
+# are only interrogative when paired with a trailing '?', which is handled
+# separately in `detect_directive`.
+_WH_QUESTION_LEADING = re.compile(
+    r"^\s*(?:what|why|how|when|where|who|which|whose|whom)\b",
+    re.IGNORECASE,
+)
+
+
+def detect_directive(text: str) -> bool:
+    """Return True if `text` reads as a durable imperative directive.
+
+    Filters applied in order:
+      1. Empty / whitespace-only → False.
+      2. Questions (leading interrogative or trailing '?') → False.
+      3. Reported-speech / habitual narration ("I never X when Y") → False.
+      4. Hedged statements ("maybe", "I think", …) → False.
+      5. Otherwise: True iff any imperative verb appears.
+    """
+    if not text or not text.strip():
+        return False
+    stripped = text.strip()
+    if stripped.endswith("?"):
+        return False
+    if _WH_QUESTION_LEADING.search(stripped):
+        return False
+    if _NARRATION_PATTERN.search(stripped):
+        return False
+    if _HEDGE_PATTERN.search(stripped):
+        return False
+    return _VERB_PATTERN.search(stripped) is not None

--- a/tests/bench_gate/test_directive_detection.py
+++ b/tests/bench_gate/test_directive_detection.py
@@ -1,0 +1,62 @@
+"""Bench gate for #374 — H1 directive detection re-entry.
+
+Per `docs/v2_enforcement.md` § H1, H1 unblocks for implementation only when
+the candidate detector hits ≥80% precision and ≥60% recall on ≥200 labeled
+coding prompts. This test scores `aelfrice.directive_detector.detect_directive`
+against the lab-side corpus and asserts the gate.
+
+Skips cleanly when `AELFRICE_CORPUS_ROOT` is unset (public CI), when the
+`directive_detection/` module dir is missing, or when the corpus has fewer
+than 200 rows (the gate requires a 200-row floor before it can fire).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_corpus_module
+
+PRECISION_GATE = 0.80
+RECALL_GATE = 0.60
+MIN_ROWS = 200
+
+
+@pytest.mark.bench_gated
+def test_directive_detection_gate(aelfrice_corpus_root: Path) -> None:
+    rows = load_corpus_module(aelfrice_corpus_root, "directive_detection")
+
+    if len(rows) < MIN_ROWS:
+        pytest.skip(
+            f"directive_detection corpus has {len(rows)} rows; gate requires "
+            f"≥{MIN_ROWS} per docs/v2_enforcement.md § H1"
+        )
+
+    from aelfrice.directive_detector import detect_directive
+
+    tp = fp = fn = tn = 0
+    for row in rows:
+        actual = row["label"] == "directive"
+        predicted = detect_directive(row["prompt"])
+        if predicted and actual:
+            tp += 1
+        elif predicted and not actual:
+            fp += 1
+        elif (not predicted) and actual:
+            fn += 1
+        else:
+            tn += 1
+
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+
+    assert precision >= PRECISION_GATE, (
+        f"directive_detection precision {precision:.3f} below "
+        f"{PRECISION_GATE} gate (TP={tp}, FP={fp}, FN={fn}, TN={tn}, "
+        f"n={len(rows)}); H1 stays deferred per docs/v2_enforcement.md § H1"
+    )
+    assert recall >= RECALL_GATE, (
+        f"directive_detection recall {recall:.3f} below {RECALL_GATE} gate "
+        f"(TP={tp}, FP={fp}, FN={fn}, TN={tn}, n={len(rows)}); "
+        f"H1 stays deferred per docs/v2_enforcement.md § H1"
+    )

--- a/tests/corpus/v2_0/README.md
+++ b/tests/corpus/v2_0/README.md
@@ -31,7 +31,9 @@ tests/corpus/v2_0/
 │   └── *.jsonl
 ├── promotion_trigger/                 #229
 │   └── *.jsonl
-└── sentiment/                         #193
+├── sentiment/                         #193
+│   └── *.jsonl
+└── directive_detection/               #374 (H1 split of #199)
     └── *.jsonl
 ```
 
@@ -62,6 +64,24 @@ required for **all** modules:
 | `wonder_consolidation` | `seed_belief` (string), `retrieved_neighbors` (list[string]) | `1`, `2`, `3`, `4`, `5` (phantom-quality rating) |
 | `promotion_trigger` | `belief_sequence` (list[string]) | `should_promote`, `should_not` |
 | `sentiment` | `user_message` (string) | `positive`, `negative`, `neutral` |
+| `directive_detection` | `prompt` (string) | `directive`, `not_directive` |
+
+### `directive_detection` re-entry gate (#374)
+
+Distinct from the other modules: this gate decides whether H1 of #199
+unblocks for implementation, not whether a shipped module continues to
+ship. Per `docs/v2_enforcement.md` § H1, H1 reopens for implementation
+when **all three** are true on a labeled sample of ≥ 200 coding prompts:
+
+- precision ≥ 0.80 (true-directive / predicted-directive)
+- recall ≥ 0.60 (true-directive / actual-directive)
+- sample published (this directory; synthetic-only per directory-of-origin
+  rules — real coding-prompt transcripts stay lab-side)
+
+If those numbers are not met, H1 stays deferred. The bench-gate test at
+`tests/bench_gate/test_directive_detection.py` evaluates the candidate
+detector at `src/aelfrice/directive_detector.py` against the labeled
+corpus.
 
 ## v0.1 acceptance (per #307)
 

--- a/tests/test_corpus_schema.py
+++ b/tests/test_corpus_schema.py
@@ -50,6 +50,10 @@ MODULES: dict[str, tuple[set[str], dict[str, str]]] = {
         {"positive", "negative", "neutral"},
         {"user_message": "str"},
     ),
+    "directive_detection": (
+        {"directive", "not_directive"},
+        {"prompt": "str"},
+    ),
 }
 
 COMMON_REQUIRED = ("id", "provenance", "labeller_note", "label")

--- a/tests/test_directive_detector.py
+++ b/tests/test_directive_detector.py
@@ -1,0 +1,47 @@
+"""Sanity tests for `aelfrice.directive_detector` (#374 H1 candidate).
+
+These are NOT the bench gate — those live in `tests/bench_gate/` and need
+the lab corpus. These cover the four spec-mandated filter behaviors so the
+detector's branching logic is exercised in public CI.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aelfrice.directive_detector import detect_directive
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "never push directly to main",
+        "always sign your commits",
+        "must use uv for python deps",
+        "don't add co-authorship to commits",
+        "do not commit large data files",
+        "avoid bypassing pre-push hooks",
+        "before merging, run the staging gate",
+        "unless the user asks, do not force-push",
+    ],
+)
+def test_directive_positives(text: str) -> None:
+    assert detect_directive(text) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "   ",
+        "what does the staging gate check?",
+        "should we rebase or merge here?",
+        "I never push to main when I'm tired",
+        "I always check git status because the worktrees confuse me",
+        "maybe we should never use force-push",
+        "I think we must rebase",
+        "the deploy ran fine",
+        "looks good",
+    ],
+)
+def test_directive_negatives(text: str) -> None:
+    assert detect_directive(text) is False


### PR DESCRIPTION
## What

Adds the H1 directive-detection re-entry harness so #374's bench-gate deferral can actually be evaluated. Does not implement H1 — the `process_directive` / TODO lifecycle / escalation / hook wiring stay deferred until the gate passes.

## Why

Per `docs/v2_enforcement.md` § H1 (and the row in `docs/V2_REENTRY_QUEUE.md`), H1 reopens for implementation only when a labeled sample of ≥200 coding prompts shows ≥0.80 precision and ≥0.60 recall. Until this PR, that gate had no candidate detector to score and no schema entry in the v2.0 corpus contract — so the deferral was unfalsifiable. This PR makes the gate evaluable.

## Changes

- **`src/aelfrice/directive_detector.py`** — candidate regex detector. 29-imperative-verb alternation reconstructed from the spec exemplars, plus three filters: wh-leading question, trailing `?`, hedge markers (`maybe`, `I think`, …), and habitual-narration ("I never X when Y" pattern from § H1's own counter-example). Pure stdlib `re`. ~85 LOC.
- **`tests/corpus/v2_0/directive_detection/`** — new corpus module dir (`.gitkeep` only — lab populates the labeled JSONL per directory-of-origin rule).
- **`tests/corpus/v2_0/README.md`** — adds the module row, per-line shape (`prompt: str`, label `directive|not_directive`), and a "re-entry gate" subsection restating the P/R/n thresholds.
- **`tests/test_corpus_schema.py`** — adds the new module to the `MODULES` validator dict.
- **`tests/bench_gate/test_directive_detection.py`** — bench-gated; skips on public CI without `AELFRICE_CORPUS_ROOT`. With corpus mounted: scores detector, computes P/R, asserts `P ≥ 0.80 ∧ R ≥ 0.60 ∧ n ≥ 200`. Failure assertions cite `docs/v2_enforcement.md § H1` so the next reader knows what re-deferring looks like.
- **`tests/test_directive_detector.py`** — 18 public-CI-runnable sanity cases covering the four filter behaviors.

## Out of scope

- The labeled corpus itself. Synthetic-only per `tests/corpus/v2_0/README.md` and the directory-of-origin rule; lab populates `aelfrice-lab/tests/corpus/v2_0/directive_detection/*.jsonl` separately.
- `process_directive`, the TODO lifecycle, repetition counter, escalation table, hook wiring. All gated on this gate passing.
- The verb-bank membership is "best-effort reconstruction from spec exemplars". The gate scores whatever detector lives in `directive_detector.py`; if the corpus shows specific verbs over- or under-fire, tune in a follow-up.

## Verification

- `uv run pytest -q` — 2181 passed, 22 skipped (the new bench-gate test skips clean without corpus, as designed).
- Discretion grep clean.
- Signed.

Closes nothing — #374 stays open until the corpus lands and the gate either passes (→ implementation unblocks) or fails (→ stays deferred per § H1).

## Summary by Sourcery

Add a candidate directive-detection detector and benchmark gate to make the H1 re-entry condition for #374 evaluable against a labeled corpus.

New Features:
- Introduce a directive detection module exposing a boolean `detect_directive` helper for identifying durable imperative directives in prompts.
- Add a bench-gated test that evaluates directive detection precision and recall against a lab corpus and enforces the H1 re-entry thresholds.
- Define a new `directive_detection` corpus module with schema and re-entry gate documentation for labeled prompts.

Enhancements:
- Extend the corpus schema validation to cover the new `directive_detection` module.

Tests:
- Add public CI sanity tests for directive detection covering positive directives and filtered-out question, hedge, and narration cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Directive detection system with built-in quality gates for accuracy validation

* **Tests**
  * Comprehensive test coverage including unit tests and performance benchmarks to ensure quality standards

* **Documentation**
  * Updated corpus schema and documentation with new module definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->