### PR TITLE
feat(hook): selective L0 injection — top-K locks per UPS turn (#373 / #199 H3)

### DIFF
--- a/docs/v2_enforcement.md
+++ b/docs/v2_enforcement.md
@@ -2,7 +2,9 @@
 
 Spec for issue [#199](https://github.com/robotrocketscience/aelfrice/issues/199). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B).
 
-Status: spec, no implementation. **Recommendation: split the triad — ship H3 only at v2.0, defer H1 with a benchmark gate, drop H2.**
+Status: H3 implemented at v2.0 ([#373](https://github.com/robotrocketscience/aelfrice/issues/373)); H1 split + deferred + bench-gated ([#374](https://github.com/robotrocketscience/aelfrice/issues/374)); H2 dropped per § H2 below.
+
+**Reading 2 picked for the SessionStart-without-prompt ambiguity (#373):** locked-belief injection moves out of SessionStart entirely and into the per-turn UserPromptSubmit hook, where a real prompt exists to score against. The SessionStart payload contains no user prompt, so any session-boot relevance signal would be a guess. The legacy all-locked SessionStart behaviour is preserved behind `[user_prompt_submit_hook] inject_all_locked = true` in `.aelfrice.toml` — a single switch that also disables UPS L0 trimming, restoring the v1.x injection contract end-to-end with no data loss.
 
 ## What's being decided
 
@@ -48,11 +50,11 @@ If a future user actually needs compliance auditing, the right path is a separat
 - [ ] **H1 deferral language.** What evidence reopens H1? (Recommendation: ≥80% precision + ≥60% recall on a labeled sample of 200 coding prompts. If that bar isn't met, H1 stays deferred.)
 - [ ] **H2 drop confirmation.** Final decision: drop, not defer. Removing the temptation to revisit "just port the safe predicates" prevents incremental erosion of the security stance.
 
-## Downstream impact (recommended path)
+## Downstream impact (as shipped)
 
-- **H3 ships.** `hook.py:329-398` SessionStart injection becomes top-K instead of all-locked. New CLI: `aelf health` shows per-session injection counts. Test: a session with 50 locked beliefs and a "git commit" prompt should inject git-relevant beliefs, not all 50.
-- **H1 stays open.** Issue #199 splits; H1 issue gets `bench-gated` label.
-- **H2 closes as `wontfix`.** Documented in CHANGELOG.md notes for v2.0: "v2.0 deliberately ships without a compliance-audit predicate language; the research line's `enforcement.py` H2 is not ported. See [v2_enforcement.md § H2](v2_enforcement.md#h2-compliance-audit--drop)."
+- **H3 shipped at v2.0 (#373).** UserPromptSubmit applies top-K (default `locked_max_k = 5`) by query overlap × `posterior_mean(alpha, beta)`. SessionStart no longer emits a `<aelfrice-baseline>` block under the default; both halves of the legacy contract revive together via `[user_prompt_submit_hook] inject_all_locked = true`. Per-session injection counts are surfaced by `aelf tail` (live-tail of the per-turn audit log; each record carries `n_beliefs` and `n_locked`).
+- **H1 split + deferred (#374).** Bench gate: ≥80% precision + ≥60% recall on a labeled sample of 200 coding prompts before reopening.
+- **H2 dropped.** v2.0 ships without a compliance-audit predicate language; the research line's `enforcement.py` H2 is not ported. The `command_succeeds:cmd` predicate would have executed arbitrary shell from belief content, with no allowlist or sandbox.
 
 ## Provenance
 

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -125,6 +125,9 @@ _CWD_KEY: Final[str] = "cwd"
 
 _UPS_SECTION: Final[str] = "user_prompt_submit_hook"
 _COLLAPSE_KEY: Final[str] = "collapse_duplicate_hashes"
+_SELECTIVE_KEY: Final[str] = "selective_locked_injection"
+_LOCKED_MAX_K_KEY: Final[str] = "locked_max_k"
+_INJECT_ALL_KEY: Final[str] = "inject_all_locked"
 _CONFIG_FILENAME: Final[str] = ".aelfrice.toml"
 
 
@@ -132,12 +135,32 @@ _CONFIG_FILENAME: Final[str] = ".aelfrice.toml"
 class UserPromptSubmitConfig:
     """Configuration for the UserPromptSubmit hook.
 
-    All fields default to their OFF/safe value so missing config degrades
-    gracefully. Loaded from `.aelfrice.toml [user_prompt_submit_hook]`
-    by `load_user_prompt_submit_config()`.
+    Fields default to the v2.0 ship state. Loaded from
+    `.aelfrice.toml [user_prompt_submit_hook]` by
+    `load_user_prompt_submit_config()`.
+
+    `selective_locked_injection` (#373 / #199 H3): when True (default at
+    v2.0), the L0 locked layer is trimmed to top-`locked_max_k` by query
+    overlap × posterior_mean. `inject_all_locked = true` is the
+    documented fallback that restores legacy all-locked injection on
+    both UPS and SessionStart with no data loss.
     """
 
     collapse_duplicate_hashes: bool = False
+    selective_locked_injection: bool = True
+    locked_max_k: int = 5
+    inject_all_locked: bool = False
+
+    def effective_locked_max_k(self) -> int | None:
+        """Resolve the L0 cap to pass into `retrieve(locked_max_k=...)`.
+
+        Returns `None` when locks should NOT be trimmed (legacy all-locked
+        path). Returns a non-negative int otherwise. `inject_all_locked`
+        wins over `selective_locked_injection`.
+        """
+        if self.inject_all_locked or not self.selective_locked_injection:
+            return None
+        return max(0, int(self.locked_max_k))
 
 
 def load_user_prompt_submit_config(
@@ -188,8 +211,48 @@ def load_user_prompt_submit_config(
                     file=serr,
                 )
                 collapse_obj = False
+            defaults = UserPromptSubmitConfig()
+            selective_obj: Any = section.get(
+                _SELECTIVE_KEY, defaults.selective_locked_injection
+            )
+            if not isinstance(selective_obj, bool):
+                print(
+                    f"aelfrice hook: ignoring [{_UPS_SECTION}] "
+                    f"{_SELECTIVE_KEY} in {candidate} (expected bool)",
+                    file=serr,
+                )
+                selective_obj = defaults.selective_locked_injection
+            max_k_obj: Any = section.get(
+                _LOCKED_MAX_K_KEY, defaults.locked_max_k
+            )
+            # Reject bool-as-int; require non-negative int.
+            if (
+                isinstance(max_k_obj, bool)
+                or not isinstance(max_k_obj, int)
+                or max_k_obj < 0
+            ):
+                print(
+                    f"aelfrice hook: ignoring [{_UPS_SECTION}] "
+                    f"{_LOCKED_MAX_K_KEY} in {candidate} "
+                    f"(expected non-negative int)",
+                    file=serr,
+                )
+                max_k_obj = defaults.locked_max_k
+            inject_all_obj: Any = section.get(
+                _INJECT_ALL_KEY, defaults.inject_all_locked
+            )
+            if not isinstance(inject_all_obj, bool):
+                print(
+                    f"aelfrice hook: ignoring [{_UPS_SECTION}] "
+                    f"{_INJECT_ALL_KEY} in {candidate} (expected bool)",
+                    file=serr,
+                )
+                inject_all_obj = defaults.inject_all_locked
             return UserPromptSubmitConfig(
                 collapse_duplicate_hashes=collapse_obj,
+                selective_locked_injection=selective_obj,
+                locked_max_k=max_k_obj,
+                inject_all_locked=inject_all_obj,
             )
         parent = current.parent
         if parent == current:
@@ -654,7 +717,10 @@ def user_prompt_submit(
         )
         config = load_user_prompt_submit_config(stderr=serr)
         retrieve_start = time.monotonic()
-        hits = _retrieve(prompt, budget)
+        hits = _retrieve(
+            prompt, budget,
+            locked_max_k=config.effective_locked_max_k(),
+        )
         if hits:
             # AC1 telemetry: record pre-collapse counts.
             n_returned = len(hits)
@@ -827,17 +893,23 @@ def _extract_prompt(raw: str) -> str | None:
     return prompt
 
 
-def _retrieve(prompt: str, token_budget: int) -> list[Belief]:
+def _retrieve(
+    prompt: str,
+    token_budget: int,
+    *,
+    locked_max_k: int | None = None,
+) -> list[Belief]:
     """Run retrieval for the given prompt and return the raw hit list.
 
-    Separating retrieval from formatting lets callers inspect the hits
-    (for telemetry, optional dedup, etc.) before the string is built.
-    Returns an empty list when the store is absent or retrieval yields
-    nothing.
+    `locked_max_k` is forwarded to `retrieve()` for the L0 selective
+    injection path (#373); `None` preserves legacy all-locked behaviour.
     """
     store = _open_store()
     try:
-        return search_for_prompt(store, prompt, token_budget=token_budget)
+        return search_for_prompt(
+            store, prompt, token_budget=token_budget,
+            locked_max_k=locked_max_k,
+        )
     finally:
         store.close()
 

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -1146,20 +1146,27 @@ def session_start(
     """Run the SessionStart hook. Always returns 0.
 
     Reads the SessionStart JSON payload from stdin (consumed for
-    protocol compatibility -- no fields are read from it at MVP) and
-    writes a baseline context block of L0 locked beliefs to stdout.
-    The block fires once per session, before any user message.
+    protocol compatibility — no fields besides session_id are
+    consumed) and emits the baseline context block to stdout. The
+    block fires once per session, before any user message.
 
-    Empty store / no locked beliefs: emit nothing (return 0). Per the
-    non-blocking hook contract, every failure path returns 0; internal
-    exceptions write to stderr and are otherwise swallowed.
+    v2.0 (#373 / #199 H3): under the default
+    `selective_locked_injection = true`, SessionStart emits NO
+    `<aelfrice-baseline>` block — locked beliefs route through the
+    per-turn UserPromptSubmit hook with prompt-scored top-K instead.
+    The SessionStart payload contains no user prompt, so any
+    SessionStart-time relevance signal would be a guess; deferring to
+    UPS lets the same locks be selected against the actual prompt.
 
-    Why locked-only: at session start there is no prompt to query
-    against, so BM25-driven L1 retrieval would have nothing to score.
-    L0 locked beliefs are the user-asserted ground truth that should
-    survive across every session regardless of context, which makes
-    them the correct content for an unconditional session-start
-    injection.
+    Backward-compat: setting `[user_prompt_submit_hook]
+    inject_all_locked = true` in `.aelfrice.toml` restores the
+    pre-v2.0 behaviour — SessionStart emits all locked beliefs as a
+    baseline block, and UPS does no L0 trimming. No data loss path.
+
+    Empty store / no locked beliefs / selective mode: emit nothing
+    (return 0). Per the non-blocking hook contract, every failure
+    path returns 0; internal exceptions write to stderr and are
+    otherwise swallowed.
     """
     sin = stdin if stdin is not None else sys.stdin
     sout = stdout if stdout is not None else sys.stdout
@@ -1186,6 +1193,11 @@ def session_start(
             if token_budget is not None
             else DEFAULT_SESSION_START_TOKEN_BUDGET
         )
+        # #373 / #199 H3: selective mode suppresses SessionStart locks
+        # entirely; locks reach the model through UPS top-K instead.
+        config = load_user_prompt_submit_config(stderr=serr)
+        if config.effective_locked_max_k() is not None:
+            return 0
         retrieve_start = time.monotonic()
         hits, body = _retrieve_baseline_with_block(budget)
         if body:

--- a/src/aelfrice/hook_search.py
+++ b/src/aelfrice/hook_search.py
@@ -68,15 +68,20 @@ def search_for_prompt(
     token_budget: int = DEFAULT_TOKEN_BUDGET,
     *,
     stderr: IO[str] | None = None,
+    locked_max_k: int | None = None,
 ) -> list[Belief]:
     """Retrieve hits for a hook prompt and record them to feedback_history.
 
-    Wraps `retrieve(store, prompt, token_budget=...)` and, after the read,
-    calls `record_retrieval` to write one audit row per returned belief.
-    Returns the retrieval result; recording failures are caught and logged
-    so the hook's read path is never blocked by a write-side error.
+    Wraps `retrieve(store, prompt, token_budget=..., locked_max_k=...)`
+    and, after the read, calls `record_retrieval` to write one audit row
+    per returned belief. `locked_max_k=None` (default) preserves the
+    legacy all-locked L0 layer; non-None engages the #373 / #199 H3
+    selective-injection path.
     """
-    hits: list[Belief] = retrieve(store, prompt, token_budget=token_budget)
+    hits: list[Belief] = retrieve(
+        store, prompt, token_budget=token_budget,
+        locked_max_k=locked_max_k,
+    )
     record_retrieval(store, hits, stderr=stderr)
     return hits
 

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -65,7 +65,7 @@ from aelfrice.bfs_multihop import (
     DEFAULT_TOTAL_BUDGET_NODES as BFS_DEFAULT_TOTAL_BUDGET_NODES,
     expand_bfs,
 )
-from aelfrice.bm25 import BM25IndexCache
+from aelfrice.bm25 import BM25IndexCache, tokenize as _bm25_tokenize
 from aelfrice.entity_extractor import extract_entities
 from aelfrice.graph_spectral import (
     DEFAULT_BM25_SEED_TOP_K,
@@ -214,6 +214,67 @@ def _estimate_tokens(text: str) -> int:
 
 def _belief_tokens(b: Belief) -> int:
     return _estimate_tokens(b.content)
+
+
+# --- L0 selective injection (#373 / #199 H3) -----------------------------
+
+# Default cap on locked beliefs injected per UPS turn. Matches the
+# research-line default in docs/v2_enforcement.md § H3.
+DEFAULT_LOCKED_MAX_K: Final[int] = 5
+
+
+def score_lock_against_query(
+    lock: Belief, query_terms: frozenset[str]
+) -> float:
+    """Score one locked belief against a tokenised query.
+
+    score = (# distinct query terms found in lock) * posterior_mean
+
+    Locks have saturated posteriors so the second factor is approximately
+    constant; the practical signal is term overlap. A score of 0 means
+    no query term appears in the lock content. Both factors are
+    non-negative so score is non-negative.
+    """
+    if not query_terms:
+        return 0.0
+    lock_terms = set(_bm25_tokenize(lock.content))
+    overlap = len(query_terms & lock_terms)
+    if overlap == 0:
+        return 0.0
+    return float(overlap) * float(lock.posterior_mean)
+
+
+def top_k_locks(
+    locks: list[Belief], query: str, k: int
+) -> list[Belief]:
+    """Return at most `k` locks ranked by query overlap × posterior_mean.
+
+    Determinism: ranking is `(score DESC, input-order ASC)`. Callers
+    pass `list_locked_beliefs()` output which is already deterministic
+    (`locked_at DESC, id ASC` per `MemoryStore.list_locked_beliefs`),
+    so the same `(locked_set_snapshot, query)` always produces the
+    same prefix.
+
+    `k <= 0` returns `[]`. `k >= len(locks)` returns all locks in their
+    relevance-ranked order. Empty / whitespace-only `query` returns
+    `locks[:k]` (no scoring possible — preserves locked_at order).
+    """
+    if k <= 0 or not locks:
+        return []
+    if not query.strip():
+        return list(locks[:k])
+    query_terms = frozenset(_bm25_tokenize(query))
+    if not query_terms:
+        return list(locks[:k])
+    # Stable sort with negative score → score DESC, original order ASC.
+    indexed = list(enumerate(locks))
+    indexed.sort(
+        key=lambda pair: (
+            -score_lock_against_query(pair[1], query_terms),
+            pair[0],
+        )
+    )
+    return [b for _, b in indexed[:k]]
 
 
 # --- Config flag resolution ----------------------------------------------

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -241,7 +241,9 @@ def score_lock_against_query(
     overlap = len(query_terms & lock_terms)
     if overlap == 0:
         return 0.0
-    return float(overlap) * float(lock.posterior_mean)
+    # Local import to keep retrieval -> scoring direction tree-shake clean.
+    from aelfrice.scoring import posterior_mean as _posterior_mean
+    return float(overlap) * _posterior_mean(lock.alpha, lock.beta)
 
 
 def top_k_locks(

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -995,6 +995,7 @@ def retrieve(
     bm25f_cache: BM25IndexCache | None = None,
     heat_kernel_enabled: bool | None = None,
     eigenbasis_cache: GraphEigenbasisCache | None = None,
+    locked_max_k: int | None = None,
 ) -> list[Belief]:
     """Return L0 locked + L2.5 entity + L1 BM25 + L3 BFS expansions.
 
@@ -1046,6 +1047,12 @@ def retrieve(
     warn_placeholder_flags()
 
     locked: list[Belief] = store.list_locked_beliefs()
+    # #373 / #199 H3: selective L0 injection. When `locked_max_k` is set
+    # to a non-negative int, score the locked set against the query and
+    # keep only the top K. Caller passes None to opt out and get legacy
+    # all-locked behaviour (--inject-all fallback path).
+    if locked_max_k is not None and locked_max_k >= 0:
+        locked = top_k_locks(locked, query, locked_max_k)
     locked_ids: set[str] = {b.id for b in locked}
 
     # Backwards-compat: when the flag is off and the caller didn't

--- a/tests/test_hook_audit.py
+++ b/tests/test_hook_audit.py
@@ -226,6 +226,13 @@ def test_session_start_writes_audit_record(
     _set_db(monkeypatch, db)
     monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
     monkeypatch.chdir(tmp_path)
+    # #373: under the v2.0 selective default SessionStart writes nothing
+    # (no body → no audit row). Opt into legacy mode to exercise the
+    # audit-contract path.
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[user_prompt_submit_hook]\ninject_all_locked = true\n",
+        encoding="utf-8",
+    )
     sin = io.StringIO(json.dumps({"session_id": "sess-start"}))
     sout = io.StringIO()
     rc = session_start(stdin=sin, stdout=sout)

--- a/tests/test_hook_session_start.py
+++ b/tests/test_hook_session_start.py
@@ -1,4 +1,11 @@
-"""SessionStart hook entry-point: payload protocol, L0-only retrieval, output."""
+"""SessionStart hook entry-point: payload protocol, output, v2.0 selective mode.
+
+v2.0 default (#373 / #199 H3): SessionStart emits no baseline block —
+locks reach the model via the per-turn UPS top-K path. The legacy
+all-locked SessionStart behaviour is preserved behind
+`[user_prompt_submit_hook] inject_all_locked = true` in
+`.aelfrice.toml`; the `_legacy_mode` fixture below exercises that path.
+"""
 from __future__ import annotations
 
 import io
@@ -13,6 +20,21 @@ from aelfrice.hook import (
 )
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
 from aelfrice.store import MemoryStore
+
+
+def _legacy_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Switch the config loader into legacy all-locked SessionStart.
+
+    Writes a `.aelfrice.toml` with `inject_all_locked = true` into
+    `tmp_path` and chdirs there so `load_user_prompt_submit_config`
+    discovers it on its parent-walk. Used by the v1.x-compat tests
+    below; selective-mode tests omit it and inherit the v2.0 default.
+    """
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[user_prompt_submit_hook]\ninject_all_locked = true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
 
 
 def _mk(
@@ -49,12 +71,43 @@ def _set_db(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
     monkeypatch.setenv("AELFRICE_DB", str(path))
 
 
-# ---- output: locked beliefs surface ------------------------------------
+# ---- v2.0 default: selective mode emits no baseline --------------------
 
 
-def test_session_start_emits_locked_beliefs(
+def test_session_start_selective_default_emits_nothing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """v2.0 default: SessionStart writes no baseline block even with locks.
+
+    Reading 2 of #373: locks route through the per-turn UPS path. The
+    SessionStart payload has no prompt, so no relevance signal exists
+    here — the hook returns early and stdout stays empty.
+    """
+    db = tmp_path / "memory.db"
+    _seed_db(
+        db,
+        [
+            _mk("L1", "user is jonsobol", LOCK_USER, "2026-04-26T00:00:00Z"),
+            _mk("L2", "primary db is sqlite", LOCK_USER, "2026-04-26T00:00:00Z"),
+        ],
+    )
+    _set_db(monkeypatch, db)
+    monkeypatch.chdir(tmp_path)  # no .aelfrice.toml — selective default
+    sin = io.StringIO("{}")
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = session_start(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    assert sout.getvalue() == ""
+
+
+# ---- legacy all-locked SessionStart (inject_all_locked = true) ---------
+
+
+def test_session_start_legacy_emits_locked_beliefs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _legacy_mode(tmp_path, monkeypatch)
     db = tmp_path / "memory.db"
     _seed_db(
         db,
@@ -76,15 +129,11 @@ def test_session_start_emits_locked_beliefs(
     assert '<belief id="L2" lock="user">primary db is sqlite</belief>' in out
 
 
-def test_session_start_skips_unlocked_beliefs(
+def test_session_start_legacy_skips_unlocked_beliefs(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """SessionStart MVP injects L0 locked beliefs only.
-
-    Empty query through retrieve() returns L0 only because FTS5 has
-    nothing to match against. Unlocked beliefs in the store must not
-    appear at session start.
-    """
+    """Legacy SessionStart still surfaces L0 only (empty query → no L1)."""
+    _legacy_mode(tmp_path, monkeypatch)
     db = tmp_path / "memory.db"
     _seed_db(
         db,
@@ -139,7 +188,13 @@ def test_session_start_returns_zero_on_empty_db(
 def test_session_start_returns_zero_on_empty_stdin(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """SessionStart payload may be empty-ish; never block on it."""
+    """SessionStart payload may be empty-ish; never block on it.
+
+    Exercised under legacy mode so we still get a non-empty stdout to
+    prove the locked-belief surfaces independent of the (drained but
+    empty) payload.
+    """
+    _legacy_mode(tmp_path, monkeypatch)
     db = tmp_path / "memory.db"
     _seed_db(
         db,
@@ -155,10 +210,11 @@ def test_session_start_returns_zero_on_empty_stdin(
     assert "L1" in sout.getvalue()
 
 
-def test_session_start_does_not_emit_user_prompt_submit_tags(
+def test_session_start_legacy_does_not_emit_user_prompt_submit_tags(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Distinct tags so the model can tell channels apart."""
+    _legacy_mode(tmp_path, monkeypatch)
     db = tmp_path / "memory.db"
     _seed_db(
         db,

--- a/tests/test_selective_locked_injection.py
+++ b/tests/test_selective_locked_injection.py
@@ -1,0 +1,263 @@
+"""Acceptance tests for #373 / #199 H3 — selective L0 injection.
+
+Each test maps to one of the issue's acceptance bullets:
+
+1. N=50 locks + a focused git-commit prompt -> <= max_k git-relevant
+   locks reach the model (not all 50).
+2. Token-budget regression: <aelfrice-memory> payload size scales with
+   max_k, not with locked-set cardinality.
+3. Locked semantics preserved: a locked belief still cannot be demoted
+   by retrieval; only its per-turn injection is conditional.
+4. Determinism: bytes-identical injection ordering for the same
+   (locked_set_snapshot, prompt) pair.
+5. inject_all_locked = true restores legacy unbounded L0 (no data loss
+   path).
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.hook import user_prompt_submit
+from aelfrice.models import BELIEF_FACTUAL, LOCK_USER, Belief
+from aelfrice.retrieval import top_k_locks
+from aelfrice.store import MemoryStore
+
+
+# Reused fixture vocabulary: 50 locks, exactly five mention `git commit`
+# (the focused-prompt target). The other 45 are off-topic. The focused
+# prompt is "what's the right git commit message format?".
+_GIT_LOCK_TEMPLATES = [
+    "git commit messages should follow conventional-commits prefix",
+    "git commit body explains the why not the what",
+    "git commit subject under 70 characters is house style",
+    "git commit signing uses ssh key id_rrs",
+    "git commit body uses heredoc for multi-line messages",
+]
+_NON_GIT_TOPICS = [
+    "react useState dependency arrays must be exhaustive",
+    "kubernetes pod resource limits prevent oom-kill cascades",
+    "tailwind class ordering uses headwind plugin",
+    "postgres autovacuum tuning depends on table churn rate",
+    "sqlite wal mode enables concurrent readers",
+    "docker compose v2 ditches the docker-compose binary",
+    "rust borrow checker rejects aliased mutable references",
+    "go context cancellation propagates through goroutines",
+    "grpc deadline propagation needs explicit context.WithDeadline",
+    "redis persistence has rdb snapshots and aof appendonly",
+]
+
+
+def _mk_lock(bid: str, content: str, locked_at: str) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=9.0,  # saturated posterior — locks
+        beta=0.5,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_USER,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _seed_50_locks(db_path: Path) -> list[str]:
+    """Seed 50 locked beliefs: 5 git-commit-relevant + 45 off-topic."""
+    store = MemoryStore(str(db_path))
+    ids: list[str] = []
+    try:
+        for i, c in enumerate(_GIT_LOCK_TEMPLATES):
+            bid = f"L_git_{i:02d}"
+            store.insert_belief(_mk_lock(
+                bid, c, f"2026-04-26T05:{i:02d}:00Z"
+            ))
+            ids.append(bid)
+        for i in range(45):
+            template = _NON_GIT_TOPICS[i % len(_NON_GIT_TOPICS)]
+            bid = f"L_off_{i:02d}"
+            store.insert_belief(_mk_lock(
+                bid, f"{template} (variant {i})",
+                f"2026-04-26T04:{i:02d}:00Z"
+            ))
+            ids.append(bid)
+    finally:
+        store.close()
+    return ids
+
+
+def _set_db(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    monkeypatch.setenv("AELFRICE_DB", str(path))
+
+
+def _write_toml(tmp_path: Path, body: str) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(body, encoding="utf-8")
+
+
+def _run_ups(prompt: str) -> str:
+    sin = io.StringIO(json.dumps({"prompt": prompt}))
+    sout = io.StringIO()
+    serr = io.StringIO()
+    rc = user_prompt_submit(stdin=sin, stdout=sout, stderr=serr)
+    assert rc == 0
+    return sout.getvalue()
+
+
+# ---- AC1 + AC2: focused prompt + payload-size scaling -------------------
+
+
+def test_focused_prompt_caps_injected_locks_at_max_k(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """50 locks, max_k=5, git-commit prompt -> exactly the 5 git locks land."""
+    db = tmp_path / "memory.db"
+    _seed_50_locks(db)
+    _set_db(monkeypatch, db)
+    monkeypatch.chdir(tmp_path)  # default config: selective on, max_k=5
+    out = _run_ups("what's the right git commit message format?")
+    # Every L_git_* should appear; no L_off_* should.
+    for i in range(5):
+        assert f'id="L_git_{i:02d}"' in out, f"missing L_git_{i:02d}"
+    assert 'id="L_off_' not in out, (
+        "off-topic lock leaked into top-K injection"
+    )
+
+
+def test_payload_scales_with_max_k_not_locked_cardinality(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Acceptance bullet 2: payload size is bounded by max_k.
+
+    Compares <aelfrice-memory> output sizes across max_k=2 vs max_k=5
+    against the same 50-lock store. The smaller k must produce a
+    strictly smaller payload — otherwise the cap isn't load-bearing.
+    """
+    db = tmp_path / "memory.db"
+    _seed_50_locks(db)
+    _set_db(monkeypatch, db)
+
+    _write_toml(tmp_path, (
+        "[user_prompt_submit_hook]\nlocked_max_k = 2\n"
+    ))
+    monkeypatch.chdir(tmp_path)
+    small = _run_ups("git commit message format")
+
+    _write_toml(tmp_path, (
+        "[user_prompt_submit_hook]\nlocked_max_k = 5\n"
+    ))
+    large = _run_ups("git commit message format")
+
+    assert len(small) < len(large), (
+        f"max_k=2 ({len(small)} bytes) should be smaller than "
+        f"max_k=5 ({len(large)} bytes)"
+    )
+    # And both must be much smaller than what 50 locks would produce
+    # under legacy. Use legacy mode as the upper-bound reference.
+    _write_toml(tmp_path, (
+        "[user_prompt_submit_hook]\ninject_all_locked = true\n"
+    ))
+    legacy = _run_ups("git commit message format")
+    assert len(large) < len(legacy)
+
+
+# ---- AC4: determinism ---------------------------------------------------
+
+
+def test_topk_locks_is_deterministic_across_repeat_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same (locked_set_snapshot, prompt) -> bytes-identical injection."""
+    db = tmp_path / "memory.db"
+    _seed_50_locks(db)
+    _set_db(monkeypatch, db)
+    monkeypatch.chdir(tmp_path)
+    prompt = "git commit message format and signing"
+    out_a = _run_ups(prompt)
+    out_b = _run_ups(prompt)
+    out_c = _run_ups(prompt)
+    assert out_a == out_b == out_c
+
+
+def test_topk_locks_helper_is_pure_and_deterministic() -> None:
+    """Unit-level guard on the scoring helper.
+
+    Ensures sort stability (input-order tiebreak when scores tie) and
+    that repeated calls return identical lists.
+    """
+    locks = [
+        _mk_lock("a", "git commit message", "2026-04-26T03:00:00Z"),
+        _mk_lock("b", "git push origin main", "2026-04-26T02:00:00Z"),
+        _mk_lock("c", "no overlap whatever", "2026-04-26T01:00:00Z"),
+        _mk_lock("d", "git commit signing key", "2026-04-26T00:00:00Z"),
+    ]
+    out1 = top_k_locks(locks, "git commit", k=2)
+    out2 = top_k_locks(locks, "git commit", k=2)
+    assert [b.id for b in out1] == [b.id for b in out2]
+    # 'a' has overlap=2 (git+commit), 'd' has overlap=2 (git+commit),
+    # 'b' has overlap=1 (git), 'c' has 0. With score tie between a/d,
+    # input-order wins -> a before d.
+    assert [b.id for b in out1] == ["a", "d"]
+
+
+# ---- AC5: inject_all_locked fallback (no data loss) ---------------------
+
+
+def test_inject_all_locked_restores_legacy_unbounded_l0(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "memory.db"
+    _seed_50_locks(db)
+    _set_db(monkeypatch, db)
+    _write_toml(tmp_path, (
+        "[user_prompt_submit_hook]\ninject_all_locked = true\n"
+    ))
+    monkeypatch.chdir(tmp_path)
+    out = _run_ups("git commit message format")
+    # All 50 locks must be present (this is the no-data-loss path).
+    git_count = sum(1 for i in range(5) if f'id="L_git_{i:02d}"' in out)
+    off_count = sum(1 for i in range(45) if f'id="L_off_{i:02d}"' in out)
+    assert git_count == 5
+    assert off_count == 45
+
+
+# ---- AC3: locked semantics preserved ------------------------------------
+
+
+def test_unselected_locks_are_not_demoted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Locks excluded from the per-turn top-K must keep their lock_level.
+
+    Selective injection trims display, not authority — `lock_level`
+    must remain LOCK_USER and demotion_pressure must not advance for
+    locks the prompt failed to score.
+    """
+    db = tmp_path / "memory.db"
+    _seed_50_locks(db)
+    _set_db(monkeypatch, db)
+    monkeypatch.chdir(tmp_path)
+    _run_ups("git commit message format")
+
+    # Re-open and verify every off-topic lock still has lock_level=user
+    # and zero demotion_pressure.
+    store = MemoryStore(str(db))
+    try:
+        all_locked = store.list_locked_beliefs()
+        assert len(all_locked) == 50, (
+            "selective injection must not delete or unlock beliefs"
+        )
+        for b in all_locked:
+            assert b.lock_level == LOCK_USER, (
+                f"{b.id}: lock_level changed to {b.lock_level}"
+            )
+            assert b.demotion_pressure == 0, (
+                f"{b.id}: demotion_pressure advanced to "
+                f"{b.demotion_pressure}"
+            )
+    finally:
+        store.close()

--- a/tests/test_user_prompt_submit_collapse.py
+++ b/tests/test_user_prompt_submit_collapse.py
@@ -187,7 +187,7 @@ def test_collapse_off_keeps_duplicates_in_output(
         _make_belief("duplicate text"),  # same as first
     ]
 
-    monkeypatch.setattr("aelfrice.hook._retrieve", lambda p, b: hits)
+    monkeypatch.setattr("aelfrice.hook._retrieve", lambda p, b, **_: hits)
     monkeypatch.setattr("aelfrice.hook._telemetry_path_for_db", lambda p: tel)
     monkeypatch.setattr("aelfrice.hook.db_path", lambda: tmp_path / "memory.db")
     monkeypatch.setattr(
@@ -221,7 +221,7 @@ def test_collapse_on_deduplicates_before_output(
         _make_belief("duplicate text"),  # same as first
     ]
 
-    monkeypatch.setattr("aelfrice.hook._retrieve", lambda p, b: hits)
+    monkeypatch.setattr("aelfrice.hook._retrieve", lambda p, b, **_: hits)
     monkeypatch.setattr("aelfrice.hook._telemetry_path_for_db", lambda p: tel)
     monkeypatch.setattr("aelfrice.hook.db_path", lambda: tmp_path / "memory.db")
     monkeypatch.setattr(
@@ -254,7 +254,7 @@ def test_telemetry_n_returned_is_pre_collapse(
         _make_belief("b"),
     ]
 
-    monkeypatch.setattr("aelfrice.hook._retrieve", lambda p, b: hits)
+    monkeypatch.setattr("aelfrice.hook._retrieve", lambda p, b, **_: hits)
     monkeypatch.setattr("aelfrice.hook._telemetry_path_for_db", lambda p: tel)
     monkeypatch.setattr("aelfrice.hook.db_path", lambda: tmp_path / "memory.db")
     monkeypatch.setattr(

--- a/tests/test_user_prompt_submit_telemetry.py
+++ b/tests/test_user_prompt_submit_telemetry.py
@@ -190,7 +190,7 @@ def test_user_prompt_submit_writes_telemetry_record(
     tel = tmp_path / "user_prompt_submit.jsonl"
     hits = [_make_belief("alpha content"), _make_belief("beta content", LOCK_USER)]
 
-    monkeypatch.setattr("aelfrice.hook._retrieve", lambda prompt, budget: hits)
+    monkeypatch.setattr("aelfrice.hook._retrieve", lambda prompt, budget, **_: hits)
     monkeypatch.setattr(
         "aelfrice.hook._telemetry_path_for_db", lambda p: tel
     )
@@ -225,7 +225,7 @@ def test_user_prompt_submit_no_telemetry_when_empty_hits(
 
     tel = tmp_path / "user_prompt_submit.jsonl"
 
-    monkeypatch.setattr("aelfrice.hook._retrieve", lambda prompt, budget: [])
+    monkeypatch.setattr("aelfrice.hook._retrieve", lambda prompt, budget, **_: [])
     monkeypatch.setattr(
         "aelfrice.hook._telemetry_path_for_db", lambda p: tel
     )
@@ -253,7 +253,7 @@ def test_telemetry_query_capped_at_500_chars(
     long_prompt = "x" * 1000
     hits = [_make_belief("some content")]
 
-    monkeypatch.setattr("aelfrice.hook._retrieve", lambda prompt, budget: hits)
+    monkeypatch.setattr("aelfrice.hook._retrieve", lambda prompt, budget, **_: hits)
     monkeypatch.setattr("aelfrice.hook._telemetry_path_for_db", lambda p: tel)
     monkeypatch.setattr("aelfrice.hook.db_path", lambda: tmp_path / "memory.db")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Implements #373 (selective L0 locked-belief injection — #199 H3 split) under the operator-chosen Reading 2: locks route through the per-turn UserPromptSubmit hook (top-K by query overlap × posterior_mean), and SessionStart no longer emits a `<aelfrice-baseline>` block. Setting `[user_prompt_submit_hook] inject_all_locked = true` in `.aelfrice.toml` restores the v1.x injection contract end-to-end.

Closes #373.

## Acceptance bullets ↔ tests

| AC | Bullet | Test |
|----|--------|------|
| 1 | N≥50 locks + focused git prompt → ≤ max_k git-relevant locks injected | `test_focused_prompt_caps_injected_locks_at_max_k` |
| 2 | `<aelfrice-memory>` payload size scales with `max_k`, not locked-set cardinality | `test_payload_scales_with_max_k_not_locked_cardinality` |
| 3 | Locked semantics preserved (no demotion, lock_level intact) | `test_unselected_locks_are_not_demoted` |
| 4 | `aelf health` (or equivalent) reports per-session injection counts | satisfied by `aelf tail` — pretty-prints `n_beliefs` / `n_locked` per audit record per fire |
| 5 | Determinism: bytes-identical injection for same `(locked_set, prompt)` | `test_topk_locks_is_deterministic_across_repeat_calls` + `test_topk_locks_helper_is_pure_and_deterministic` |
| — | `inject_all_locked` fallback (no data loss) | `test_inject_all_locked_restores_legacy_unbounded_l0` |

## How it ships

- `[user_prompt_submit_hook]` gains `selective_locked_injection` (bool, default `true`), `locked_max_k` (int, default `5`), `inject_all_locked` (bool, default `false`). All three degrade to defaults on missing/malformed TOML with a stderr trace; never raises.
- Scoring formula matches the spec: `overlap_count × posterior_mean(alpha, beta)`. Tiebreak is input-order ASC against `list_locked_beliefs()`'s deterministic `(locked_at DESC, id ASC)` output.
- SessionStart returns early before opening the store under selective mode — the payload contains no prompt and so no relevance signal exists; flat `<aelfrice-baseline>` payload size satisfies AC2.

## Atomic commits (6)

1. `refactor(retrieval): add top_k_locks helper for selective L0 injection (#373)`
2. `feat(retrieval): retrieve() accepts locked_max_k for selective L0 (#373)`
3. `feat(hook): selective L0 injection on UserPromptSubmit (#373 / #199 H3)`
4. `feat(hook): SessionStart suppresses locked-baseline under selective mode (#373)`
5. `test(hook): acceptance tests for selective L0 injection (#373)`
6. `docs(v2_enforcement): mark H3 shipped, record Reading 2 disposition (#373)`

## Test plan

- [x] full suite: `2170 passed, 20 skipped` (was 2164 + 6 new acceptance cases)
- [x] discretion grep against `git diff github/main...HEAD`: clean
- [x] backwards-compat: `inject_all_locked = true` in `.aelfrice.toml` restores v1.x SessionStart all-locked + UPS unbounded L0
- [ ] reviewer: confirm there's no v1.x consumer of `<aelfrice-baseline>` outside the hook tests that the new default would break silently
- [ ] reviewer: confirm `aelf tail` is acceptable as the "or equivalent" injection-count surface for AC4 (alternative: extend `aelf health` with a recent-injection metric — small follow-up)

## Summary by Sourcery

Implement selective top-K injection of locked beliefs via the UserPromptSubmit hook and disable baseline locked injection at SessionStart by default, with a config-driven fallback to legacy all-locked behavior.

New Features:
- Add configuration options to control selective locked-belief injection, including a top-K cap and a flag to restore legacy all-locked behavior.
- Introduce query-aware scoring and top-K selection for locked beliefs in retrieval, surfaced through hook-based prompt search.

Enhancements:
- Update SessionStart to suppress baseline locked-belief emission under the new selective injection default while preserving audit behavior in legacy mode.
- Extend hook search and retrieval plumbing to propagate a locked_max_k cap and keep behavior deterministic for a given locked set and prompt.
- Validate and default new TOML config fields robustly to ensure graceful degradation on malformed configuration.

Documentation:
- Update v2 enforcement documentation to record H3 as shipped, explain the chosen SessionStart reading, and describe downstream impact including configuration and observability surfaces.

Tests:
- Add acceptance tests covering selective locked injection behavior, payload-size scaling with max_k, determinism of top-K selection, and the inject_all_locked fallback path.
- Adjust existing hook tests to account for the new retrieval signature and SessionStart behavior in both default and legacy modes.