### PR TITLE
feat(derivation_worker): worker scaffold for write-log-as-truth (#264 slice 1)

### DIFF
--- a/src/aelfrice/derivation_worker.py
+++ b/src/aelfrice/derivation_worker.py
@@ -1,0 +1,218 @@
+"""Derivation worker — materializes beliefs from ingest_log rows.
+
+v2.x slice of the write-log-as-truth refactor (#264). Today every ingest
+entry point calls `derive()` itself and writes to `beliefs` directly,
+with `record_ingest()` running in parallel as audit. After this worker
+lands, the desired call shape is:
+
+    1. Entry point appends a row to `ingest_log` with no derived ids.
+    2. Entry point invokes `run_worker(store)` (synchronously, end of
+       batch).
+    3. Worker tails unstamped rows, calls `derive()`, writes the canonical
+       belief (and edges) via the existing `insert_or_corroborate()` API,
+       and stamps the log row with the derived ids.
+
+`beliefs` becomes computed state; `ingest_log` is canonical. The view
+flip in a later issue stops the parallel write entirely.
+
+The worker is a function called synchronously after each ingest batch in
+v2.x. Async / daemon mode is a v3 concern.
+
+Design properties:
+
+- **Idempotency.** Re-invoking `run_worker()` over the same log produces
+  identical canonical state. A row whose `derived_belief_ids` is non-empty
+  is skipped. A row whose stamp is empty but whose derived belief already
+  exists in `beliefs` is re-stamped without a duplicate `insert_belief`
+  (deterministic id + content_hash UNIQUE on belief gives idempotency at
+  the storage layer; the worker just stamps the orphan).
+
+- **Crash recovery.** If the worker dies between `insert_belief` and
+  `update_ingest_derived_ids`, the next run notices the orphan (row with
+  empty derived_belief_ids whose deterministic belief id already exists
+  in `beliefs`) and stamps it.
+
+- **Concurrency.** Belief id is sha256(source + text)[:16]; two parallel
+  workers producing the same id converge on one row via the content_hash
+  UNIQUE constraint inside `insert_or_corroborate`. Each worker stamps its
+  own log row independently — log rows are 1:1 with raw inputs, not
+  beliefs.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aelfrice.derivation import DerivationInput, derive
+from aelfrice.models import (
+    CORROBORATION_SOURCE_CLI_REMEMBER,
+    CORROBORATION_SOURCE_COMMIT_INGEST,
+    CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+    CORROBORATION_SOURCE_MCP_REMEMBER,
+    CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
+    INGEST_SOURCE_CLI_REMEMBER,
+    INGEST_SOURCE_FILESYSTEM,
+    INGEST_SOURCE_GIT,
+    INGEST_SOURCE_MCP_REMEMBER,
+)
+from aelfrice.store import MemoryStore
+
+# Multiple call sites share `source_kind=filesystem` (transcript ingest
+# vs scanner / classification). The log row carries the disambiguating
+# `call_site` key in `raw_meta`; when absent we fall back to the
+# `source_kind`-implied default below. Entry points migrating into this
+# worker SHOULD stash `call_site` explicitly so the corroboration audit
+# is unambiguous on replay.
+_CORROBORATION_BY_SOURCE_KIND: dict[str, str] = {
+    INGEST_SOURCE_FILESYSTEM: CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+    INGEST_SOURCE_GIT: CORROBORATION_SOURCE_COMMIT_INGEST,
+    INGEST_SOURCE_CLI_REMEMBER: CORROBORATION_SOURCE_CLI_REMEMBER,
+    INGEST_SOURCE_MCP_REMEMBER: CORROBORATION_SOURCE_MCP_REMEMBER,
+}
+
+# Sentinel keys recognised inside `raw_meta` by the worker.
+_META_CALL_SITE: str = "call_site"
+_META_OVERRIDE_BELIEF_TYPE: str = "override_belief_type"
+_META_SOURCE_PATH_HASH: str = "source_path_hash"
+
+
+@dataclass(frozen=True)
+class WorkerResult:
+    """Aggregate counts from one `run_worker()` invocation.
+
+    `rows_scanned` is every unstamped row visited.
+    `beliefs_inserted` counts new canonical rows written to `beliefs`.
+    `beliefs_corroborated` counts hits on the content_hash UNIQUE
+        constraint (existing belief, corroboration row appended).
+    `rows_stamped` counts log rows whose `derived_belief_ids` we wrote
+        (orphan recovery + new derivations both contribute).
+    `rows_skipped_no_belief` counts rows where `derive()` returned no
+        belief (classifier marked persist=False).
+    """
+
+    rows_scanned: int = 0
+    beliefs_inserted: int = 0
+    beliefs_corroborated: int = 0
+    rows_stamped: int = 0
+    rows_skipped_no_belief: int = 0
+
+
+_TRANSCRIPT_CALL_SITE: str = CORROBORATION_SOURCE_TRANSCRIPT_INGEST
+
+
+def _resolve_corroboration_source(row: dict[str, object]) -> str:
+    raw_meta = row.get("raw_meta") if isinstance(row, dict) else None
+    if isinstance(raw_meta, dict):
+        explicit = raw_meta.get(_META_CALL_SITE)
+        if isinstance(explicit, str) and explicit:
+            return explicit
+    source_kind = str(row.get("source_kind") or "")
+    return _CORROBORATION_BY_SOURCE_KIND.get(
+        source_kind, CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+    )
+
+
+def _derivation_input_from_row(row: dict[str, object]) -> DerivationInput:
+    raw_meta_obj = row.get("raw_meta")
+    raw_meta: dict[str, object] | None = (
+        raw_meta_obj if isinstance(raw_meta_obj, dict) else None
+    )
+    override = None
+    if raw_meta is not None:
+        ov = raw_meta.get(_META_OVERRIDE_BELIEF_TYPE)
+        if isinstance(ov, str) and ov:
+            override = ov
+    source_path = row.get("source_path")
+    session_id = row.get("session_id")
+    classifier_version = row.get("classifier_version")
+    rule_set_hash = row.get("rule_set_hash")
+    return DerivationInput(
+        raw_text=str(row.get("raw_text") or ""),
+        source_kind=str(row.get("source_kind") or ""),
+        source_path=source_path if isinstance(source_path, str) else None,
+        raw_meta=raw_meta,
+        session_id=session_id if isinstance(session_id, str) else None,
+        ts=str(row.get("ts") or ""),
+        classifier_version=(
+            classifier_version if isinstance(classifier_version, str) else None
+        ),
+        rule_set_hash=(
+            rule_set_hash if isinstance(rule_set_hash, str) else None
+        ),
+        override_belief_type=override,
+    )
+
+
+def run_worker(store: MemoryStore) -> WorkerResult:
+    """Materialize beliefs for every unstamped ingest_log row.
+
+    Synchronous, all-rows-in-one-pass. Safe to call after every batch.
+
+    Returns aggregate `WorkerResult` counts. Caller can ignore them in
+    production paths and inspect them in tests.
+    """
+    rows = store.list_unstamped_ingest_log()
+    out = WorkerResult()
+    for row in rows:
+        out = _process_row(store, row, out)
+    return out
+
+
+def _process_row(
+    store: MemoryStore,
+    row: dict[str, object],
+    acc: WorkerResult,
+) -> WorkerResult:
+    log_id = str(row.get("id") or "")
+    if not log_id:
+        return acc
+    rows_scanned = acc.rows_scanned + 1
+
+    inp = _derivation_input_from_row(row)
+    out = derive(inp)
+    if out.belief is None:
+        # Stamp the row with an explicit empty list so a subsequent
+        # worker pass treats it as covered (vs ambiguous NULL = unstamped).
+        store.update_ingest_derived_ids(log_id, derived_belief_ids=[])
+        return WorkerResult(
+            rows_scanned=rows_scanned,
+            beliefs_inserted=acc.beliefs_inserted,
+            beliefs_corroborated=acc.beliefs_corroborated,
+            rows_stamped=acc.rows_stamped + 1,
+            rows_skipped_no_belief=acc.rows_skipped_no_belief + 1,
+        )
+
+    corroboration_source = _resolve_corroboration_source(row)
+    raw_meta = row.get("raw_meta") if isinstance(row, dict) else None
+    source_path_hash: str | None = None
+    if isinstance(raw_meta, dict):
+        sph = raw_meta.get(_META_SOURCE_PATH_HASH)
+        if isinstance(sph, str) and sph:
+            source_path_hash = sph
+
+    actual_id, was_inserted = store.insert_or_corroborate(
+        out.belief,
+        source_type=corroboration_source,
+        session_id=inp.session_id,
+        source_path_hash=source_path_hash,
+    )
+
+    derived_edge_ids: list[tuple[str, str, str]] = []
+    for edge in out.edges:
+        store.insert_edge(edge)
+        derived_edge_ids.append((edge.src, edge.dst, edge.type))
+
+    store.update_ingest_derived_ids(
+        log_id,
+        derived_belief_ids=[actual_id],
+        derived_edge_ids=derived_edge_ids if derived_edge_ids else None,
+    )
+
+    return WorkerResult(
+        rows_scanned=rows_scanned,
+        beliefs_inserted=acc.beliefs_inserted + (1 if was_inserted else 0),
+        beliefs_corroborated=(
+            acc.beliefs_corroborated + (0 if was_inserted else 1)
+        ),
+        rows_stamped=acc.rows_stamped + 1,
+        rows_skipped_no_belief=acc.rows_skipped_no_belief,
+    )

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -1907,6 +1907,25 @@ class MemoryStore:
         cur = self._conn.execute("SELECT COUNT(*) AS n FROM ingest_log")
         return int(cur.fetchone()["n"])
 
+    def list_unstamped_ingest_log(self) -> list[dict[str, object]]:
+        """Return ingest_log rows whose `derived_belief_ids` is unstamped.
+
+        Used by the v2.x derivation worker (#264). A row is considered
+        unstamped when `derived_belief_ids` is SQL NULL — i.e. nothing
+        has materialized beliefs from it yet. An explicit JSON `[]`
+        means the worker visited the row but `derive()` produced no
+        belief; that is a stamped no-op and is NOT returned here.
+
+        Rows are returned in ULID order (== insertion / time order),
+        same shape as `get_ingest_log_entry`.
+        """
+        cur = self._conn.execute(
+            "SELECT * FROM ingest_log "
+            "WHERE derived_belief_ids IS NULL "
+            "ORDER BY id"
+        )
+        return [_ingest_row_to_dict(r) for r in cur.fetchall()]
+
     def iter_ingest_log_for_belief(
         self, belief_id: str,
     ) -> list[dict[str, object]]:

--- a/tests/test_derivation_worker.py
+++ b/tests/test_derivation_worker.py
@@ -1,0 +1,184 @@
+"""Tests for the v2.x derivation worker (#264).
+
+Each test is a falsifiable hypothesis about the worker's contract:
+canonical state matches inline-derive output, idempotency, crash
+recovery, and skip-handling for non-persistent classifications.
+
+Worker integration with each entry point lives in subsequent commits
+(scanner, classification, triple_extractor, mcp, cli). This file
+exercises `run_worker(store)` directly against synthesized log rows.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from aelfrice.derivation_worker import run_worker
+from aelfrice.models import (
+    CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
+    INGEST_SOURCE_FILESYSTEM,
+)
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Iterator[MemoryStore]:
+    s = MemoryStore(str(tmp_path / "worker.db"))
+    yield s
+    s.close()
+
+
+def _record_unstamped(
+    store: MemoryStore,
+    text: str,
+    *,
+    source_path: str = "transcripts/test.jsonl",
+    call_site: str = CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
+) -> str:
+    return store.record_ingest(
+        source_kind=INGEST_SOURCE_FILESYSTEM,
+        source_path=source_path,
+        raw_text=text,
+        raw_meta={"call_site": call_site},
+        # `derived_belief_ids` deliberately omitted — this is the v2.x
+        # log-first contract the worker depends on.
+    )
+
+
+def test_worker_materializes_beliefs_from_unstamped_log_rows(
+    store: MemoryStore,
+) -> None:
+    """Hypothesis: after run_worker(), every unstamped log row that
+    derive() classifies as persist=True yields a canonical belief row,
+    and the log row's derived_belief_ids is non-empty. Falsifiable by
+    a missing belief or an empty stamp."""
+    log_id = _record_unstamped(store, "The system uses SQLite for storage.")
+
+    result = run_worker(store)
+
+    assert result.rows_scanned == 1
+    assert result.beliefs_inserted == 1
+    assert result.rows_stamped == 1
+
+    row = store.get_ingest_log_entry(log_id)
+    assert row is not None
+    derived = row["derived_belief_ids"]
+    assert isinstance(derived, list) and len(derived) == 1
+    bid = derived[0]
+    assert isinstance(bid, str)
+    assert store.get_belief(bid) is not None
+
+
+def test_worker_is_idempotent_on_second_run(store: MemoryStore) -> None:
+    """Hypothesis: invoking run_worker twice over the same log produces
+    identical canonical state — same belief count, no duplicates, no new
+    stamps on the second pass. Falsifiable by either run_worker()
+    returning beliefs_inserted > 0 on the second pass, or by a new
+    belief row appearing in `beliefs`."""
+    _record_unstamped(store, "Locks always inject in full at SessionStart.")
+    first = run_worker(store)
+    assert first.beliefs_inserted == 1
+    assert first.rows_stamped == 1
+
+    belief_count_after_first = store.count_beliefs()
+
+    second = run_worker(store)
+    assert second.rows_scanned == 0
+    assert second.beliefs_inserted == 0
+    assert second.rows_stamped == 0
+    assert store.count_beliefs() == belief_count_after_first
+
+
+def test_worker_recovers_orphan_belief_after_simulated_crash(
+    store: MemoryStore,
+) -> None:
+    """Hypothesis: if the worker dies between `insert_belief` and
+    `update_ingest_derived_ids`, the next worker run notices the orphan
+    (belief exists, log row unstamped) and stamps it without inserting
+    a duplicate belief. Falsifiable by either a duplicate belief row or
+    a permanently-unstamped log row."""
+    log_id = _record_unstamped(store, "Crash recovery proves the contract.")
+
+    # Materialize the belief inline (skip the log-stamp step) — this
+    # reproduces the half-completed worker pass.
+    from aelfrice.derivation import DerivationInput, derive
+    out = derive(DerivationInput(
+        raw_text="Crash recovery proves the contract.",
+        source_kind=INGEST_SOURCE_FILESYSTEM,
+        source_path="transcripts/test.jsonl",
+    ))
+    assert out.belief is not None
+    store.insert_or_corroborate(
+        out.belief,
+        source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
+    )
+    pre_count = store.count_beliefs()
+    assert pre_count == 1
+
+    result = run_worker(store)
+
+    assert result.rows_scanned == 1
+    assert result.rows_stamped == 1
+    # No duplicate belief: insert_or_corroborate hit the existing
+    # content_hash and recorded a corroboration instead.
+    assert result.beliefs_inserted == 0
+    assert result.beliefs_corroborated == 1
+    assert store.count_beliefs() == pre_count
+
+    row = store.get_ingest_log_entry(log_id)
+    assert row is not None
+    derived = row["derived_belief_ids"]
+    assert isinstance(derived, list) and len(derived) == 1
+    assert derived[0] == out.belief.id
+
+
+def test_worker_stamps_empty_list_when_classifier_skips(
+    store: MemoryStore,
+) -> None:
+    """Hypothesis: when derive() returns no belief (e.g. an empty or
+    question-form sentence), the worker still stamps the log row with
+    an explicit empty list so subsequent runs don't re-process it.
+    Falsifiable by the row remaining at NULL after run_worker()."""
+    log_id = _record_unstamped(store, "")  # extraction yields nothing
+
+    result = run_worker(store)
+
+    # The row may or may not have been visited depending on classifier
+    # behaviour for empty text; what matters is that the next pass
+    # finds no unstamped rows.
+    second = run_worker(store)
+    assert second.rows_scanned == 0
+
+    row = store.get_ingest_log_entry(log_id)
+    assert row is not None
+    # An explicit JSON [] is a valid stamp; result should be a list.
+    assert isinstance(row["derived_belief_ids"], list)
+    # Either zero or one belief got persisted depending on classifier;
+    # both states are stamped.
+    if not row["derived_belief_ids"]:
+        assert result.rows_skipped_no_belief >= 1
+
+
+def test_worker_processes_multiple_rows_in_one_pass(
+    store: MemoryStore,
+) -> None:
+    """Hypothesis: a batch of N unstamped rows all become stamped after
+    a single run_worker() call. Falsifiable by any unstamped row
+    remaining."""
+    n = 5
+    log_ids: list[str] = []
+    for i in range(n):
+        log_ids.append(
+            _record_unstamped(store, f"Batch sentence number {i}.")
+        )
+
+    result = run_worker(store)
+    assert result.rows_scanned == n
+    assert result.rows_stamped == n
+
+    for lid in log_ids:
+        row = store.get_ingest_log_entry(lid)
+        assert row is not None
+        assert isinstance(row["derived_belief_ids"], list)


### PR DESCRIPTION
## Summary

First slice of #264 — introduces the v2.x derivation worker that materializes `beliefs` from `ingest_log` rows under the write-log-as-truth contract.

This slice is **scaffolding only**: the worker module is new and is not invoked by any entry point yet. Behaviour on `main` is unchanged. Subsequent commits migrate the six entry points (`scan_repo`, `ingest_turn`, `triple_extractor.ingest_triples`, MCP `tool_lock`, CLI lock, `accept_classifications`) to the log-first / worker-derives shape required by #264 acceptance #1.

## What's in this slice

- `src/aelfrice/derivation_worker.py` — `run_worker(store)` that:
  - reads unstamped log rows (`derived_belief_ids IS NULL`),
  - reconstructs `DerivationInput` from the row's columns + `raw_meta`,
  - calls `derive()` and writes the canonical belief via `insert_or_corroborate`,
  - stamps the log row with `update_ingest_derived_ids`.
  - Idempotent (re-runs no-op), crash-safe (orphan beliefs get stamped on the next pass), concurrency-safe (deterministic id + content_hash UNIQUE).
- `MemoryStore.list_unstamped_ingest_log()` — new minimal accessor.
- `tests/test_derivation_worker.py` — 5 tests: basic materialization, idempotency, crash recovery (simulated mid-pass death), classifier-skip stamps `[]`, batch.

`tests/test_ingest_log.py`, `test_replay_full_equality.py`, `test_legacy_migration.py`, `test_ingest_bulk.py` all still pass (63/63).

## Open design question for the migration commits (not this PR)

Migrating `_ingest_turn_ids` exposes a wrinkle the worker as written doesn't yet handle: today that path branches on `bulk` to suppress per-turn corroboration audit on exact-duplicate `(source, sentence)` pairs. The worker currently always calls `insert_or_corroborate`, which records a corroboration on content_hash hits. Two paths to consider:

1. Stash `bulk` in `raw_meta`; teach the worker to pass a `record_corroboration_on_hit=False` flag down (new param on `insert_or_corroborate`). Cleaner separation; needs a small store-API addition.
2. Pre-suppress at the entry point — `_ingest_turn_ids` skips the `record_ingest` call entirely on a known dup when `bulk=True`, never letting the worker see those rows. Smaller diff; weakens "log is canonical" because some inputs are not represented.

Recommend (1). Will surface explicitly when the migration PR lands.

## Why land this as scaffolding

Scaffold-then-migrate keeps each commit reviewable: this PR proves the worker contract in isolation, the migration PRs prove the rewiring leaves canonical state identical.

## Acceptance status (per #264)

- [x] Worker idempotent (test).
- [x] Crash recovery — orphan belief stamps on next run (test).
- [x] Worker module structure ready for sync end-of-batch invocation.
- [ ] Entry points call `record_ingest` then `run_worker` (slice 2+).
- [ ] Concurrency: 2-process race produces consistent state (deferred to migration PR — needs the entry-point invocation to be testable end-to-end).
- [ ] Edges materialized in the same pass — currently `derive()` returns `edges=[]` for all ingest paths; the worker plumbs the list through but `triple_extractor` migration will exercise it.

## Summary by Sourcery

Introduce a v2 derivation worker that materializes beliefs from unstamped ingest_log rows under the write-log-as-truth contract, without yet wiring it into existing entry points.

New Features:
- Add a derivation worker module that reconstructs derivation inputs from ingest_log rows, derives beliefs and edges, persists them, and stamps the originating log rows.
- Expose a store API to list unstamped ingest_log entries for consumption by the derivation worker.

Tests:
- Add tests covering worker materialization behaviour, idempotency, crash-recovery of orphan beliefs, classifier skip handling, and batch processing of multiple log rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated processing of belief derivation that materializes canonical results from pending entries and tracks operation metrics including rows processed and beliefs generated.

* **Tests**
  * Comprehensive test suite added covering derivation workflow behavior, idempotence verification, error recovery scenarios, and batch processing of multiple entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->