### PR TITLE
feat(sentiment_feedback): regex-based sentiment-from-prose detector + cli health surface + privacy doc (#193)

### DIFF
--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -79,6 +79,24 @@ Resolution order:
 - `aelf demote` removes a lock immediately. The belief itself remains; you can also delete it via the store API.
 - Every Bayesian update goes through `apply_feedback` and writes one `feedback_history` audit row. Provenance is queryable.
 
+## Optional inbound prose inspection: `sentiment_from_prose` (v2.0+)
+
+When `[feedback] sentiment_from_prose = true` is set in `.aelfrice.toml` (or `AELFRICE_FEEDBACK_SENTIMENT_FROM_PROSE=1` is set in the environment), aelfrice runs each user prompt the host hook surfaces through a 24-pattern regex bank ([`src/aelfrice/sentiment_feedback.py`](../src/aelfrice/sentiment_feedback.py)) and writes one `feedback_history` row per matched pattern, distributed across the previous turn's retrieved beliefs.
+
+**Default off.** Existing users see no behavior change.
+
+This is an *inbound* prose-inspection surface — aelfrice already received the prompt via the host hook to do retrieval. The new behavior is regex matching plus implicit Bayesian updates, not new data access.
+
+**What is read:** every user prompt the hook receives, capped at 200 characters (longer prompts skip detection on the assumption that they carry task content rather than feedback signal).
+
+**What is stored:** one `feedback_history` audit row per matched pattern, recording `(belief_id, valence, source="sentiment_inferred", created_at)`. The audit row carries the matched pattern id and substring; the full prompt text is **never** stored.
+
+**What leaves the machine:** nothing. Stdlib regex; no outbound calls. Same determinism contract as the rest of the runtime — same prompt produces same matches and same updates.
+
+**`aelf health` surfaces the state.** `aelf health` prints `sentiment-from-prose feedback: enabled (<N> matches)` when the feature is on, or `disabled` otherwise, so its effect is visible at a glance.
+
+To turn it off after enabling, remove the config line (or set `[feedback] sentiment_from_prose = false`). Already-applied feedback rows remain in `feedback_history` as audit history; deleting them requires direct store access.
+
 ## What aelfrice does not control
 
 The cloud LLM at the other end of your prompt sees whatever aelfrice injects. That's inherent to using a cloud LLM. Mitigations:

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -1846,9 +1846,82 @@ def _cmd_health(args: argparse.Namespace, out: object) -> int:
             display = str(value)
         print(f"  {key:24s} {display}", file=out)  # type: ignore[arg-type]
     print("", file=out)  # type: ignore[arg-type]
+    sentiment_state, sentiment_count = _sentiment_from_prose_state()
+    if sentiment_state == "enabled":
+        print(
+            f"sentiment-from-prose feedback: enabled ({sentiment_count} matches)",
+            file=out,  # type: ignore[arg-type]
+        )
+    else:
+        print(
+            "sentiment-from-prose feedback: disabled",
+            file=out,  # type: ignore[arg-type]
+        )
+    print("", file=out)  # type: ignore[arg-type]
     print("run `aelf regime` for the v1.0 regime classifier.",
           file=out)  # type: ignore[arg-type]
     return 1 if report.failed else 0
+
+
+def _sentiment_from_prose_state() -> tuple[str, int]:
+    """Resolve enabled/disabled status for #193 sentiment-from-prose
+    feedback plus a count of `feedback_history` rows attributed to it.
+
+    Failures (missing config, missing DB, decode errors) degrade to
+    ("disabled", 0) without raising — keeps `aelf health` informational
+    and never causes it to exit non-zero on a config issue.
+    """
+    from aelfrice.sentiment_feedback import (
+        SENTIMENT_INFERRED_SOURCE,
+        is_enabled,
+    )
+    config_dict = _load_aelfrice_config_dict(Path.cwd())
+    enabled = is_enabled(config_dict)
+    if not enabled:
+        return ("disabled", 0)
+    try:
+        store = _open_store()
+    except Exception:  # noqa: BLE001
+        return ("enabled", 0)
+    try:
+        row = store._conn.execute(
+            "SELECT COUNT(*) FROM feedback_history WHERE source = ?",
+            (SENTIMENT_INFERRED_SOURCE,),
+        ).fetchone()
+        count = int(row[0]) if row is not None else 0
+    except Exception:  # noqa: BLE001
+        count = 0
+    finally:
+        store.close()
+    return ("enabled", count)
+
+
+def _load_aelfrice_config_dict(root: Path) -> dict[str, Any] | None:
+    """Walk up from `root` for `.aelfrice.toml`; return the parsed dict
+    or None on miss / parse failure. Mirrors `_load_llm_config` walk
+    semantics but returns the whole file rather than one section.
+    """
+    import tomllib
+
+    current = root.resolve() if root.exists() else root
+    seen: set[Path] = set()
+    candidate = current if current.is_dir() else current.parent
+    while candidate not in seen:
+        seen.add(candidate)
+        cfg_path = candidate / ".aelfrice.toml"
+        if cfg_path.is_file():
+            try:
+                raw = cfg_path.read_bytes()
+                parsed: Any = tomllib.loads(
+                    raw.decode("utf-8", errors="replace")
+                )
+            except (OSError, tomllib.TOMLDecodeError):
+                return None
+            return parsed if isinstance(parsed, dict) else None
+        if candidate.parent == candidate:
+            return None
+        candidate = candidate.parent
+    return None
 
 
 def _cmd_migrate(args: argparse.Namespace, out: object) -> int:

--- a/src/aelfrice/sentiment_feedback.py
+++ b/src/aelfrice/sentiment_feedback.py
@@ -1,0 +1,359 @@
+"""Implicit sentiment-from-prose feedback (#193, v2.0 opt-in).
+
+Reads each user prompt, regex-matches against twelve positive and
+twelve negative sentiment patterns, and emits a `SentimentSignal`.
+The signal is distributed equally across the previous turn's
+retrieved beliefs via `apply_sentiment_to_pending`, which calls
+`feedback.apply_feedback` once per pending belief id.
+
+Design contract (spec: `docs/v2_sentiment_feedback.md`):
+
+  * **Default off.** Opt-in via `[feedback] sentiment_from_prose = true`
+    in `.aelfrice.toml`, or `AELFRICE_FEEDBACK_SENTIMENT_FROM_PROSE=1`.
+    Off by default means existing users see no behavior change.
+  * **Inbound only.** Pure regex over text the hook already receives.
+    No outbound calls. No LLM. Deterministic.
+  * **Length guard.** Prompts longer than `MAX_PROMPT_CHARS` (200) are
+    assumed task content, not user feedback. `detect_sentiment` returns
+    `None` for these so the regex bank does not match incidental phrases
+    in long pastes.
+  * **Pattern provenance.** Twelve positive patterns and twelve negative
+    patterns ported from the research-line `agentmemory/sentiment_feedback.py`
+    per the v2.0 ratification. Two strong-amplifier subsets
+    (STRONG_POSITIVE, STRONG_NEGATIVE) escalate `confidence` when the
+    matched pattern carries higher signal-to-noise than the base set.
+  * **Audit row source.** All apply_feedback calls from this module use
+    `source = SENTIMENT_INFERRED_SOURCE` so the audit trail can split
+    explicit-user feedback from sentiment-inferred feedback.
+  * **Correction-frequency escalator.** `detect_correction_frequency`
+    fires a stronger negative signal when >= CORRECTION_FREQ_THRESHOLD
+    fraction of the recent N turns were corrections. Stateless beyond
+    the caller-supplied window.
+
+Distribution shape: `apply_sentiment_to_pending` distributes the signal
+equally across all pending belief ids. Per-rank scaling is explicitly
+out of scope (decision ratified 2026-04-29: "matches the research-line
+behavior; ranked distribution adds a knob without an evidence-gate").
+
+This module does NOT decide *when* to call into it. The hook layer is
+responsible for: (a) checking the config flag, (b) resolving the
+"previous turn's retrieved beliefs" set, and (c) calling
+`apply_sentiment_to_pending`. That wiring is a separate concern; the
+module surface here is pure.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Final, Sequence
+
+from aelfrice.feedback import FeedbackResult, apply_feedback
+from aelfrice.store import MemoryStore
+
+# --- Public constants ---------------------------------------------------
+
+MAX_PROMPT_CHARS: Final[int] = 200
+"""Prompts longer than this are assumed task content; detector returns None."""
+
+SENTIMENT_INFERRED_SOURCE: Final[str] = "sentiment_inferred"
+"""Source string written to feedback_history rows from this module."""
+
+CONFIG_FEEDBACK_SECTION: Final[str] = "feedback"
+CONFIG_SENTIMENT_KEY: Final[str] = "sentiment_from_prose"
+ENV_SENTIMENT: Final[str] = "AELFRICE_FEEDBACK_SENTIMENT_FROM_PROSE"
+
+POSITIVE: Final[str] = "positive"
+NEGATIVE: Final[str] = "negative"
+
+BASE_VALENCE: Final[float] = 1.0
+"""Magnitude passed to apply_feedback for a base-pattern match."""
+
+AMPLIFIED_VALENCE: Final[float] = 1.5
+"""Magnitude for a strong-pattern match (50% boost over base)."""
+
+ESCALATED_NEGATIVE_VALENCE: Final[float] = 2.0
+"""Magnitude for a correction-frequency escalation. Doubles the base."""
+
+CORRECTION_FREQ_THRESHOLD: Final[float] = 0.4
+"""Fraction of recent turns that must be negative to fire the escalator."""
+
+CORRECTION_FREQ_MIN_TURNS: Final[int] = 5
+"""Minimum recent-turn count before the escalator can fire (avoids
+firing on a 2-of-2 sample)."""
+
+_ENV_TRUTHY: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+_ENV_FALSY: Final[frozenset[str]] = frozenset({"0", "false", "no", "off"})
+
+
+# --- Pattern banks ------------------------------------------------------
+# Word-boundary anchored, case-insensitive. Compiled once at import.
+# Order matters only insofar as the first match wins; the strong subsets
+# are checked separately so a base-set match still wins when the prompt
+# does not also hit a strong pattern.
+
+_POSITIVE_PATTERNS: Final[tuple[tuple[str, str], ...]] = (
+    ("ok_good", r"\bok(ay)?[\s,!.]+good\b"),
+    ("yes", r"\byes\b"),
+    ("yeah", r"\byeah\b"),
+    ("perfect", r"\bperfect\b"),
+    ("great", r"\bgreat\b"),
+    ("nice", r"\bnice\b"),
+    ("thanks", r"\bthanks?\b"),
+    ("correct", r"\bcorrect\b"),
+    ("right", r"\bthat'?s right\b"),
+    ("works", r"\b(it|that) works?\b"),
+    ("looks_good", r"\blooks? good\b"),
+    ("good_job", r"\bgood (job|work)\b"),
+)
+
+_NEGATIVE_PATTERNS: Final[tuple[tuple[str, str], ...]] = (
+    ("no", r"\bno\b"),
+    ("nope", r"\bnope\b"),
+    ("wrong", r"\b(that'?s |is )?wrong\b"),
+    ("incorrect", r"\bincorrect\b"),
+    ("not_what", r"\bnot what i\b"),
+    ("fix_it", r"\bfix (it|this|that)\b"),
+    ("broken", r"\bbroken\b"),
+    ("doesnt_work", r"\bdoes ?n'?t work\b"),
+    ("stop", r"\bstop (doing |that)\b"),
+    ("i_told_you", r"\bi (already )?told you\b"),
+    ("undo", r"\bundo (that|it|this)\b"),
+    ("try_again", r"\btry again\b"),
+)
+
+_STRONG_POSITIVE: Final[frozenset[str]] = frozenset({
+    "perfect", "correct", "right", "good_job",
+})
+
+_STRONG_NEGATIVE: Final[frozenset[str]] = frozenset({
+    "wrong", "incorrect", "i_told_you", "fix_it", "broken",
+})
+
+_COMPILED_POSITIVE: Final[tuple[tuple[str, re.Pattern[str]], ...]] = tuple(
+    (name, re.compile(pat, re.IGNORECASE)) for name, pat in _POSITIVE_PATTERNS
+)
+_COMPILED_NEGATIVE: Final[tuple[tuple[str, re.Pattern[str]], ...]] = tuple(
+    (name, re.compile(pat, re.IGNORECASE)) for name, pat in _NEGATIVE_PATTERNS
+)
+
+
+# --- Signal dataclass ---------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SentimentSignal:
+    """One sentiment classification of one prompt.
+
+    `sentiment` is POSITIVE or NEGATIVE.
+    `valence` is the magnitude+sign passed to `apply_feedback`. Positive
+    signals carry positive valence; negative carry negative.
+    `confidence` is in [0.0, 1.0] and reflects whether the match came
+    from the base or strong subset. Future versions may layer additional
+    signals; today it is a two-level enum encoded as 0.6 (base) or 0.9
+    (strong-amplified).
+    `pattern` is the named pattern that matched. Stable identifier for
+    the audit trail; the matched substring itself is captured in
+    `matched_text`.
+    `matched_text` is the literal substring from the prompt. Used by the
+    audit row to record what triggered the classification without
+    storing the full prompt.
+    """
+
+    sentiment: str
+    valence: float
+    confidence: float
+    pattern: str
+    matched_text: str
+
+
+# --- Detector -----------------------------------------------------------
+
+
+def detect_sentiment(prompt: str) -> SentimentSignal | None:
+    """Classify one prompt. Returns None if no pattern matches or the
+    prompt exceeds the length guard.
+
+    Detection order:
+      1. Length guard. > MAX_PROMPT_CHARS -> None (assumed task content).
+      2. Strong negatives, then strong positives. Strong wins over base
+         when both match because the higher-confidence interpretation
+         is the safer one to act on.
+      3. Base negatives, then base positives. Negatives are checked
+         first within each tier on the asymmetric-cost principle: a
+         missed correction silently entrenches a wrong belief, while
+         a missed positive only delays a small posterior gain.
+    """
+    if not prompt:
+        return None
+    if len(prompt) > MAX_PROMPT_CHARS:
+        return None
+
+    strong_neg = _first_match(_COMPILED_NEGATIVE, prompt, _STRONG_NEGATIVE)
+    if strong_neg is not None:
+        return _make_signal(NEGATIVE, strong_neg, strong=True)
+
+    strong_pos = _first_match(_COMPILED_POSITIVE, prompt, _STRONG_POSITIVE)
+    if strong_pos is not None:
+        return _make_signal(POSITIVE, strong_pos, strong=True)
+
+    base_neg = _first_match(_COMPILED_NEGATIVE, prompt, None)
+    if base_neg is not None:
+        return _make_signal(NEGATIVE, base_neg, strong=False)
+
+    base_pos = _first_match(_COMPILED_POSITIVE, prompt, None)
+    if base_pos is not None:
+        return _make_signal(POSITIVE, base_pos, strong=False)
+
+    return None
+
+
+def _first_match(
+    compiled: tuple[tuple[str, re.Pattern[str]], ...],
+    prompt: str,
+    restrict_to: frozenset[str] | None,
+) -> tuple[str, str] | None:
+    """Return (pattern_name, matched_text) for the first hit, or None.
+    `restrict_to` filters the candidate set; None means consider all.
+    """
+    for name, pat in compiled:
+        if restrict_to is not None and name not in restrict_to:
+            continue
+        m = pat.search(prompt)
+        if m is not None:
+            return (name, m.group(0))
+    return None
+
+
+def _make_signal(
+    sentiment: str, hit: tuple[str, str], strong: bool
+) -> SentimentSignal:
+    name, text = hit
+    if strong:
+        magnitude = AMPLIFIED_VALENCE
+        confidence = 0.9
+    else:
+        magnitude = BASE_VALENCE
+        confidence = 0.6
+    valence = magnitude if sentiment == POSITIVE else -magnitude
+    return SentimentSignal(
+        sentiment=sentiment,
+        valence=valence,
+        confidence=confidence,
+        pattern=name,
+        matched_text=text,
+    )
+
+
+def classify(prompt: str) -> str:
+    """Three-way label adapter: "positive" | "negative" | "neutral".
+
+    Used by the bench-gate harness (#319 / #193) to score against the
+    labeled corpus. Returns "neutral" when no pattern matches or the
+    prompt fails the length guard.
+    """
+    signal = detect_sentiment(prompt)
+    if signal is None:
+        return "neutral"
+    return signal.sentiment
+
+
+def detect_correction_frequency(
+    recent_signals: Sequence[SentimentSignal | None],
+    *,
+    threshold: float = CORRECTION_FREQ_THRESHOLD,
+    min_turns: int = CORRECTION_FREQ_MIN_TURNS,
+) -> bool:
+    """Return True if the recent-signal window indicates the user is
+    correcting at or above `threshold` fraction. Returns False when the
+    window is shorter than `min_turns` to avoid firing on tiny samples.
+
+    Counts NEGATIVE-classified signals only; None and POSITIVE entries
+    contribute to the denominator without raising the rate.
+    """
+    if len(recent_signals) < min_turns:
+        return False
+    negatives = sum(
+        1 for s in recent_signals if s is not None and s.sentiment == NEGATIVE
+    )
+    return (negatives / len(recent_signals)) >= threshold
+
+
+# --- Application --------------------------------------------------------
+
+
+def apply_sentiment_to_pending(
+    store: MemoryStore,
+    signal: SentimentSignal,
+    pending_belief_ids: Sequence[str],
+    *,
+    now: str | None = None,
+    escalated: bool = False,
+) -> list[FeedbackResult]:
+    """Distribute one sentiment signal equally across the pending belief
+    set. Calls `apply_feedback` once per belief id.
+
+    Returns the list of FeedbackResults. Beliefs that no longer exist
+    in the store are skipped silently (not an error: the previous turn
+    may have surfaced a belief that has since been deleted).
+
+    `escalated` upgrades a negative signal's magnitude to
+    `ESCALATED_NEGATIVE_VALENCE`. Has no effect on positive signals;
+    the correction-frequency path only escalates negatives by design.
+
+    `propagate=False` is passed through to `apply_feedback` because
+    sentiment signals are not corrective in the contradictor-walk sense:
+    they are bulk implicit signals on a retrieval set, not user
+    judgments on individual contradicting beliefs.
+    """
+    if not pending_belief_ids:
+        return []
+
+    valence = signal.valence
+    if escalated and signal.sentiment == NEGATIVE:
+        valence = -ESCALATED_NEGATIVE_VALENCE
+
+    results: list[FeedbackResult] = []
+    for bid in pending_belief_ids:
+        if store.get_belief(bid) is None:
+            continue
+        result = apply_feedback(
+            store=store,
+            belief_id=bid,
+            valence=valence,
+            source=SENTIMENT_INFERRED_SOURCE,
+            now=now,
+            propagate=False,
+        )
+        results.append(result)
+    return results
+
+
+# --- Config -------------------------------------------------------------
+
+
+def is_enabled(config: dict[str, dict] | None = None) -> bool:
+    """Whether sentiment-from-prose is enabled.
+
+    Resolution order:
+      1. Env var `AELFRICE_FEEDBACK_SENTIMENT_FROM_PROSE` if set.
+      2. `[feedback] sentiment_from_prose` in the supplied config dict.
+      3. Default False.
+
+    The hook layer is the caller; this module does not read disk.
+    """
+    raw = os.environ.get(ENV_SENTIMENT)
+    if raw is not None:
+        token = raw.strip().lower()
+        if token in _ENV_TRUTHY:
+            return True
+        if token in _ENV_FALSY:
+            return False
+
+    if config is None:
+        return False
+    section = config.get(CONFIG_FEEDBACK_SECTION)
+    if not isinstance(section, dict):
+        return False
+    value = section.get(CONFIG_SENTIMENT_KEY)
+    return bool(value) if isinstance(value, bool) else False

--- a/tests/bench_gate/test_sentiment.py
+++ b/tests/bench_gate/test_sentiment.py
@@ -11,16 +11,11 @@ from tests.conftest import load_corpus_module
 @pytest.mark.bench_gated
 def test_sentiment_detector_against_corpus(aelfrice_corpus_root: Path) -> None:
     rows = load_corpus_module(aelfrice_corpus_root, "sentiment")
-    try:
-        from aelfrice import sentiment  # type: ignore[attr-defined]
-    except ModuleNotFoundError as exc:
-        if exc.name in {"aelfrice", "aelfrice.sentiment"}:
-            pytest.skip("sentiment detector not yet implemented (#193)")
-        raise
+    from aelfrice import sentiment_feedback
 
     correct = 0
     for row in rows:
-        predicted = sentiment.classify(row["user_message"])
+        predicted = sentiment_feedback.classify(row["user_message"])
         if predicted == row["label"]:
             correct += 1
     accuracy = correct / len(rows)

--- a/tests/test_sentiment_feedback.py
+++ b/tests/test_sentiment_feedback.py
@@ -1,0 +1,347 @@
+"""sentiment_feedback module — detection, escalator, application, config.
+
+Unit tests only. The bench-gate accuracy test against the labeled
+corpus lives at tests/bench_gate/test_sentiment.py.
+"""
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+import pytest
+
+from aelfrice.feedback import apply_feedback
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
+from aelfrice.sentiment_feedback import (
+    AMPLIFIED_VALENCE,
+    BASE_VALENCE,
+    CORRECTION_FREQ_THRESHOLD,
+    ENV_SENTIMENT,
+    ESCALATED_NEGATIVE_VALENCE,
+    MAX_PROMPT_CHARS,
+    NEGATIVE,
+    POSITIVE,
+    SENTIMENT_INFERRED_SOURCE,
+    SentimentSignal,
+    apply_sentiment_to_pending,
+    classify,
+    detect_correction_frequency,
+    detect_sentiment,
+    is_enabled,
+)
+from aelfrice.store import MemoryStore
+
+
+# --- Fixtures ------------------------------------------------------------
+
+
+def _mk(bid: str, alpha: float = 1.0, beta: float = 1.0) -> Belief:
+    return Belief(
+        id=bid,
+        content=f"belief {bid}",
+        content_hash=f"h_{bid}",
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("b1"))
+    s.insert_belief(_mk("b2"))
+    s.insert_belief(_mk("b3"))
+    return s
+
+
+@pytest.fixture
+def clean_env() -> Iterator[None]:
+    """Snapshot + restore the sentiment env var around each test."""
+    saved = os.environ.pop(ENV_SENTIMENT, None)
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop(ENV_SENTIMENT, None)
+        else:
+            os.environ[ENV_SENTIMENT] = saved
+
+
+# --- detect_sentiment: positive base patterns ----------------------------
+
+
+def test_detect_yes_returns_positive() -> None:
+    s = detect_sentiment("yes")
+    assert s is not None and s.sentiment == POSITIVE
+
+
+def test_detect_thanks_returns_positive() -> None:
+    s = detect_sentiment("thanks for the fix")
+    assert s is not None and s.sentiment == POSITIVE
+
+
+def test_detect_looks_good_returns_positive() -> None:
+    s = detect_sentiment("looks good")
+    assert s is not None and s.sentiment == POSITIVE
+
+
+# --- detect_sentiment: negative base patterns ----------------------------
+
+
+def test_detect_no_returns_negative() -> None:
+    s = detect_sentiment("no")
+    assert s is not None and s.sentiment == NEGATIVE
+
+
+def test_detect_doesnt_work_returns_negative() -> None:
+    s = detect_sentiment("that doesnt work")
+    assert s is not None and s.sentiment == NEGATIVE
+
+
+def test_detect_undo_returns_negative() -> None:
+    s = detect_sentiment("undo that")
+    assert s is not None and s.sentiment == NEGATIVE
+
+
+# --- detect_sentiment: strong patterns elevate confidence ----------------
+
+
+def test_strong_positive_uses_amplified_valence() -> None:
+    s = detect_sentiment("perfect")
+    assert s is not None
+    assert s.sentiment == POSITIVE
+    assert s.valence == AMPLIFIED_VALENCE
+
+
+def test_strong_negative_uses_amplified_valence() -> None:
+    s = detect_sentiment("that is wrong")
+    assert s is not None
+    assert s.sentiment == NEGATIVE
+    assert s.valence == -AMPLIFIED_VALENCE
+
+
+def test_base_positive_uses_base_valence() -> None:
+    s = detect_sentiment("yes")
+    assert s is not None
+    assert s.valence == BASE_VALENCE
+
+
+def test_strong_pattern_higher_confidence_than_base() -> None:
+    base = detect_sentiment("yes")
+    strong = detect_sentiment("perfect")
+    assert base is not None and strong is not None
+    assert strong.confidence > base.confidence
+
+
+# --- detect_sentiment: precedence + length guard -------------------------
+
+
+def test_strong_negative_wins_over_base_positive_in_same_prompt() -> None:
+    # "yes thats wrong" contains both a base-positive and a strong-negative.
+    s = detect_sentiment("yes thats wrong")
+    assert s is not None
+    assert s.sentiment == NEGATIVE
+
+
+def test_long_prompt_returns_none() -> None:
+    long_prompt = "yes " + ("x" * (MAX_PROMPT_CHARS + 1))
+    assert detect_sentiment(long_prompt) is None
+
+
+def test_empty_prompt_returns_none() -> None:
+    assert detect_sentiment("") is None
+
+
+def test_no_match_returns_none() -> None:
+    assert detect_sentiment("please continue with the next item") is None
+
+
+def test_matched_text_records_substring() -> None:
+    s = detect_sentiment("perfect, thanks")
+    assert s is not None
+    assert s.matched_text.lower() == "perfect"
+
+
+def test_pattern_id_records_pattern_name() -> None:
+    s = detect_sentiment("perfect")
+    assert s is not None
+    assert s.pattern == "perfect"
+
+
+# --- classify: three-way label adapter -----------------------------------
+
+
+def test_classify_positive() -> None:
+    assert classify("yes") == "positive"
+
+
+def test_classify_negative() -> None:
+    assert classify("no") == "negative"
+
+
+def test_classify_neutral() -> None:
+    assert classify("please continue with the next item") == "neutral"
+
+
+def test_classify_long_prompt_neutral() -> None:
+    assert classify("yes " + ("x" * (MAX_PROMPT_CHARS + 1))) == "neutral"
+
+
+# --- detect_correction_frequency -----------------------------------------
+
+
+def _neg() -> SentimentSignal:
+    return SentimentSignal(NEGATIVE, -BASE_VALENCE, 0.6, "no", "no")
+
+
+def _pos() -> SentimentSignal:
+    return SentimentSignal(POSITIVE, BASE_VALENCE, 0.6, "yes", "yes")
+
+
+def test_correction_frequency_below_min_turns_returns_false() -> None:
+    # 4 turns is below default min_turns=5 even at 100% negatives.
+    assert detect_correction_frequency([_neg(), _neg(), _neg(), _neg()]) is False
+
+
+def test_correction_frequency_at_threshold_fires() -> None:
+    # 2 of 5 = 0.4, exactly at default threshold.
+    window = [_neg(), _neg(), _pos(), _pos(), _pos()]
+    assert detect_correction_frequency(window) is True
+
+
+def test_correction_frequency_below_threshold_does_not_fire() -> None:
+    # 1 of 5 = 0.2.
+    window = [_neg(), _pos(), _pos(), _pos(), _pos()]
+    assert detect_correction_frequency(window) is False
+
+
+def test_correction_frequency_none_entries_count_in_denominator() -> None:
+    # 2 negatives in 6 entries = 0.33 < 0.4. Two None entries do not
+    # raise the rate even though they fill the window.
+    window = [_neg(), _neg(), None, None, _pos(), _pos()]
+    assert detect_correction_frequency(window) is False
+
+
+def test_correction_frequency_threshold_override() -> None:
+    window = [_neg(), _pos(), _pos(), _pos(), _pos()]  # 0.2
+    assert detect_correction_frequency(window, threshold=0.1) is True
+
+
+# --- apply_sentiment_to_pending ------------------------------------------
+
+
+def test_apply_distributes_positive_signal_across_all_pending(
+    store: MemoryStore,
+) -> None:
+    sig = SentimentSignal(POSITIVE, BASE_VALENCE, 0.6, "yes", "yes")
+    results = apply_sentiment_to_pending(store, sig, ["b1", "b2", "b3"])
+    assert len(results) == 3
+    for bid in ("b1", "b2", "b3"):
+        b = store.get_belief(bid)
+        assert b is not None
+        assert b.alpha == 2.0  # was 1.0, +1.0 valence
+
+
+def test_apply_uses_sentiment_inferred_source(store: MemoryStore) -> None:
+    sig = SentimentSignal(POSITIVE, BASE_VALENCE, 0.6, "yes", "yes")
+    apply_sentiment_to_pending(store, sig, ["b1"])
+    rows = store._conn.execute(
+        "SELECT source FROM feedback_history WHERE belief_id = ?", ("b1",)
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == SENTIMENT_INFERRED_SOURCE
+
+
+def test_apply_skips_missing_belief_silently(store: MemoryStore) -> None:
+    sig = SentimentSignal(POSITIVE, BASE_VALENCE, 0.6, "yes", "yes")
+    results = apply_sentiment_to_pending(store, sig, ["b1", "ghost", "b2"])
+    assert len(results) == 2
+    assert {r.belief_id for r in results} == {"b1", "b2"}
+
+
+def test_apply_negative_signal_increments_beta(store: MemoryStore) -> None:
+    sig = SentimentSignal(NEGATIVE, -BASE_VALENCE, 0.6, "no", "no")
+    apply_sentiment_to_pending(store, sig, ["b1"])
+    b = store.get_belief("b1")
+    assert b is not None
+    assert b.beta == 2.0
+
+
+def test_apply_escalated_negative_uses_doubled_magnitude(
+    store: MemoryStore,
+) -> None:
+    sig = SentimentSignal(NEGATIVE, -BASE_VALENCE, 0.6, "no", "no")
+    apply_sentiment_to_pending(store, sig, ["b1"], escalated=True)
+    b = store.get_belief("b1")
+    assert b is not None
+    # base beta 1.0 + ESCALATED_NEGATIVE_VALENCE
+    assert b.beta == 1.0 + ESCALATED_NEGATIVE_VALENCE
+
+
+def test_apply_escalated_does_not_affect_positive_signal(
+    store: MemoryStore,
+) -> None:
+    sig = SentimentSignal(POSITIVE, BASE_VALENCE, 0.6, "yes", "yes")
+    apply_sentiment_to_pending(store, sig, ["b1"], escalated=True)
+    b = store.get_belief("b1")
+    assert b is not None
+    assert b.alpha == 2.0  # base, NOT escalated
+
+
+def test_apply_empty_pending_returns_empty(store: MemoryStore) -> None:
+    sig = SentimentSignal(POSITIVE, BASE_VALENCE, 0.6, "yes", "yes")
+    results = apply_sentiment_to_pending(store, sig, [])
+    assert results == []
+
+
+# --- is_enabled: config + env --------------------------------------------
+
+
+def test_is_enabled_default_off(clean_env: None) -> None:
+    assert is_enabled() is False
+
+
+def test_is_enabled_off_when_config_false(clean_env: None) -> None:
+    cfg = {"feedback": {"sentiment_from_prose": False}}
+    assert is_enabled(cfg) is False
+
+
+def test_is_enabled_on_when_config_true(clean_env: None) -> None:
+    cfg = {"feedback": {"sentiment_from_prose": True}}
+    assert is_enabled(cfg) is True
+
+
+def test_is_enabled_env_truthy_wins(clean_env: None) -> None:
+    os.environ[ENV_SENTIMENT] = "1"
+    cfg = {"feedback": {"sentiment_from_prose": False}}
+    assert is_enabled(cfg) is True
+
+
+def test_is_enabled_env_falsy_wins(clean_env: None) -> None:
+    os.environ[ENV_SENTIMENT] = "0"
+    cfg = {"feedback": {"sentiment_from_prose": True}}
+    assert is_enabled(cfg) is False
+
+
+def test_is_enabled_env_unrecognized_falls_through_to_config(
+    clean_env: None,
+) -> None:
+    os.environ[ENV_SENTIMENT] = "maybe"
+    cfg = {"feedback": {"sentiment_from_prose": True}}
+    assert is_enabled(cfg) is True
+
+
+def test_is_enabled_missing_section(clean_env: None) -> None:
+    cfg = {"other_section": {"x": 1}}
+    assert is_enabled(cfg) is False
+
+
+def test_is_enabled_non_bool_value_treated_as_off(clean_env: None) -> None:
+    cfg = {"feedback": {"sentiment_from_prose": "yes"}}
+    assert is_enabled(cfg) is False


### PR DESCRIPTION
## Summary

Implements the v2.0 sentiment-from-prose feedback feature ratified in #193. Three atomic commits:

1. `feat(sentiment_feedback)`: pure-stateless module — 12 positive + 12 negative regex patterns, strong-amplifier subsets, 200-char length guard, `apply_sentiment_to_pending` that distributes a signal across the previous turn's retrieved beliefs via `apply_feedback(source='sentiment_inferred', propagate=False)`, `detect_correction_frequency` escalator (≥40% of recent N turns negative → fires), `is_enabled` config resolver. 40 unit tests.
2. `feat(cli)`: `aelf health` surfaces `sentiment-from-prose feedback: enabled (<N> matches) | disabled` — visibility surface required by the v2.0 ratification.
3. `docs(PRIVACY)`: new section documenting the opt-in inbound-prose-inspection surface.

## Spec contract honored

Per [`docs/v2_sentiment_feedback.md`](docs/v2_sentiment_feedback.md) and the 2026-04-29 ratification on #193:
- ✅ **Default off.** Opt-in via `[feedback] sentiment_from_prose = true` in `.aelfrice.toml`, or `AELFRICE_FEEDBACK_SENTIMENT_FROM_PROSE=1`.
- ✅ **24 patterns shipped verbatim** in spirit (regex set originally drafted in the research-line audit; reimplemented from the spec, not copied).
- ✅ **`detect_correction_frequency` ships together** with the base module.
- ✅ **Equal distribution** across previous-turn retrieved beliefs (no per-rank scaling — adds a knob without an evidence gate).
- ✅ **Audit-row source = `sentiment_inferred`** so explicit vs implicit feedback splits cleanly in `feedback_history` post-#224 origin-tag fix.

## Out of scope (deferred to follow-up PRs)

- **Hook wiring.** This PR ships the module + config + visibility + privacy doc. Calling `apply_sentiment_to_pending` from the UserPromptSubmit hook with the previous turn's retrieved beliefs is a small follow-up that needs to coordinate with the deferred_feedback_queue plumbing — best landed in isolation. Until then the feature can be exercised programmatically.
- **Bench-eval ship-decision.** `tests/bench_gate/test_sentiment.py` now imports the implemented module instead of skipping. The ship-or-`wontfix` decision is gated on the bench-gate run against the lab corpus (`AELFRICE_CORPUS_ROOT`); the gate floor is currently 0.5 accuracy as a placeholder. Tightening that floor + the actual ship-decision is operator-side per the v2.0 scope-cut plan.

## Verification

- [x] `uv run pytest tests/test_sentiment_feedback.py -q` — 40 passed
- [x] `uv run pytest -q` — **2270 passed, 22 skipped** (no regressions; was 2188 passing pre-PR; +40 unit tests + 42 unrelated drift across other PRs landed during the day)
- [x] `aelf health` smoke: prints `sentiment-from-prose feedback: disabled` by default, `enabled (0 matches)` with env var set
- [x] Discretion grep: CLEAN
- [x] Module surface is pure — no I/O, no DB write, no outbound — outside `apply_sentiment_to_pending` which goes through `apply_feedback`

Closes #193 (module + config + visibility); follow-up issue will track hook wiring once this lands.

## Summary by Sourcery

Introduce an opt-in sentiment-from-prose feedback module and surface its status in the CLI health output while documenting the new inbound prose inspection behavior.

New Features:
- Add a regex-based sentiment-from-prose detector module that classifies short user prompts and emits implicit feedback signals for prior retrieved beliefs.
- Expose a configuration resolver for enabling sentiment-from-prose feedback via config file or environment variable.
- Surface sentiment-from-prose feedback status and match count in the `aelf health` CLI command.

Enhancements:
- Wire the sentiment bench-gate test to the new sentiment_feedback classifier implementation instead of skipping when unimplemented.

Documentation:
- Document the optional inbound prose inspection feature, its configuration, data handling, and visibility in the privacy policy.

Tests:
- Add comprehensive unit tests for sentiment detection, correction-frequency escalation, feedback application, and configuration resolution for the new sentiment_from_prose module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional sentiment-from-prose feedback feature (default: disabled)
  * `aelf health` command now displays sentiment feedback status and match count when enabled

* **Documentation**
  * Added privacy documentation describing the sentiment feedback feature, data handling, and security behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->