### PR TITLE
feat(relationship_detector): semantic contradiction detector — audit-only ship (#201)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2137,6 +2137,8 @@ def _cmd_doctor(args: argparse.Namespace, out: object) -> int:
         return _cmd_doctor_replay(args, out)
     if getattr(args, "dedup", False):
         return _cmd_doctor_dedup(args, out)
+    if getattr(args, "relationships", False):
+        return _cmd_doctor_relationships(args, out)
     scope = getattr(args, "scope", None)
     exit_code = 0
     if scope in (None, "hooks"):
@@ -2222,6 +2224,69 @@ def _cmd_doctor_dedup(args: argparse.Namespace, out: object) -> int:
         store.close()
 
     print(format_audit_report(report), file=out)  # type: ignore[arg-type]
+    return 0
+
+
+def _cmd_doctor_relationships(args: argparse.Namespace, out: object) -> int:
+    """Run the v2.0 semantic-relationship audit (#201).
+
+    Walks the store, classifies near-pair relationships
+    (``contradicts`` / ``refines``) by modality + quantifier signal
+    divergence, and prints a report. Read-only: no edges are inserted,
+    no beliefs are mutated. The write-path ``CONTRADICTS`` hook + new
+    ``POTENTIALLY_STALE`` edge type is the bench-gated R2 deferred
+    behind the corpus benchmark.
+
+    Exit 0 on success regardless of pair count — pairs are diagnostic,
+    not failure conditions. Exit 1 only on store-open errors.
+    """
+    from aelfrice.relationship_detector import (
+        RelationshipDetectorConfig,
+        format_audit_report,
+        load_relationship_detector_config,
+        relationships_audit,
+    )
+
+    config = load_relationship_detector_config()
+    j_override = getattr(args, "relationships_jaccard", None)
+    c_override = getattr(args, "relationships_confidence", None)
+    mp_override = getattr(args, "relationships_max_pairs", None)
+    config = RelationshipDetectorConfig(
+        jaccard_min=(
+            float(j_override) if j_override is not None else config.jaccard_min
+        ),
+        residual_overlap_min=config.residual_overlap_min,
+        confidence_min=(
+            float(c_override)
+            if c_override is not None
+            else config.confidence_min
+        ),
+        max_candidate_pairs=(
+            int(mp_override)
+            if mp_override is not None
+            else config.max_candidate_pairs
+        ),
+    )
+
+    store = _open_store()
+    try:
+        report = relationships_audit(
+            store,
+            jaccard_min=config.jaccard_min,
+            residual_overlap_min=config.residual_overlap_min,
+            confidence_min=config.confidence_min,
+            max_candidate_pairs=config.max_candidate_pairs,
+        )
+    except ValueError as exc:
+        print(f"aelf doctor relationships: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        store.close()
+
+    print(
+        format_audit_report(report, confidence_min=config.confidence_min),
+        file=out,  # type: ignore[arg-type]
+    )
     return 0
 
 
@@ -3070,6 +3135,61 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
             "with --dedup: cap reported duplicate pairs after Jaccard "
             "prefilter; deterministic truncation by (id_a, id_b). "
             "Default: [dedup] max_candidate_pairs in .aelfrice.toml > 5000."
+        ),
+    )
+    p_doctor.add_argument(
+        "--relationships",
+        dest="relationships",
+        action="store_true",
+        default=False,
+        help=(
+            "classify near-pair belief relationships "
+            "(contradicts/refines) by modality + quantifier signals "
+            "(#201). Read-only: no edges are inserted. Bypasses the "
+            "hooks/graph checks. Tune via --relationships-jaccard / "
+            "--relationships-confidence / --relationships-max-pairs "
+            "or [relationship_detector] in .aelfrice.toml."
+        ),
+    )
+    p_doctor.add_argument(
+        "--relationships-jaccard",
+        dest="relationships_jaccard",
+        type=float,
+        default=None,
+        metavar="F",
+        help=(
+            "with --relationships: minimum Jaccard token overlap "
+            "(0.0-1.0) for the candidate-pair prefilter (shared with "
+            "dedup). Default: [relationship_detector] jaccard_min in "
+            ".aelfrice.toml > 0.4."
+        ),
+    )
+    p_doctor.add_argument(
+        "--relationships-confidence",
+        dest="relationships_confidence",
+        type=float,
+        default=None,
+        metavar="F",
+        help=(
+            "with --relationships: score floor at which a "
+            "`contradicts` verdict is reported as auto-emit eligible "
+            "(for the deferred write-path hook). Sub-confidence pairs "
+            "still surface in the audit. Default: "
+            "[relationship_detector] confidence_min in .aelfrice.toml "
+            "> 0.5."
+        ),
+    )
+    p_doctor.add_argument(
+        "--relationships-max-pairs",
+        dest="relationships_max_pairs",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "with --relationships: cap reported pairs after Jaccard "
+            "prefilter; deterministic truncation by (id_a, id_b). "
+            "Default: [relationship_detector] max_candidate_pairs in "
+            ".aelfrice.toml > 5000."
         ),
     )
     p_doctor.set_defaults(func=_cmd_doctor)

--- a/src/aelfrice/relationship_detector.py
+++ b/src/aelfrice/relationship_detector.py
@@ -1,0 +1,594 @@
+"""Semantic relationship detector (#201) — audit-only ship.
+
+Stdlib-only port of the research-line `relationship_detector.py`.
+For two beliefs that share enough lexical overlap to be plausibly
+about the same subject, classify the relationship by **modality**
+(negation) + **quantifier axis** (universal / frequent / occasional
+/ rare / negative) signal divergence.
+
+Output verdict is one of:
+
+* ``contradicts`` — agreeing residual content tokens (the
+  subject/predicate of the belief) but disagreeing modality. Either
+  one side negates and the other affirms, or both have quantifiers
+  whose axes are far apart (e.g. universal vs negative).
+* ``refines`` — agreeing residual content tokens *and* agreeing
+  modality. One belief sharpens or scopes the other.
+* ``unrelated`` — residual-content overlap below the relatedness
+  floor.
+
+This module is the **detector**. The audit-only CLI surface
+(``aelf doctor relationships``) lives in ``cli.py``; the write-path
+hook that would actually insert ``CONTRADICTS`` edges and the new
+``POTENTIALLY_STALE`` edge type for sub-confidence pairs are the
+bench-gated R2 deferred behind the corpus benchmark per the #201
+ratification. ``SUPERSEDES`` is intentionally not produced here —
+that verdict is the dedup module's job (``aelf doctor dedup``).
+
+Detection is regex / token-set heuristics — no LLM, no embedding.
+
+## Design notes
+
+* **Quantifier "missing" is not "neutral".** ``has_quantifier`` is
+  tracked separately from ``quantifier_axis``. Without this guard,
+  ``"use uv"`` (no quantifier) vs ``"always use uv"`` (axis = +1.0)
+  trips the contradiction gate at axis distance 1.0; the first
+  belief is silent on frequency, not asserting a neutral one.
+* **Negation contractions match against raw content, not tokens.**
+  The bm25 tokenizer splits ``don't`` into ``["don", "t"]`` so
+  contracted negations are unreachable from the cached frozenset. A
+  separate regex on the raw content bridges the gap; both ``'`` and
+  ``’`` and apostrophe-stripped forms (``dont``, ``cant``) match.
+* **Residual-content overlap (subject-extraction granularity).**
+  Agreement is measured on tokens after subtracting modality,
+  quantifier, and stopword tokens. Mitigates the spec's flagged
+  false-positive shape (``"use uv for python deps"`` vs
+  ``"never use pip in this project"`` overlap on ``use`` but not on
+  any substantive content; verdict stays ``unrelated``).
+"""
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Final, IO, cast
+
+from aelfrice.bm25 import tokenize
+from aelfrice.dedup import _jaccard_prefiltered_pairs, jaccard
+from aelfrice.store import MemoryStore
+
+CONFIG_FILENAME: Final[str] = ".aelfrice.toml"
+SECTION: Final[str] = "relationship_detector"
+JACCARD_KEY: Final[str] = "jaccard_min"
+CONFIDENCE_KEY: Final[str] = "confidence_min"
+MAX_CANDIDATE_PAIRS_KEY: Final[str] = "max_candidate_pairs"
+
+# --- Verdict labels ----------------------------------------------------
+
+LABEL_CONTRADICTS: Final[str] = "contradicts"
+LABEL_REFINES: Final[str] = "refines"
+LABEL_UNRELATED: Final[str] = "unrelated"
+
+VERDICT_LABELS: Final[frozenset[str]] = frozenset(
+    {LABEL_CONTRADICTS, LABEL_REFINES, LABEL_UNRELATED}
+)
+
+# --- Defaults (research-line + #201 ratification) ----------------------
+
+# Pair must share this much Jaccard token overlap to enter the
+# classifier. Same shape as dedup's prefilter so the unified-pass can
+# reuse the candidate pool.
+DEFAULT_JACCARD_MIN: Final[float] = 0.4
+# Minimum residual-content Jaccard for the pair to be considered
+# plausibly about the same subject. Below this, verdict is
+# ``unrelated`` regardless of modality signals.
+DEFAULT_RESIDUAL_OVERLAP_MIN: Final[float] = 0.4
+# Auto-flag ``contradicts`` only at score >= this floor. Audit
+# reports both sides; only the high-confidence half is eligible for
+# the deferred write-path hook.
+DEFAULT_CONFIDENCE_MIN: Final[float] = 0.5
+DEFAULT_MAX_CANDIDATE_PAIRS: Final[int] = 5000
+
+# --- Modality vocabulary -----------------------------------------------
+
+# Token-level negation markers (post-tokenize, post-stopword). We
+# also do a separate regex pass on the raw content for contractions.
+_NEGATION_TOKENS: Final[frozenset[str]] = frozenset({
+    "not", "no", "never", "none", "nothing", "nobody", "nowhere",
+    "neither", "nor", "without", "avoid", "refuse", "prohibit",
+    "prohibited", "disallow", "disallowed", "forbid", "forbidden",
+    "deny", "denied",
+})
+
+# Negation contractions: matched on the raw content. Every English
+# negation contraction ends in ``n't`` after a stem (``do``, ``wo``,
+# ``ca``, ``shouldn``, ``ai``, …), so an apostrophe-form pattern is
+# all we need. ``'`` and ``’`` both match. The apostrophe-stripped
+# form is enumerated separately to catch typos and naive transcripts.
+_CONTRACTION_NEGATION_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b\w+n['’]t\b|"
+    r"\b(?:dont|doesnt|didnt|isnt|arent|wasnt|werent|hasnt|havent|hadnt|"
+    r"shouldnt|wouldnt|couldnt|mustnt|mightnt|wont|cant|shant|aint)\b",
+    re.IGNORECASE,
+)
+
+# --- Quantifier axis ---------------------------------------------------
+#
+# The axis is a real-valued frequency claim. Two quantifiers conflict
+# when their axes are far apart (e.g. universal vs negative). A
+# missing quantifier is *not* a neutral 0.0 — see Signals.has_quantifier.
+
+QUANT_AXIS: Final[dict[str, float]] = {
+    # universal
+    "always": 1.0,
+    "every": 1.0,
+    "all": 1.0,
+    "must": 1.0,
+    # frequent
+    "usually": 0.6,
+    "often": 0.6,
+    "mostly": 0.6,
+    "frequently": 0.6,
+    # occasional
+    "sometimes": 0.0,
+    "occasionally": 0.0,
+    # rare
+    "rarely": -0.6,
+    "seldom": -0.6,
+    # negative
+    "never": -1.0,
+}
+
+_QUANTIFIER_TOKENS: Final[frozenset[str]] = frozenset(QUANT_AXIS)
+
+# --- Stopwords ---------------------------------------------------------
+#
+# Excluded from the residual-content overlap check. Modality and
+# quantifier tokens are ALSO subtracted so the residual is the
+# subject/predicate of the belief.
+_STOPWORDS: Final[frozenset[str]] = frozenset({
+    "a", "an", "the", "is", "are", "was", "were", "be", "been",
+    "being", "to", "of", "in", "on", "for", "with", "by", "and",
+    "or", "but", "if", "then", "than", "as", "at", "from", "this",
+    "that", "these", "those", "it", "its", "i", "you", "we", "they",
+    "he", "she", "him", "her", "them", "us", "me", "my", "your",
+    "our", "their", "his", "hers", "do", "does", "did", "have",
+    "has", "had", "will", "would", "should", "could", "can",
+    "into", "about", "over", "under", "out", "up", "down", "use",
+    "used", "using", "uses", "any", "some", "t", "s", "don", "won",
+    "doesn", "didn", "isn", "aren", "wasn", "weren", "shouldn",
+    "wouldn", "couldn", "hasn", "haven", "hadn", "cant", "wont",
+    "dont", "isnt",
+} | _NEGATION_TOKENS | _QUANTIFIER_TOKENS)
+
+
+# --- Signal extraction -------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Signals:
+    """Modality + quantifier signals extracted from one belief."""
+    tokens: tuple[str, ...]
+    residual_content: frozenset[str]
+    has_negation: bool
+    has_quantifier: bool
+    quantifier_axis: float
+
+
+def _has_contraction_negation(text: str) -> bool:
+    """Detect negation contractions on the raw content.
+
+    The bm25 tokenizer drops apostrophes, so ``don't`` becomes
+    ``("don", "t")`` and is unreachable from the cached token set.
+    """
+    return bool(_CONTRACTION_NEGATION_RE.search(text))
+
+
+def extract_signals(text: str) -> Signals:
+    """Tokenise + classify modality and quantifier signals."""
+    toks = tokenize(text)
+    tok_set = set(toks)
+    has_negation = bool(tok_set & _NEGATION_TOKENS) or _has_contraction_negation(text)
+    quantifier_token: str | None = None
+    for t in toks:
+        if t in QUANT_AXIS:
+            quantifier_token = t
+            break
+    has_quantifier = quantifier_token is not None
+    quantifier_axis = QUANT_AXIS[quantifier_token] if quantifier_token else 0.0
+    residual = frozenset(t for t in tok_set if t not in _STOPWORDS)
+    return Signals(
+        tokens=tuple(toks),
+        residual_content=residual,
+        has_negation=has_negation,
+        has_quantifier=has_quantifier,
+        quantifier_axis=quantifier_axis,
+    )
+
+
+# --- Verdict classifier ------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RelationshipVerdict:
+    """Verdict + score for one belief pair."""
+    label: str
+    score: float
+    residual_overlap: float
+    rationale: str
+
+
+def _residual_jaccard(a: frozenset[str], b: frozenset[str]) -> float:
+    if not a and not b:
+        return 0.0
+    union = a | b
+    if not union:
+        return 0.0
+    return len(a & b) / len(union)
+
+
+def analyze(
+    text_a: str,
+    text_b: str,
+    *,
+    residual_overlap_min: float = DEFAULT_RESIDUAL_OVERLAP_MIN,
+) -> RelationshipVerdict:
+    """Classify the relationship between two belief texts.
+
+    Pure function over the two strings. Read by the audit pass and by
+    the bench gate at ``relationship_detector.classify``.
+    """
+    sa = extract_signals(text_a)
+    sb = extract_signals(text_b)
+    overlap = _residual_jaccard(sa.residual_content, sb.residual_content)
+    if overlap < residual_overlap_min:
+        return RelationshipVerdict(
+            label=LABEL_UNRELATED,
+            score=0.0,
+            residual_overlap=overlap,
+            rationale="residual_overlap_below_floor",
+        )
+
+    n_term = 1.0 if sa.has_negation != sb.has_negation else 0.0
+    if sa.has_quantifier and sb.has_quantifier:
+        # Axis distance / 2 lands in [0.0, 1.0].
+        q_term = abs(sa.quantifier_axis - sb.quantifier_axis) / 2.0
+    else:
+        # Missing quantifier is silent, not neutral.
+        q_term = 0.0
+    score = (n_term + q_term) / 2.0
+    if score > 0.0:
+        rationale = (
+            "negation_and_quantifier_disagree"
+            if n_term and q_term
+            else "negation_disagrees"
+            if n_term
+            else "quantifier_axes_disagree"
+        )
+        return RelationshipVerdict(
+            label=LABEL_CONTRADICTS,
+            score=round(score, 3),
+            residual_overlap=overlap,
+            rationale=rationale,
+        )
+    return RelationshipVerdict(
+        label=LABEL_REFINES,
+        score=0.0,
+        residual_overlap=overlap,
+        rationale="modality_agrees",
+    )
+
+
+def classify(text_a: str, text_b: str) -> str:
+    """Bench-gate entry point: return the verdict label only."""
+    return analyze(text_a, text_b).label
+
+
+# --- Audit report types ------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RelationshipPair:
+    """Pair-level result emitted by the audit."""
+    belief_a_id: str
+    belief_b_id: str
+    label: str
+    score: float
+    residual_overlap: float
+    rationale: str
+
+
+@dataclass
+class RelationshipsAuditReport:
+    """Summary of one audit pass over the store."""
+    n_beliefs_scanned: int
+    n_candidate_pairs: int
+    n_contradicts_high: int
+    n_contradicts_low: int
+    n_refines: int
+    truncated: bool
+    pairs: tuple[RelationshipPair, ...] = field(default_factory=tuple)
+
+
+# --- Top-level audit entry point ---------------------------------------
+
+
+def relationships_audit(
+    store: MemoryStore,
+    *,
+    jaccard_min: float = DEFAULT_JACCARD_MIN,
+    residual_overlap_min: float = DEFAULT_RESIDUAL_OVERLAP_MIN,
+    confidence_min: float = DEFAULT_CONFIDENCE_MIN,
+    max_candidate_pairs: int = DEFAULT_MAX_CANDIDATE_PAIRS,
+) -> RelationshipsAuditReport:
+    """Walk the store, classify near-pair relationships, return a report.
+
+    Read-only: no edges are inserted, no beliefs are mutated. Reuses
+    dedup's Jaccard prefilter (``_jaccard_prefiltered_pairs``) for
+    candidate-pair generation — the unified-pass shape from the
+    ratification comment is achieved by sharing the prefilter, not
+    by sharing the full classifier.
+
+    ``unrelated`` verdicts are dropped from the pair list.
+
+    Raises ``ValueError`` on malformed thresholds.
+    """
+    for name, val in (
+        ("jaccard_min", jaccard_min),
+        ("residual_overlap_min", residual_overlap_min),
+        ("confidence_min", confidence_min),
+    ):
+        if not 0.0 <= val <= 1.0:
+            raise ValueError(f"{name} must be in [0.0, 1.0], got {val}")
+    if max_candidate_pairs < 1:
+        raise ValueError(
+            f"max_candidate_pairs must be >= 1, got {max_candidate_pairs}",
+        )
+
+    beliefs = store.list_beliefs_for_indexing()
+    n_beliefs = len(beliefs)
+    if n_beliefs < 2:
+        return RelationshipsAuditReport(
+            n_beliefs_scanned=n_beliefs,
+            n_candidate_pairs=0,
+            n_contradicts_high=0,
+            n_contradicts_low=0,
+            n_refines=0,
+            truncated=False,
+        )
+
+    candidates, raw_count, truncated = _jaccard_prefiltered_pairs(
+        beliefs,
+        jaccard_min=jaccard_min,
+        max_pairs=max_candidate_pairs,
+    )
+
+    pairs: list[RelationshipPair] = []
+    for id_a, content_a, id_b, content_b, _ta, _tb, _j in candidates:
+        verdict = analyze(
+            content_a,
+            content_b,
+            residual_overlap_min=residual_overlap_min,
+        )
+        if verdict.label == LABEL_UNRELATED:
+            continue
+        pairs.append(
+            RelationshipPair(
+                belief_a_id=id_a,
+                belief_b_id=id_b,
+                label=verdict.label,
+                score=verdict.score,
+                residual_overlap=verdict.residual_overlap,
+                rationale=verdict.rationale,
+            )
+        )
+
+    pairs.sort(key=lambda p: (p.belief_a_id, p.belief_b_id))
+
+    n_contra_hi = sum(
+        1 for p in pairs
+        if p.label == LABEL_CONTRADICTS and p.score >= confidence_min
+    )
+    n_contra_lo = sum(
+        1 for p in pairs
+        if p.label == LABEL_CONTRADICTS and p.score < confidence_min
+    )
+    n_ref = sum(1 for p in pairs if p.label == LABEL_REFINES)
+
+    return RelationshipsAuditReport(
+        n_beliefs_scanned=n_beliefs,
+        n_candidate_pairs=raw_count,
+        n_contradicts_high=n_contra_hi,
+        n_contradicts_low=n_contra_lo,
+        n_refines=n_ref,
+        truncated=truncated,
+        pairs=tuple(pairs),
+    )
+
+
+# --- Config loader -----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RelationshipDetectorConfig:
+    """Resolved ``[relationship_detector]`` section of `.aelfrice.toml`."""
+    jaccard_min: float = DEFAULT_JACCARD_MIN
+    residual_overlap_min: float = DEFAULT_RESIDUAL_OVERLAP_MIN
+    confidence_min: float = DEFAULT_CONFIDENCE_MIN
+    max_candidate_pairs: int = DEFAULT_MAX_CANDIDATE_PAIRS
+
+
+def _load_unit_float(
+    section: dict[str, Any],
+    key: str,
+    default: float,
+    candidate: Path,
+    serr: IO[str],
+) -> float:
+    obj: Any = section.get(key, default)
+    if isinstance(obj, bool) or not isinstance(obj, (int, float)):
+        print(
+            f"aelfrice relationship_detector: ignoring [{SECTION}] {key} in "
+            f"{candidate} (expected float in [0.0, 1.0])",
+            file=serr,
+        )
+        return default
+    val = float(obj)
+    if not 0.0 <= val <= 1.0:
+        print(
+            f"aelfrice relationship_detector: ignoring [{SECTION}] {key} in "
+            f"{candidate} (expected float in [0.0, 1.0])",
+            file=serr,
+        )
+        return default
+    return val
+
+
+def load_relationship_detector_config(
+    start: Path | None = None,
+) -> RelationshipDetectorConfig:
+    """Walk up from `start` looking for `.aelfrice.toml`.
+
+    Missing file / missing section / malformed TOML / wrong-typed
+    values all degrade to defaults with a stderr trace; never raises.
+    """
+    serr: IO[str] = sys.stderr
+    current = (start if start is not None else Path.cwd()).resolve()
+    seen: set[Path] = set()
+    while current not in seen:
+        seen.add(current)
+        candidate = current / CONFIG_FILENAME
+        if candidate.is_file():
+            try:
+                raw = candidate.read_bytes()
+            except OSError as exc:
+                print(
+                    f"aelfrice relationship_detector: cannot read {candidate}: "
+                    f"{exc}",
+                    file=serr,
+                )
+                return RelationshipDetectorConfig()
+            try:
+                parsed: dict[str, Any] = tomllib.loads(
+                    raw.decode("utf-8", errors="replace"),
+                )
+            except tomllib.TOMLDecodeError as exc:
+                print(
+                    f"aelfrice relationship_detector: malformed TOML in "
+                    f"{candidate}: {exc}",
+                    file=serr,
+                )
+                return RelationshipDetectorConfig()
+            section_obj: Any = parsed.get(SECTION, {})
+            if not isinstance(section_obj, dict):
+                return RelationshipDetectorConfig()
+            section = cast(dict[str, Any], section_obj)
+            jm = _load_unit_float(
+                section, JACCARD_KEY, DEFAULT_JACCARD_MIN,
+                candidate, serr,
+            )
+            cm = _load_unit_float(
+                section, CONFIDENCE_KEY, DEFAULT_CONFIDENCE_MIN,
+                candidate, serr,
+            )
+            mp_obj: Any = section.get(
+                MAX_CANDIDATE_PAIRS_KEY, DEFAULT_MAX_CANDIDATE_PAIRS,
+            )
+            if (
+                isinstance(mp_obj, bool)
+                or not isinstance(mp_obj, int)
+                or mp_obj < 1
+            ):
+                print(
+                    f"aelfrice relationship_detector: ignoring [{SECTION}] "
+                    f"{MAX_CANDIDATE_PAIRS_KEY} in {candidate} "
+                    f"(expected positive int)",
+                    file=serr,
+                )
+                mp_resolved = DEFAULT_MAX_CANDIDATE_PAIRS
+            else:
+                mp_resolved = mp_obj
+            return RelationshipDetectorConfig(
+                jaccard_min=jm,
+                confidence_min=cm,
+                max_candidate_pairs=mp_resolved,
+            )
+        if current.parent == current:
+            break
+        current = current.parent
+    return RelationshipDetectorConfig()
+
+
+# --- Report formatter --------------------------------------------------
+
+
+def format_audit_report(
+    report: RelationshipsAuditReport,
+    *,
+    confidence_min: float = DEFAULT_CONFIDENCE_MIN,
+    max_pairs_displayed: int = 25,
+) -> str:
+    """Render a `RelationshipsAuditReport` as a plain-text block."""
+    lines: list[str] = []
+    lines.append("aelf doctor relationships")
+    lines.append("=" * 40)
+    lines.append(f"Beliefs scanned         : {report.n_beliefs_scanned}")
+    lines.append(f"Candidate pairs visited : {report.n_candidate_pairs}")
+    if report.truncated:
+        lines.append(
+            f"  (pair list truncated at {DEFAULT_MAX_CANDIDATE_PAIRS} — "
+            f"see [relationship_detector] max_candidate_pairs)"
+        )
+    lines.append(
+        f"Contradicts (auto-emit eligible, score >= {confidence_min:.2f}) : "
+        f"{report.n_contradicts_high}"
+    )
+    lines.append(
+        f"Contradicts (audit-only, sub-confidence)                    : "
+        f"{report.n_contradicts_low}"
+    )
+    lines.append(
+        f"Refines (modality agrees, partial overlap)                  : "
+        f"{report.n_refines}"
+    )
+    lines.append("")
+    if not report.pairs:
+        lines.append("No related belief pairs above the configured floor.")
+        return "\n".join(lines)
+    lines.append("Top pairs (label, score, residual overlap):")
+    for p in report.pairs[:max_pairs_displayed]:
+        lines.append(
+            f"  {p.belief_a_id}  ~  {p.belief_b_id}  "
+            f"[{p.label}]  s={p.score:.3f}  o={p.residual_overlap:.3f}  "
+            f"({p.rationale})"
+        )
+    if len(report.pairs) > max_pairs_displayed:
+        lines.append(
+            f"  ... ({len(report.pairs) - max_pairs_displayed} more)"
+        )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "DEFAULT_CONFIDENCE_MIN",
+    "DEFAULT_JACCARD_MIN",
+    "DEFAULT_MAX_CANDIDATE_PAIRS",
+    "DEFAULT_RESIDUAL_OVERLAP_MIN",
+    "LABEL_CONTRADICTS",
+    "LABEL_REFINES",
+    "LABEL_UNRELATED",
+    "VERDICT_LABELS",
+    "RelationshipDetectorConfig",
+    "RelationshipPair",
+    "RelationshipVerdict",
+    "RelationshipsAuditReport",
+    "Signals",
+    "analyze",
+    "classify",
+    "extract_signals",
+    "format_audit_report",
+    "load_relationship_detector_config",
+    "relationships_audit",
+]

--- a/tests/test_relationship_detector.py
+++ b/tests/test_relationship_detector.py
@@ -1,0 +1,230 @@
+"""Unit tests for `aelfrice.relationship_detector` (#201).
+
+17 tests covering signal extraction, the verdict classifier, the
+audit pass against a real `MemoryStore` fixture, and the
+`.aelfrice.toml` config loader. The audit is read-only — every
+audit-level test asserts that no edges and no beliefs were
+inserted/mutated by the audit pass.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
+from aelfrice.relationship_detector import (
+    DEFAULT_CONFIDENCE_MIN,
+    DEFAULT_JACCARD_MIN,
+    LABEL_CONTRADICTS,
+    LABEL_REFINES,
+    LABEL_UNRELATED,
+    RelationshipDetectorConfig,
+    analyze,
+    classify,
+    extract_signals,
+    format_audit_report,
+    load_relationship_detector_config,
+    relationships_audit,
+)
+from aelfrice.store import MemoryStore
+
+
+# --- Signal extraction (3 tests) ---------------------------------------
+
+
+def test_signals_negation_word_and_contraction() -> None:
+    assert extract_signals("never push to main").has_negation is True
+    assert extract_signals("don't push to main").has_negation is True
+    assert extract_signals("won’t push directly").has_negation is True
+    assert extract_signals("just push to main").has_negation is False
+
+
+def test_signals_quantifier_axis_and_presence() -> None:
+    s_always = extract_signals("always commit signed")
+    assert s_always.has_quantifier is True
+    assert s_always.quantifier_axis == 1.0
+    s_never = extract_signals("never commit secrets")
+    assert s_never.has_quantifier is True
+    assert s_never.quantifier_axis == -1.0
+    s_silent = extract_signals("commit signed")
+    assert s_silent.has_quantifier is False
+    # Missing quantifier is silent, not neutral; axis defaults to 0.0
+    # but consumers must consult has_quantifier first.
+    assert s_silent.quantifier_axis == 0.0
+
+
+def test_signals_residual_strips_modality_quantifier_stopwords() -> None:
+    s = extract_signals("never always use the cat on mat")
+    # "never", "always", "use", "the", "on" all subtracted; "cat",
+    # "mat" remain.
+    assert "cat" in s.residual_content
+    assert "mat" in s.residual_content
+    assert "never" not in s.residual_content
+    assert "always" not in s.residual_content
+    assert "use" not in s.residual_content
+
+
+# --- Verdict classifier (7 tests) --------------------------------------
+
+
+def test_unrelated_when_residual_overlap_below_floor() -> None:
+    v = analyze("the sky is blue", "water is wet")
+    assert v.label == LABEL_UNRELATED
+    assert v.score == 0.0
+
+
+def test_negation_disagreement_is_contradicts() -> None:
+    v = analyze("cats are mammals", "cats are not mammals")
+    assert v.label == LABEL_CONTRADICTS
+    assert v.score > 0.0
+    assert "negation" in v.rationale
+
+
+def test_quantifier_axis_disagreement_is_contradicts() -> None:
+    v = analyze("python is always fast", "python is rarely fast")
+    assert v.label == LABEL_CONTRADICTS
+    assert v.score > 0.0
+
+
+def test_missing_quantifier_does_not_contradict_universal() -> None:
+    # Spec design note: "use uv" (silent) vs "always use uv" (axis=+1)
+    # must NOT trigger contradicts. has_quantifier guards this.
+    v = analyze("python is fast", "python is always fast")
+    assert v.label == LABEL_REFINES
+    assert v.score == 0.0
+
+
+def test_subject_mismatch_guard_via_residual_overlap() -> None:
+    # Spec example: "use uv for python deps" + "never use pip in this
+    # project" overlap on "use" only (which is a stopword), residual
+    # disjoint — verdict is unrelated.
+    v = analyze(
+        "use uv for python deps",
+        "never use pip in this project",
+    )
+    assert v.label == LABEL_UNRELATED
+
+
+def test_modality_agreement_is_refines() -> None:
+    # Residual {python, deps, fast} ∩ {python, deps, slow} / union
+    # clears the 0.4 relatedness floor; modality silent on both
+    # sides; verdict refines.
+    v = analyze("python deps are fast", "python deps are slow")
+    assert v.label == LABEL_REFINES
+
+
+def test_classify_sugar_returns_label_string() -> None:
+    # Bench-gate API: classify(a, b) -> str ∈ VERDICT_LABELS.
+    assert classify("cats are mammals", "cats are not mammals") == LABEL_CONTRADICTS
+    assert classify("the sky is blue", "water is wet") == LABEL_UNRELATED
+
+
+# --- Audit pass against a real store (5 tests) -------------------------
+
+
+def _insert(store: MemoryStore, bid: str, content: str) -> None:
+    store.insert_belief(
+        Belief(
+            id=bid,
+            content=content,
+            content_hash=f"h_{bid}",
+            alpha=1.0,
+            beta=1.0,
+            type=BELIEF_FACTUAL,
+            lock_level=LOCK_NONE,
+            locked_at=None,
+            demotion_pressure=0,
+            created_at="2026-05-03T00:00:00Z",
+            last_retrieved_at=None,
+        )
+    )
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    return MemoryStore(":memory:")
+
+
+def test_audit_empty_store(store: MemoryStore) -> None:
+    report = relationships_audit(store)
+    assert report.n_beliefs_scanned == 0
+    assert report.pairs == ()
+
+
+def test_audit_finds_contradicts_pair(store: MemoryStore) -> None:
+    _insert(store, "b1", "always use uv for python deps")
+    _insert(store, "b2", "never use uv for python deps")
+    _insert(store, "b3", "the cat sat on the mat")
+    report = relationships_audit(store)
+    contra = [p for p in report.pairs if p.label == LABEL_CONTRADICTS]
+    assert len(contra) == 1
+    assert contra[0].belief_a_id == "b1"
+    assert contra[0].belief_b_id == "b2"
+
+
+def test_audit_is_read_only(store: MemoryStore) -> None:
+    _insert(store, "b1", "always use uv for python deps")
+    _insert(store, "b2", "never use uv for python deps")
+    before = store.list_beliefs_for_indexing()
+    relationships_audit(store)
+    after = store.list_beliefs_for_indexing()
+    assert before == after
+    cur = store._conn.execute("SELECT COUNT(*) FROM edges")  # type: ignore[attr-defined]
+    assert cur.fetchone()[0] == 0
+
+
+def test_audit_truncates_at_max_candidate_pairs(store: MemoryStore) -> None:
+    for i in range(5):
+        _insert(store, f"b{i}", "deploy via terraform on aws cluster")
+    report = relationships_audit(store, max_candidate_pairs=3)
+    assert report.truncated is True
+
+
+def test_audit_invalid_threshold_raises(store: MemoryStore) -> None:
+    with pytest.raises(ValueError):
+        relationships_audit(store, jaccard_min=1.5)
+    with pytest.raises(ValueError):
+        relationships_audit(store, max_candidate_pairs=0)
+
+
+# --- Report formatter + config loader (2 tests) ------------------------
+
+
+def test_format_audit_report_renders_pair_lines(store: MemoryStore) -> None:
+    _insert(store, "b1", "always use uv for python deps")
+    _insert(store, "b2", "never use uv for python deps")
+    report = relationships_audit(store)
+    text = format_audit_report(report)
+    assert "aelf doctor relationships" in text
+    assert LABEL_CONTRADICTS in text
+    assert "b1" in text and "b2" in text
+
+
+def test_config_loader_overrides_and_falls_back(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    # No config -> defaults.
+    cfg = load_relationship_detector_config(start=tmp_path)
+    assert cfg.jaccard_min == DEFAULT_JACCARD_MIN
+    assert cfg.confidence_min == DEFAULT_CONFIDENCE_MIN
+    # Valid overrides load.
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[relationship_detector]\n"
+        "jaccard_min = 0.55\n"
+        "confidence_min = 0.7\n"
+        "max_candidate_pairs = 100\n"
+    )
+    cfg = load_relationship_detector_config(start=tmp_path)
+    assert cfg.jaccard_min == 0.55
+    assert cfg.confidence_min == 0.7
+    assert cfg.max_candidate_pairs == 100
+    # Malformed values fall back with stderr trace.
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[relationship_detector]\n"
+        "jaccard_min = 1.5\n"
+        "max_candidate_pairs = 0\n"
+    )
+    cfg = load_relationship_detector_config(start=tmp_path)
+    assert cfg == RelationshipDetectorConfig()
+    assert "ignoring" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Audit slice (R1) of the semantic relationship detector ratified in `docs/v2_relationship_detector.md`. Closes the half of #201 that can ship before the corpus benchmark; the write-path hook + `POTENTIALLY_STALE` edge type are the bench-gated R2 follow-up.

## What lands

- `src/aelfrice/relationship_detector.py` — stdlib-only detector. Classifies near-paraphrase belief pairs into `contradicts`, `refines`, or `unrelated` by modality + quantifier signal divergence. Shares dedup's Jaccard-prefiltered candidate-pair pool (one prefilter pass feeds both modules — the unified-pass shape from the ratification comment).
- `aelf doctor --relationships` CLI surface, mirroring `--dedup`. Tunable via `--relationships-jaccard / --relationships-confidence / --relationships-max-pairs` or the `[relationship_detector]` section of `.aelfrice.toml`.
- 17 tests covering verdict logic on hand-crafted pairs, an end-to-end pass through a `MemoryStore(":memory:")`, and the config loader.

## Read-only

No edges inserted, no beliefs mutated. The write-path CONTRADICTS hook + new POTENTIALLY_STALE edge type is the R2 deferred behind the bench gate paired with #197.

## Design notes worth flagging in review

- **Quantifier "missing" ≠ "neutral".** `has_quantifier` is tracked separately from `quantifier_axis`. Without this, `"use uv"` (no quantifier) vs `"always use uv"` (axis = +1.0) tripped the contradiction gate at axis distance 1.0, which is wrong — the first belief is silent on frequency, not asserting a neutral one.
- **Negation contractions caught off the raw content, not the token set.** The bm25 tokenizer splits `don't` into `["don", "t"]` so contracted negations are unreachable from the cached frozenset. A separate regex on the raw content bridges this. Both `'` and `’` and apostrophe-stripped forms (`dont`, `cant`) match.
- **Residual-content overlap (subject-extraction granularity).** Agreement requires high overlap on tokens after subtracting modality/quantifier/stopword tokens. Mitigates the spec's flagged false-positive shape (`"use uv for python deps"` vs `"never use pip in this project"` overlap on `use` but not on substantive content; verdict stays `unrelated`).

## Verified against the live store

`uv run aelf doctor --relationships` on the local store: **6391 beliefs scanned, 34 auto-emit-eligible contradicts, 1657 refines, 0 sub-confidence contradicts**. The pair list reflects real signal — most refines pairs are paraphrase-shaped beliefs sharing residual content with no modality divergence; the 34 auto-emit pool is what would be eligible for write-path emission once the bench gate clears.

## Test plan

- [x] `uv run pytest tests/test_relationship_detector.py` — 17 / 17.
- [x] `uv run pytest tests/test_dedup.py` — passes (no regression on shared candidate-pair generator).
- [x] `uv run pytest --ignore=tests/bench_gate --ignore=tests/e2e` — 2238 / 2238 passed, 15 skipped.
- [x] `uv run aelf doctor --relationships --help` — flags render correctly under `aelf doctor`.

## Out of scope (R2, bench-gated)

- Write-path hook on `ingest_turn` / `apply_feedback` after the dedup R2 corpus benchmark clears.
- New `POTENTIALLY_STALE` edge type schema add for sub-threshold contradicts.
- LIMITATIONS.md § Sharp edges line 36 rewrite — that's a write-path-shipped statement, not an audit-only statement, so it stays accurate until R2.

Closes part of #201.

## Summary by Sourcery

Add an audit-only semantic relationship detector for beliefs and expose it via the `aelf doctor --relationships` CLI command.

New Features:
- Introduce a semantic relationship detector that classifies belief pairs as contradicts, refines, or unrelated based on modality and quantifier signals.
- Add an `aelf doctor --relationships` CLI mode with configurable thresholds and limits for relationship detection, including Jaccard overlap, confidence, and max pairs.
- Provide configurable defaults for relationship detection via a `[relationship_detector]` section in `.aelfrice.toml`.

Enhancements:
- Share the deduplication Jaccard prefilter candidate-pair pool with the new relationship detector to reuse indexing work.
- Add plain-text reporting for relationship audits summarizing scan counts, verdict breakdowns, and top pairs.

Tests:
- Add unit tests for signal extraction, verdict classification, audit behavior against an in-memory store, report formatting, and config loading for the relationship detector.