### PR TITLE
feat: lock-management surface — unlock + promote (#391)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -18,7 +18,9 @@ DB resolves from `$AELFRICE_DB`, then `<git-common-dir>/aelfrice/memory.db` when
 | `search <query> [--budget N]` | L0 locked + L2.5 entity-index (v1.3+) + L1 FTS5 BM25, token-budgeted (default 2,400 at v1.3+, 2,000 prior). L2.5 default-on; disable via `[retrieval] entity_index_enabled = false` in `.aelfrice.toml` or `AELFRICE_ENTITY_INDEX=0` in the env. Distinguishes "store empty" from "no match". |
 | `lock <statement>` | Insert at `(α, β) = (9.0, 0.5)` with `lock_level=user`. Idempotent — re-lock upgrades existing. |
 | `locked [--pressured]` | List locks. With `--pressured`, only those with `demotion_pressure > 0`. |
-| `demote <belief_id>` | Drop a user lock. Belief itself remains. |
+| `unlock <belief_id>` | Drop a user-lock without changing origin. Idempotent. Writes a `lock:unlock` audit row. |
+| `demote <belief_id>` | Drop a user lock (one tier per call: lock first, then user_validated). Delegates to `unlock` for the lock-drop path so an audit row is always written. |
+| `promote <belief_id> [--source user_validated]` | Promote an `agent_inferred` belief to `user_validated`. Alias of `validate`; identical semantics and flags. |
 | `validate <belief_id> [--source user_validated]` | Promote an `agent_inferred` belief to a user-validated origin (v1.2+). |
 | `feedback <belief_id> <used\|harmful> [--source S]` | `used` ⇒ α += 1; `harmful` ⇒ β += 1. Harmful feedback through outbound `CONTRADICTS` threads to user-locks bumps their demotion_pressure; ≥5 ⇒ auto-demote. |
 | `resolve` | Sweep unresolved `CONTRADICTS` threads. Picks a winner per precedence (`user_stated > user_corrected > document_recent`) and inserts a `SUPERSEDES` thread. Idempotent. |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -36,13 +36,13 @@ Tools register under the `aelf:` namespace.
 | `aelf:locked` | — | `pressured` | `{kind, n, locked[]}` |
 | `aelf:demote` | `belief_id` | — | `{kind, id, demoted}` |
 | `aelf:unlock` | `belief_id` | — | `{kind, id, unlocked, audit_event_id?}` |
-| `aelf:validate` | `belief_id` | `source` (default `user_validated`) | `{kind, id, prior_origin, new_origin, audit_event_id?}` |
-| `aelf:promote` | `belief_id` | `source` (default `user_validated`) | `{kind, id, prior_origin, new_origin, audit_event_id?}` |
+| `aelf:validate` | `belief_id` | `source` (default `user_validated`) | `{kind, id, prior_origin, new_origin, audit_event_id?}` on success; `{kind: "validate.error", id, error}` on invalid request |
+| `aelf:promote` | `belief_id` | `source` (default `user_validated`) | same union as `aelf:validate` |
 | `aelf:feedback` | `belief_id`, `signal` | `source` | `{kind, id, signal, prior_alpha, new_alpha, prior_beta, new_beta, pressured_locks, demoted_locks}` |
 | `aelf:stats` | — | — | `{kind, beliefs, threads, locked, feedback_events, ...}` |
 | `aelf:health` | — | — | `{kind, regime, description, classification_confidence?, features?}` |
 
-`signal` is `"used"` or `"harmful"`. `aelf:unlock` drops a user-lock without touching origin and always writes a `lock:unlock` audit row; idempotent on already-unlocked beliefs. `aelf:promote` is a first-class alias of `aelf:validate` — identical semantics and return shape. Both `aelf:validate` and `aelf:promote` promote an `agent_inferred` belief to a user-validated origin tier (v1.2+).
+`signal` is `"used"` or `"harmful"`. `aelf:unlock` drops a user-lock without touching origin and writes a `lock:unlock` audit row when a lock is actually removed; idempotent on already-unlocked beliefs (no row written). `aelf:promote` is a first-class alias of `aelf:validate` — identical semantics and return shape. Both `aelf:validate` and `aelf:promote` promote an `agent_inferred` belief to a user-validated origin tier (v1.2+).
 
 ## `aelf:onboard` polymorphism
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,6 +1,6 @@
 # MCP
 
-aelfrice exposes nine memory tools through a [Model Context Protocol](https://modelcontextprotocol.io) server. The agent calls them mid-turn; you don't have to invoke them yourself.
+aelfrice exposes eleven memory tools through a [Model Context Protocol](https://modelcontextprotocol.io) server. The agent calls them mid-turn; you don't have to invoke them yourself.
 
 Lifecycle commands (`setup`, `unsetup`, `migrate`, `doctor`, `upgrade`, `uninstall`) are CLI-only.
 
@@ -35,12 +35,14 @@ Tools register under the `aelf:` namespace.
 | `aelf:lock` | `statement` | — | `{kind, id, action}` |
 | `aelf:locked` | — | `pressured` | `{kind, n, locked[]}` |
 | `aelf:demote` | `belief_id` | — | `{kind, id, demoted}` |
-| `aelf:validate` | `belief_id` | `source` (default `user_validated`) | `{kind, id, origin, source}` |
+| `aelf:unlock` | `belief_id` | — | `{kind, id, unlocked, audit_event_id?}` |
+| `aelf:validate` | `belief_id` | `source` (default `user_validated`) | `{kind, id, prior_origin, new_origin, audit_event_id?}` |
+| `aelf:promote` | `belief_id` | `source` (default `user_validated`) | `{kind, id, prior_origin, new_origin, audit_event_id?}` |
 | `aelf:feedback` | `belief_id`, `signal` | `source` | `{kind, id, signal, prior_alpha, new_alpha, prior_beta, new_beta, pressured_locks, demoted_locks}` |
 | `aelf:stats` | — | — | `{kind, beliefs, threads, locked, feedback_events, ...}` |
 | `aelf:health` | — | — | `{kind, regime, description, classification_confidence?, features?}` |
 
-`signal` is `"used"` or `"harmful"`. Validation promotes an `agent_inferred` belief to a user-validated origin tier (v1.2+).
+`signal` is `"used"` or `"harmful"`. `aelf:unlock` drops a user-lock without touching origin and always writes a `lock:unlock` audit row; idempotent on already-unlocked beliefs. `aelf:promote` is a first-class alias of `aelf:validate` — identical semantics and return shape. Both `aelf:validate` and `aelf:promote` promote an `agent_inferred` belief to a user-validated origin tier (v1.2+).
 
 ## `aelf:onboard` polymorphism
 

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -859,10 +859,8 @@ def _cmd_demote(args: argparse.Namespace, out: object) -> int:
             return 1
         # One tier per call: lock first, then user_validated.
         if belief.lock_level == LOCK_USER:
-            belief.lock_level = LOCK_NONE
-            belief.locked_at = None
-            belief.demotion_pressure = 0
-            store.update_belief(belief)
+            from aelfrice.promotion import unlock
+            unlock(store, args.belief_id)
             print(f"demoted: {args.belief_id}", file=out)  # type: ignore[arg-type]
             return 0
         if belief.origin == ORIGIN_USER_VALIDATED:

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -903,6 +903,31 @@ def _cmd_validate(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _cmd_unlock(args: argparse.Namespace, out: object) -> int:
+    """Drop a user-lock without touching origin. Inverse of `aelf lock`."""
+    from aelfrice.promotion import unlock
+
+    store = _open_store()
+    try:
+        try:
+            result = unlock(store, args.belief_id)
+        except ValueError as e:
+            print(str(e), file=sys.stderr)
+            return 1
+        if result.already_unlocked:
+            print(f"already unlocked: {args.belief_id}", file=out)  # type: ignore[arg-type]
+            return 0
+        print(f"unlocked: {args.belief_id}", file=out)  # type: ignore[arg-type]
+    finally:
+        store.close()
+    return 0
+
+
+def _cmd_promote(args: argparse.Namespace, out: object) -> int:
+    """Promote agent_inferred -> user_validated. Alias of `aelf validate`."""
+    return _cmd_validate(args, out)
+
+
 def _cmd_resolve(args: argparse.Namespace, out: object) -> int:
     """Resolve all unresolved CONTRADICTS threads via the v1.0.1 tie-breaker."""
     _ = args
@@ -2902,6 +2927,31 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         ),
     )
     p_validate.set_defaults(func=_cmd_validate)
+
+    # Explicit unlock — clears user-lock, writes lock:unlock audit row.
+    p_unlock = sub.add_parser(
+        "unlock",
+        help="drop a user-lock on a belief (writes audit row)",
+    )
+    p_unlock.add_argument("belief_id", help="id of the belief to unlock")
+    p_unlock.set_defaults(func=_cmd_unlock)
+
+    # promote: user-facing alias of validate. Same handler, same flags.
+    p_promote = sub.add_parser(
+        "promote",
+        help="promote an agent_inferred belief to user_validated (alias of validate)",
+    )
+    p_promote.add_argument(
+        "belief_id", help="id of the belief to promote",
+    )
+    p_promote.add_argument(
+        "--source", default="user_validated",
+        help=(
+            "audit-row source suffix; written as 'promotion:<source>' "
+            "in feedback_history. Defaults to 'user_validated'."
+        ),
+    )
+    p_promote.set_defaults(func=_cmd_promote)
 
     # Hidden: contradiction-resolution maintenance verb. `aelf doctor` flags
     # when a run is needed; users rarely invoke it directly.

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -273,10 +273,8 @@ def tool_demote(store: MemoryStore, *, belief_id: str) -> dict[str, Any]:
             "error": "belief not found",
         }
     if belief.lock_level == LOCK_USER:
-        belief.lock_level = LOCK_NONE
-        belief.locked_at = None
-        belief.demotion_pressure = 0
-        store.update_belief(belief)
+        from aelfrice.promotion import unlock
+        unlock(store, belief_id)
         return {"kind": "demote.demoted", "id": belief_id, "demoted": True}
     if belief.origin == ORIGIN_USER_VALIDATED:
         from aelfrice.promotion import devalidate

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -335,6 +335,54 @@ def tool_validate(
     }
 
 
+def tool_unlock(store: MemoryStore, *, belief_id: str) -> dict[str, Any]:
+    """Drop a user-lock without touching origin.
+
+    Idempotent: calling on an already-unlocked belief returns
+    unlocked=False (no-op). Returns unlocked=True when the lock
+    was actually cleared. Always writes a lock:unlock audit row on
+    the active path.
+    """
+    from aelfrice.promotion import unlock
+
+    try:
+        result = unlock(store, belief_id)
+    except ValueError as e:
+        return {
+            "kind": "unlock.not_found",
+            "id": belief_id,
+            "unlocked": False,
+            "error": str(e),
+        }
+    if result.already_unlocked:
+        return {
+            "kind": "unlock.already",
+            "id": belief_id,
+            "unlocked": False,
+        }
+    return {
+        "kind": "unlock.unlocked",
+        "id": belief_id,
+        "unlocked": True,
+        "audit_event_id": result.audit_event_id,
+    }
+
+
+def tool_promote(
+    store: MemoryStore,
+    *,
+    belief_id: str,
+    source: str = "user_validated",
+) -> dict[str, Any]:
+    """Promote agent_inferred -> user_validated. Alias of tool_validate.
+
+    Exists as a first-class tool so MCP callers can use the more
+    intuitive name. Identical semantics and return shape to
+    tool_validate.
+    """
+    return tool_validate(store, belief_id=belief_id, source=source)
+
+
 def tool_feedback(
     store: MemoryStore,
     *,
@@ -500,6 +548,26 @@ def serve() -> None:
             store.close()
 
     @mcp.tool()
+    def aelf_unlock(belief_id: str) -> dict[str, Any]:
+        store = _open_default_store()
+        try:
+            return tool_unlock(store, belief_id=belief_id)
+        finally:
+            store.close()
+
+    @mcp.tool()
+    def aelf_promote(
+        belief_id: str, source: str = "user_validated",
+    ) -> dict[str, Any]:
+        store = _open_default_store()
+        try:
+            return tool_promote(
+                store, belief_id=belief_id, source=source,
+            )
+        finally:
+            store.close()
+
+    @mcp.tool()
     def aelf_feedback(
         belief_id: str, signal: str, source: str = "user",
     ) -> dict[str, Any]:
@@ -532,7 +600,8 @@ def serve() -> None:
     # themselves. They serve no runtime purpose.
     _registered = (
         aelf_onboard, aelf_search, aelf_lock, aelf_locked,
-        aelf_demote, aelf_validate, aelf_feedback, aelf_stats, aelf_health,
+        aelf_demote, aelf_validate, aelf_unlock, aelf_promote,
+        aelf_feedback, aelf_stats, aelf_health,
     )
     del _registered
 

--- a/src/aelfrice/promotion.py
+++ b/src/aelfrice/promotion.py
@@ -13,11 +13,16 @@ Reversibility lives in `cli._cmd_demote`: when given a
 back to `agent_inferred` and writes a `promotion:revert_to_agent_inferred`
 audit row.
 
-Audit row shape (every successful promote and devalidate):
+`unlock()` clears a user-lock without touching origin. It is the
+pure inverse of `aelf lock`. Writes a `lock:unlock` audit row.
+Idempotent — re-unlocking an already-unlocked belief is a no-op.
+
+Audit row shape (every successful promote, devalidate, and unlock):
   - belief_id = subject's id
   - valence   = 0.0  (replay-safe; ignored by feedback math)
   - source    = 'promotion:user_validated' or
-                'promotion:revert_to_agent_inferred'
+                'promotion:revert_to_agent_inferred' or
+                'lock:unlock'
   - created_at = ISO-8601 UTC, Z-suffixed
 """
 from __future__ import annotations
@@ -27,6 +32,7 @@ from datetime import datetime, timezone
 from typing import Final
 
 from aelfrice.models import (
+    LOCK_NONE,
     LOCK_USER,
     ORIGIN_AGENT_INFERRED,
     ORIGIN_USER_STATED,
@@ -38,6 +44,7 @@ SOURCE_PROMOTE_USER_VALIDATED: Final[str] = "promotion:user_validated"
 SOURCE_REVERT_TO_AGENT_INFERRED: Final[str] = (
     "promotion:revert_to_agent_inferred"
 )
+SOURCE_LOCK_UNLOCK: Final[str] = "lock:unlock"
 
 
 @dataclass(frozen=True)
@@ -53,6 +60,18 @@ class PromotionResult:
     new_origin: str
     audit_event_id: int | None
     already_validated: bool
+
+
+@dataclass(frozen=True)
+class UnlockResult:
+    """Outcome of one `unlock` call.
+
+    `audit_event_id` is None when `already_unlocked=True`
+    (idempotent path — no row is written).
+    """
+    belief_id: str
+    already_unlocked: bool
+    audit_event_id: int | None
 
 
 def _utc_now_iso() -> str:
@@ -173,4 +192,52 @@ def devalidate(
         new_origin=ORIGIN_AGENT_INFERRED,
         audit_event_id=audit_id,
         already_validated=False,
+    )
+
+
+def unlock(
+    store: MemoryStore,
+    belief_id: str,
+    *,
+    source_label: str = SOURCE_LOCK_UNLOCK,
+    now: str | None = None,
+) -> UnlockResult:
+    """Clear the user-lock on a belief. Pure inverse of `aelf lock`.
+
+    Does not touch origin — the belief's origin tier is unchanged.
+    Clears `lock_level`, `locked_at`, and `demotion_pressure`.
+
+    Idempotent: unlocking an already-unlocked belief is a no-op
+    (returns `already_unlocked=True`, writes no audit row).
+
+    Refusal cases (raise ValueError):
+      - belief not found
+
+    Writes a `lock:unlock` audit row on the active (non-idempotent)
+    path so the lock-management history is complete.
+    """
+    belief = store.get_belief(belief_id)
+    if belief is None:
+        raise ValueError(f"belief not found: {belief_id}")
+    if belief.lock_level != LOCK_USER:
+        return UnlockResult(
+            belief_id=belief_id,
+            already_unlocked=True,
+            audit_event_id=None,
+        )
+    belief.lock_level = LOCK_NONE
+    belief.locked_at = None
+    belief.demotion_pressure = 0
+    store.update_belief(belief)
+    timestamp = now if now is not None else _utc_now_iso()
+    audit_id = store.insert_feedback_event(
+        belief_id=belief_id,
+        valence=0.0,
+        source=source_label,
+        created_at=timestamp,
+    )
+    return UnlockResult(
+        belief_id=belief_id,
+        already_unlocked=False,
+        audit_event_id=audit_id,
     )

--- a/src/aelfrice/slash_commands/promote.md
+++ b/src/aelfrice/slash_commands/promote.md
@@ -1,0 +1,18 @@
+---
+name: aelf:promote
+description: Promote an agent_inferred belief to user_validated origin. Alias of aelf:validate with identical semantics.
+argument-hint: The belief ID to promote
+allowed-tools:
+  - Bash
+---
+<objective>
+Promote an agent_inferred belief to the user_validated origin tier. This is
+a provenance change only — alpha/beta posteriors are unchanged. Idempotent:
+promoting an already-validated belief exits 0 with an "already validated"
+message. This command is a first-class alias of `aelf validate`.
+</objective>
+
+<process>
+Run: `uv run aelf promote "$ARGUMENTS"`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/slash_commands/unlock.md
+++ b/src/aelfrice/slash_commands/unlock.md
@@ -1,0 +1,18 @@
+---
+name: aelf:unlock
+description: Drop the user-lock on a belief without changing its origin. Writes a lock:unlock audit row. Idempotent.
+argument-hint: The belief ID to unlock
+allowed-tools:
+  - Bash
+---
+<objective>
+Clear the user-lock on a belief. The belief remains in the store with its
+origin tier intact — only the lock is removed. Idempotent: calling unlock
+on an already-unlocked belief exits 0 with an "already unlocked" message
+and writes no audit row.
+</objective>
+
+<process>
+Run: `uv run aelf unlock "$ARGUMENTS"`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/tests/test_lock_management.py
+++ b/tests/test_lock_management.py
@@ -1,0 +1,474 @@
+"""#391 acceptance tests — unlock/promote/demote parity (CLI + MCP).
+
+Covers:
+- unlock() idempotency, error paths, audit row, field clearing
+- demote lock-drop path writes audit row (regression)
+- promote CLI parity with validate CLI
+- tool_unlock / tool_promote MCP shape parity
+- lock state machine round-trip: locked → unlocked → re-locked
+"""
+from __future__ import annotations
+
+import argparse
+import io
+
+import pytest
+
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    LOCK_NONE,
+    LOCK_USER,
+    ORIGIN_AGENT_INFERRED,
+    ORIGIN_USER_VALIDATED,
+    Belief,
+)
+from aelfrice.mcp_server import tool_demote, tool_promote, tool_unlock, tool_validate
+from aelfrice.promotion import SOURCE_LOCK_UNLOCK, UnlockResult, unlock
+from aelfrice.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mk(
+    bid: str,
+    *,
+    lock: str = LOCK_NONE,
+    locked_at: str | None = None,
+    origin: str = ORIGIN_AGENT_INFERRED,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+    demotion_pressure: int = 0,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=f"belief {bid}",
+        content_hash=f"h_{bid}",
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=lock,
+        locked_at=locked_at,
+        demotion_pressure=demotion_pressure,
+        created_at="2026-05-01T00:00:00Z",
+        last_retrieved_at=None,
+        origin=origin,
+    )
+
+
+def _seed(*beliefs: Belief) -> MemoryStore:
+    s = MemoryStore(":memory:")
+    for b in beliefs:
+        s.insert_belief(b)
+    return s
+
+
+def _locked_belief(bid: str, **kwargs) -> Belief:
+    return _mk(
+        bid,
+        lock=LOCK_USER,
+        locked_at="2026-05-01T01:00:00Z",
+        alpha=9.0,
+        beta=0.5,
+        origin="user_stated",
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# unlock() — idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_unlock_clears_lock_level() -> None:
+    s = _seed(_locked_belief("A"))
+    result = unlock(s, "A")
+    assert result.already_unlocked is False
+    after = s.get_belief("A")
+    assert after is not None
+    assert after.lock_level == LOCK_NONE
+
+
+def test_unlock_clears_locked_at() -> None:
+    s = _seed(_locked_belief("A"))
+    unlock(s, "A")
+    after = s.get_belief("A")
+    assert after is not None
+    assert after.locked_at is None
+
+
+def test_unlock_clears_demotion_pressure() -> None:
+    b = _locked_belief("A", demotion_pressure=3)
+    s = _seed(b)
+    unlock(s, "A")
+    after = s.get_belief("A")
+    assert after is not None
+    assert after.demotion_pressure == 0
+
+
+def test_unlock_does_not_touch_origin() -> None:
+    b = _locked_belief("A")
+    s = _seed(b)
+    original_origin = b.origin
+    unlock(s, "A")
+    after = s.get_belief("A")
+    assert after is not None
+    assert after.origin == original_origin
+
+
+def test_unlock_does_not_touch_alpha_beta() -> None:
+    b = _locked_belief("A")
+    s = _seed(b)
+    unlock(s, "A")
+    after = s.get_belief("A")
+    assert after is not None
+    assert after.alpha == b.alpha
+    assert after.beta == b.beta
+
+
+def test_unlock_idempotent_second_call_no_op() -> None:
+    s = _seed(_locked_belief("A"))
+    first = unlock(s, "A")
+    second = unlock(s, "A")
+    assert first.already_unlocked is False
+    assert second.already_unlocked is True
+    assert second.audit_event_id is None
+
+
+def test_unlock_idempotent_writes_only_one_audit_row() -> None:
+    s = _seed(_locked_belief("A"))
+    unlock(s, "A")
+    unlock(s, "A")  # no-op
+    assert s.count_feedback_events() == 1
+
+
+def test_unlock_idempotent_on_never_locked_belief() -> None:
+    s = _seed(_mk("A"))  # never locked
+    result = unlock(s, "A")
+    assert result.already_unlocked is True
+    assert result.audit_event_id is None
+    assert s.count_feedback_events() == 0
+
+
+# ---------------------------------------------------------------------------
+# unlock() — error path
+# ---------------------------------------------------------------------------
+
+
+def test_unlock_raises_value_error_on_missing_belief() -> None:
+    s = _seed(_mk("A"))
+    with pytest.raises(ValueError, match="belief not found"):
+        unlock(s, "ghost")
+
+
+# ---------------------------------------------------------------------------
+# unlock() — audit row
+# ---------------------------------------------------------------------------
+
+
+def test_unlock_writes_lock_unlock_audit_row() -> None:
+    s = _seed(_locked_belief("A"))
+    unlock(s, "A")
+    events = s.list_feedback_events()
+    assert len(events) == 1
+    assert events[0].source == SOURCE_LOCK_UNLOCK
+
+
+def test_unlock_audit_row_source_prefix() -> None:
+    s = _seed(_locked_belief("A"))
+    unlock(s, "A")
+    ev = s.list_feedback_events()[0]
+    assert ev.source.startswith("lock:")
+
+
+def test_unlock_audit_row_has_zero_valence() -> None:
+    s = _seed(_locked_belief("A"))
+    unlock(s, "A")
+    ev = s.list_feedback_events()[0]
+    assert ev.valence == 0.0
+
+
+def test_unlock_audit_row_belief_id_is_subject() -> None:
+    s = _seed(_locked_belief("A"), _locked_belief("B"))
+    unlock(s, "A")
+    ev = s.list_feedback_events()[0]
+    assert ev.belief_id == "A"
+
+
+def test_unlock_audit_row_carries_now_kwarg() -> None:
+    s = _seed(_locked_belief("A"))
+    unlock(s, "A", now="2026-05-01T12:00:00Z")
+    ev = s.list_feedback_events()[0]
+    assert ev.created_at == "2026-05-01T12:00:00Z"
+
+
+def test_unlock_returns_audit_event_id_on_active_path() -> None:
+    s = _seed(_locked_belief("A"))
+    result = unlock(s, "A")
+    assert isinstance(result.audit_event_id, int)
+    assert result.audit_event_id > 0
+
+
+# ---------------------------------------------------------------------------
+# demote lock-drop path writes audit row (regression for #391)
+# ---------------------------------------------------------------------------
+
+
+def test_demote_lock_drop_writes_lock_unlock_row() -> None:
+    """tool_demote lock-drop path now writes lock:unlock audit row via unlock()."""
+    s = _seed(_locked_belief("A"))
+    tool_demote(s, belief_id="A")
+    events = s.list_feedback_events()
+    assert len(events) == 1
+    assert events[0].source == SOURCE_LOCK_UNLOCK
+
+
+def test_demote_lock_drop_result_shape() -> None:
+    s = _seed(_locked_belief("A"))
+    result = tool_demote(s, belief_id="A")
+    assert result["kind"] == "demote.demoted"
+    assert result["id"] == "A"
+    assert result["demoted"] is True
+
+
+def test_demote_still_clears_lock_level() -> None:
+    s = _seed(_locked_belief("A"))
+    tool_demote(s, belief_id="A")
+    after = s.get_belief("A")
+    assert after is not None
+    assert after.lock_level == LOCK_NONE
+
+
+# ---------------------------------------------------------------------------
+# promote CLI parity — aelf validate and aelf promote identical outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_promote_and_validate_produce_same_origin_change(
+    tmp_path: pytest.TempPathFactory,
+) -> None:
+    """validate and promote share _cmd_validate; outcome must be identical.
+
+    Uses file-backed stores so we can re-open after the CLI handler closes.
+    """
+    import os
+    from aelfrice.cli import _cmd_promote, _cmd_validate
+    import unittest.mock as mock
+
+    db_v = str(tmp_path / "v.db")  # type: ignore[operator]
+    db_p = str(tmp_path / "p.db")  # type: ignore[operator]
+
+    for db in (db_v, db_p):
+        s = MemoryStore(db)
+        s.insert_belief(_mk("X", origin=ORIGIN_AGENT_INFERRED))
+        s.close()
+
+    def make_args() -> argparse.Namespace:
+        ns = argparse.Namespace()
+        ns.belief_id = "X"
+        ns.source = "user_validated"
+        return ns
+
+    with mock.patch.dict(os.environ, {"AELFRICE_DB": db_v}):
+        rc_v = _cmd_validate(make_args(), io.StringIO())
+    with mock.patch.dict(os.environ, {"AELFRICE_DB": db_p}):
+        rc_p = _cmd_promote(make_args(), io.StringIO())
+
+    assert rc_v == rc_p == 0
+
+    sv = MemoryStore(db_v)
+    sp = MemoryStore(db_p)
+    try:
+        after_v = sv.get_belief("X")
+        after_p = sp.get_belief("X")
+        assert after_v is not None and after_p is not None
+        assert after_v.origin == after_p.origin == ORIGIN_USER_VALIDATED
+    finally:
+        sv.close()
+        sp.close()
+
+
+def test_promote_and_validate_same_audit_row_source(
+    tmp_path: pytest.TempPathFactory,
+) -> None:
+    import os
+    from aelfrice.cli import _cmd_promote, _cmd_validate
+    import unittest.mock as mock
+
+    db_v = str(tmp_path / "v2.db")  # type: ignore[operator]
+    db_p = str(tmp_path / "p2.db")  # type: ignore[operator]
+
+    for db in (db_v, db_p):
+        s = MemoryStore(db)
+        s.insert_belief(_mk("X"))
+        s.close()
+
+    def make_args() -> argparse.Namespace:
+        ns = argparse.Namespace()
+        ns.belief_id = "X"
+        ns.source = "user_validated"
+        return ns
+
+    with mock.patch.dict(os.environ, {"AELFRICE_DB": db_v}):
+        _cmd_validate(make_args(), io.StringIO())
+    with mock.patch.dict(os.environ, {"AELFRICE_DB": db_p}):
+        _cmd_promote(make_args(), io.StringIO())
+
+    sv = MemoryStore(db_v)
+    sp = MemoryStore(db_p)
+    try:
+        evs_v = sv.list_feedback_events()
+        evs_p = sp.list_feedback_events()
+        assert len(evs_v) == len(evs_p) == 1
+        assert evs_v[0].source == evs_p[0].source
+    finally:
+        sv.close()
+        sp.close()
+
+
+# ---------------------------------------------------------------------------
+# MCP tool_unlock shape parity
+# ---------------------------------------------------------------------------
+
+
+def test_tool_unlock_active_path_shape() -> None:
+    s = _seed(_locked_belief("A"))
+    result = tool_unlock(s, belief_id="A")
+    assert result["kind"] == "unlock.unlocked"
+    assert result["id"] == "A"
+    assert result["unlocked"] is True
+    assert "audit_event_id" in result
+
+
+def test_tool_unlock_already_unlocked_shape() -> None:
+    s = _seed(_mk("A"))  # never locked
+    result = tool_unlock(s, belief_id="A")
+    assert result["kind"] == "unlock.already"
+    assert result["id"] == "A"
+    assert result["unlocked"] is False
+
+
+def test_tool_unlock_not_found_shape() -> None:
+    s = _seed(_mk("A"))
+    result = tool_unlock(s, belief_id="ghost")
+    assert result["kind"] == "unlock.not_found"
+    assert result["unlocked"] is False
+    assert "error" in result
+
+
+def test_tool_unlock_clears_lock_in_store() -> None:
+    s = _seed(_locked_belief("A"))
+    tool_unlock(s, belief_id="A")
+    after = s.get_belief("A")
+    assert after is not None
+    assert after.lock_level == LOCK_NONE
+
+
+# ---------------------------------------------------------------------------
+# MCP tool_promote shape parity with tool_validate
+# ---------------------------------------------------------------------------
+
+
+def test_tool_promote_active_path_shape_matches_validate() -> None:
+    s_v = _seed(_mk("X"))
+    s_p = _seed(_mk("X"))
+    result_v = tool_validate(s_v, belief_id="X")
+    result_p = tool_promote(s_p, belief_id="X")
+    # Both should return same structure / kind
+    assert result_v["kind"] == result_p["kind"]
+    assert result_v.keys() == result_p.keys()
+
+
+def test_tool_promote_changes_origin() -> None:
+    s = _seed(_mk("X", origin=ORIGIN_AGENT_INFERRED))
+    result = tool_promote(s, belief_id="X")
+    assert result["kind"] == "validate.promoted"
+    after = s.get_belief("X")
+    assert after is not None
+    assert after.origin == ORIGIN_USER_VALIDATED
+
+
+def test_tool_promote_idempotent_already_path() -> None:
+    s = _seed(_mk("X", origin=ORIGIN_USER_VALIDATED))
+    result = tool_promote(s, belief_id="X")
+    assert result["kind"] == "validate.already"
+
+
+def test_tool_promote_writes_same_audit_source_as_validate() -> None:
+    s_v = _seed(_mk("X"))
+    s_p = _seed(_mk("X"))
+    tool_validate(s_v, belief_id="X")
+    tool_promote(s_p, belief_id="X")
+    evs_v = s_v.list_feedback_events()
+    evs_p = s_p.list_feedback_events()
+    assert len(evs_v) == len(evs_p) == 1
+    assert evs_v[0].source == evs_p[0].source
+
+
+# ---------------------------------------------------------------------------
+# Lock state machine round-trip: locked → unlocked → re-locked
+# ---------------------------------------------------------------------------
+
+
+def test_lock_unlock_relock_round_trip() -> None:
+    """Full round-trip: lock a belief, unlock it, re-lock it."""
+    from aelfrice.mcp_server import tool_lock
+
+    s = MemoryStore(":memory:")
+
+    # Lock via tool_lock (inserts new belief at lock priors)
+    lock_result = tool_lock(s, statement="the sky is blue")
+    bid = lock_result["id"]
+
+    belief_after_lock = s.get_belief(bid)
+    assert belief_after_lock is not None
+    assert belief_after_lock.lock_level == LOCK_USER
+
+    # Unlock
+    result = unlock(s, bid)
+    assert result.already_unlocked is False
+    belief_after_unlock = s.get_belief(bid)
+    assert belief_after_unlock is not None
+    assert belief_after_unlock.lock_level == LOCK_NONE
+
+    # Re-lock by calling tool_lock again — lock is idempotent
+    relock_result = tool_lock(s, statement="the sky is blue")
+    assert relock_result["action"] in ("locked", "upgraded")
+    belief_after_relock = s.get_belief(bid)
+    assert belief_after_relock is not None
+    assert belief_after_relock.lock_level == LOCK_USER
+
+
+def test_lock_unlock_relock_audit_trail() -> None:
+    """Audit trail after round-trip: at least a lock:unlock row exists."""
+    from aelfrice.mcp_server import tool_lock
+
+    s = MemoryStore(":memory:")
+    lock_result = tool_lock(s, statement="another locked fact")
+    bid = lock_result["id"]
+
+    unlock(s, bid)
+
+    events = s.list_feedback_events()
+    sources = [ev.source for ev in events]
+    assert SOURCE_LOCK_UNLOCK in sources
+
+
+def test_unlock_after_relock_clears_again() -> None:
+    """unlock() after a re-lock cycle clears the lock a second time."""
+    from aelfrice.mcp_server import tool_lock
+
+    s = MemoryStore(":memory:")
+    tool_lock(s, statement="re-lockable fact")
+    bid = list(s.list_locked_beliefs())[0].id
+
+    unlock(s, bid)
+    tool_lock(s, statement="re-lockable fact")  # re-lock same content
+    second_unlock = unlock(s, bid)
+    assert second_unlock.already_unlocked is False
+
+    final = s.get_belief(bid)
+    assert final is not None
+    assert final.lock_level == LOCK_NONE

--- a/tests/test_lock_management.py
+++ b/tests/test_lock_management.py
@@ -23,7 +23,7 @@ from aelfrice.models import (
     Belief,
 )
 from aelfrice.mcp_server import tool_demote, tool_promote, tool_unlock, tool_validate
-from aelfrice.promotion import SOURCE_LOCK_UNLOCK, UnlockResult, unlock
+from aelfrice.promotion import SOURCE_LOCK_UNLOCK, unlock
 from aelfrice.store import MemoryStore
 
 

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -26,6 +26,8 @@ EXPECTED_COMMANDS = (
     "search",
     "lock",
     "locked",
+    "unlock",
+    "promote",
     "status",
     "doctor",
     "setup",


### PR DESCRIPTION
## Summary

Closes #391 (Track E of #382). Extends the lock-management surface
with `unlock` and `promote` (CLI + MCP), and gives the existing
`demote` lock-clearing path an audit row for parity.

- `aelf unlock <belief_id>` / `aelf_unlock` MCP tool — pure inverse
  of `aelf lock`. Clears `lock_level` / `locked_at` /
  `demotion_pressure`; **does not touch origin**. Idempotent
  (re-unlock of an unlocked belief is a no-op, no audit row).
- `aelf promote <belief_id>` / `aelf_promote` MCP tool — alias of
  `aelf validate`. Functionally identical; both forms ship for
  surface-discoverability per the issue.
- `demote` lock-clearing path now writes a `lock:unlock` audit row
  (was previously silent). Devalidate path unchanged
  (`promotion:revert_to_agent_inferred`).
- New `promotion.unlock(store, belief_id, *, source_label, now)`
  alongside `promote()` / `devalidate()`. Returns `UnlockResult`.
  Refuses (`ValueError`) on belief-not-found.

## Audit-row inventory after this PR

| op | source label |
|---|---|
| `aelf lock` (re-assert) | corroboration row (existing) |
| `aelf unlock` / `demote`-lock-drop | `lock:unlock` (new) |
| `aelf promote` / `aelf validate` | `promotion:user_validated` |
| `demote`-devalidate | `promotion:revert_to_agent_inferred` |

## Test plan

- [x] `tests/test_lock_management.py` — 31 tests:
      idempotency, error paths, lock-state machine round-trip
      (lock → unlock → re-lock), CLI parity (`unlock` ≡
      demote-lock-drop), `validate` ≡ `promote`, MCP shape parity.
- [x] Full suite: 2273 passed, 22 skipped, ~34s. Zero regressions.
- [x] Discretion grep: clean.

## Out of scope

- Any change to `aelf lock` semantics.
- The `demote`-devalidate path (already audited).
- Track A edge types, Track B `aelf reason`/`aelf wonder` (siblings
  of #382).

## Rollback

`git revert <pr-merge-sha>` — schema-additive only (new audit row
source label), no migrations, no shipped consumers depend on the
new label yet.

## Summary by Sourcery

Extend lock management with explicit unlock and promote operations across CLI, MCP tools, and audit logging, and add comprehensive acceptance tests for the lock state machine.

New Features:
- Add unlock operation to promotion layer, CLI, MCP tools, and slash commands to drop user locks without changing origin while recording audit events.
- Introduce promote as a first-class alias of validate in CLI, MCP tools, and slash commands for more discoverable belief promotion.

Enhancements:
- Route demote’s lock-drop path through the shared unlock helper so it now records a lock:unlock audit row.
- Expand MCP and CLI documentation to describe the new unlock and promote tools and their behaviors.

Documentation:
- Document the new aelf:unlock and aelf:promote MCP tools and CLI commands, including response shapes and semantics.

Tests:
- Add lock management acceptance tests covering unlock idempotency and auditing, demote regression behavior, promote/validate parity, MCP tool shapes, and lock→unlock→re-lock round trips.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `unlock` command to remove user-locks from beliefs while preserving their origin tier and audit trail.
  * Added `promote` command as an alias to `validate` for promoting agent-inferred beliefs to user-validated status.
  * Added new MCP tools `aelf:unlock` and `aelf:promote` for programmatic lock and promotion management.

* **Bug Fixes**
  * Updated `demote` command to properly log unlock operations through audit events.

* **Documentation**
  * Added command documentation for `unlock` and `promote`.
  * Updated MCP tool specifications and tool count (nine → eleven tools).

* **Tests**
  * Added comprehensive test suite for unlock, promote, and demote behavior across CLI and MCP interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->