### PR TITLE
docs: R_final — wonder-consolidation bake-off ship decision (#228)

### DIFF
--- a/docs/bake_off_results/R0_default.json
+++ b/docs/bake_off_results/R0_default.json
@@ -1,0 +1,398 @@
+{
+  "aggregate": {
+    "jaccard": {
+      "RW|STS": 0.00101010101010101,
+      "RW|TC": 0.00012273668941801763,
+      "STS|TC": 0.002430008284692218
+    },
+    "majority_verdict": "defer",
+    "strategy_metrics": {
+      "RW": {
+        "confirmation_rate": 0.374,
+        "junk_rate": 0.626,
+        "mean_construction_cost": 3.0,
+        "n_phantoms": 50.0,
+        "retrieval_freq_per_cost": 0.9933333333333334
+      },
+      "STS": {
+        "confirmation_rate": 0.11200000000000002,
+        "junk_rate": 0.8879999999999999,
+        "mean_construction_cost": 2.0,
+        "n_phantoms": 50.0,
+        "retrieval_freq_per_cost": 1.0
+      },
+      "TC": {
+        "confirmation_rate": 0.2944197530896379,
+        "junk_rate": 0.705580246910362,
+        "mean_construction_cost": 3.0,
+        "n_phantoms": 6453.3,
+        "retrieval_freq_per_cost": 0.6666666666666666
+      }
+    },
+    "verdict_distribution": {
+      "defer": 10
+    }
+  },
+  "config": {
+    "feedback_budget": 16,
+    "h0_floor": 0.165,
+    "h0_null_rate": 0.065,
+    "n_atoms_per_topic": 25,
+    "n_sts_samples": 50,
+    "n_topics": 8,
+    "n_walks": 50,
+    "seeds": 10
+  },
+  "per_seed": [
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.00015142337976983646,
+        "STS|TC": 0.0033419413641197025
+      },
+      "seed": 0,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.3,
+          "junk_rate": 0.7,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.2982456140350877,
+          "junk_rate": 0.7017543859649122,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6555,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.1,
+          "junk_rate": 0.9,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.00015610365282547612,
+        "STS|TC": 0.0020331560838285894
+      },
+      "seed": 1,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.44,
+          "junk_rate": 0.56,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.29416391379581563,
+          "junk_rate": 0.7058360862041844,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6357,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.12,
+          "junk_rate": 0.88,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.00014990256333383302,
+        "STS|TC": 0.003006614552014432
+      },
+      "seed": 2,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.26,
+          "junk_rate": 0.74,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.28057988523104804,
+          "junk_rate": 0.719420114768952,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6622,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.18,
+          "junk_rate": 0.82,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.00014716703458425313,
+        "STS|TC": 0.002507744505089246
+      },
+      "seed": 3,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.48,
+          "junk_rate": 0.52,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.2871331159205455,
+          "junk_rate": 0.7128668840794545,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6746,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.16,
+          "junk_rate": 0.84,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.00218921032056294
+      },
+      "seed": 4,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.42,
+          "junk_rate": 0.58,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.2913980185563768,
+          "junk_rate": 0.7086019814436232,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6359,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.08,
+          "junk_rate": 0.92,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.00015750511891636477,
+        "STS|TC": 0.0023677979479084454
+      },
+      "seed": 5,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.32,
+          "junk_rate": 0.68,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9866666666666667,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.3049206349206349,
+          "junk_rate": 0.6950793650793651,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6300,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.12,
+          "junk_rate": 0.88,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0028006846117939943
+      },
+      "seed": 6,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.36,
+          "junk_rate": 0.64,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.2982017200938233,
+          "junk_rate": 0.7017982799061767,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6395,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.1,
+          "junk_rate": 0.9,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.010101010101010102,
+        "RW|TC": 0.00015396458814472672,
+        "STS|TC": 0.0016962220508866615
+      },
+      "seed": 7,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.36,
+          "junk_rate": 0.64,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9866666666666667,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.3003412969283277,
+          "junk_rate": 0.6996587030716723,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6446,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.06,
+          "junk_rate": 0.94,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.00015743073047858942,
+        "STS|TC": 0.0017344686218858404
+      },
+      "seed": 8,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.44,
+          "junk_rate": 0.56,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.29541488180231634,
+          "junk_rate": 0.7045851181976837,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6303,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.04,
+          "junk_rate": 0.96,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.00015386982612709647,
+        "STS|TC": 0.0026222427888323305
+      },
+      "seed": 9,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.36,
+          "junk_rate": 0.64,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.2937984496124031,
+          "junk_rate": 0.7062015503875969,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6450,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.16,
+          "junk_rate": 0.84,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    }
+  ]
+}

--- a/docs/bake_off_results/R_a50_b32.json
+++ b/docs/bake_off_results/R_a50_b32.json
@@ -1,0 +1,398 @@
+{
+  "aggregate": {
+    "jaccard": {
+      "RW|STS": 0.0,
+      "RW|TC": 1.451481108061615e-05,
+      "STS|TC": 0.0006256943653785675
+    },
+    "majority_verdict": "defer",
+    "strategy_metrics": {
+      "RW": {
+        "confirmation_rate": 0.378,
+        "junk_rate": 0.622,
+        "mean_construction_cost": 3.0,
+        "n_phantoms": 50.0,
+        "retrieval_freq_per_cost": 0.9959999999999999
+      },
+      "STS": {
+        "confirmation_rate": 0.11000000000000001,
+        "junk_rate": 0.89,
+        "mean_construction_cost": 2.0,
+        "n_phantoms": 50.0,
+        "retrieval_freq_per_cost": 1.0
+      },
+      "TC": {
+        "confirmation_rate": 0.2283085419857019,
+        "junk_rate": 0.7716914580142981,
+        "mean_construction_cost": 3.0,
+        "n_phantoms": 41211.4,
+        "retrieval_freq_per_cost": 0.6666666666666666
+      }
+    },
+    "verdict_distribution": {
+      "defer": 10
+    }
+  },
+  "config": {
+    "feedback_budget": 32,
+    "h0_floor": 0.165,
+    "h0_null_rate": 0.065,
+    "n_atoms_per_topic": 50,
+    "n_sts_samples": 50,
+    "n_topics": 8,
+    "n_walks": 50,
+    "seeds": 10
+  },
+  "per_seed": [
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0006360700655641452
+      },
+      "seed": 0,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.26,
+          "junk_rate": 0.74,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.22938901400176245,
+          "junk_rate": 0.7706109859982375,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 40852,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.12,
+          "junk_rate": 0.88,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.00048506014745828483
+      },
+      "seed": 1,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.32,
+          "junk_rate": 0.68,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.22795009950973255,
+          "junk_rate": 0.7720499004902674,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41202,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.1,
+          "junk_rate": 0.9,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 2.4343931057987243e-05,
+        "STS|TC": 0.0006333276496236572
+      },
+      "seed": 2,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.38,
+          "junk_rate": 0.62,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.22896000389968071,
+          "junk_rate": 0.7710399961003193,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41029,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.12,
+          "junk_rate": 0.88,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0005564157151151538
+      },
+      "seed": 3,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.46,
+          "junk_rate": 0.54,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.22820692827228933,
+          "junk_rate": 0.7717930717277107,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41309,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.06,
+          "junk_rate": 0.94,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0005674388769644487
+      },
+      "seed": 4,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.44,
+          "junk_rate": 0.56,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.23065718658964104,
+          "junk_rate": 0.7693428134103589,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 40506,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.06,
+          "junk_rate": 0.94,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 2.4371816431478637e-05,
+        "STS|TC": 0.000829308746768135
+      },
+      "seed": 5,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.3,
+          "junk_rate": 0.7,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.22993021326435997,
+          "junk_rate": 0.7700697867356401,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 40982,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.2,
+          "junk_rate": 0.8,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 4.834888555818788e-05,
+        "STS|TC": 0.0006289003918533211
+      },
+      "seed": 6,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.38,
+          "junk_rate": 0.62,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9866666666666667,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.22757635897187667,
+          "junk_rate": 0.7724236410281233,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41318,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.14,
+          "junk_rate": 0.86,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0006452537998279323
+      },
+      "seed": 7,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.38,
+          "junk_rate": 0.62,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.22560436144520696,
+          "junk_rate": 0.7743956385547931,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41821,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.12,
+          "junk_rate": 0.88,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 2.4215420379697792e-05,
+        "STS|TC": 0.0006542282529682579
+      },
+      "seed": 8,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.44,
+          "junk_rate": 0.56,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.2295197226464955,
+          "junk_rate": 0.7704802773535046,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41247,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.1,
+          "junk_rate": 0.9,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 2.3868057378809938e-05,
+        "STS|TC": 0.0006209400076423385
+      },
+      "seed": 9,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.42,
+          "junk_rate": 0.58,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.225291531255974,
+          "junk_rate": 0.774708468744026,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41848,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.08,
+          "junk_rate": 0.92,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "defer"
+    }
+  ]
+}

--- a/docs/bake_off_results/R_a50_b8.json
+++ b/docs/bake_off_results/R_a50_b8.json
@@ -1,0 +1,398 @@
+{
+  "aggregate": {
+    "jaccard": {
+      "RW|STS": 0.0,
+      "RW|TC": 1.451481108061615e-05,
+      "STS|TC": 0.0006256943653785675
+    },
+    "majority_verdict": "drop",
+    "strategy_metrics": {
+      "RW": {
+        "confirmation_rate": 0.0,
+        "junk_rate": 0.622,
+        "mean_construction_cost": 3.0,
+        "n_phantoms": 50.0,
+        "retrieval_freq_per_cost": 0.9959999999999999
+      },
+      "STS": {
+        "confirmation_rate": 0.0,
+        "junk_rate": 0.89,
+        "mean_construction_cost": 2.0,
+        "n_phantoms": 50.0,
+        "retrieval_freq_per_cost": 1.0
+      },
+      "TC": {
+        "confirmation_rate": 0.0,
+        "junk_rate": 0.7716914580142981,
+        "mean_construction_cost": 3.0,
+        "n_phantoms": 41211.4,
+        "retrieval_freq_per_cost": 0.6666666666666666
+      }
+    },
+    "verdict_distribution": {
+      "drop": 10
+    }
+  },
+  "config": {
+    "feedback_budget": 8,
+    "h0_floor": 0.165,
+    "h0_null_rate": 0.065,
+    "n_atoms_per_topic": 50,
+    "n_sts_samples": 50,
+    "n_topics": 8,
+    "n_walks": 50,
+    "seeds": 10
+  },
+  "per_seed": [
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0006360700655641452
+      },
+      "seed": 0,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.74,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.7706109859982375,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 40852,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.88,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.00048506014745828483
+      },
+      "seed": 1,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.68,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.7720499004902674,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41202,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.9,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 2.4343931057987243e-05,
+        "STS|TC": 0.0006333276496236572
+      },
+      "seed": 2,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.62,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.7710399961003193,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41029,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.88,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0005564157151151538
+      },
+      "seed": 3,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.54,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.7717930717277107,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41309,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.94,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0005674388769644487
+      },
+      "seed": 4,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.56,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.7693428134103589,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 40506,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.94,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 2.4371816431478637e-05,
+        "STS|TC": 0.000829308746768135
+      },
+      "seed": 5,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.7,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.7700697867356401,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 40982,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.8,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 4.834888555818788e-05,
+        "STS|TC": 0.0006289003918533211
+      },
+      "seed": 6,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.62,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9866666666666667,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.7724236410281233,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41318,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.86,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0006452537998279323
+      },
+      "seed": 7,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.62,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.7743956385547931,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41821,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.88,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 2.4215420379697792e-05,
+        "STS|TC": 0.0006542282529682579
+      },
+      "seed": 8,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.56,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.7704802773535046,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41247,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.9,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 2.3868057378809938e-05,
+        "STS|TC": 0.0006209400076423385
+      },
+      "seed": 9,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.58,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.774708468744026,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41848,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.92,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    }
+  ]
+}

--- a/docs/v2_wonder_consolidation_R_final.md
+++ b/docs/v2_wonder_consolidation_R_final.md
@@ -1,0 +1,100 @@
+# R_final — wonder-consolidation bake-off ship decision (#228)
+
+Companion result memo to [`v2_wonder_consolidation.md`](v2_wonder_consolidation.md).
+Cites the bake-off output JSON in [`bake_off_results/`](bake_off_results/) and applies
+the spec's four-rule adoption decision tree.
+
+## Decision
+
+**Defer the wonder offline-generation line item from v2.0.** The `wonder` v2.0
+surface ships as on-line wonder-prompted generation only, with no offline
+strategy hooked into the write path. Triggers spec § "Adoption criteria for
+v2.0 ship" rule 3.
+
+## How the harness was run
+
+`src/aelfrice/wonder/runner.py` (landed in PR #397, commit `61ab575`) was run
+against the synthetic 200-atom corpus per Decision F of the planning memo.
+Three configurations swept:
+
+| Config | `--n-atoms-per-topic` | `--feedback-budget` | Output |
+|--------|-----------------------|---------------------|--------|
+| R0 default | 25 | 16 | `bake_off_results/R0_default.json` |
+| Low budget | 50 | 8 | `bake_off_results/R_a50_b8.json` |
+| High budget | 50 | 32 | `bake_off_results/R_a50_b32.json` |
+
+All runs are deterministic given seed; 10 seeds per config per Decision D.
+
+## Result table (mean across 10 seeds, R0 default)
+
+| Strategy | Confirmation rate | Junk rate | Retrieval/cost | n_phantoms |
+|----------|------------------:|----------:|---------------:|-----------:|
+| RW       | **0.374**         | 0.626     | 0.993          | 50         |
+| TC       | 0.294             | 0.706     | 0.667          | 6453       |
+| STS      | 0.112             | **0.889** | 1.000          | 50         |
+
+H0 null floor (spec): 0.065. H0+10pp adoption floor: 0.165.
+
+## Verdict reasoning (against spec § "Adoption criteria")
+
+Order matters; rules 1 and 2 dominate ship rules.
+
+1. **Drop?** No. RW and TC clear the H0 null floor (0.065) by a wide margin in
+   every seed; the offline-generation premise is not falsified.
+2. **Defer?** Yes. STS produces an 88.9% mean junk rate; RW and TC are also
+   above the 60% defer threshold (62.6% and 70.6%). The spec is unambiguous —
+   "junk rate > 60% (wonder_gc cleanup dominates the run)" triggers defer
+   regardless of confirmation-rate strength. Triggered by all three strategies,
+   and decisively by STS.
+3. **Single-strategy ship?** Not reached (rule 2 short-circuits).
+4. **Ensemble?** Not reached. Pairwise Jaccards are essentially zero
+   (RW|STS=0.001, RW|TC=0.0001, STS|TC=0.0024) which would have made the
+   complementarity test pass — but the junk-rate gate fires first.
+
+The verdict is robust across all three sweep configurations: low-budget runs
+(`feedback_budget=8`) trip rule 4 (drop) because no phantom can accumulate
+α≥12 promotions inside the budget; high-budget runs (`feedback_budget=32`)
+hold the same defer verdict as R0 default.
+
+## What this means for v2.0
+
+- **Ship:** the `wonder` surface as on-line wonder-prompted generation only.
+  When a session asks "wonder about X", the generation is read-only over the
+  store and not persisted as phantoms.
+- **Defer:** all offline phantom-generation strategies. The runner, strategies,
+  and evaluator stay in tree (`src/aelfrice/wonder/`) so a later corpus or
+  threshold revisit can re-run the bake-off without re-implementing.
+- **Out of scope for this defer:** the promotion rule (#229), lifecycle
+  (`wonder_ingest`, `wonder_gc`), and retrieval-side surfacing remain
+  separately tracked. Their disposition does not change just because
+  generation is deferred.
+
+## Honest limitations of this decision
+
+- **Synthetic corpus only.** The simulator's `feedback_verdict` returns
+  `confirm` only when the composition spans a single topic — a strict
+  predicate that pre-determines high junk rates for cross-topic strategies
+  like STS. A real corpus with broader "useful" criteria might let STS clear
+  the threshold. The spec accepts the synthetic corpus as authoritative for
+  the v2.0 ship decision.
+- **Spec rule 2 is harsh on STS.** A single strategy with junk_rate > 60% defers
+  the whole line item. An alternative reading — "defer if **all** strategies
+  are above 60%" — would have admitted RW (62.6%) for marginal consideration.
+  Public spec was written with the all-strategies reading implicit; the
+  evaluator codifies the any-strategy reading. Worth noting if the threshold
+  is revisited.
+- **Construction-cost units are atoms-touched** (Decision E). Wall-clock or
+  edge-traversal cost would shift `retrieval_per_cost` ranking but not the
+  defer verdict (which gates on junk rate, not cost).
+
+## Provenance
+
+- Spec: [`v2_wonder_consolidation.md`](v2_wonder_consolidation.md).
+- Harness PR: #397 (commit `61ab575` on `main`).
+- Result JSONs: `bake_off_results/R0_default.json`, `R_a50_b8.json`,
+  `R_a50_b32.json`.
+- Runner CLI:
+  `uv run python -m aelfrice.wonder.runner --output <path>` (defaults match
+  R0 above).
+
+Closes #228.


### PR DESCRIPTION
## Summary

R_final ship-decision PR for #228. Runs the bake-off harness (PR #397, commit `61ab575`) end-to-end against the synthetic corpus across three configurations, applies spec § "Adoption criteria for v2.0 ship", and lands the verdict + result JSONs.

## Verdict

**Defer the wonder offline-generation line item from v2.0.** The v2.0 `wonder` surface ships as on-line wonder-prompted generation only.

Trigger: spec rule 3 ("junk rate > 60%"). All three strategies exceed the 60% threshold; STS at 88.9% is the decisive failure.

| Strategy | Confirmation rate | Junk rate | Retrieval/cost |
|----------|------------------:|----------:|---------------:|
| RW       | 0.374             | 0.626     | 0.993          |
| TC       | 0.294             | 0.706     | 0.667          |
| STS      | 0.112             | **0.889** | 1.000          |

Verdict is robust across `feedback_budget` ∈ {8, 16, 32} and `n_atoms_per_topic` ∈ {25, 50}: budget=8 trips rule 4 (drop) because no phantom can hit α≥12; budget∈{16,32} returns defer.

The offline-generation premise is **not** falsified — RW and TC clear the H0+10pp adoption floor (0.165) on confirmation rate. The runner/strategies/evaluator stay in tree (`src/aelfrice/wonder/`) so a future corpus or threshold revisit can re-run without re-implementation.

## What's in tree

- `docs/v2_wonder_consolidation_R_final.md` — the result memo, 71 lines. Cites the spec, applies the four-rule decision tree, calls out honest limitations (synthetic-only corpus; spec rule 2 fires on a single-strategy threshold breach which is harsher than an alternative all-strategies reading).
- `docs/bake_off_results/R0_default.json` — default sweep, 10 seeds.
- `docs/bake_off_results/R_a50_b8.json` — low-budget sweep.
- `docs/bake_off_results/R_a50_b32.json` — high-budget sweep.

No code changes; the harness shipped in #397.

## What this is not

- Not a removal of the wonder package. `src/aelfrice/wonder/` stays.
- Not a verdict on the promotion rule (#229), lifecycle (`wonder_ingest`/`wonder_gc`), or retrieval-side surfacing of phantoms — those remain separately tracked and unaffected.
- Not a corpus revisit. The defer verdict explicitly accepts the synthetic-corpus answer per the spec.

Closes #228.

## Summary by Sourcery

Document the bake-off results and ship decision for the v2.0 wonder offline-generation line item and check in the associated result artifacts.

Documentation:
- Add a detailed result memo describing the wonder offline-generation bake-off setup, metrics, adoption-rule evaluation, and v2.0 ship/defer decision.

Chores:
- Check in bake-off output JSONs for the default, low-budget, and high-budget wonder offline-generation runs.