### PR TITLE
refactor(ingest): route ingest_turn through derivation worker (#264 part 1)

### DIFF
--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -22,7 +22,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import cast
 
-from aelfrice.derivation import DerivationInput, derive
+from aelfrice.derivation_worker import run_worker
 from aelfrice.extraction import extract_sentences
 from aelfrice.models import (
     ANCHOR_TEXT_MAX_LEN,
@@ -69,16 +69,15 @@ def ingest_turn(
     `source_id` is still accepted for adapter parity but is not yet
     persisted.
 
-    `bulk` (v1.6+, keyword-only) signals the call is part of a
-    multi-turn batch (e.g. a research-line `wonder_ingest` pipeline).
-    When True, per-turn side effects that are redundant inside a batch
-    are skipped: currently `store.record_corroboration` for duplicate
-    sentences. The canonical `beliefs` row and the `ingest_log` write
-    (the v2.0 source-of-truth ingest record) are always produced —
-    `bulk=True` produces the same final belief state as `bulk=False`
-    for the same input sequence; only the corroboration audit table
-    differs. Reserved for future per-turn-cost reductions as new side
-    effects land. Default-off preserves current behavior.
+    `bulk` (v1.6+, keyword-only) is now a no-op (kept for API parity).
+    Under #264 the entry point no longer owns dedup-or-corroborate
+    decisions — every raw sentence appends a row to `ingest_log` and
+    the derivation worker handles canonical-belief insert vs
+    corroborate via `insert_or_corroborate`. The pre-#264 bulk
+    fast-path that suppressed `record_corroboration` on duplicates is
+    gone; both `bulk=True` and `bulk=False` now produce identical
+    audit-table state. The keyword-only signature is preserved so
+    existing batch callers do not need to change.
 
     Returns the number of beliefs inserted (or that would have been
     inserted if not already present).
@@ -97,66 +96,59 @@ def _ingest_turn_ids(
     session_id: str | None = None,
     created_at: str | None = None,
     *,
-    bulk: bool = False,
+    bulk: bool = False,  # noqa: ARG001
 ) -> list[str]:
-    """Internal variant of ingest_turn returning the inserted belief ids.
+    """Internal variant of ingest_turn returning the derived belief ids.
 
-    `ingest_jsonl` uses the id list to wire DERIVED_FROM edges
-    between turns within a session. Public callers should use
-    `ingest_turn` (which discards the list and returns the count).
+    Under #264 the entry point's job collapses to: split the turn into
+    sentences, append one log row per sentence (unstamped), then invoke
+    the derivation worker once at end-of-batch. The worker handles
+    `derive()` + `insert_or_corroborate` + log-stamping. The returned
+    list is the per-sentence derived belief id (in input order, with
+    duplicates dropped) — `ingest_jsonl` uses the last entry to wire
+    DERIVED_FROM edges between consecutive turns within a session.
     """
     sentences = extract_sentences(text)
     if not sentences:
         return []
 
     ts = created_at or _now_utc_iso()
-    inserted: list[str] = []
+    # Snapshot the canonical belief set so we can identify which derived
+    # ids in this turn correspond to brand-new inserts (vs corroborations
+    # of already-known beliefs). Preserves the pre-#264 public contract
+    # that `ingest_turn` returns the count of newly-inserted beliefs.
+    ids_before: set[str] = set(store.list_belief_ids())
+
+    log_ids: list[str] = []
     for sentence in sentences:
-        out = derive(DerivationInput(
-            raw_text=sentence,
-            source_kind=INGEST_SOURCE_FILESYSTEM,
-            source_path=source,
-            session_id=session_id,
-            ts=ts,
-        ))
-        if out.belief is None:
-            continue
-        belief_id = out.belief.id
-        if store.get_belief(belief_id) is not None:
-            # Exact (source, sentence) duplicate: record a corroboration
-            # so re-assertions are observable. Canonical row unchanged.
-            # bulk=True skips this — corroboration noise is uninteresting
-            # in batch ingest and is the only currently-redundant per-turn
-            # side effect.
-            if not bulk:
-                store.record_corroboration(
-                    belief_id,
-                    source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
-                    session_id=session_id,
-                )
-            continue
-        # v2.0 #205 parallel-write: log the classifier input before
-        # materializing the belief. belief_id is deterministic on
-        # (source, sentence) so derived_belief_ids is known up-front.
-        store.record_ingest(
+        log_id = store.record_ingest(
             source_kind=INGEST_SOURCE_FILESYSTEM,
             source_path=source,
             raw_text=sentence,
-            derived_belief_ids=[belief_id],
             session_id=session_id,
             ts=ts,
+            raw_meta={"call_site": CORROBORATION_SOURCE_TRANSCRIPT_INGEST},
         )
-        # Cross-source dedup: same content from a different source
-        # produces the same content_hash but a different belief_id.
-        # insert_or_corroborate records a corroboration row on hit
-        # instead of silently inserting a duplicate belief row.
-        actual_id, was_inserted = store.insert_or_corroborate(
-            out.belief,
-            source_type=CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
-            session_id=session_id,
-        )
-        if was_inserted:
-            inserted.append(actual_id)
+        log_ids.append(log_id)
+
+    # Worker is idempotent and scans all unstamped rows; calling it once
+    # at end-of-turn is the per-batch invocation pattern from the spec.
+    run_worker(store)
+
+    inserted: list[str] = []
+    seen: set[str] = set()
+    for log_id in log_ids:
+        entry = store.get_ingest_log_entry(log_id)
+        if entry is None:
+            continue
+        ids = entry.get("derived_belief_ids") or []
+        if not isinstance(ids, list):
+            continue
+        for bid in ids:
+            if (isinstance(bid, str) and bid not in ids_before
+                    and bid not in seen):
+                seen.add(bid)
+                inserted.append(bid)
     return inserted
 
 

--- a/tests/test_ingest_bulk.py
+++ b/tests/test_ingest_bulk.py
@@ -1,11 +1,13 @@
 """Tests for the `bulk=` parameter on `ingest_turn` (issue #194).
 
-`bulk=True` is a research-line / batch-ingest hint. Per-turn side
-effects that are redundant inside a multi-turn batch are skipped:
-currently `store.record_corroboration` for duplicate sentences. The
-canonical `beliefs` row and the v2.0 `ingest_log` write are always
-produced — `bulk=True` and `bulk=False` produce the same final belief
-state; only the corroboration audit table differs.
+`bulk=True` was originally a research-line / batch-ingest hint that
+suppressed `store.record_corroboration` for duplicate sentences. Under
+#264 the entry point no longer owns dedup-or-corroborate decisions —
+every raw sentence appends a row to `ingest_log` and the derivation
+worker handles canonical-belief insert vs corroborate via
+`insert_or_corroborate`. The bulk parameter is now a no-op kept for
+API parity; both `bulk=True` and `bulk=False` produce identical final
+state including the corroboration audit table.
 
 In-memory store, deterministic, no LLM/IO.
 """
@@ -58,10 +60,15 @@ def test_bulk_unique_sentences_same_final_belief_state() -> None:
     assert sorted(store_bulk.list_belief_ids()) == sorted(store_normal.list_belief_ids())
 
 
-def test_bulk_skips_corroboration_on_duplicates() -> None:
-    """Re-ingesting a duplicate sentence in bulk mode does NOT record a
-    corroboration. In non-bulk mode it does. Belief table is identical
-    in both cases.
+def test_bulk_is_now_a_noop_under_pr264() -> None:
+    """Post-#264: bulk=True and bulk=False produce identical state in
+    every observable way — same beliefs, same corroboration count, same
+    log rows. The bulk parameter is preserved for API parity but no
+    longer changes behavior. The pre-#264 fast-path that skipped
+    record_corroboration on duplicate sentences is gone (the entry
+    point no longer calls record_corroboration directly; the worker's
+    insert_or_corroborate records a corroboration on every duplicate
+    raw input).
     """
     text = "The sky is blue."
     source = "user"
@@ -82,10 +89,14 @@ def test_bulk_skips_corroboration_on_duplicates() -> None:
     assert len(bulk_ids) == 1
 
     bid = bulk_ids[0]
-    # bulk=False records a corroboration on each duplicate (2 corroborations)
+    # Two duplicate ingests after the first produce two corroboration
+    # rows in BOTH modes — the worker's insert_or_corroborate runs on
+    # every duplicate raw input regardless of bulk.
     assert store_normal.count_corroborations(bid) == 2
-    # bulk=True records none
-    assert store_bulk.count_corroborations(bid) == 0
+    assert store_bulk.count_corroborations(bid) == 2
+    # And the log row count is also identical (3 raw inputs each).
+    assert store_normal.count_ingest_log() == 3
+    assert store_bulk.count_ingest_log() == 3
 
 
 def test_bulk_writes_ingest_log() -> None:

--- a/tests/test_ingest_log.py
+++ b/tests/test_ingest_log.py
@@ -379,17 +379,27 @@ def test_ingest_turn_writes_log_row_per_new_belief(
         assert all(r["session_id"] == "s-1" for r in rows)
 
 
-def test_ingest_turn_dedup_does_not_double_log(store: MemoryStore) -> None:
-    """Hypothesis: re-ingesting the same (source, sentence) skips the
-    belief insert AND skips the log row (dedup is idempotent on both).
-    Falsifiable if log count grows on the no-op second call."""
+def test_ingest_turn_dedup_writes_log_row_per_raw_input(
+    store: MemoryStore,
+) -> None:
+    """Hypothesis (post-#264 contract shift): the ingest log is the
+    canonical record of raw classifier inputs. Re-ingesting the same
+    (source, sentence) writes a NEW log row but does NOT add a duplicate
+    canonical belief — the derivation worker corroborates instead.
+    Falsifiable if log count is unchanged on the second call (old #205
+    contract) OR if a duplicate belief row appears."""
     from aelfrice.ingest import ingest_turn
     text = "The default port is 8080 for the dashboard service."
     ingest_turn(store, text, source="user")
     log_after_first = store.count_ingest_log()
+    beliefs_after_first = store.count_beliefs()
     ingest_turn(store, text, source="user")
     log_after_second = store.count_ingest_log()
-    assert log_after_first == log_after_second
+    beliefs_after_second = store.count_beliefs()
+    # Log row added for the re-ingest (canonical raw-input record).
+    assert log_after_second == log_after_first + 1
+    # Belief table unchanged — worker corroborates, not inserts.
+    assert beliefs_after_second == beliefs_after_first
 
 
 def test_ingest_triples_writes_log_row_per_new_belief(

--- a/tests/test_ingest_via_worker.py
+++ b/tests/test_ingest_via_worker.py
@@ -1,0 +1,141 @@
+"""Integration tests for the post-#264 ingest_turn → derivation_worker
+call shape.
+
+Each test states a falsifiable hypothesis about the new contract:
+
+    ingest_turn writes one log row per sentence (unstamped at the
+    moment of write), then run_worker materializes beliefs and stamps
+    every log row's `derived_belief_ids`.
+
+These tests anchor the *new* invariants. They will catch any future
+regression that re-introduces direct `derive()` / `insert_belief()`
+calls in the entry point and bypasses the worker.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from aelfrice.ingest import ingest_turn
+from aelfrice.replay import replay_full_equality
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Iterator[MemoryStore]:
+    s = MemoryStore(str(tmp_path / "ingest-via-worker.db"))
+    yield s
+    s.close()
+
+
+def test_every_log_row_is_stamped_after_ingest_turn(
+    store: MemoryStore,
+) -> None:
+    """Hypothesis: after ingest_turn returns, no row in `ingest_log`
+    remains unstamped — the worker ran end-of-turn and stamped every
+    row written by the entry point. Falsifiable by any row whose
+    `derived_belief_ids IS NULL` after the call (the worker did not
+    run, or the entry point bypassed the worker for some sentences).
+    """
+    text = (
+        "The configuration file lives at /etc/aelfrice/conf. "
+        "The default port is 8080 for the dashboard."
+    )
+    ingest_turn(store, text, source="user")
+    unstamped = store.list_unstamped_ingest_log()
+    assert unstamped == [], f"unstamped rows: {unstamped}"
+
+
+def test_log_row_carries_call_site_metadata(store: MemoryStore) -> None:
+    """Hypothesis: the entry point stamps `raw_meta.call_site` =
+    `transcript_ingest` so the worker can resolve the corroboration
+    source unambiguously. Falsifiable if `raw_meta` is missing or
+    carries a different call_site."""
+    ingest_turn(store, "The sky is blue.", source="user")
+    rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT raw_meta FROM ingest_log"
+    ).fetchall()
+    assert rows
+    import json
+    for row in rows:
+        meta = json.loads(row["raw_meta"]) if row["raw_meta"] else None
+        assert isinstance(meta, dict)
+        assert meta.get("call_site") == "transcript_ingest"
+
+
+def test_question_sentence_stamps_log_row_with_empty_derived_ids(
+    store: MemoryStore,
+) -> None:
+    """Hypothesis: a sentence the classifier rejects (persist=False —
+    e.g. a question) still produces a log row, and the worker stamps
+    that row with an explicit empty list (sentinel for 'visited, no
+    belief'). Falsifiable if no log row exists OR if the row remains
+    NULL-stamped (which would cause the worker to re-process it on
+    every subsequent call)."""
+    text = "What is the default port?"
+    ingest_turn(store, text, source="user")
+    rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT derived_belief_ids FROM ingest_log "
+        "WHERE raw_text = ?",
+        ("What is the default port?",),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["derived_belief_ids"] == "[]"
+    # And no beliefs were inserted.
+    assert store.count_beliefs() == 0
+
+
+def test_replay_full_equality_passes_after_ingest(store: MemoryStore) -> None:
+    """Hypothesis (CI gate): after a representative ingest_turn run, the
+    full-equality replay probe reports zero drift — every log row
+    re-derives to a shape-equal canonical belief. This is the tripwire
+    for missed entry points: any caller that bypasses the worker (writes
+    `beliefs` directly without a matching log row) shows up as
+    `canonical_orphan`; any worker bug that produces a different
+    canonical belief shows up as `mismatched` or `derived_orphan`.
+
+    Falsifiable by any non-zero drift counter."""
+    text = (
+        "The configuration file lives at /etc/aelfrice/conf. "
+        "The default port is 8080 for the dashboard. "
+        "Aelfrice stores beliefs in a SQLite database. "
+        "The scheduler runs every five minutes by default."
+    )
+    ingest_turn(store, text, source="user", session_id="sess-1")
+    # Re-ingest to exercise the corroboration path.
+    ingest_turn(store, text, source="user", session_id="sess-2")
+    report = replay_full_equality(store)
+    assert report.total_log_rows > 0
+    assert report.matched == report.total_log_rows, (
+        f"replay drift: matched={report.matched}, "
+        f"mismatched={report.mismatched}, "
+        f"derived_orphan={report.derived_orphan}, "
+        f"canonical_orphan={report.canonical_orphan}, "
+        f"examples={report.drift_examples}"
+    )
+    assert report.mismatched == 0
+    assert report.derived_orphan == 0
+    assert report.canonical_orphan == 0
+
+
+def test_ingest_turn_idempotent_after_worker_path(store: MemoryStore) -> None:
+    """Hypothesis: re-ingesting the same text under the worker path is
+    idempotent on the canonical belief set even though it adds new log
+    rows. `ingest_turn`'s public return (newly-inserted count) is 0 on
+    re-run. Falsifiable if a duplicate belief appears OR if the second
+    call's return value is non-zero."""
+    text = "Atomic commits beat batched commits."
+    n1 = ingest_turn(store, text, source="user")
+    assert n1 == 1
+    beliefs_after_first = store.count_beliefs()
+    n2 = ingest_turn(store, text, source="user")
+    assert n2 == 0  # no new beliefs
+    assert store.count_beliefs() == beliefs_after_first
+    # But two log rows now exist for the same sentence.
+    rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT COUNT(*) AS n FROM ingest_log WHERE raw_text = ?",
+        (text,),
+    ).fetchone()
+    assert rows["n"] == 2


### PR DESCRIPTION
Closes part 1 of #264 — converts the **`ingest_turn` → `_ingest_turn_ids`** entry point to the worker-routed call shape from `docs/v2_derivation_worker.md`. Five remaining entry points (scanner, classification, cli, mcp_server, triple_extractor) follow in a separate PR.

## What changes

`_ingest_turn_ids` no longer derives + insert/corroborates beliefs itself. It now:

1. Splits the turn into sentences (unchanged).
2. Appends one `ingest_log` row per sentence with `derived_belief_ids = NULL`, stamping `raw_meta.call_site = transcript_ingest` so the worker can resolve the corroboration source unambiguously.
3. Invokes `run_worker(store)` once at end-of-turn (per-batch invocation pattern from the spec — single-row entry points invoke inline, batch entry points invoke at end).
4. Reads stamped `derived_belief_ids` back from the log rows, filters to ids not present before the turn, and returns those (preserves `ingest_turn`'s public "newly-inserted count" return contract via a `list_belief_ids()` snapshot).

## Decisions adopted (per #264 comment)

- **D1 single-tx:** **deferred** — implementing it requires a `store.transaction()` context-manager API that is out of scope here. The worker's existing idempotency + orphan-recovery handles partial-batch crashes; spec acknowledges this in the crash-recovery section. Will be picked up alongside `aelf doctor --derive-pending` in PR 2.
- **D2 auto-derive-on-startup:** in PR 2 (couples with `aelf doctor`).
- **D3 edges in same pass:** **adopted** (worker already does this in `_process_row`).
- **D4 worker-only-insert split:** **adopted** — this PR makes direct `insert_belief()` *unused* by `ingest_turn`; #265 makes it *forbidden* behind a feature flag.

## Behavior shifts (deliberate, called out for review)

| Before | After | Why |
|---|---|---|
| Re-ingesting same `(source, sentence)` did NOT add an `ingest_log` row. | Re-ingesting writes a new log row. | The log is canonical per `docs/design/write-log-as-truth.md`. The belief table is unchanged via `insert_or_corroborate`'s `content_hash UNIQUE`. |
| `bulk=True` suppressed `record_corroboration` on duplicate sentences. | `bulk=` is a no-op kept for API parity. | The entry point no longer calls `record_corroboration` directly; the worker's `insert_or_corroborate` records a corroboration on every duplicate raw input. The bulk fast-path no longer has a place to live. |

Two tests (`test_ingest_turn_dedup_does_not_double_log`, `test_bulk_skips_corroboration_on_duplicates`) are renamed and rewritten to assert the new contract.

## CI tripwires added

`tests/test_ingest_via_worker.py` (5 tests):

- Every log row is stamped after `ingest_turn` returns (no orphans).
- `raw_meta.call_site = transcript_ingest` stamped on every row.
- Question sentences stamp the row with explicit `[]` (sentinel for "visited, no belief").
- `replay_full_equality` reports zero drift across an ingest+re-ingest workload — **this is the regression backstop** for the remaining 5 entry points. Any future caller that bypasses the worker will show up as `canonical_orphan`.
- Re-ingest is idempotent on the canonical belief set even though it adds new log rows.

## Tests

`uv run pytest`: **2375 passed, 22 skipped** (unchanged skip count vs main).

## Out of scope (deferred to PR 2)

- `scanner.py`, `classification.py`, `cli.py`, `mcp_server.py`, `triple_extractor.py` entry-point conversions.
- `aelf doctor --derive-pending` subcommand + auto-startup hook (D2).
- `store.transaction()` context manager + single-tx wrapping (D1).
- `LIMITATIONS.md` "re-classification requires re-onboard" caveat removal.
- The view-flip / direct-`insert_belief()` ban (#265).

Splitting along entry-point lines keeps each PR reviewable; the equality-gate test makes drift between PRs detectable.

## Summary by Sourcery

Route ingest_turn through the derivation worker by making _ingest_turn_ids append ingest_log rows and delegate belief derivation and insertion to the worker, while preserving the public contract of returning newly inserted belief counts.

Enhancements:
- Make _ingest_turn_ids write one ingest_log row per sentence, invoke the derivation worker once per turn, and derive returned belief IDs from worker-stamped log entries rather than inline derivation.
- Change re-ingest behavior so each raw input always produces a new ingest_log row while avoiding duplicate canonical beliefs via worker-driven corroboration.
- Deprecate ingest_turn's bulk flag into a no-op that maintains API parity but yields identical beliefs, corroborations, and log rows in all modes.

Tests:
- Update existing ingest deduplication and bulk tests to reflect the worker-routed ingest contract and the new logging/corroboration behavior.
- Add integration tests that verify ingest_turn runs the worker to stamp all log rows, stamps call_site metadata, correctly handles question sentences with empty derived_belief_ids, maintains replay_full_equality with zero drift, and remains idempotent on canonical beliefs despite additional log rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Ingestion switched to a batched, log-driven flow that records every raw input and deterministically computes newly inserted beliefs; bulk mode is now a no-op and both modes produce identical observable results.
  * Duplicate inputs now append log rows while avoiding duplicate belief insertions, preserving accurate per-turn insertion counts.

* **Tests**
  * Updated and added integration/unit tests to validate logging, idempotency, metadata stamping, and replay equality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->