### PR TITLE
chore(cli): drop 5 unused imports flagged by ruff F401

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -60,9 +60,7 @@ from aelfrice.health import (
 from aelfrice.models import (
     CORROBORATION_SOURCE_CLI_REMEMBER,
     INGEST_SOURCE_CLI_REMEMBER,
-    LOCK_NONE,
     LOCK_USER,
-    ORIGIN_AGENT_INFERRED,
     ORIGIN_USER_STATED,
     ORIGIN_USER_VALIDATED,
 )
@@ -102,13 +100,11 @@ from aelfrice.llm_classifier import (
 )
 from aelfrice.lifecycle import (
     PACKAGE_NAME as _PKG,
-    UpdateStatus,
     check_for_update,
     clear_cache as _clear_update_cache,
     format_update_banner as _format_update_banner,
     is_disabled as _update_check_disabled,
     detect_reachable_installs,
-    is_newer,
     maybe_check_for_update_async,
     read_cache as _read_update_cache,
     uninstall as _lifecycle_uninstall,
@@ -126,7 +122,7 @@ from aelfrice.setup import (
     SEARCH_TOOL_BASH_SCRIPT_NAME,
     SEARCH_TOOL_SCRIPT_NAME,
     SESSION_START_HOOK_SCRIPT_NAME,
-    SLASH_COMMANDS_DIR_DEFAULT,
+    SLASH_COMMANDS_DIR_DEFAULT,  # noqa: F401 — re-exported for monkeypatch in tests
     SettingsScope,
     TRANSCRIPT_LOGGER_SCRIPT_NAME,
     clean_dangling_shims,
@@ -2401,7 +2397,7 @@ def _cmd_doctor_replay(args: argparse.Namespace, out: object) -> int:
     store, runs `replay_full_equality`, prints the report, and returns
     0 or 1 based on drift counts and the ``--max-drift`` threshold.
     """
-    from aelfrice.replay import replay_full_equality, FullEqualityReport
+    from aelfrice.replay import replay_full_equality
 
     max_drift: int | None = getattr(args, "max_drift", None)
     _de_raw = getattr(args, "drift_examples", None)


### PR DESCRIPTION
Removes 5 unused imports from \`src/aelfrice/cli.py\` flagged by \`ruff check --select F401\`:

- \`aelfrice.models.LOCK_NONE\`
- \`aelfrice.models.ORIGIN_AGENT_INFERRED\`
- \`aelfrice.lifecycle.UpdateStatus\`
- \`aelfrice.lifecycle.is_newer\`
- \`aelfrice.replay.FullEqualityReport\` (the redundant binding inside \`_cmd_doctor_replay\`)

Kept (with \`# noqa: F401\`):

- \`aelfrice.setup.SLASH_COMMANDS_DIR_DEFAULT\` — \`tests/test_cli_setup.py\` monkeypatches \`cli.SLASH_COMMANDS_DIR_DEFAULT\`. Removing the re-export breaks 3 tests; \`noqa\` documents the intent.

Picked up loose end from Setr-2026-05-04 handoff.

Verification: \`ruff check --select F401\` clean; \`tests/test_cli*.py\` + \`tests/test_lifecycle.py\` 138 passed, 2 skipped.

Refs: handoff \`Setr-2026-05-04-end-of-session.md\` §"Loose ends".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up unused imports and reorganized internal module dependencies for improved code maintainability. No changes to user-facing CLI functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->