### PR TITLE
docs(corpus): reconcile contradiction labels + add #201 synthetic carve-out

### DIFF
--- a/tests/corpus/v2_0/README.md
+++ b/tests/corpus/v2_0/README.md
@@ -60,7 +60,7 @@ required for **all** modules:
 |---|---|---|
 | `dedup` | `belief_a` (string), `belief_b` (string) | `duplicate`, `near-duplicate`, `distinct` |
 | `enforcement` | `user_directive` (string), `agent_output` (string) | `compliant`, `violated`, `n/a` |
-| `contradiction` | `belief_a` (string), `belief_b` (string) | `contradicts`, `compatible`, `unrelated` |
+| `contradiction` | `belief_a` (string), `belief_b` (string) | `contradicts`, `refines`, `unrelated` |
 | `wonder_consolidation` | `seed_belief` (string), `retrieved_neighbors` (list[string]) | `1`, `2`, `3`, `4`, `5` (phantom-quality rating) |
 | `promotion_trigger` | `belief_sequence` (list[string]) | `should_promote`, `should_not` |
 | `sentiment` | `user_message` (string) | `positive`, `negative`, `neutral` |
@@ -88,6 +88,13 @@ corpus.
 - ≥ 50 non-seed entries per module file (300 total).
 - Real examples only — no synthetic generation in v0.1. Synthetic scaffolding
   is permitted in v0.2 after #228 settles consolidation strategy.
+- **Carve-outs (synthetic-allowed at v0.1):** `directive_detection/` per #374
+  H1 re-entry rules, and `contradiction/` per #201 — the relationship
+  detector is a regex/heuristic over modality + quantifier axes where
+  controlled synthetic distribution is the cleanest way to exercise each
+  axis. Real examples are still preferred and may be mixed in; synthetic
+  rows must declare `provenance: "synthetic-vN.M"` so future re-labellers
+  can distinguish.
 - Schema validation runs in CI (see `tests/test_corpus_schema.py`).
 
 ## Validation

--- a/tests/test_corpus_schema.py
+++ b/tests/test_corpus_schema.py
@@ -35,7 +35,7 @@ MODULES: dict[str, tuple[set[str], dict[str, str]]] = {
         {"user_directive": "str", "agent_output": "str"},
     ),
     "contradiction": (
-        {"contradicts", "compatible", "unrelated"},
+        {"contradicts", "refines", "unrelated"},
         {"belief_a": "str", "belief_b": "str"},
     ),
     "wonder_consolidation": (


### PR DESCRIPTION
## Summary

Two corpus-schema fixes that unblock #201 R2 corpus authoring.

### 1. Label vocabulary mismatch (real bug, not just docs)

The detector at `src/aelfrice/relationship_detector.py` defines:

```python
LABEL_CONTRADICTS = "contradicts"
LABEL_REFINES     = "refines"
LABEL_UNRELATED   = "unrelated"
```

But `tests/corpus/v2_0/README.md` and `tests/test_corpus_schema.py` listed allowed contradiction labels as `{contradicts, compatible, unrelated}`. The bench gate at `tests/bench_gate/test_contradiction.py:24` is direct equality:

```python
predicted = relationship_detector.classify(row["belief_a"], row["belief_b"])
if predicted == row["label"]:
    correct += 1
```

So any corpus row labelled `compatible` was structurally unmatchable — the detector never emits that string. Reconciling both the README spec and the schema validator to the detector vocabulary (`refines`).

### 2. Synthetic carve-out for `contradiction/`

Mirrors the existing `directive_detection/` carve-out (#374 H1 re-entry rules). The relationship detector is a regex/heuristic over modality + quantifier axes; controlled synthetic distribution is the cleanest way to exercise each axis. Synthetic rows must declare `provenance: "synthetic-vN.M"` so future re-labellers can distinguish.

This is also a precedent question — without it, #201 R2 corpus authoring is structurally blocked on the v0.1 → v0.2 unlock, which itself depends on the #228 ship-decision PR (currently deferred per the R0 dry-run).

## Tests

- `uv run pytest tests/test_corpus_schema.py -q` → `1 passed, 7 skipped`.

## Discretion

Diff scrub against the standard wordlist returned clean.

## Summary by Sourcery

Align contradiction corpus schema with detector labels and document a synthetic-data carve-out for the contradiction module.

Bug Fixes:
- Update allowed contradiction labels in the corpus schema from `compatible` to `refines` to match the relationship detector outputs.

Enhancements:
- Document a synthetic-data carve-out for the contradiction module, including provenance requirements for synthetic rows in v0.1 corpora.

Documentation:
- Clarify contradiction module label vocabulary and synthetic-data carve-outs in the v2_0 corpus README.