### PR TITLE
feat(session_id): T3 helper + ingest/CLI/MCP env-var fallback (#192)

### DIFF
--- a/docs/session_id_propagation.md
+++ b/docs/session_id_propagation.md
@@ -1,0 +1,86 @@
+# session_id propagation contract
+
+Implements [#192](https://github.com/robotrocketscience/aelfrice/issues/192)
+(phantom-prereqs T3). Every ingest entry point that produces a row
+in `beliefs` or `ingest_log` is responsible for stamping a
+`session_id` so downstream consumers can distinguish *N sessions
+asserted X once each* from *one session asserted X N times*.
+
+## What `session_id` means
+
+A `session_id` is a string that identifies the conversational or
+operational context that produced an ingest event. Different
+surfaces produce structurally different session strings; downstream
+code should treat the value as opaque.
+
+| surface | session_id source | shape |
+|---|---|---|
+| `ingest_turn()` (library) | explicit kwarg → `$AELF_SESSION_ID` → NULL+warn | caller-defined |
+| `aelf-transcript-logger` JSONL → replay | `sessionId` field on the JSONL turn | caller-defined |
+| `hook_commit_ingest` | `sha256(branch + commit_hash)[:16]` | 16-hex |
+| `scanner.scan_repo` (filesystem onboard) | `sha256(scan:<root>:<ts>)[:16]` | 16-hex |
+| `classification.accept_classifications` (onboard accept) | active `OnboardSession.id` | UUID-ish |
+| `aelf lock` CLI | `--id` arg → `$AELF_SESSION_ID` → NULL+warn | caller-defined |
+| MCP `aelf_lock` tool | MCP `session_id` arg → `$AELF_SESSION_ID` → NULL+warn | caller-defined |
+
+A NULL `session_id` means "no session attribution available";
+session-coherent retrieval skips NULL rows so legacy data and
+unattributed writes don't cause false-positive cross-session
+co-occurrence signals.
+
+## Inference contract (#192 R0 ratification, 2026-05-03)
+
+Three surfaces share a single inference contract via
+`aelfrice.session_resolution.resolve_session_id(explicit, surface_name=...)`:
+
+1. `ingest.ingest_turn` (Q1.a)
+2. `cli._cmd_lock` — `aelf lock` (Q3.a)
+3. `mcp_server.tool_lock` — MCP `aelf_lock` (Q4.a)
+
+Resolution order:
+
+1. **Explicit value** — if the caller passes `session_id`, that
+   wins unconditionally.
+2. **Environment** — read `$AELF_SESSION_ID`. The variable is
+   intended to be set by a hook or harness wrapping a long-running
+   ingest call site.
+3. **NULL + warn** — if neither is set, the call proceeds with
+   `session_id=NULL` and emits a one-shot stderr warn keyed on the
+   `surface_name`. Subsequent calls from the same surface in the
+   same process are silent (one warn per surface per process).
+
+## Surfaces with structural session sources
+
+These do **not** call the helper because they have a deterministic
+session source already:
+
+* **`hook_commit_ingest`** — the commit hash + branch is the session.
+* **`scanner.scan_repo`** — `_derive_scan_session_id(root, ts)`
+  produces a synthetic per-scan id; reproducible from the same root
+  and timestamp.
+* **`classification.accept_classifications`** — `OnboardSession.id`
+  IS the session; no inference needed.
+* **`transcript_logger`** — writes the upstream JSONL with the
+  `sessionId` field intact; replay through `ingest_turn()` is what
+  propagates it onto beliefs.
+
+## Operator notes
+
+* To set the env var for a long ingest run:
+  `export AELF_SESSION_ID="$(uuidgen)"`. The value is opaque; any
+  non-empty string is accepted.
+* Warns go to stderr only. Capture via `2>session-warns.log` if
+  needed. Once-per-surface dedup means a long batch produces at
+  most a few lines, not thousands.
+* `aelf lock` accepts `--id <session-id>` as an explicit override;
+  see `aelf lock --help`.
+* The MCP `aelf_lock` tool accepts a `session_id` field in its
+  request envelope; the MCP layer fills it from the active session
+  context.
+
+## What is NOT in scope for #192
+
+* `aelf_correct` MCP tool (Q4 ratified out-of-scope; future track).
+* Synthetic per-process UUIDs as a fallback (Q1.c rejected — env
+  var is the single inference surface).
+* Backfilling NULL `session_id` on legacy beliefs.

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -120,6 +120,7 @@ from aelfrice.project_warm import (
 )
 from aelfrice.retrieval import DEFAULT_TOKEN_BUDGET, retrieve
 from aelfrice.scanner import scan_repo
+from aelfrice.session_resolution import resolve_session_id
 from aelfrice.setup import (
     COMMIT_INGEST_SCRIPT_NAME,
     SEARCH_TOOL_BASH_SCRIPT_NAME,
@@ -793,10 +794,15 @@ def _cmd_lock(args: argparse.Namespace, out: object) -> int:
     store = _open_store()
     try:
         now = _utc_now_iso()
+        sid = resolve_session_id(
+            getattr(args, "session_id", None),
+            surface_name="aelf lock",
+        )
         derived = derive(DerivationInput(
             raw_text=args.statement,
             source_kind=INGEST_SOURCE_CLI_REMEMBER,
             ts=now,
+            session_id=sid,
         ))
         # cli_remember always produces a belief.
         assert derived.belief is not None
@@ -808,11 +814,13 @@ def _cmd_lock(args: argparse.Namespace, out: object) -> int:
                 source_kind=INGEST_SOURCE_CLI_REMEMBER,
                 raw_text=args.statement,
                 derived_belief_ids=[bid],
+                session_id=sid,
                 ts=now,
             )
             actual_id, was_inserted = store.insert_or_corroborate(
                 derived.belief,
                 source_type=CORROBORATION_SOURCE_CLI_REMEMBER,
+                session_id=sid,
             )
             if was_inserted:
                 print(f"locked: {actual_id}", file=out)  # type: ignore[arg-type]
@@ -2894,6 +2902,14 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
 
     p_lock = sub.add_parser("lock", help="insert (or upgrade) a user-locked belief")
     p_lock.add_argument("statement", help="belief text to lock as ground truth")
+    p_lock.add_argument(
+        "--id", dest="session_id", default=None,
+        help=(
+            "session_id to stamp on the locked belief and ingest_log row. "
+            "Defaults to $AELF_SESSION_ID; warns to stderr and writes NULL "
+            "if neither is set (#192)."
+        ),
+    )
     p_lock.set_defaults(func=_cmd_lock)
 
     p_locked = sub.add_parser("locked", help="list locked beliefs")

--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -24,6 +24,7 @@ from typing import cast
 
 from aelfrice.derivation_worker import run_worker
 from aelfrice.extraction import extract_sentences
+from aelfrice.session_resolution import resolve_session_id
 from aelfrice.models import (
     ANCHOR_TEXT_MAX_LEN,
     CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
@@ -81,10 +82,17 @@ def ingest_turn(
 
     Returns the number of beliefs inserted (or that would have been
     inserted if not already present).
+
+    When the caller omits `session_id`, the helper
+    :func:`aelfrice.session_resolution.resolve_session_id` reads
+    ``$AELF_SESSION_ID`` as the inference fallback (#192 Q1.a). If
+    neither is set, the call proceeds with a NULL session_id and
+    emits a one-shot stderr warn keyed on the entry-point name.
     """
     return len(_ingest_turn_ids(
         store=store, text=text, source=source,
-        session_id=session_id, created_at=created_at,
+        session_id=resolve_session_id(session_id, surface_name="ingest_turn"),
+        created_at=created_at,
         bulk=bulk,
     ))
 

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -61,6 +61,7 @@ from aelfrice.models import (
 )
 from aelfrice.retrieval import DEFAULT_TOKEN_BUDGET, retrieve
 from aelfrice.scanner import scan_repo
+from aelfrice.session_resolution import resolve_session_id
 from aelfrice.store import MemoryStore
 
 _FEEDBACK_VALENCES: Final[dict[str, float]] = {"used": 1.0, "harmful": -1.0}
@@ -206,11 +207,12 @@ def tool_lock(
     session_id: str | None = None,
 ) -> dict[str, Any]:
     now = _utc_now_iso()
+    sid = resolve_session_id(session_id, surface_name="mcp aelf_lock")
     out = derive(DerivationInput(
         raw_text=statement,
         source_kind=INGEST_SOURCE_MCP_REMEMBER,
         ts=now,
-        session_id=session_id,
+        session_id=sid,
     ))
     # mcp_remember always produces a belief.
     assert out.belief is not None
@@ -222,11 +224,13 @@ def tool_lock(
             source_kind=INGEST_SOURCE_MCP_REMEMBER,
             raw_text=statement,
             derived_belief_ids=[bid],
+            session_id=sid,
             ts=now,
         )
         actual_id, was_inserted = store.insert_or_corroborate(
             out.belief,
             source_type=CORROBORATION_SOURCE_MCP_REMEMBER,
+            session_id=sid,
         )
         if was_inserted:
             return {"kind": "lock.created", "id": actual_id, "action": "locked"}

--- a/src/aelfrice/session_resolution.py
+++ b/src/aelfrice/session_resolution.py
@@ -1,0 +1,78 @@
+"""Session-id inference for ingest entry points.
+
+Per the phantom-prereqs T3 contract (#192), every ingest entry point
+that takes an explicit `session_id` parameter must, when the caller
+omits it, attempt one inference step before falling back to NULL.
+
+This module is the single source of that step: read the
+``AELF_SESSION_ID`` environment variable, warn-once-per-surface to
+stderr if unset, and return the resolved value (which may be ``None``).
+
+The two surfaces that consult this helper today are:
+
+  * ``aelfrice.ingest.ingest_turn`` — library-direct ingest path.
+  * ``aelfrice.cli._cmd_lock`` — the ``aelf lock`` CLI subcommand.
+  * ``aelfrice.mcp_server.tool_lock`` — the MCP ``aelf_lock`` tool.
+
+Surfaces with their own per-call session context (commit-ingest hook,
+JSONL replay, onboard scanner/classification) do **not** call this
+helper: they have a structurally-correct session_id source already.
+
+Per the R0 ratification (Q5.a) the warn channel is
+``print(..., file=sys.stderr)``, matching the existing config-warn
+convention. No structured logger; no new dependency.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_ENV_VAR = "AELF_SESSION_ID"
+
+# Surfaces that have already emitted their warn line in this process.
+# We warn at most once per surface to avoid spamming long-lived
+# library callers (e.g. a benchmark that calls ingest_turn in a loop
+# without a session_id and without the env var set).
+_WARNED: set[str] = set()
+
+
+def resolve_session_id(
+    explicit: str | None,
+    *,
+    surface_name: str,
+) -> str | None:
+    """Resolve the session_id for an ingest call site.
+
+    Order:
+
+      1. ``explicit`` if non-empty — caller-passed value wins.
+      2. ``AELF_SESSION_ID`` env var if set and non-empty.
+      3. ``None`` and a one-shot stderr warn keyed on surface_name.
+
+    The returned ``None`` is propagated to the store layer where it
+    becomes a ``NULL`` ``session_id`` column on the inserted row.
+
+    ``surface_name`` is included in the warn line so operators can
+    tell which entry point lost the attribution. It is also the key
+    used to dedupe warns within a process: a single surface emits its
+    warn at most once per process lifetime.
+    """
+    if explicit:
+        return explicit
+    env = os.environ.get(_ENV_VAR)
+    if env:
+        return env
+    if surface_name not in _WARNED:
+        _WARNED.add(surface_name)
+        print(
+            f"aelfrice: {surface_name}: no session_id and ${_ENV_VAR} unset; "
+            f"writing NULL session attribution",
+            file=sys.stderr,
+        )
+    return None
+
+
+def _reset_warned_for_tests() -> None:
+    """Test-only hook: clear the per-surface warn dedupe set."""
+    _WARNED.clear()

--- a/tests/test_session_id_propagation.py
+++ b/tests/test_session_id_propagation.py
@@ -1,0 +1,231 @@
+"""#192 phantom-prereqs T3 — session_id propagation across ingest entry points.
+
+Covers the three call sites that consume
+:func:`aelfrice.session_resolution.resolve_session_id`:
+
+  * ``ingest.ingest_turn`` (Q1.a, library-direct)
+  * ``cli._cmd_lock`` (Q3.a, CLI ``aelf lock``)
+  * ``mcp_server.tool_lock`` (Q4.a, MCP ``aelf_lock``)
+
+Each surface must:
+
+  * stamp an explicit ``session_id`` on the resulting belief and the
+    ingest_log row;
+  * fall back to ``$AELF_SESSION_ID`` when the caller omits it;
+  * write NULL and warn-once when neither is present.
+
+The producer-side surfaces (scanner.scan_repo, classification onboard
+accept) already shipped via #357 and have their own tests; this file
+only covers the helper-driven inference path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+from aelfrice import ingest, mcp_server, session_resolution
+from aelfrice.cli import _cmd_lock
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture
+def db_path_fixture(tmp_path: Path) -> Path:
+    return tmp_path / "aelfrice.db"
+
+
+@pytest.fixture
+def store(db_path_fixture: Path) -> MemoryStore:
+    s = MemoryStore(str(db_path_fixture))
+    yield s
+    try:
+        s.close()
+    except Exception:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure every test starts with a clean warn-dedupe set and no env var."""
+    monkeypatch.delenv("AELF_SESSION_ID", raising=False)
+    session_resolution._reset_warned_for_tests()
+
+
+def _belief_session_ids(s: MemoryStore | Path) -> list[str | None]:
+    s2 = MemoryStore(str(s)) if isinstance(s, Path) else s
+    try:
+        rows = s2._conn.execute(
+            "SELECT session_id FROM beliefs ORDER BY id"
+        ).fetchall()
+    finally:
+        if isinstance(s, Path):
+            s2.close()
+    return [r["session_id"] for r in rows]
+
+
+def _ingest_log_session_ids(s: MemoryStore | Path) -> list[str | None]:
+    s2 = MemoryStore(str(s)) if isinstance(s, Path) else s
+    try:
+        rows = s2._conn.execute(
+            "SELECT session_id FROM ingest_log ORDER BY ts"
+        ).fetchall()
+    finally:
+        if isinstance(s, Path):
+            s2.close()
+    return [r["session_id"] for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# resolver helper
+
+def test_resolve_explicit_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AELF_SESSION_ID", "from-env")
+    assert (
+        session_resolution.resolve_session_id("explicit", surface_name="x")
+        == "explicit"
+    )
+
+
+def test_resolve_env_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AELF_SESSION_ID", "from-env")
+    assert session_resolution.resolve_session_id(None, surface_name="x") == "from-env"
+
+
+def test_resolve_null_warns_once(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert session_resolution.resolve_session_id(None, surface_name="ingest_turn") is None
+    captured = capsys.readouterr()
+    assert "ingest_turn" in captured.err
+    assert "AELF_SESSION_ID" in captured.err
+
+    # Second call from same surface: silent.
+    assert session_resolution.resolve_session_id(None, surface_name="ingest_turn") is None
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+    # Different surface: warns again.
+    assert session_resolution.resolve_session_id(None, surface_name="aelf lock") is None
+    captured = capsys.readouterr()
+    assert "aelf lock" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# ingest_turn (Q1.a)
+
+def test_ingest_turn_explicit_session_id_stamped(store: MemoryStore) -> None:
+    ingest.ingest_turn(
+        store,
+        text="The system uses SQLite for storage.",
+        source="t-ingest-explicit",
+        session_id="sess-explicit",
+    )
+    assert _belief_session_ids(store) == ["sess-explicit"]
+
+
+def test_ingest_turn_env_fallback(
+    store: MemoryStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AELF_SESSION_ID", "sess-from-env")
+    ingest.ingest_turn(
+        store,
+        text="The system uses SQLite for storage.",
+        source="t-ingest-env",
+    )
+    assert _belief_session_ids(store) == ["sess-from-env"]
+
+
+def test_ingest_turn_no_session_writes_null_and_warns(
+    store: MemoryStore, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ingest.ingest_turn(
+        store,
+        text="The system uses SQLite for storage.",
+        source="t-ingest-null",
+    )
+    assert _belief_session_ids(store) == [None]
+    err = capsys.readouterr().err
+    assert "ingest_turn" in err
+    assert "AELF_SESSION_ID" in err
+
+
+# ---------------------------------------------------------------------------
+# CLI _cmd_lock (Q3.a)
+
+def _make_lock_args(statement: str, session_id: str | None = None) -> argparse.Namespace:
+    return argparse.Namespace(statement=statement, session_id=session_id)
+
+
+def test_cli_lock_explicit_session_id_stamped(
+    db_path_fixture: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "aelfrice.cli._open_store", lambda: MemoryStore(str(db_path_fixture))
+    )
+    rc = _cmd_lock(_make_lock_args("locked statement A", "sess-cli"), io.StringIO())
+    assert rc == 0
+    assert _belief_session_ids(db_path_fixture) == ["sess-cli"]
+    assert _ingest_log_session_ids(db_path_fixture) == ["sess-cli"]
+
+
+def test_cli_lock_env_fallback(
+    db_path_fixture: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AELF_SESSION_ID", "sess-cli-env")
+    monkeypatch.setattr(
+        "aelfrice.cli._open_store", lambda: MemoryStore(str(db_path_fixture))
+    )
+    rc = _cmd_lock(_make_lock_args("locked statement B"), io.StringIO())
+    assert rc == 0
+    assert _belief_session_ids(db_path_fixture) == ["sess-cli-env"]
+    assert _ingest_log_session_ids(db_path_fixture) == ["sess-cli-env"]
+
+
+def test_cli_lock_null_and_warns(
+    db_path_fixture: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        "aelfrice.cli._open_store", lambda: MemoryStore(str(db_path_fixture))
+    )
+    rc = _cmd_lock(_make_lock_args("locked statement C"), io.StringIO())
+    assert rc == 0
+    assert _belief_session_ids(db_path_fixture) == [None]
+    assert _ingest_log_session_ids(db_path_fixture) == [None]
+    assert "aelf lock" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# MCP tool_lock (Q4.a)
+
+def test_mcp_lock_explicit_session_id_stamped(store: MemoryStore) -> None:
+    out = mcp_server.tool_lock(
+        store, statement="mcp locked A", session_id="sess-mcp"
+    )
+    assert out["action"] in ("locked", "corroborated")
+    assert _belief_session_ids(store) == ["sess-mcp"]
+    assert _ingest_log_session_ids(store) == ["sess-mcp"]
+
+
+def test_mcp_lock_env_fallback(
+    store: MemoryStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AELF_SESSION_ID", "sess-mcp-env")
+    out = mcp_server.tool_lock(store, statement="mcp locked B")
+    assert out["action"] in ("locked", "corroborated")
+    assert _belief_session_ids(store) == ["sess-mcp-env"]
+
+
+def test_mcp_lock_null_and_warns(
+    store: MemoryStore, capsys: pytest.CaptureFixture[str]
+) -> None:
+    out = mcp_server.tool_lock(store, statement="mcp locked C")
+    assert out["action"] in ("locked", "corroborated")
+    assert _belief_session_ids(store) == [None]
+    assert "mcp aelf_lock" in capsys.readouterr().err


### PR DESCRIPTION
Closes #192 — phantom-prereqs T3 / session_id propagation.

## What this lands

The producer-side surfaces (scanner, classification onboard accept,
MCP tool_lock kwarg) already shipped via #357. This PR closes the
remaining consumer-side gap from the R0 ratification (2026-05-03):
single-source inference contract, three surfaces consume it, plus
tests and architecture doc.

### Helper module — `src/aelfrice/session_resolution.py`

`resolve_session_id(explicit, *, surface_name)` resolves session_id
in the order:

1. Explicit value (caller-passed) wins.
2. `$AELF_SESSION_ID` env var.
3. `None` + a one-shot stderr warn keyed on `surface_name`.

One warn per surface per process — long ingest loops don't spam.

### Surfaces wired to the helper

| Q | surface | change |
|---|---|---|
| Q1.a | `ingest.ingest_turn` | helper consulted when caller omits session_id |
| Q3.a | `cli._cmd_lock` (`aelf lock`) | new `--id` arg; helper fallback; plumbed to DerivationInput, record_ingest, insert_or_corroborate |
| Q4.a | `mcp_server.tool_lock` (MCP `aelf_lock`) | helper wrapped around envelope session_id; plumbed to record_ingest, insert_or_corroborate |

Surfaces with structural session sources (commit-ingest hook,
scanner, onboard accept, transcript JSONL) are unchanged — they
already produce a deterministic session_id and don't need inference.

### Tests — `tests/test_session_id_propagation.py`

12 tests covering:
- resolver: explicit-wins, env-fallback, NULL+warn-once-per-surface
- ingest_turn: explicit / env / NULL on beliefs
- aelf lock CLI: explicit / env / NULL on beliefs + ingest_log
- MCP aelf_lock: explicit / env / NULL on beliefs + ingest_log

### Docs — `docs/session_id_propagation.md`

Per-surface session_id source table, inference contract,
operator notes, scope-out items.

## Spec acceptance check

1. ✅ Every listed entry point accepts an optional `session_id` kwarg.
2. ✅ Explicit `session_id` lands on belief and ingest_log/corroboration rows.
3. ✅ When omitted, helper attempts inference (env var); per-surface warn dedup.
4. ✅ When inference fails, call proceeds with NULL and emits stderr warn.
5. ✅ All in-tree call sites for these entry points either pass session_id or get the env-var fallback.
6. ✅ Documentation: `docs/session_id_propagation.md`.

## Verification

- 2387 passed / 22 skipped on `uv run pytest -x -q`.
- Discretion grep clean.
- All commits SSH-signed (G).
- Atomic commit-per-surface per CLAUDE.md commit conventions.

## Out of scope (per R0 ratification Q4.a / Q6.a)

- `aelf_correct` MCP tool — future track if needed.
- transcript_logger expansion — JSONL stamping is already correct;
  belief-stamp propagation is at replay via `ingest_turn`.
