### PR TITLE
refactor(corpus): share VERDICT_LABELS + enforce synthetic provenance format

### DIFF
--- a/tests/test_corpus_schema.py
+++ b/tests/test_corpus_schema.py
@@ -16,11 +16,19 @@ once labelling is complete across all six modules. See
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
 
+from aelfrice.relationship_detector import VERDICT_LABELS
+
 CORPUS_ROOT = Path(__file__).parent / "corpus" / "v2_0"
+
+# Synthetic provenance must follow `synthetic-vN.M` per the README carve-out
+# (`tests/corpus/v2_0/README.md` § v0.1 acceptance). The format guarantees
+# future re-labellers can pivot off the version suffix instead of free-text.
+SYNTHETIC_PROVENANCE_RE = re.compile(r"^synthetic-v\d+\.\d+$")
 
 
 # Module → (allowed labels, extra-required-fields-spec)
@@ -35,7 +43,9 @@ MODULES: dict[str, tuple[set[str], dict[str, str]]] = {
         {"user_directive": "str", "agent_output": "str"},
     ),
     "contradiction": (
-        {"contradicts", "refines", "unrelated"},
+        # Sourced from the detector to prevent drift between corpus schema
+        # and the runtime vocabulary in src/aelfrice/relationship_detector.py.
+        set(VERDICT_LABELS),
         {"belief_a": "str", "belief_b": "str"},
     ),
     "wonder_consolidation": (
@@ -159,6 +169,15 @@ def test_corpus_module_files_valid(module: str) -> None:
                 for field in COMMON_REQUIRED:
                     _check_field(row, field, "str", where)
 
+                # Synthetic provenance must follow `synthetic-vN.M`. README
+                # carve-out at tests/corpus/v2_0/README.md § v0.1 acceptance.
+                prov = row["provenance"]
+                if prov.startswith("synthetic"):
+                    assert SYNTHETIC_PROVENANCE_RE.match(prov), (
+                        f"{where}: synthetic provenance {prov!r} must match "
+                        f"`synthetic-vN.M` (e.g. 'synthetic-v0.1')"
+                    )
+
                 # Module-specific.
                 for field, spec in extra_spec.items():
                     _check_field(row, field, spec, where)
@@ -186,4 +205,23 @@ def test_corpus_root_readme_present() -> None:
     """The schema contract README must exist alongside the corpus."""
     assert (CORPUS_ROOT / "README.md").is_file(), (
         "tests/corpus/v2_0/README.md is required — it documents the schema"
+    )
+
+
+def test_synthetic_provenance_regex() -> None:
+    """`synthetic-vN.M` must accept versioned, reject sloppy variants."""
+    assert SYNTHETIC_PROVENANCE_RE.match("synthetic-v0.1")
+    assert SYNTHETIC_PROVENANCE_RE.match("synthetic-v12.34")
+    assert not SYNTHETIC_PROVENANCE_RE.match("synthetic")
+    assert not SYNTHETIC_PROVENANCE_RE.match("synthetic-v1")
+    assert not SYNTHETIC_PROVENANCE_RE.match("synthetic-foo")
+    assert not SYNTHETIC_PROVENANCE_RE.match("synthetic-v0.1-extra")
+
+
+def test_contradiction_labels_match_detector() -> None:
+    """Schema's contradiction allowed-labels must equal detector's runtime set."""
+    schema_labels, _ = MODULES["contradiction"]
+    assert schema_labels == set(VERDICT_LABELS), (
+        "MODULES['contradiction'] label set drifted from "
+        "aelfrice.relationship_detector.VERDICT_LABELS — re-import or update."
     )


### PR DESCRIPTION
## Summary

Two follow-ups to merged PR #401 surfaced by automated review:

1. **Centralize `CONTRADICTION_LABELS`.** `tests/test_corpus_schema.py`
   now imports `VERDICT_LABELS` from `aelfrice.relationship_detector`
   instead of redeclaring `{"contradicts", "refines", "unrelated"}`
   inline. Detector is the source of truth; the duplicated constant
   was the root cause of the `compatible`-vs-`refines` drift that
   #401 fixed.

2. **Enforce synthetic provenance format.** Per
   `tests/corpus/v2_0/README.md` § v0.1 acceptance: synthetic rows
   in the carve-out modules (`contradiction/`, `directive_detection/`)
   must declare `provenance: "synthetic-vN.M"` so future re-labellers
   can pivot off the version suffix. Previously enforced only in the
   README; now enforced by `SYNTHETIC_PROVENANCE_RE` against any row
   whose `provenance` starts with `synthetic`. Catches sloppy
   `synthetic`, `synthetic-v1`, `synthetic-foo`, etc.

## Test plan

- [x] `uv run pytest tests/test_corpus_schema.py -v` → 3 passed, 7
      skipped (corpus dirs empty as expected; new direct tests
      `test_synthetic_provenance_regex` and
      `test_contradiction_labels_match_detector` exercise the new
      surface).
- [x] Discretion grep against PR diff: clean.

## Out of scope

- The structural mismatch between schema-test imports and runtime
  vocabulary in **other** modules (`dedup`, `enforcement`, etc.).
  Each module's labels live in different files; harmonizing those
  is a larger refactor that would touch the bench-gate runners.

## Summary by Sourcery

Align contradiction corpus schema labels with the detector’s verdict vocabulary and enforce a strict format for synthetic provenance entries in the corpus.

Enhancements:
- Centralize contradiction verdict labels in the corpus schema by sourcing them from aelfrice.relationship_detector.VERDICT_LABELS to avoid drift.
- Add a regex-based check ensuring synthetic corpus rows use a versioned provenance format synthetic-vN.M and introduce tests to validate this constraint and the label alignment.

Tests:
- Add tests to verify the synthetic provenance regex behavior and to ensure contradiction module labels remain in sync with VERDICT_LABELS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for synthetic provenance format and to ensure contradiction labels remain synchronized with runtime configuration.

* **Chores**
  * Enhanced schema validation to prevent configuration and runtime drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->