### PR TITLE
test(replay): hypothesis-based replay-equality probe (#403 part B)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,4 +140,7 @@ dev = [
     "pytest>=8.0",
     "pytest-timeout>=2.3",
     "pyright>=1.1.409",
+    # Property-based testing for replay-soak gate (#403). Pure Python,
+    # no GPU/network deps; consistent with the v1.x install promise.
+    "hypothesis>=6.100",
 ]

--- a/tests/test_replay_hypothesis.py
+++ b/tests/test_replay_hypothesis.py
@@ -1,0 +1,208 @@
+"""Property-based replay-equality probe for #403 (replay-soak gate, B).
+
+Generates random sequences of (raw_text, source_kind, source_path) tuples via
+hypothesis, ingests each through the live `derive() -> record_ingest +
+insert_belief` path, then asserts `replay_full_equality(store)` reports
+`mismatched + derived_orphan == 0`.
+
+Catches nondeterminism in `derive()` under arbitrary public-domain inputs:
+order effects, source_path leakage between rows, hidden mutable state, or
+any future change that lets two derive() calls on the same raw_text
+produce different (id, content_hash, type, origin) tuples.
+
+The seed pool is small and deliberately product-domain (no `~/.claude/`-derived
+text); hypothesis explores subsets, ordering, multiplicity, and source_kind /
+source_path combinations. Bounded scope per spec — does not change
+`replay_full_equality()` itself.
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from aelfrice.derivation import DerivationInput, derive
+from aelfrice.models import (
+    INGEST_SOURCE_CLI_REMEMBER,
+    INGEST_SOURCE_FEEDBACK_LOOP_SYNTHESIS,
+    INGEST_SOURCE_FILESYSTEM,
+    INGEST_SOURCE_GIT,
+    INGEST_SOURCE_MCP_REMEMBER,
+    INGEST_SOURCE_PYTHON_AST,
+)
+from aelfrice.replay import replay_full_equality
+from aelfrice.store import MemoryStore
+
+_TS = "2026-01-01T00:00:00+00:00"
+
+# Public-domain / product-domain seed sentences. Each is shaped to
+# reliably produce a belief through the current classifier; hypothesis
+# composes them into sequences. Adding a sentence that derive() rejects
+# is harmless — replay treats persist=False as informational.
+_SEED_TEXTS: tuple[str, ...] = (
+    "The configuration database is stored at /var/lib/aelfrice/brain.db.",
+    "The default listening port for the web server is 8443 on all interfaces.",
+    "The retention class for filesystem ingest is short.",
+    "Backups run nightly at 02:00 UTC against the canonical store.",
+    "FTS5 search powers the L1 retrieval lane in aelfrice v1.x.",
+    "Pre-push hook enforces the directory-of-origin boundary.",
+    "Python 3.12 is the minimum supported runtime for the package.",
+    "The signing key for release tags is stored at ~/.ssh/id_rrs.",
+)
+
+_SOURCE_KINDS: tuple[str, ...] = (
+    INGEST_SOURCE_FILESYSTEM,
+    INGEST_SOURCE_GIT,
+    INGEST_SOURCE_PYTHON_AST,
+    INGEST_SOURCE_MCP_REMEMBER,
+    INGEST_SOURCE_CLI_REMEMBER,
+    INGEST_SOURCE_FEEDBACK_LOOP_SYNTHESIS,
+)
+
+
+# Each seed text gets a stable (source_kind, source_path) identity tuple.
+# `derive()` keys `belief.id` on (raw_text, source_path or source_kind),
+# while `content_hash` keys on raw_text only. Mixing the same raw_text
+# under two different identity tuples collides on UNIQUE(content_hash)
+# at insert and produces derived_orphan rows on replay (because replay
+# re-derives per-row using the row's identity). Production handles
+# dedup-by-hash on insert; the replay-soak invariant the gate enforces
+# is "each raw_text has a stable identity across its lifetime in the log."
+# The strategy honors that invariant by binding identity to text.
+_IDENTITY_BY_TEXT: dict[str, tuple[str, str | None]] = {
+    t: (
+        _SOURCE_KINDS[i % len(_SOURCE_KINDS)],
+        None if i % 3 == 0 else f"src:{i:02d}",
+    )
+    for i, t in enumerate(_SEED_TEXTS)
+}
+
+
+@st.composite
+def _row(draw: st.DrawFn) -> tuple[str, str, str | None]:
+    text = draw(st.sampled_from(_SEED_TEXTS))
+    kind, path = _IDENTITY_BY_TEXT[text]
+    return text, kind, path
+
+
+_row_strategy = _row()
+
+
+@given(rows=st.lists(_row_strategy, min_size=0, max_size=12))
+@settings(
+    max_examples=40,
+    deadline=None,
+)
+@pytest.mark.timeout(60)
+def test_replay_full_equality_no_drift_on_random_ingest(
+    rows: list[tuple[str, str, str | None]],
+) -> None:
+    """Hypothesis: for any sequence of valid (raw_text, source_kind, source_path)
+    rows ingested via the production write path, replay_full_equality reports
+    `mismatched + derived_orphan == 0`. Falsifiable if any rerun of derive()
+    on the same raw_text produces a non-equal belief, or any row produces a
+    belief id absent from the canonical store.
+    """
+    # Per-example store: hypothesis re-runs the body many times; each run
+    # needs a clean db so prior-example state does not bleed in.
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "hypothesis_replay.db"
+        store = MemoryStore(str(db_path))
+        try:
+            _run_one(store, rows)
+        finally:
+            store.close()
+
+
+def _run_one(
+    store: MemoryStore,
+    rows: list[tuple[str, str, str | None]],
+) -> None:
+    for i, (raw_text, source_kind, source_path) in enumerate(rows):
+        inp = DerivationInput(
+            raw_text=raw_text,
+            source_kind=source_kind,
+            source_path=source_path,
+            ts=_TS,
+        )
+        out = derive(inp)
+        if out.belief is None:
+            # Classifier declined to persist; informational only — skip
+            # both record_ingest and insert_belief. Replay walks
+            # ingest_log rows, so a missing log row is consistent with a
+            # missing belief.
+            continue
+        # The store enforces UNIQUE on (id) and on (content_hash). Two
+        # different (raw_text, source_path) inputs can produce the same
+        # content_hash with different ids; collapse to the existing
+        # canonical row in that case so replay sees a consistent store.
+        existing_by_hash = store.get_belief_by_content_hash(out.belief.content_hash)
+        belief_id_for_log = (
+            existing_by_hash.id if existing_by_hash is not None else out.belief.id
+        )
+        store.record_ingest(
+            source_kind=source_kind,
+            source_path=source_path,
+            raw_text=raw_text,
+            derived_belief_ids=[belief_id_for_log],
+            ts=_TS,
+            log_id=f"log_{i:03d}_{belief_id_for_log[:8]}",
+        )
+        if existing_by_hash is None and store.get_belief(out.belief.id) is None:
+            store.insert_belief(out.belief)
+
+    report = replay_full_equality(store)
+    assert report.implemented is True
+    assert report.mismatched == 0, (
+        f"replay drift: {report.mismatched} mismatched rows out of "
+        f"{report.total_log_rows}"
+    )
+    assert report.derived_orphan == 0, (
+        f"replay orphan: {report.derived_orphan} derived-orphan rows"
+    )
+
+
+def test_inconsistent_identity_for_same_text_produces_drift(tmp_path: Path) -> None:
+    """Tripwire: documents the soak-gate corpus invariant.
+
+    If the SAME raw_text is ingested under two different identity tuples
+    (source_kind/source_path), insert dedups on UNIQUE(content_hash) but
+    replay re-derives the second log row's identity to a fresh belief id
+    that is absent from the canonical store, producing a derived_orphan.
+    The replay-soak corpus authoring discipline (#403 § A) must enforce
+    text → identity stability; this test will start failing the day the
+    derivation scheme decouples id from source_path, and the corpus rule
+    can be relaxed at that point.
+    """
+    store = MemoryStore(str(tmp_path / "drift.db"))
+    try:
+        text = "FTS5 search powers the L1 retrieval lane in aelfrice v1.x."
+        for i, (kind, path) in enumerate(
+            [(INGEST_SOURCE_FILESYSTEM, "src:a"), (INGEST_SOURCE_FILESYSTEM, "src:b")]
+        ):
+            inp = DerivationInput(
+                raw_text=text, source_kind=kind, source_path=path, ts=_TS,
+            )
+            out = derive(inp)
+            assert out.belief is not None
+            existing = store.get_belief_by_content_hash(out.belief.content_hash)
+            chosen_id = existing.id if existing is not None else out.belief.id
+            store.record_ingest(
+                source_kind=kind,
+                source_path=path,
+                raw_text=text,
+                derived_belief_ids=[chosen_id],
+                ts=_TS,
+                log_id=f"drift_{i}",
+            )
+            if existing is None:
+                store.insert_belief(out.belief)
+        report = replay_full_equality(store)
+        assert report.derived_orphan >= 1, (
+            "expected derived_orphan>=1 when same text has inconsistent identity"
+        )
+    finally:
+        store.close()

--- a/uv.lock
+++ b/uv.lock
@@ -38,6 +38,7 @@ onboard-llm = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "hypothesis" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-timeout" },
@@ -59,6 +60,7 @@ provides-extras = ["mcp", "onboard-llm", "archive", "benchmarks"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis", specifier = ">=6.100" },
     { name = "pyright", specifier = ">=1.1.409" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-timeout", specifier = ">=2.3" },
@@ -867,6 +869,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/52/1b54cb569509c725a32c1315261ac9fd0e6b91bbbf74d86fca10d3376164/huggingface_hub-1.12.0.tar.gz", hash = "sha256:7c3fe85e24b652334e5d456d7a812cd9a071e75630fac4365d9165ab5e4a34b6", size = 763091, upload-time = "2026-04-24T13:32:08.674Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/2b/ef03ddb96bd1123503c2bd6932001020292deea649e9bf4caa2cb65a85bf/huggingface_hub-1.12.0-py3-none-any.whl", hash = "sha256:d74939969585ee35748bd66de09baf84099d461bda7287cd9043bfb99b0e424d", size = 646806, upload-time = "2026-04-24T13:32:06.717Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.152.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/c7/3147bd903d6b18324a016d43a259cf5b4bb4545e1ead6773dc8a0374e70a/hypothesis-6.152.4.tar.gz", hash = "sha256:31c8f9ce619716f543e2710b489b1633c833586641d9e6c94cee03f109a5afc4", size = 466444, upload-time = "2026-04-27T20:18:37.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/89/0f50dd0d92e8a7dffc24f69ab910ff81db89b2f082ba42682bd57695e4d2/hypothesis-6.152.4-py3-none-any.whl", hash = "sha256:e730fd93c7578182efadc7f90b3c5437ee4d55edf738930eb5043c81ac1d97e8", size = 532145, upload-time = "2026-04-27T20:18:35.043Z" },
 ]
 
 [[package]]
@@ -2237,6 +2251,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## #403 deliverable B — hypothesis-based replay-equality probe

Property: for any sequence of `(raw_text, source_kind, source_path)` rows ingested via the production write path, `replay_full_equality(store)` reports `mismatched + derived_orphan == 0`.

Catches:
- Nondeterminism in `derive()` under arbitrary inputs.
- Order effects between log rows.
- Source-path leakage / hidden mutable state.
- Future regressions in the (id, content_hash, type, origin) tuple shape.

### Strategy

Hypothesis composes sequences from a public-domain seed pool (8 product-domain sentences) over the 6 active source_kinds. Each text is bound to a stable `(source_kind, source_path)` identity tuple — see the inline comment in the test for why.

### Two tests

1. `test_replay_full_equality_no_drift_on_random_ingest` — the property assertion above. `max_examples=40`, ~0.5s.
2. `test_inconsistent_identity_for_same_text_produces_drift` — tripwire that asserts the negative (same text + conflicting identity → orphan). Documents *why* the corpus invariant exists; will start failing when a future schema change makes id source-independent, signalling that the corpus rule can be relaxed.

### Out of scope (deferred to spec memo)

Deliverables A (scheduled `replay-soak.yml` cron + public-safe corpus) and C (consecutive-green-days surface) require ratification of two queen-tier design questions: corpus authoring discipline (directory-of-origin boundary) and status-surface mechanism (committed file vs artifact vs branch). Spec memo to follow on the issue.

### Verification

- `uv run pytest tests/test_replay_hypothesis.py` → 2 passed in 0.43s.
- `uv run pyright tests/test_replay_hypothesis.py` → 0 errors.
- `uv run pytest tests/ --ignore=tests/e2e -q` → 2387 passed, 20 skipped.
- Discretion grep clean.
- Both commits SSH-signed `G`.

Closes part of #403.

## Summary by Sourcery

Add property-based tests to verify replay equality behavior under randomized ingest sequences and inconsistent identity scenarios.

Enhancements:
- Extend development dependencies with Hypothesis to support property-based replay testing.

Tests:
- Introduce Hypothesis-based test that ingests randomized sequences of (raw_text, source_kind, source_path) and asserts replay_full_equality reports no mismatches or derived orphans.
- Add regression test ensuring that ingesting identical text under conflicting identities produces replay drift, documenting the corpus identity invariant.