### PR TITLE
feat(bench): TEMPORAL_NEXT edge type + ship-gate harness (+5pp BFS uplift) (#386)

### DIFF
--- a/docs/bfs_multihop.md
+++ b/docs/bfs_multihop.md
@@ -189,7 +189,8 @@ is the noisiest signal in the v1.2 ingest output).
 | `IMPLEMENTS`   | 0.65   | provenance     | "B implements A" — source is an implementation, target is the spec/claim being implemented. Slightly below DERIVED_FROM (0.70) because IMPLEMENTS is a more specific kind of derivation, but the dependency is almost as strong: an implementation becomes stale when its spec is superseded. Triple extractor produces `IMPLEMENTS` from "X implements Y" / "X is an implementation of Y" / "X realizes Y" / "X fulfills Y". **v2.0 ship-gate (#385):** the edge stays at weight 0.65 only while it clears a ≥+5pp BFS multi-hop hit@k uplift on the labeled `implements_edge/` corpus vs. the same fixture run with this entry zeroed; gate harness lives at `tests/bench_gate/test_bfs_multihop_implements.py`. Below-floor closes #385 as `wontfix`. |
 | `SUPPORTS`     | 0.60   | evidential     | "B argues for A" — supporting evidence is useful adjacent context but lower-priority than provenance or supersession. |
 | `CITES`        | 0.40   | referential    | "B mentions A" — weakest of the explicitly-relational edges. Per v1.0 `EDGE_VALENCE`, CITES is half of SUPPORTS for valence propagation; mirror that here. |
-| `RELATES_TO`   | 0.30   | informational  | The catch-all. Triple extractor produces `RELATES_TO` from "X relates to Y" / "X is related to Y" — the loosest relational verbs. Low weight, but non-zero so densely-connected `RELATES_TO` neighborhoods can still surface the *single* highest-`bm25` hit they reach. **v2.0 ship-gate (#383):** the edge stays at weight 0.30 only while it clears a ≥+5pp BFS multi-hop hit@k uplift on the labeled `bfs_relates_to/` corpus vs. the same fixture run with this entry zeroed; gate harness lives at `tests/bench_gate/test_bfs_multihop_relates_to.py`. Per #382 Decision A2 (operator ratification 2026-05-04) the universal +5pp bar replaced the umbrella's proposed +3pp floor — `RELATES_TO` is the most generic catch-all and has the highest over-fit risk among Track A edges. Below-floor closes #383 as `wontfix`. |
+| `RELATES_TO`      | 0.30   | informational  | The catch-all. Triple extractor produces `RELATES_TO` from "X relates to Y" / "X is related to Y" — the loosest relational verbs. Low weight, but non-zero so densely-connected `RELATES_TO` neighborhoods can still surface the *single* highest-`bm25` hit they reach. **v2.0 ship-gate (#383):** the edge stays at weight 0.30 only while it clears a ≥+5pp BFS multi-hop hit@k uplift on the labeled `bfs_relates_to/` corpus vs. the same fixture run with this entry zeroed; gate harness lives at `tests/bench_gate/test_bfs_multihop_relates_to.py`. Per #382 Decision A2 (operator ratification 2026-05-04) the universal +5pp bar replaced the umbrella's proposed +3pp floor — `RELATES_TO` is the most generic catch-all and has the highest over-fit risk among Track A edges. Below-floor closes #383 as `wontfix`. |
+| `TEMPORAL_NEXT`   | 0.25   | structural     | "B is the chronological successor of A" — pure structural adjacency with no evidential or argumentative content. Placed just below RELATES_TO (0.30) because RELATES_TO at least implies topical connection; temporal ordering does not. Non-zero so chains of temporally adjacent beliefs can still reach the single closest content hit. **v2.0 ship-gate (#386):** the edge stays at weight 0.25 only while it clears a ≥+5pp BFS multi-hop hit@k uplift on the labeled `temporal_next_edge/` corpus vs. the same fixture run with this entry zeroed; gate harness lives at `tests/bench_gate/test_bfs_multihop_temporal_next.py`. Per #382 Decision A2 the universal +5pp bar applies. Below-floor closes #386 as `wontfix`. |
 
 **Retroactive bench gate for `DERIVED_FROM` (#388).** `DERIVED_FROM` shipped
 at v1.2.0 as part of the ingest enrichment wave, before the #382 Track A
@@ -211,13 +212,14 @@ silently changing valence semantics.
 ```python
 # src/aelfrice/bfs_multihop.py
 BFS_EDGE_WEIGHTS: dict[str, float] = {
-    EDGE_SUPERSEDES:   0.90,
-    EDGE_CONTRADICTS:  0.85,
-    EDGE_DERIVED_FROM: 0.70,
-    EDGE_IMPLEMENTS:   0.65,
-    EDGE_SUPPORTS:     0.60,
-    EDGE_CITES:        0.40,
-    EDGE_RELATES_TO:   0.30,
+    EDGE_SUPERSEDES:    0.90,
+    EDGE_CONTRADICTS:   0.85,
+    EDGE_DERIVED_FROM:  0.70,
+    EDGE_IMPLEMENTS:    0.65,
+    EDGE_SUPPORTS:      0.60,
+    EDGE_CITES:         0.40,
+    EDGE_RELATES_TO:    0.30,
+    EDGE_TEMPORAL_NEXT: 0.25,
 }
 ```
 

--- a/src/aelfrice/bfs_multihop.py
+++ b/src/aelfrice/bfs_multihop.py
@@ -37,6 +37,7 @@ from aelfrice.models import (
     EDGE_RELATES_TO,
     EDGE_SUPERSEDES,
     EDGE_SUPPORTS,
+    EDGE_TEMPORAL_NEXT,
     Belief,
     Edge,
 )
@@ -63,6 +64,7 @@ BFS_EDGE_WEIGHTS: dict[str, float] = {
     EDGE_SUPPORTS: 0.60,
     EDGE_CITES: 0.40,
     EDGE_RELATES_TO: 0.30,
+    EDGE_TEMPORAL_NEXT: 0.25,
 }
 
 

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -30,6 +30,7 @@ EDGE_SUPERSEDES: Final[str] = "SUPERSEDES"
 EDGE_RELATES_TO: Final[str] = "RELATES_TO"
 EDGE_DERIVED_FROM: Final[str] = "DERIVED_FROM"
 EDGE_IMPLEMENTS: Final[str] = "IMPLEMENTS"
+EDGE_TEMPORAL_NEXT: Final[str] = "TEMPORAL_NEXT"
 
 # Edge-type valence multipliers for propagation.
 # Positive = propagate same sign; negative = invert; 0.0 = no propagation.
@@ -41,6 +42,11 @@ EDGE_IMPLEMENTS: Final[str] = "IMPLEMENTS"
 # (0.70) because IMPLEMENTS is a more specific kind of derivation, but the
 # dependency is almost as strong: an implementation becomes stale when its
 # spec is superseded.
+# TEMPORAL_NEXT (0.2): chronological-adjacency edge — source is the temporal
+# successor of target. Pure structural signal with no evidential or
+# argumentative content, so valence is positive-but-small. Placed below
+# RELATES_TO (0.3) because temporal ordering carries even less
+# content-correlation than the catch-all relational edge.
 EDGE_VALENCE: Final[dict[str, float]] = {
     EDGE_SUPPORTS: 1.0,
     EDGE_CITES: 0.5,
@@ -49,6 +55,7 @@ EDGE_VALENCE: Final[dict[str, float]] = {
     EDGE_RELATES_TO: 0.3,
     EDGE_DERIVED_FROM: 0.5,
     EDGE_IMPLEMENTS: 0.65,
+    EDGE_TEMPORAL_NEXT: 0.2,
 }
 
 EDGE_TYPES: Final[frozenset[str]] = frozenset(EDGE_VALENCE.keys())

--- a/src/aelfrice/triple_extractor.py
+++ b/src/aelfrice/triple_extractor.py
@@ -38,6 +38,7 @@ from aelfrice.models import (
     EDGE_RELATES_TO,
     EDGE_SUPERSEDES,
     EDGE_SUPPORTS,
+    EDGE_TEMPORAL_NEXT,
     INGEST_SOURCE_GIT,
     Edge,
 )
@@ -157,6 +158,16 @@ _PATTERNS: Final[tuple[_RelationPattern, ...]] = (
     _build_pattern("is an implementation of", EDGE_IMPLEMENTS),
     _build_pattern("realizes", EDGE_IMPLEMENTS),
     _build_pattern("fulfills", EDGE_IMPLEMENTS),
+    # TEMPORAL_NEXT: source = temporal successor, target = temporal predecessor.
+    # "follows" / "comes after" / "is after" / "succeeds" all express
+    # that the subject belief occurred or applies chronologically after
+    # the object belief. Patterns require multi-token verb phrases or
+    # unambiguous verbs to avoid over-firing on common prose ("after"
+    # alone, "next" alone, bare "follows" with a direct object).
+    _build_pattern("follows", EDGE_TEMPORAL_NEXT),
+    _build_pattern("comes after", EDGE_TEMPORAL_NEXT),
+    _build_pattern("is after", EDGE_TEMPORAL_NEXT),
+    _build_pattern("succeeds", EDGE_TEMPORAL_NEXT),
 )
 
 

--- a/tests/bench_gate/test_bfs_multihop_temporal_next.py
+++ b/tests/bench_gate/test_bfs_multihop_temporal_next.py
@@ -1,0 +1,131 @@
+"""Bench gate for #386 — Track A `TEMPORAL_NEXT` edge type ship gate.
+
+Per #382 Decision A2 (operator ratification 2026-05-04 at
+https://github.com/robotrocketscience/aelfrice/issues/382#issuecomment-4372683018),
+`TEMPORAL_NEXT` ships only when it demonstrates **≥+5pp BFS multi-hop hit@k
+uplift** on the labeled fixture vs. the same fixture run with
+`BFS_EDGE_WEIGHTS[TEMPORAL_NEXT]` zeroed (which causes the BFS expander to
+skip TEMPORAL_NEXT edges per `bfs_multihop.py:155-160`).
+
+Skips cleanly when `AELFRICE_CORPUS_ROOT` is unset (public CI), when the
+`temporal_next_edge/` module dir is missing, or when the corpus has fewer than
+`MIN_ROWS` non-seed rows (the gate requires a row floor before uplift
+measurement is statistically meaningful).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_corpus_module
+
+UPLIFT_FLOOR = 0.05  # +5pp per #382 Decision A2 (universal Track A bar)
+MIN_ROWS = 30  # public-tree floor; lab corpus is expected to exceed this
+
+
+def _build_store(tmp_path: Path, row: dict, arm: str):
+    """Materialize a row's beliefs + edges into a transient MemoryStore.
+
+    `arm` namespaces the db path so the two arms (with/without TEMPORAL_NEXT)
+    don't collide on the same SQLite file.
+    """
+    from aelfrice.bfs_multihop import expand_bfs  # noqa: F401  (sanity import)
+    from aelfrice.models import BELIEF_FACTUAL, Belief, Edge
+    from aelfrice.store import MemoryStore
+
+    db_path = tmp_path / f"{row['id']}-{arm}.db"
+    store = MemoryStore(str(db_path))
+    for b in row["beliefs"]:
+        belief = Belief(
+            id=b["id"],
+            content=b["text"],
+            content_hash=f"h_{b['id']}",
+            alpha=1.0,
+            beta=1.0,
+            type=BELIEF_FACTUAL,
+            lock_level="none",
+            locked_at=None,
+            demotion_pressure=0,
+            created_at="2026-05-04T00:00:00Z",
+            last_retrieved_at=None,
+        )
+        store.insert_belief(belief)
+    for e in row["edges"]:
+        store.insert_edge(
+            Edge(src=e["src"], dst=e["dst"], type=e["type"], weight=float(e["weight"]))
+        )
+    return store
+
+
+def _row_hits(row: dict, store) -> int:
+    """Run BFS expansion on a row's seeds and count how many of the
+    row's `expected_hit_ids` appear in the top-k expansions."""
+    from aelfrice.bfs_multihop import expand_bfs
+
+    seeds = []
+    for sid in row["seed_ids"]:
+        b = store.get_belief(sid)
+        assert b is not None, f"row {row['id']}: seed {sid} not in row beliefs"
+        seeds.append(b)
+    expansions = expand_bfs(seeds, store)
+    k = int(row["k"])
+    top_ids = {hop.belief.id for hop in expansions[:k]}
+    expected = set(row["expected_hit_ids"])
+    return len(top_ids & expected)
+
+
+@pytest.mark.bench_gated
+def test_temporal_next_edge_uplift(
+    aelfrice_corpus_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rows = [
+        r for r in load_corpus_module(aelfrice_corpus_root, "temporal_next_edge")
+        if not r.get("seed", False)
+    ]
+
+    if len(rows) < MIN_ROWS:
+        pytest.skip(
+            f"temporal_next_edge corpus has {len(rows)} non-seed rows; gate requires "
+            f"≥{MIN_ROWS} for stable uplift measurement"
+        )
+
+    from aelfrice.bfs_multihop import BFS_EDGE_WEIGHTS
+    from aelfrice.models import EDGE_TEMPORAL_NEXT
+
+    total_targets = sum(len(r["expected_hit_ids"]) for r in rows)
+    assert total_targets > 0, "corpus has zero expected_hit_ids; cannot grade"
+
+    # Arm 1: full edge weights (TEMPORAL_NEXT at its production weight 0.25).
+    with_hits = 0
+    for row in rows:
+        store = _build_store(tmp_path, row, arm="with")
+        try:
+            with_hits += _row_hits(row, store)
+        finally:
+            store.close()
+
+    # Arm 2: zero out TEMPORAL_NEXT. The BFS expander treats edge_w == 0.0 as
+    # "skip" without marking visited, so this isolates the edge's
+    # contribution to reachability.
+    monkeypatch.setitem(BFS_EDGE_WEIGHTS, EDGE_TEMPORAL_NEXT, 0.0)
+    without_hits = 0
+    for row in rows:
+        store = _build_store(tmp_path, row, arm="without")
+        try:
+            without_hits += _row_hits(row, store)
+        finally:
+            store.close()
+
+    with_rate = with_hits / total_targets
+    without_rate = without_hits / total_targets
+    uplift = with_rate - without_rate
+
+    assert uplift >= UPLIFT_FLOOR, (
+        f"TEMPORAL_NEXT uplift {uplift:+.3f} below +{UPLIFT_FLOOR:.2f} floor "
+        f"(with={with_rate:.3f}, without={without_rate:.3f}, n_rows={len(rows)}, "
+        f"n_targets={total_targets}). Per #382 Decision A2, edge ships only "
+        f"on ≥+5pp uplift; below-floor closes #386 as wontfix."
+    )

--- a/tests/corpus/v2_0/README.md
+++ b/tests/corpus/v2_0/README.md
@@ -37,7 +37,9 @@ tests/corpus/v2_0/
 │   └── *.jsonl
 ├── bfs_relates_to/                    #383 (Track A edge: RELATES_TO)
 │   └── *.jsonl
-└── derived_from_edge/                 #388 (Track A retroactive gate: DERIVED_FROM)
+├── derived_from_edge/                 #388 (Track A retroactive gate: DERIVED_FROM)
+│   └── *.jsonl
+└── temporal_next_edge/                #386 (Track A edge: TEMPORAL_NEXT)
     └── *.jsonl
 ```
 
@@ -72,6 +74,7 @@ required for **all** modules:
 | `bfs_relates_to` | `beliefs` (list[obj]), `edges` (list[obj]), `seed_ids` (list[string]), `expected_hit_ids` (list[string]), `k` (int) | `graded` |
 | `implements_edge` | `beliefs` (list[obj]), `edges` (list[obj]), `seed_ids` (list[string]), `expected_hit_ids` (list[string]), `k` (int) | `graded` |
 | `derived_from_edge` | `beliefs` (list[obj]), `edges` (list[obj]), `seed_ids` (list[string]), `expected_hit_ids` (list[string]), `k` (int) | `graded` |
+| `temporal_next_edge` | `beliefs` (list[obj]), `edges` (list[obj]), `seed_ids` (list[string]), `expected_hit_ids` (list[string]), `k` (int) | `graded` |
 
 ### `directive_detection` re-entry gate (#374)
 
@@ -185,6 +188,23 @@ between the full-weights run and the `DERIVED_FROM=0` run. Threshold ≥0.05.
 Public-tree fixtures may live here (synthetic-only); real-traffic fixtures
 stay lab-side per directory-of-origin rules. The bench-gate test at
 `tests/bench_gate/test_bfs_multihop_derived_from.py` skips cleanly when the
+module dir is empty or has fewer rows than the floor below.
+
+### `temporal_next_edge` ship gate (#386)
+
+Track A sub-issue of #382. The `TEMPORAL_NEXT` edge type is wired schema-side
+(`models.EDGE_TEMPORAL_NEXT`, `bfs_multihop.BFS_EDGE_WEIGHTS[TEMPORAL_NEXT] = 0.25`,
+`triple_extractor` regex emit) but does not ship until it demonstrates a
+**≥+5pp BFS multi-hop hit@k uplift on the fixture** vs. the same fixture
+run with `BFS_EDGE_WEIGHTS[TEMPORAL_NEXT]` zeroed. Per #382 Decision A2 the
+universal +5pp bar applies (same as all Track A edges).
+
+Per-row shape is identical to `bfs_relates_to`. Aggregation: same formula.
+Threshold ≥0.05.
+
+Public-tree fixtures may live here (synthetic-only); real-traffic fixtures
+stay lab-side per directory-of-origin rules. The bench-gate test at
+`tests/bench_gate/test_bfs_multihop_temporal_next.py` skips cleanly when the
 module dir is empty or has fewer rows than the floor below.
 
 ## v0.1 acceptance (per #307)

--- a/tests/test_bfs_multihop.py
+++ b/tests/test_bfs_multihop.py
@@ -58,6 +58,7 @@ from aelfrice.models import (
     EDGE_RELATES_TO,
     EDGE_SUPERSEDES,
     EDGE_SUPPORTS,
+    EDGE_TEMPORAL_NEXT,
     LOCK_NONE,
     Belief,
     Edge,
@@ -641,6 +642,7 @@ def test_edge_weights_match_spec() -> None:
         EDGE_SUPPORTS: 0.60,
         EDGE_CITES: 0.40,
         EDGE_RELATES_TO: 0.30,
+        EDGE_TEMPORAL_NEXT: 0.25,
     }
 
 

--- a/tests/test_corpus_schema.py
+++ b/tests/test_corpus_schema.py
@@ -94,6 +94,16 @@ MODULES: dict[str, tuple[set[str], dict[str, str]]] = {
             "k": "int",
         },
     ),
+    "temporal_next_edge": (
+        {"graded"},
+        {
+            "beliefs": "list[belief]",
+            "edges": "list[edge]",
+            "seed_ids": "list[str]",
+            "expected_hit_ids": "list[str]",
+            "k": "int",
+        },
+    ),
 }
 
 COMMON_REQUIRED = ("id", "provenance", "labeller_note", "label")


### PR DESCRIPTION
Closes #386.

Adds `TEMPORAL_NEXT` edge type to the graph + retrieval pipeline, gated by the +5pp BFS multi-hop hit@k uplift bar (#382 Decision A2). Mirrors the #383 RELATES_TO / #407 TESTS scaffolding pattern.

## Semantics

Source belief = temporal successor; target belief = temporal predecessor. Directional, structural (chronological adjacency, no evidential or argumentative content).

## Weights

- `BFS_EDGE_WEIGHTS[EDGE_TEMPORAL_NEXT] = 0.25` — placed one step below the catch-all `RELATES_TO` (0.30) because `RELATES_TO` at minimum implies topical connection; pure temporal ordering does not. Weakest reachability signal in the table.
- `EDGE_VALENCE[EDGE_TEMPORAL_NEXT] = 0.20` — positive but small. Less than `RELATES_TO`'s 0.3 for the same reason: feedback propagated across a TEMPORAL_NEXT edge has weak content-correlation.

## Triple-extractor patterns

Four new emits in `_PATTERNS`: `follows`, `comes after`, `is after`, `succeeds`. Multi-token phrases or unambiguous verbs only — no bare `after` / `next`, which would over-fire on common prose.

## Bench gate

`tests/bench_gate/test_bfs_multihop_temporal_next.py` — clones the #407 TESTS gate harness shape:

- Two-arm uplift measurement: full-weights run vs. `BFS_EDGE_WEIGHTS[EDGE_TEMPORAL_NEXT] = 0.0`.
- `UPLIFT_FLOOR = 0.05` (universal +5pp Track A bar, per #382 Decision A2).
- `MIN_ROWS = 30`; skips cleanly when `tests/corpus/v2_0/temporal_next_edge/` has fewer rows.

Empty `.gitkeep` placeholder for the corpus dir; public-tree synthetic fixtures may live there per #383 PR convention. Real-traffic fixtures stay lab-side.

If the gate misses, this issue closes as `wontfix` per #382 Decision A2 (no audit-only escape hatch).

## Verification

- `uv run pytest -x -q` → 2394 passed, 26 skipped (new gate skips because corpus dir is empty).
- `tests/test_bfs_multihop.py::test_edge_weights_match_spec` updated with the new entry; passes.
- All 4 commits SSH-signed (G).

## Files

| File | Change |
| --- | --- |
| `src/aelfrice/models.py` | `EDGE_TEMPORAL_NEXT` constant + `EDGE_VALENCE` entry |
| `src/aelfrice/bfs_multihop.py` | `BFS_EDGE_WEIGHTS` entry |
| `src/aelfrice/triple_extractor.py` | 4 regex patterns |
| `tests/bench_gate/test_bfs_multihop_temporal_next.py` | new bench-gate harness |
| `tests/corpus/v2_0/temporal_next_edge/.gitkeep` | empty corpus dir |
| `tests/corpus/v2_0/README.md` | module schema row + ship-gate subsection |
| `tests/test_corpus_schema.py` | `temporal_next_edge` module validator entry |
| `tests/test_bfs_multihop.py` | spec-test updated for new entry |
| `docs/bfs_multihop.md` | `TEMPORAL_NEXT` row + ship-gate note |

## Summary by Sourcery

Introduce TEMPORAL_NEXT edge type to BFS multi-hop retrieval with a performance-gated ship harness and corresponding corpus schema and documentation updates.

New Features:
- Add TEMPORAL_NEXT edge constant with valence, weight, and triple-extractor patterns to model and retrieval pipelines.
- Define temporal_next_edge corpus module and schema for benchmarking BFS multi-hop uplift of TEMPORAL_NEXT edges.

Enhancements:
- Document TEMPORAL_NEXT edge semantics, weight, and ship-gate criteria alongside existing BFS edge weights.
- Align BFS edge weight specs and tests with the new TEMPORAL_NEXT entry.

Tests:
- Add bench-gated BFS multi-hop test harness for TEMPORAL_NEXT that measures hit@k uplift against a zero-weight control arm.
- Extend corpus schema tests to validate the temporal_next_edge module layout and grading fields.