### PR TITLE
test(bench): retroactive ship gate for DERIVED_FROM edge (+5pp BFS uplift) (#388)

### DIFF
--- a/docs/bfs_multihop.md
+++ b/docs/bfs_multihop.md
@@ -185,11 +185,21 @@ is the noisiest signal in the v1.2 ingest output).
 |----------------|--------|----------------|-----------|
 | `SUPERSEDES`   | 0.90   | decisional     | "B replaces A" — the most actionable adjacency. If the query hit A, the user almost certainly wants B. Highest weight. |
 | `CONTRADICTS`  | 0.85   | decisional     | "B disagrees with A" — surfacing it lets the agent flag the conflict instead of acting on a contradicted belief. Slightly below SUPERSEDES because contradictions are not always resolved (the v1.0.1 contradiction tie-breaker may not have fired yet). |
-| `DERIVED_FROM` | 0.70   | provenance     | "B's content depends on A" — strong contextual coupling, per the v1.2 ingest enrichment spec ("sibling becomes stale if A is superseded"). Following it surfaces parent decisions. |
+| `DERIVED_FROM` | 0.70   | provenance     | "B's content depends on A" — strong contextual coupling, per the v1.2 ingest enrichment spec ("sibling becomes stale if A is superseded"). Following it surfaces parent decisions. Triple extractor produces `DERIVED_FROM` from "X is derived from Y" / "X is based on Y" / "X extends Y". **Retroactive ship-gate (#388):** shipped pre-bench-gate at v1.2; now must clear the same ≥+5pp BFS multi-hop hit@k uplift bar as the other Track A edges per #382 ratification; gate harness at `tests/bench_gate/test_bfs_multihop_derived_from.py`. Below-floor closes #388 as `wontfix`. |
 | `IMPLEMENTS`   | 0.65   | provenance     | "B implements A" — source is an implementation, target is the spec/claim being implemented. Slightly below DERIVED_FROM (0.70) because IMPLEMENTS is a more specific kind of derivation, but the dependency is almost as strong: an implementation becomes stale when its spec is superseded. Triple extractor produces `IMPLEMENTS` from "X implements Y" / "X is an implementation of Y" / "X realizes Y" / "X fulfills Y". **v2.0 ship-gate (#385):** the edge stays at weight 0.65 only while it clears a ≥+5pp BFS multi-hop hit@k uplift on the labeled `implements_edge/` corpus vs. the same fixture run with this entry zeroed; gate harness lives at `tests/bench_gate/test_bfs_multihop_implements.py`. Below-floor closes #385 as `wontfix`. |
 | `SUPPORTS`     | 0.60   | evidential     | "B argues for A" — supporting evidence is useful adjacent context but lower-priority than provenance or supersession. |
 | `CITES`        | 0.40   | referential    | "B mentions A" — weakest of the explicitly-relational edges. Per v1.0 `EDGE_VALENCE`, CITES is half of SUPPORTS for valence propagation; mirror that here. |
 | `RELATES_TO`   | 0.30   | informational  | The catch-all. Triple extractor produces `RELATES_TO` from "X relates to Y" / "X is related to Y" — the loosest relational verbs. Low weight, but non-zero so densely-connected `RELATES_TO` neighborhoods can still surface the *single* highest-`bm25` hit they reach. **v2.0 ship-gate (#383):** the edge stays at weight 0.30 only while it clears a ≥+5pp BFS multi-hop hit@k uplift on the labeled `bfs_relates_to/` corpus vs. the same fixture run with this entry zeroed; gate harness lives at `tests/bench_gate/test_bfs_multihop_relates_to.py`. Per #382 Decision A2 (operator ratification 2026-05-04) the universal +5pp bar replaced the umbrella's proposed +3pp floor — `RELATES_TO` is the most generic catch-all and has the highest over-fit risk among Track A edges. Below-floor closes #383 as `wontfix`. |
+
+**Retroactive bench gate for `DERIVED_FROM` (#388).** `DERIVED_FROM` shipped
+at v1.2.0 as part of the ingest enrichment wave, before the #382 Track A
+ship-gate ratification. Per #382 Decision A2 (operator ratification
+2026-05-04), all Track A edges must demonstrate ≥+5pp BFS multi-hop hit@k
+uplift — no audit-only escape hatch (Decision A3). The retroactive gate
+harness lives at `tests/bench_gate/test_bfs_multihop_derived_from.py` and
+reads labeled fixtures from `tests/corpus/v2_0/derived_from_edge/`. The
+edge remains at weight 0.70 while the gate is pending; below-floor closes
+#388 as `wontfix` and the weight entry drops to 0.0.
 
 Constants live in `src/aelfrice/retrieval.py` next to the BFS
 implementation, not in `models.py` — the BFS weights are a

--- a/tests/bench_gate/test_bfs_multihop_derived_from.py
+++ b/tests/bench_gate/test_bfs_multihop_derived_from.py
@@ -1,0 +1,134 @@
+"""Bench gate for #388 — Track A `DERIVED_FROM` edge type ship gate.
+
+DERIVED_FROM was added pre-bench-gate (#382 ratification) and must now
+demonstrate the same +5pp uplift bar as the other Track A edges.
+
+Per #382 Decision A2 (operator ratification 2026-05-04 at
+https://github.com/robotrocketscience/aelfrice/issues/382#issuecomment-4372683018),
+`DERIVED_FROM` ships only when it demonstrates **≥+5pp BFS multi-hop hit@k
+uplift** on the labeled fixture vs. the same fixture run with
+`BFS_EDGE_WEIGHTS[DERIVED_FROM]` zeroed (which causes the BFS expander to
+skip DERIVED_FROM edges per `bfs_multihop.py:155-160`).
+
+Skips cleanly when `AELFRICE_CORPUS_ROOT` is unset (public CI), when the
+`derived_from_edge/` module dir is missing, or when the corpus has fewer than
+`MIN_ROWS` non-seed rows (the gate requires a row floor before uplift
+measurement is statistically meaningful).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_corpus_module
+
+UPLIFT_FLOOR = 0.05  # +5pp per #382 Decision A2 (universal Track A bar)
+MIN_ROWS = 30  # public-tree floor; lab corpus is expected to exceed this
+
+
+def _build_store(tmp_path: Path, row: dict, arm: str):
+    """Materialize a row's beliefs + edges into a transient MemoryStore.
+
+    `arm` namespaces the db path so the two arms (with/without DERIVED_FROM)
+    don't collide on the same SQLite file.
+    """
+    from aelfrice.bfs_multihop import expand_bfs  # noqa: F401  (sanity import)
+    from aelfrice.models import BELIEF_FACTUAL, Belief, Edge
+    from aelfrice.store import MemoryStore
+
+    db_path = tmp_path / f"{row['id']}-{arm}.db"
+    store = MemoryStore(str(db_path))
+    for b in row["beliefs"]:
+        belief = Belief(
+            id=b["id"],
+            content=b["text"],
+            content_hash=f"h_{b['id']}",
+            alpha=1.0,
+            beta=1.0,
+            type=BELIEF_FACTUAL,
+            lock_level="none",
+            locked_at=None,
+            demotion_pressure=0,
+            created_at="2026-05-04T00:00:00Z",
+            last_retrieved_at=None,
+        )
+        store.insert_belief(belief)
+    for e in row["edges"]:
+        store.insert_edge(
+            Edge(src=e["src"], dst=e["dst"], type=e["type"], weight=float(e["weight"]))
+        )
+    return store
+
+
+def _row_hits(row: dict, store) -> int:
+    """Run BFS expansion on a row's seeds and count how many of the
+    row's `expected_hit_ids` appear in the top-k expansions."""
+    from aelfrice.bfs_multihop import expand_bfs
+
+    seeds = []
+    for sid in row["seed_ids"]:
+        b = store.get_belief(sid)
+        assert b is not None, f"row {row['id']}: seed {sid} not in row beliefs"
+        seeds.append(b)
+    expansions = expand_bfs(seeds, store)
+    k = int(row["k"])
+    top_ids = {hop.belief.id for hop in expansions[:k]}
+    expected = set(row["expected_hit_ids"])
+    return len(top_ids & expected)
+
+
+@pytest.mark.bench_gated
+def test_derived_from_edge_uplift(
+    aelfrice_corpus_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rows = [
+        r for r in load_corpus_module(aelfrice_corpus_root, "derived_from_edge")
+        if not r.get("seed", False)
+    ]
+
+    if len(rows) < MIN_ROWS:
+        pytest.skip(
+            f"derived_from_edge corpus has {len(rows)} non-seed rows; gate requires "
+            f"≥{MIN_ROWS} for stable uplift measurement"
+        )
+
+    from aelfrice.bfs_multihop import BFS_EDGE_WEIGHTS
+    from aelfrice.models import EDGE_DERIVED_FROM
+
+    total_targets = sum(len(r["expected_hit_ids"]) for r in rows)
+    assert total_targets > 0, "corpus has zero expected_hit_ids; cannot grade"
+
+    # Arm 1: full edge weights (DERIVED_FROM at its production weight 0.70).
+    with_hits = 0
+    for row in rows:
+        store = _build_store(tmp_path, row, arm="with")
+        try:
+            with_hits += _row_hits(row, store)
+        finally:
+            store.close()
+
+    # Arm 2: zero out DERIVED_FROM. The BFS expander treats edge_w == 0.0 as
+    # "skip" without marking visited, so this isolates the edge's
+    # contribution to reachability.
+    monkeypatch.setitem(BFS_EDGE_WEIGHTS, EDGE_DERIVED_FROM, 0.0)
+    without_hits = 0
+    for row in rows:
+        store = _build_store(tmp_path, row, arm="without")
+        try:
+            without_hits += _row_hits(row, store)
+        finally:
+            store.close()
+
+    with_rate = with_hits / total_targets
+    without_rate = without_hits / total_targets
+    uplift = with_rate - without_rate
+
+    assert uplift >= UPLIFT_FLOOR, (
+        f"DERIVED_FROM uplift {uplift:+.3f} below +{UPLIFT_FLOOR:.2f} floor "
+        f"(with={with_rate:.3f}, without={without_rate:.3f}, n_rows={len(rows)}, "
+        f"n_targets={total_targets}). Per #382 Decision A2, edge ships only "
+        f"on ≥+5pp uplift; below-floor closes #388 as wontfix."
+    )

--- a/tests/corpus/v2_0/README.md
+++ b/tests/corpus/v2_0/README.md
@@ -35,7 +35,9 @@ tests/corpus/v2_0/
 │   └── *.jsonl
 ├── directive_detection/               #374 (H1 split of #199)
 │   └── *.jsonl
-└── bfs_relates_to/                    #383 (Track A edge: RELATES_TO)
+├── bfs_relates_to/                    #383 (Track A edge: RELATES_TO)
+│   └── *.jsonl
+└── derived_from_edge/                 #388 (Track A retroactive gate: DERIVED_FROM)
     └── *.jsonl
 ```
 
@@ -69,6 +71,7 @@ required for **all** modules:
 | `directive_detection` | `prompt` (string) | `directive`, `not_directive` |
 | `bfs_relates_to` | `beliefs` (list[obj]), `edges` (list[obj]), `seed_ids` (list[string]), `expected_hit_ids` (list[string]), `k` (int) | `graded` |
 | `implements_edge` | `beliefs` (list[obj]), `edges` (list[obj]), `seed_ids` (list[string]), `expected_hit_ids` (list[string]), `k` (int) | `graded` |
+| `derived_from_edge` | `beliefs` (list[obj]), `edges` (list[obj]), `seed_ids` (list[string]), `expected_hit_ids` (list[string]), `k` (int) | `graded` |
 
 ### `directive_detection` re-entry gate (#374)
 
@@ -147,6 +150,41 @@ between the full-weights run and the `IMPLEMENTS=0` run. Threshold ≥0.05.
 Public-tree fixtures may live here (synthetic-only); real-traffic fixtures
 stay lab-side per directory-of-origin rules. The bench-gate test at
 `tests/bench_gate/test_bfs_multihop_implements.py` skips cleanly when the
+module dir is empty or has fewer rows than the floor below.
+
+### `derived_from_edge` ship gate (#388)
+
+Retroactive bench gate per #382 ratification. `DERIVED_FROM` was added
+pre-bench-gate (shipped at v1.2.0 as part of the ingest enrichment wave)
+and must now demonstrate the same **≥+5pp BFS multi-hop hit@k uplift on
+the fixture** vs. the same fixture run with `BFS_EDGE_WEIGHTS[DERIVED_FROM]`
+zeroed. Per #382 Decision A2, the universal +5pp bar applies retroactively;
+per A3 there is no audit-only escape hatch.
+
+`DERIVED_FROM` is wired schema-side (`models.EDGE_DERIVED_FROM`,
+`bfs_multihop.BFS_EDGE_WEIGHTS[DERIVED_FROM] = 0.70`,
+`triple_extractor` regex emit via "is derived from" / "is based on" /
+"extends" phrases) and remains in place while the gate is pending.
+
+Per-row shape is identical to `bfs_relates_to` and `implements_edge`:
+
+- `beliefs` — list of `{"id": str, "text": str}`.
+- `edges` — list of `{"src": str, "dst": str, "type": str, "weight": float}`.
+  Edge `type` must be one of the live `EDGE_TYPES`; rows should include
+  `DERIVED_FROM` edges to test that the edge adds hits beyond what stronger
+  edges already reach.
+- `seed_ids` — non-empty list of belief ids the BFS expands from.
+- `expected_hit_ids` — non-empty list of belief ids that should be reached
+  in the top-k expansion.
+- `k` — integer ≥ 1; the rank cutoff used to compute hit@k.
+
+Aggregation: hit-rate is `Σ |reached(row) ∩ expected_hit_ids(row)| /
+Σ |expected_hit_ids(row)|` across all rows; uplift is the difference
+between the full-weights run and the `DERIVED_FROM=0` run. Threshold ≥0.05.
+
+Public-tree fixtures may live here (synthetic-only); real-traffic fixtures
+stay lab-side per directory-of-origin rules. The bench-gate test at
+`tests/bench_gate/test_bfs_multihop_derived_from.py` skips cleanly when the
 module dir is empty or has fewer rows than the floor below.
 
 ## v0.1 acceptance (per #307)

--- a/tests/test_corpus_schema.py
+++ b/tests/test_corpus_schema.py
@@ -84,6 +84,16 @@ MODULES: dict[str, tuple[set[str], dict[str, str]]] = {
             "k": "int",
         },
     ),
+    "derived_from_edge": (
+        {"graded"},
+        {
+            "beliefs": "list[belief]",
+            "edges": "list[edge]",
+            "seed_ids": "list[str]",
+            "expected_hit_ids": "list[str]",
+            "k": "int",
+        },
+    ),
 }
 
 COMMON_REQUIRED = ("id", "provenance", "labeller_note", "label")


### PR DESCRIPTION
Closes #388.

Adds the +5pp BFS multi-hop bench gate for the **already-existing** `DERIVED_FROM` edge type. Audit-only adoption was rejected per #382 ratification, so DERIVED_FROM must demonstrate the same uplift bar as the other Track A edges (RELATES_TO #383, TESTS #407, TEMPORAL_NEXT #410, IMPLEMENTS #408).

## What this PR does and does not change

This PR is **test/docs only**. The edge type itself already ships in `main`:

- `EDGE_DERIVED_FROM` constant in `src/aelfrice/models.py` (valence 0.5).
- `BFS_EDGE_WEIGHTS[EDGE_DERIVED_FROM] = 0.70` in `src/aelfrice/bfs_multihop.py`.
- Three triple-extractor patterns ("is derived from", "is based on", "extends").

Those land unchanged. This PR only adds the retroactive bench gate that #382 ratification requires.

## Bench gate

`tests/bench_gate/test_bfs_multihop_derived_from.py` — clones the harness shape from #407 / #410:

- Two-arm uplift measurement: full-weights run vs. `BFS_EDGE_WEIGHTS[EDGE_DERIVED_FROM] = 0.0`.
- `UPLIFT_FLOOR = 0.05` (universal +5pp Track A bar).
- `MIN_ROWS = 30`; skips cleanly when `tests/corpus/v2_0/derived_from_edge/` has fewer rows.

Empty `.gitkeep` placeholder for the corpus dir; lab-side fixtures populate the real measurement.

If the gate misses, this issue closes as `wontfix` per #382 ratification (no audit-only escape hatch). DERIVED_FROM stays in main even on `wontfix` — the edge has been live for several releases — but the gate close documents that retrieval-uplift evidence does not back it.

## Verification

- `uv run pytest -x -q` → 2396 passed, 28 skipped (new gate skips because corpus dir is empty).
- Both commits SSH-signed (G).
- `src/` and `tests/test_bfs_multihop.py` are untouched (`git diff --stat` confirms).

## Files

| File | Change |
| --- | --- |
| `tests/bench_gate/test_bfs_multihop_derived_from.py` | new bench-gate harness |
| `tests/corpus/v2_0/derived_from_edge/.gitkeep` | empty corpus dir |
| `tests/corpus/v2_0/README.md` | module schema row + ship-gate subsection |
| `tests/test_corpus_schema.py` | `derived_from_edge` module validator entry |
| `docs/bfs_multihop.md` | ship-gate note for DERIVED_FROM |

## Summary by Sourcery

Add a retroactive BFS multi-hop bench gate for the existing DERIVED_FROM edge type and document its corpus schema and gating rules.

New Features:
- Introduce a bench-gated uplift test harness for the DERIVED_FROM Track A edge using labeled corpus fixtures.

Enhancements:
- Extend the v2.0 corpus schema and validator to support a new derived_from_edge module.
- Document the DERIVED_FROM edge’s triple-extractor behavior and retroactive ship-gate requirements in the BFS multihop docs.

Documentation:
- Describe the derived_from_edge corpus module and its ship gate in the v2.0 corpus README, including row schema and aggregation details.

Tests:
- Add a bench_gate test that measures hit@k uplift with and without DERIVED_FROM edges and enforces a ≥+5pp threshold, skipping when corpus data are insufficient.
- Create an empty derived_from_edge corpus directory (with .gitkeep) wired into the test corpus schema for future fixtures.