### PR TITLE
fix(ci): drop removed --exclude-mail flag from lychee link-check (#414)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -29,7 +29,6 @@ jobs:
             --no-progress
             --max-concurrency 4
             --accept 200,206,429
-            --exclude-mail
             './**/*.md'
             './**/*.rst'
           fail: false


### PR DESCRIPTION
## Summary

Fixes #414. The scheduled `link-check` workflow has been failing on every run since lychee removed the deprecated `--exclude-mail` flag (lycheeverse/lychee#1669, lycheeverse/lychee#1691). The pinned `lychee-action@v2.8.0` ships a lychee version that errors immediately:

```
error: unexpected argument '--exclude-mail' found
```

mailto: links are excluded by default in current lychee, so dropping the flag preserves the prior workflow behavior. No actual links were checked when the action erred out — once this lands the next scheduled run will produce real link-rot signal (and may file a follow-up issue if any are found, which is the workflow working as designed).

## Test plan

- [ ] Watch next scheduled `link-check` run (or trigger via workflow_dispatch) — should run lychee to completion instead of erroring on argument parsing.
- [ ] Confirm any new "link-check: broken links detected" issue (if filed) lists actual broken URLs, not the `--exclude-mail` error.

## Refs

- Upstream removal: https://github.com/lycheeverse/lychee/pull/1691
- Failing run: https://github.com/robotrocketscience/aelfrice/actions/runs/25337902650

## Summary by Sourcery

CI:
- Remove the deprecated --exclude-mail flag from the lychee link-check GitHub Actions workflow to restore compatibility with the current lychee version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated link validation configuration in the build pipeline to enhance validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->