### PR TITLE
refactor(scanner): route regex path through derivation worker (#264)

### DIFF
--- a/src/aelfrice/scanner.py
+++ b/src/aelfrice/scanner.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Final
 
-from aelfrice.derivation import DerivationInput, derive
+from aelfrice.derivation_worker import run_worker
 from aelfrice.inedible import is_inedible
 from aelfrice.models import (
     CORROBORATION_SOURCE_FILESYSTEM_INGEST,
@@ -221,10 +221,22 @@ def scan_repo(
     skipped_non_persisting = 0
     skipped_noise = 0
 
+    # #264 part 2: regex path defers belief materialization to
+    # `derivation_worker.run_worker`. Each regex candidate appends one
+    # unstamped row to `ingest_log`; one worker invocation at end-of-scan
+    # stamps every row, dedup-or-corroborates against `beliefs`, and
+    # writes edges. Snapshot the canonical id set up front so we can
+    # back-fill scanner accounting from log entries after the worker
+    # runs (preserves the public ScanResult contract). The LLM path
+    # remains direct-write — its alpha/beta/origin/audit_source are not
+    # yet representable in `raw_meta` for the worker to reconstruct.
+    ids_before: set[str] = set(store.list_belief_ids())
+    regex_log_ids: list[str] = []
+
     # Two-pass when an llm_router is supplied: first collect the
     # noise-filtered candidates, then route them all through the
     # batched LLM call. Single-pass when no router (default OFF):
-    # derive() handles the regex-classify path inline.
+    # the regex path delegates to the derivation worker after the loop.
     filtered: list[SentenceCandidate] = []
     for candidate in candidates:
         if is_noise(candidate.text, cfg):
@@ -297,35 +309,61 @@ def scan_repo(
                     created_at=timestamp,
                 )
         else:
-            # Regex path: delegate belief derivation to pure derive().
-            out = derive(DerivationInput(
-                raw_text=candidate.text,
+            # Regex path: append one unstamped log row. The worker
+            # invocation after this loop calls derive() + writes the
+            # canonical belief via insert_or_corroborate + stamps the
+            # row. `call_site` disambiguates the corroboration audit
+            # since INGEST_SOURCE_FILESYSTEM is shared with other
+            # entry points (transcript ingest, hook commit ingest).
+            log_id = store.record_ingest(
                 source_kind=INGEST_SOURCE_FILESYSTEM,
                 source_path=candidate.source,
-                ts=created_at,
+                raw_text=candidate.text,
                 session_id=sid,
-            ))
-            if out.belief is None:
+                ts=created_at,
+                raw_meta={"call_site": CORROBORATION_SOURCE_FILESYSTEM_INGEST},
+            )
+            regex_log_ids.append(log_id)
+
+    # End-of-batch worker invocation. Idempotent: scans every unstamped
+    # row in the store, including any orphaned by a crashed prior scan.
+    # Ours are the rows we just appended; the worker derives, dedups,
+    # and stamps each with `derived_belief_ids`. Calling once per scan
+    # rather than per candidate keeps the cost O(unstamped) instead of
+    # O(unstamped × candidates).
+    if regex_log_ids:
+        run_worker(store)
+
+        # Back-fill scanner accounting from the stamped log rows. Three
+        # outcomes per log row, mirroring the pre-#264 inline branches:
+        #   - empty derived_belief_ids → derive() returned no belief
+        #     (persist=False) → skipped_non_persisting.
+        #   - derived id already in `ids_before` → known belief
+        #     corroborated → skipped_existing.
+        #   - derived id new since `ids_before` → inserted. Counted at
+        #     most once per id so two log rows that converge on the
+        #     same belief still report inserted=1.
+        seen_new: set[str] = set()
+        for log_id in regex_log_ids:
+            entry = store.get_ingest_log_entry(log_id)
+            if entry is None:
+                continue
+            ids = entry.get("derived_belief_ids")
+            if not isinstance(ids, list) or not ids:
                 skipped_non_persisting += 1
                 continue
-            belief_id = out.belief.id
-            if store.get_belief(belief_id) is not None:
-                skipped_existing += 1
-                continue
-            store.record_ingest(
-                source_kind=INGEST_SOURCE_FILESYSTEM,
-                source_path=candidate.source,
-                raw_text=candidate.text,
-                derived_belief_ids=[belief_id],
-                session_id=sid,
-                ts=created_at,
-            )
-            _, was_inserted = store.insert_or_corroborate(
-                out.belief,
-                source_type=CORROBORATION_SOURCE_FILESYSTEM_INGEST,
-            )
-            if was_inserted:
-                inserted += 1
+            for bid in ids:
+                if not isinstance(bid, str):
+                    continue
+                if bid in ids_before:
+                    skipped_existing += 1
+                elif bid not in seen_new:
+                    seen_new.add(bid)
+                    inserted += 1
+                else:
+                    # Same belief id already counted in this scan
+                    # (two regex log rows hashed to the same id).
+                    skipped_existing += 1
 
     return ScanResult(
         inserted=inserted,

--- a/tests/test_scanner_via_worker.py
+++ b/tests/test_scanner_via_worker.py
@@ -1,0 +1,135 @@
+"""Integration tests for the post-#264 scan_repo (regex path) →
+derivation_worker call shape.
+
+Each test states a falsifiable hypothesis about the new contract:
+
+    scan_repo (with no llm_router) writes one log row per
+    noise-survived candidate and invokes run_worker once at
+    end-of-scan. The worker derives + dedup-or-corroborates +
+    stamps every row.
+
+These tests anchor the new invariants for the scanner regex path. The
+LLM-classify path is intentionally untouched in this PR — its
+alpha/beta/origin/audit_source are not yet representable in
+`raw_meta` for the worker to reconstruct.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from aelfrice.replay import replay_full_equality
+from aelfrice.scanner import scan_repo
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Iterator[MemoryStore]:
+    s = MemoryStore(str(tmp_path / "scanner-via-worker.db"))
+    yield s
+    s.close()
+
+
+def _seed_repo(root: Path) -> None:
+    """Drop a tiny doc-only tree the filesystem extractor will see.
+
+    Two paragraphs in a single .md file is enough to produce multiple
+    candidates without depending on git or AST extraction.
+    """
+    (root / "README.md").write_text(
+        "The configuration file lives at /etc/aelfrice/conf.\n"
+        "\n"
+        "The default port is 8080 for the dashboard.\n"
+        "\n"
+        "Aelfrice stores beliefs in a SQLite database.\n",
+        encoding="utf-8",
+    )
+
+
+def test_every_log_row_is_stamped_after_scan(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: after scan_repo returns, no row in `ingest_log`
+    remains unstamped — the worker ran end-of-scan. Falsifiable by any
+    row whose `derived_belief_ids IS NULL` after the call (worker did
+    not run, or scanner bypassed the worker for some candidates)."""
+    _seed_repo(tmp_path)
+    scan_repo(store, tmp_path)
+    unstamped = store.list_unstamped_ingest_log()
+    assert unstamped == [], f"unstamped rows: {unstamped}"
+
+
+def test_log_row_carries_call_site_metadata(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: the regex path stamps
+    `raw_meta.call_site = filesystem_ingest` so the worker resolves
+    the corroboration source unambiguously even though the scanner
+    shares `source_kind=filesystem` with other entry points.
+    Falsifiable if any scanner-written row is missing the key or
+    carries a different call_site."""
+    _seed_repo(tmp_path)
+    scan_repo(store, tmp_path)
+    rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT raw_meta FROM ingest_log"
+    ).fetchall()
+    assert rows
+    for row in rows:
+        meta = json.loads(row["raw_meta"]) if row["raw_meta"] else None
+        assert isinstance(meta, dict)
+        assert meta.get("call_site") == "filesystem_ingest"
+
+
+def test_replay_full_equality_passes_after_scan(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis (CI gate): after a scan_repo run, the full-equality
+    replay probe reports zero drift. Tripwire for the regex path
+    bypassing the worker (`canonical_orphan`) or the worker producing
+    a different canonical belief than direct derive (`mismatched`).
+    Falsifiable by any non-zero drift counter."""
+    _seed_repo(tmp_path)
+    scan_repo(store, tmp_path)
+    # Second scan exercises the corroboration path inside the worker.
+    scan_repo(store, tmp_path)
+    report = replay_full_equality(store)
+    assert report.total_log_rows > 0
+    assert report.matched == report.total_log_rows, (
+        f"replay drift: matched={report.matched}, "
+        f"mismatched={report.mismatched}, "
+        f"derived_orphan={report.derived_orphan}, "
+        f"canonical_orphan={report.canonical_orphan}, "
+        f"examples={report.drift_examples}"
+    )
+    assert report.mismatched == 0
+    assert report.derived_orphan == 0
+    assert report.canonical_orphan == 0
+
+
+def test_scan_repo_idempotent_after_worker_path(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: re-scanning the same tree under the worker path is
+    idempotent on the canonical belief set even though it adds new log
+    rows (one per candidate, per scan). `ScanResult.inserted` is 0 on
+    the second run; the second scan's candidates all classify as
+    skipped_existing. Falsifiable by a duplicate belief OR by a
+    non-zero `inserted` on the second scan."""
+    _seed_repo(tmp_path)
+    first = scan_repo(store, tmp_path)
+    assert first.inserted >= 1
+    beliefs_after_first = store.count_beliefs()
+
+    second = scan_repo(store, tmp_path)
+    assert second.inserted == 0
+    assert second.skipped_existing >= first.inserted
+    assert store.count_beliefs() == beliefs_after_first
+
+    # Two log rows for each persistable candidate (one per scan).
+    rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT COUNT(*) AS n FROM ingest_log",
+    ).fetchone()
+    assert rows["n"] >= 2 * first.inserted


### PR DESCRIPTION
## Summary
- Convert `scanner.py` regex path to the post-#264 worker call shape: each
  candidate writes one unstamped `ingest_log` row, then `run_worker(store)`
  runs once at end-of-scan to derive + dedup-or-corroborate + stamp.
- LLM-classify path is intentionally untouched. Converting it needs a
  worker-side override for `alpha/beta/origin/audit_source` (regex
  derive() can't reconstruct those from `raw_meta` alone). Filing as
  follow-up.
- Mirror the `tests/test_ingest_via_worker.py` shape from #399: log-row
  stamped invariant, `call_site` metadata invariant, `replay_full_equality`
  CI gate, and re-scan idempotence.

## What changed
**`src/aelfrice/scanner.py`** — drop `from aelfrice.derivation import …`;
import `run_worker`. In `scan_repo`:
- snapshot `list_belief_ids()` as `ids_before` before the candidate loop
- regex branch appends `record_ingest(..., raw_meta={"call_site":
  filesystem_ingest})` and the returned log id to `regex_log_ids`
- after the loop, call `run_worker(store)` once
- back-fill `ScanResult.inserted / skipped_existing /
  skipped_non_persisting` by inspecting each stamped log row's
  `derived_belief_ids` against `ids_before`

**`tests/test_scanner_via_worker.py`** — four tests:
1. `test_every_log_row_is_stamped_after_scan`
2. `test_log_row_carries_call_site_metadata`
3. `test_replay_full_equality_passes_after_scan`
4. `test_scan_repo_idempotent_after_worker_path`

## Behavior shifts (deliberate, matching #399)
- Re-scanning the same tree now writes a new `ingest_log` row per
  surviving candidate. The log is canonical; the belief table is
  unchanged via `insert_or_corroborate`'s `content_hash UNIQUE`.
- The pre-#264 fast-skip on `store.get_belief(id) is not None` is gone —
  the worker corroborates on every duplicate raw input.

## Verification
- `uv run pytest` → 2400 passed, 30 skipped.
- Discretion grep clean.

## Out of scope (follow-ups)
- LLM-classify path conversion (needs worker raw_meta override for
  alpha/beta/origin/audit_source).
- `classification.py`, `cli.py`, `mcp_server.py`, `triple_extractor.py`
  conversions (per the planning memo, in subsequent PRs).
- `aelf doctor --derive-pending` subcommand.
- `LIMITATIONS.md` cleanup.

## Test plan
- [x] `uv run pytest tests/test_scanner_via_worker.py` — 4 passed
- [x] `uv run pytest tests/test_scanner_scan_repo.py tests/regression/test_scan_repo_noise_filter_end_to_end.py` — 29 passed
- [x] Full `uv run pytest` — 2400 passed
- [x] `uv run --with ruff ruff check src/aelfrice/scanner.py` — clean

## Summary by Sourcery

Route the scanner's regex classification path through the derivation worker and backfill scan accounting from ingest log entries, while preserving the public ScanResult contract.

Enhancements:
- Defer regex-based belief derivation to a single end-of-scan worker run that processes unstamped ingest_log rows and materializes beliefs via insert-or-corroborate.
- Track pre-scan belief IDs and derive inserted/skipped_existing/skipped_non_persisting counts by inspecting stamped ingest_log entries, ensuring idempotent behavior on repeated scans.
- Attach call_site metadata to filesystem regex ingest_log rows to disambiguate corroboration origin across shared source kinds.

Tests:
- Add integration tests validating that scan_repo leaves no unstamped ingest_log rows, propagates call_site metadata, maintains replay_full_equality with the worker path, and remains idempotent on canonical beliefs across repeated scans.