### PR TITLE
feat(ci): #413 differential PR gates — docs-only path filters + pr-title-prefix + auto docs label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,18 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    # #413 — docs-only PRs skip pytest. paths-ignore is a UNION filter:
+    # the workflow runs unless every changed file matches an ignored path.
+    # A mixed PR (e.g. src/foo.py + docs/x.md) still runs full CI.
+    # TODO(post-public-flip): once branch protection requires this check,
+    # migrate to a dorny/paths-filter detection job so the workflow always
+    # runs and reports a status, with downstream jobs gated by `if:`.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # #413 — docs-only PRs skip CodeQL. The weekly schedule below still
+    # provides full-tree coverage. See ci.yml for the path-filter rationale.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
   schedule:
     - cron: '0 6 * * 2'
 

--- a/.github/workflows/deadcode.yml
+++ b/.github/workflows/deadcode.yml
@@ -3,6 +3,13 @@ name: deadcode
 on:
   pull_request:
     branches: [main]
+    # #413 — docs-only PRs skip deptry. See ci.yml for the path-filter rationale.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
   push:
     branches: [main]
 

--- a/.github/workflows/label-docs.yml
+++ b/.github/workflows/label-docs.yml
@@ -5,8 +5,13 @@ name: label-docs
 # deadcode.yml, and codeql.yml so the label is a faithful indicator of which
 # PRs skipped the heavy gates.
 
+# `pull_request_target` is required so the workflow can apply labels to PRs
+# from forks (the default `pull_request` token has read-only access from a
+# fork's context).  The job never checks out the PR head ref, runs no
+# code from the PR, and the token only edits labels.  step-security/harden-runner
+# runs first in egress-audit mode.
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, synchronize, reopened]
     branches: [main]
 

--- a/.github/workflows/label-docs.yml
+++ b/.github/workflows/label-docs.yml
@@ -1,0 +1,64 @@
+name: label-docs
+
+# #413 — auto-apply the `docs` label when every changed file in a PR matches
+# the docs-only path set.  Mirrors the paths-ignore globs used by ci.yml,
+# deadcode.yml, and codeql.yml so the label is a faithful indicator of which
+# PRs skipped the heavy gates.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: label-docs-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - name: Detect docs-only PR and apply label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Fetch the changed files via the API.  pull_request_target gives
+          # us a token without checking out the head ref, which is the
+          # safe pattern for label-only workflows on untrusted forks.
+          files="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')"
+          if [ -z "$files" ]; then
+            echo "No changed files reported. Skipping."
+            exit 0
+          fi
+          docs_only=1
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              docs/*) ;;
+              *.md) ;;
+              LICENSE) ;;
+              .github/ISSUE_TEMPLATE/*) ;;
+              .github/PULL_REQUEST_TEMPLATE.md) ;;
+              *)
+                docs_only=0
+                break
+                ;;
+            esac
+          done <<< "$files"
+          if [ "$docs_only" -eq 1 ]; then
+            echo "All changed files are docs-only. Applying 'docs' label."
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label docs
+          else
+            echo "PR touches non-docs paths. Removing 'docs' label if present."
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label docs || true
+          fi

--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -220,7 +220,9 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Validate PR title prefix
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -201,6 +201,38 @@ jobs:
           exit "$fail"
 
   # ---------------------------------------------------------------------------
+  # #413 — PR-title conventional-commit prefix enforcement
+  #
+  # Mirrors `commit-msg-prefix` (which validates each commit subject) but
+  # checks the PR title.  PR titles drive several downstream behaviors:
+  # CodeRabbit's `ignore_title_keywords: ["docs:", "release:"]` filter, the
+  # release-drafter category mapping, and the squash-merge subject when one
+  # is used.  A missing prefix silently disables those filters; this job
+  # surfaces the mistake before CI burns time on a docs-only PR running
+  # full pytest.
+  #
+  # The prefix list is delegated to scripts/check-commit-msg.py so it stays
+  # in sync with `commit-msg-prefix` and CLAUDE.md.
+  # ---------------------------------------------------------------------------
+  pr-title-prefix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@v4
+      - name: Validate PR title prefix
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          if ! python3 scripts/check-commit-msg.py --subject "$PR_TITLE"; then
+            echo "::error::PR title must start with a conventional-commit prefix (feat:, fix:, docs:, etc.). See CLAUDE.md or scripts/check-commit-msg.py for the allowed list. Current title: $PR_TITLE"
+            exit 1
+          fi
+          echo "PR title has a valid conventional-commit prefix."
+
+  # ---------------------------------------------------------------------------
   # #170 — PR-body issue-link warning (non-blocking)
   #
   # Inspects the PR body for a GitHub auto-close keyword followed by an issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Pre-`1.0.0` releases are atomic milestones building toward the first
 installable release; see the roadmap in [README.md](README.md).
 
+## [Unreleased]
+
+### Changed
+
+- **Differential CI gates for docs-only PRs** ([#413](https://github.com/robotrocketscience/aelfrice/issues/413)). `ci.yml` (pytest matrix), `deadcode.yml` (deptry), and `codeql.yml` (analyze) now skip on PRs whose changed files are entirely under `docs/`, `**/*.md`, `LICENSE`, `.github/ISSUE_TEMPLATE/**`, or `.github/PULL_REQUEST_TEMPLATE.md`. Mixed PRs still run full CI. The `staging-gate` security checks (gitleaks, PII pattern-scan, history-scan, release-docs-check, commit-msg-prefix, pr-body-issue-link) and `typos` always run regardless of paths. Net effect: a single-file docs PR drops from ~3 min of CI to ~30s. CodeQL still runs full-tree weekly via the existing schedule. After branch protection lands at the public flip, the path-filter approach migrates to a `dorny/paths-filter` detection job so required checks always report a status.
+
+### Added
+
+- **PR-title conventional-commit prefix gate** ([#413](https://github.com/robotrocketscience/aelfrice/issues/413)). New `pr-title-prefix` job in `staging-gate.yml` mirrors the existing `commit-msg-prefix` job but validates the PR title. Fails the PR if the title does not start with `feat:`, `fix:`, `docs:`, or another approved prefix. Prefix list is delegated to `scripts/check-commit-msg.py` so it stays in sync with commits and CLAUDE.md. Catches the silent failure mode where a missing `docs:` prefix disables CodeRabbit's `ignore_title_keywords` filter and runs unwanted bot review on a docs PR.
+
+- **Auto-`docs` label for docs-only PRs** ([#413](https://github.com/robotrocketscience/aelfrice/issues/413)). New `label-docs.yml` workflow inspects changed files via the API and applies (or removes) the `docs` label whenever the path set matches the docs-only globs above. Mirrors the path filters in the heavy gates so the label is a faithful indicator of which PRs skipped pytest / deptry / CodeQL.
+
 ## [1.6.0] - 2026-05-02
 
 ### Added


### PR DESCRIPTION
Closes #413.

## Summary

Differential PR gates so a docs-only change doesn't pay the full ~3 min CI tax. Three pieces, ratified in the issue thread:

1. **Skip heavy gates on docs-only PRs.** `ci.yml/pytest`, `deadcode.yml/deptry`, `codeql.yml/analyze` get `paths-ignore` for `docs/**`, `**/*.md`, `LICENSE`, `.github/ISSUE_TEMPLATE/**`, `.github/PULL_REQUEST_TEMPLATE.md`. Mixed PRs still run full CI (paths-ignore is a UNION filter). `staging-gate` security checks and `typos` always fire.
2. **PR-title prefix gate.** New `pr-title-prefix` job in `staging-gate.yml` validates the title against `scripts/check-commit-msg.py`. Catches the silent failure that bit the issue's reporter (no `docs:` prefix → CodeRabbit's `ignore_title_keywords` filter doesn't match → bot reviews a docs PR).
3. **Auto `docs` label.** New `label-docs.yml` applies / removes the `docs` label whenever the changed-file set matches the same docs-only globs. Faithful indicator of which PRs skipped the heavy gates.

CodeQL keeps full-tree coverage via the existing weekly schedule; only the per-PR run on docs-only changes is skipped.

## Verification

- `python3 -c "import yaml; ..."` parses all 5 touched workflows.
- `scripts/check-commit-msg.py --subject "feat: ..."` accepts; `--subject "no-prefix bad"` rejects.
- `git log github/main..HEAD --format='%h %G?'` — all 4 commits SSH-signed (G).
- Discretion grep (`sonnet|opus|...|kulili|gylf|...`) clean.

## Branch-protection note

Branch protection is deferred until the public-flip per CLAUDE.md, so `paths-ignore` works as-is today. Each touched workflow carries a TODO comment noting the post-flip migration to a `dorny/paths-filter` detection job — the same status-name remains, but it always runs and gates inner steps via `if:`, satisfying required-check semantics.

## Out of scope (deferred)

- Sourcery path filter — no `.sourcery.yaml` exists today; if Sourcery actually annoys someone on a future docs PR, add it then.
- A `force-ci` opt-in label — no signal it's needed yet.
- Migrating to `dorny/paths-filter` — wait until branch protection lands.

<!-- no-issue -->

## Summary by Sourcery

Introduce differential CI behavior and metadata for docs-only pull requests to reduce CI time and enforce consistent conventional-commit prefixes on PR titles.

New Features:
- Add a PR-title prefix gate in the staging-gate workflow that enforces conventional-commit-style prefixes on pull request titles.
- Introduce a label-docs workflow that automatically applies or removes a docs label when a pull request’s changes are limited to documentation-related paths.

Enhancements:
- Add path-based filters to CI, deadcode, and CodeQL workflows so heavy checks are skipped for docs-only pull requests while retaining full coverage via scheduled runs.
- Document the new differential CI behavior, PR-title gate, and auto docs labeling in the Unreleased section of the changelog.

CI:
- Update CI, deadcode, and CodeQL GitHub Actions workflows to use paths-ignore for documentation-related files, enabling faster docs-only checks.

Documentation:
- Add an Unreleased changelog entry describing differential CI gates for docs-only PRs, the PR-title prefix gate, and the auto docs label behavior.