### PR TITLE
ci(flag-stale-open-prs): refresh origin/main before is-ancestor check

### DIFF
--- a/.github/workflows/flag-stale-open-prs.yml
+++ b/.github/workflows/flag-stale-open-prs.yml
@@ -44,6 +44,14 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -e
+          # Refresh origin/main once per job. The runner captures
+          # origin/main via actions/checkout at job start; under
+          # concurrency.cancel-in-progress=false this run can be queued
+          # behind another, during which main may advance again. Without
+          # this fetch the is-ancestor check below uses a stale view of
+          # origin/main and re-flags PRs that are already on top of live
+          # main. See #418.
+          git fetch origin main --quiet
           # JSON: [{number, headRefName, isCrossRepository, labels}]
           # --limit 1000 disables default pagination so every open PR is processed.
           prs=$(gh pr list --state open --base main --limit 1000 \


### PR DESCRIPTION
## Summary

Closes #418. The `flag-stale-open-prs.yml` workflow's
`git merge-base --is-ancestor origin/main "origin/$head"` probe
(line 69) ran against whatever `origin/main` the runner picked up
from `actions/checkout` at job start. Under
`concurrency.cancel-in-progress: false` a queued run can wait while
`main` advances again, so `origin/main` in the runner is stale
relative to the live branch. PRs already rebased onto the live `main`
then get re-flagged `attn:merge-conflict`.

## Change

One line of code, six lines of comment:

```yaml
git fetch origin main --quiet
```

inserted right after `set -e`, before the PR-list loop. Per-iteration
`git fetch origin "$head"` on line 67 is unchanged.

## Why job-scoped, not per-iteration

`main` doesn't change mid-job (a `push` to `main` would trigger a new
queued run, not modify this one). One fetch suffices.

## Evidence the bug fires today

- PR #399 (2026-05-04 15:46–15:47): label cleared manually, workflow
  re-added it within 1m.
- PR #416 (2026-05-04 19:40 / 19:44): bot re-posted "behind main"
  comment twice while local `git merge-base --is-ancestor` returned
  true.

## Test plan

- [x] Local `yamllint` parses cleanly (no syntax change beyond a
  shell-block insertion).
- [ ] Real-world: next time `main` advances and a PR is rebased onto
  it, `attn:merge-conflict` is cleared on the PR's first eligible
  workflow run rather than re-asserted.
- [ ] Workflow log shows `From github.com:robotrocketscience/aelfrice
  branch main -> FETCH_HEAD` line before the per-PR loop.

## Out of scope

- Comment-spam dedupe on the rebase prompt.
- The unrelated label race observed in the closed-issue path of
  `aelf-scan.sh` (filed separately if needed).

## Summary by Sourcery

CI:
- Refresh origin/main once per job in the flag-stale-open-prs GitHub Actions workflow to avoid using a stale merge base.