### PR TITLE
feat(retrieve_uplift): per-flag NDCG@k bench harness for v1.7 default-on flip (#154)

### DIFF
--- a/tests/bench_gate/test_retrieve_uplift.py
+++ b/tests/bench_gate/test_retrieve_uplift.py
@@ -1,0 +1,45 @@
+"""Bench gate for #154 default-on flip — per-flag retrieve() NDCG@k uplift.
+
+Loads the lab-mounted `retrieve_uplift` corpus and asserts that no
+v1.7 flag regresses mean NDCG@k against the all-flags-off baseline.
+A regression is the trigger to leave that flag default-off; a
+positive uplift is the trigger to flip it default-on.
+
+This test DOES NOT assert a specific positive uplift threshold.
+That's an operator decision per flag, made on the resulting evidence
+table — see the runner CLI:
+
+    AELFRICE_CORPUS_ROOT=~/projects/aelfrice-lab/tests/corpus/v2_0 \\
+        python -m tests.retrieve_uplift_runner
+
+The bench-gate test only enforces the no-regression invariant; it
+fails loudly if any flag is net-negative, succeeds quietly otherwise.
+
+Skips on public CI (corpus absent) per the directory-of-origin rule.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_corpus_module
+from tests.retrieve_uplift_runner import run_per_flag_uplift
+
+
+@pytest.mark.bench_gated
+def test_retrieve_per_flag_no_regression(aelfrice_corpus_root: Path) -> None:
+    rows = load_corpus_module(aelfrice_corpus_root, "retrieve_uplift")
+    assert rows, "retrieve_uplift corpus produced zero rows"
+
+    results = run_per_flag_uplift(rows)
+    regressions = [r for r in results if r.uplift < 0]
+    detail = "\n".join(
+        f"  {r.flag}: NDCG_off={r.mean_ndcg_off:.4f} "
+        f"NDCG_on={r.mean_ndcg_on:.4f} uplift={r.uplift:+.4f}"
+        for r in results
+    )
+    assert not regressions, (
+        f"v1.7 flags regress NDCG@k against baseline:\n{detail}\n"
+        f"regressing flags: {[r.flag for r in regressions]}"
+    )

--- a/tests/corpus/v2_0/README.md
+++ b/tests/corpus/v2_0/README.md
@@ -43,6 +43,8 @@ tests/corpus/v2_0/
 │   └── *.jsonl
 ├── tests_edge/                        #384 (Track A edge: TESTS)
 │   └── *.jsonl
+├── retrieve_uplift/                   #154 (v1.7 default-on flip — per-flag NDCG@k)
+│   └── *.jsonl
 ├── reasoning/                         #389 (Track B: aelf reason)
 │   └── *.jsonl
 └── wonder_online/                     #389 (Track B: aelf wonder)
@@ -82,6 +84,7 @@ required for **all** modules:
 | `derived_from_edge` | `beliefs` (list[obj]), `edges` (list[obj]), `seed_ids` (list[string]), `expected_hit_ids` (list[string]), `k` (int) | `graded` |
 | `temporal_next_edge` | `beliefs` (list[obj]), `edges` (list[obj]), `seed_ids` (list[string]), `expected_hit_ids` (list[string]), `k` (int) | `graded` |
 | `tests_edge` | `beliefs` (list[obj]), `edges` (list[obj]), `seed_ids` (list[string]), `expected_hit_ids` (list[string]), `k` (int) | `graded` |
+| `retrieve_uplift` | `query` (string), `beliefs` (list[obj]), `edges` (list[obj]), `expected_top_k` (list[string], **ordered**), `k` (int) | `graded` |
 | `reasoning` | `query` (string), `beliefs` (list[obj]), `edges` (list[obj]), `expected_hit_ids` (list[string]), `baseline_search_only_top_k` (list[string]), `k` (int) | `graded` |
 | `wonder_online` | `beliefs` (list[obj]), `edges` (list[obj]), `seed_id` (string), `expected_candidate_ids` (list[string]) | `graded` |
 

--- a/tests/retrieve_uplift_runner.py
+++ b/tests/retrieve_uplift_runner.py
@@ -1,0 +1,292 @@
+"""Per-flag retrieve() uplift harness for #154 default-on flip.
+
+Loads `tests/corpus/v2_0/retrieve_uplift/*.jsonl` rows. For each row:
+build a transient `MemoryStore` from the row's beliefs + edges,
+then run `retrieve(store, query, k=row["k"], ...)` once with each
+v1.7 flag toggled on while the others stay at default-off, plus
+once with all flags off (the baseline). Score each result list with
+NDCG@k against `expected_top_k`. Per-flag uplift is the mean
+delta over the corpus.
+
+Five flags exercised:
+
+- `use_bm25f_anchors` (#148)
+- `use_signed_laplacian` (#149) — placeholder; warns if true
+- `use_heat_kernel` (#150) — wired via `heat_kernel_enabled`
+- `use_posterior_ranking` (#151) — wired via non-zero `posterior_weight`
+- `use_hrr_structural` (#152) — placeholder; warns if true
+
+The placeholders that haven't yet plumbed into `retrieve()` will
+trivially produce uplift=0 — the harness reports that as evidence
+that the flag is a no-op until the underlying lane lands.
+
+Two consumers:
+
+- `tests/bench_gate/test_retrieve_uplift.py` — bench-gate test
+  asserting no per-flag uplift regression (uplift ≥ 0).
+- Lab-side ad-hoc inspection via
+  `python -m tests.retrieve_uplift_runner --corpus-root <path>`
+  prints the per-flag NDCG table.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    LOCK_NONE,
+    ORIGIN_AGENT_INFERRED,
+    Belief,
+    Edge,
+)
+from aelfrice.retrieval import retrieve
+from aelfrice.store import MemoryStore
+
+_TS = "2026-05-05T00:00:00+00:00"
+
+# Five v1.7 flags. Each entry maps the flag name to a `kwargs` lambda
+# that produces the kwargs to pass to `retrieve()` when the flag is
+# toggled ON. Flags not in this dict are kept at their default-off
+# state. `use_signed_laplacian` and `use_hrr_structural` are
+# placeholder-only in main today — listed here so the harness records
+# their no-op status; once the lanes land in `retrieve()`, only this
+# table needs the new wire.
+FLAG_KWARGS: dict[str, Callable[[], dict]] = {  # type: ignore[type-arg]
+    "use_bm25f_anchors": lambda: {"use_bm25f_anchors": True},
+    "use_signed_laplacian": lambda: {},  # placeholder; warning-only flag
+    "use_heat_kernel": lambda: {"heat_kernel_enabled": True},
+    "use_posterior_ranking": lambda: {"posterior_weight": 0.5},
+    "use_hrr_structural": lambda: {},  # placeholder; warning-only flag
+}
+
+# Baseline: all flags off. Heat-kernel and BFS off; posterior weight
+# zero so the BM25-only ordering is the comparison floor.
+BASELINE_KWARGS: dict = {  # type: ignore[type-arg]
+    "use_bm25f_anchors": False,
+    "heat_kernel_enabled": False,
+    "posterior_weight": 0.0,
+    "bfs_enabled": False,
+    "entity_index_enabled": True,  # default-on already; not part of #154
+}
+
+
+def _default_k(row: dict) -> int:  # type: ignore[type-arg]
+    return int(row.get("k", 10))
+
+
+def _belief_from_row(b: dict) -> Belief:  # type: ignore[type-arg]
+    """Build a Belief from a corpus row's belief dict.
+
+    Required: `id`, `content`. Optional: `type`, `alpha`, `beta`.
+    Defaults match the factual/agent-inferred shape.
+    """
+    return Belief(
+        id=b["id"],
+        content=b["content"],
+        content_hash=f"corpus:{b['id']}",
+        alpha=float(b.get("alpha", 1.0)),
+        beta=float(b.get("beta", 1.0)),
+        type=b.get("type", BELIEF_FACTUAL),
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at=_TS,
+        last_retrieved_at=None,
+        origin=ORIGIN_AGENT_INFERRED,
+    )
+
+
+def _edge_from_row(e: dict) -> Edge:  # type: ignore[type-arg]
+    return Edge(
+        src=e["src"],
+        dst=e["dst"],
+        type=e["type"],
+        weight=float(e.get("weight", 0.5)),
+        anchor_text=e.get("anchor_text"),
+    )
+
+
+def ndcg_at_k(
+    result_ids: list[str],
+    expected_top_k: list[str],
+    k: int,
+) -> float:
+    """Graded NDCG@k.
+
+    `expected_top_k` is the ground-truth ranking, top first. Relevance
+    of the i-th expected belief (0-indexed) is `k - i` (so the top
+    expected belief has the highest relevance, the k-th has rel=1,
+    anything outside has rel=0).
+
+    Returns 0.0 when expected_top_k is empty (NDCG undefined; treat
+    as zero-uplift signal).
+    """
+    if not expected_top_k:
+        return 0.0
+    rel: dict[str, int] = {
+        bid: max(0, k - i) for i, bid in enumerate(expected_top_k[:k])
+    }
+    dcg = 0.0
+    for i, bid in enumerate(result_ids[:k], start=1):
+        r = rel.get(bid, 0)
+        if r:
+            dcg += r / math.log2(i + 1)
+    ideal_rels = sorted(rel.values(), reverse=True)
+    idcg = sum(
+        r / math.log2(i + 1) for i, r in enumerate(ideal_rels, start=1)
+    )
+    return dcg / idcg if idcg else 0.0
+
+
+@dataclass(frozen=True)
+class FlagUplift:
+    """Per-flag NDCG@k summary."""
+    flag: str
+    n_rows: int
+    mean_ndcg_off: float
+    mean_ndcg_on: float
+
+    @property
+    def uplift(self) -> float:
+        return self.mean_ndcg_on - self.mean_ndcg_off
+
+
+def _seed_store(store: MemoryStore, row: dict) -> None:  # type: ignore[type-arg]
+    for b in row.get("beliefs", []):
+        store.insert_belief(_belief_from_row(b))
+    for e in row.get("edges", []):
+        store.insert_edge(_edge_from_row(e))
+
+
+def _retrieve_ids(
+    store: MemoryStore, query: str, k: int, **flag_kwargs,  # type: ignore[no-untyped-def]
+) -> list[str]:
+    kwargs = {**BASELINE_KWARGS, **flag_kwargs}
+    results = retrieve(store, query, l1_limit=k, **kwargs)
+    return [b.id for b in results[:k]]
+
+
+_db_counter = [0]
+
+
+def _row_ndcg(
+    row: dict,  # type: ignore[type-arg]
+    k: int,
+    flag_kwargs: dict,  # type: ignore[type-arg]
+    tmp_root: Path,
+) -> float:
+    """One retrieve() call against a fresh store; return NDCG@k.
+
+    Each call gets its own SQLite path (monotonic counter) so adjacent
+    rows can't bleed state across the comparison and identical
+    `flag_kwargs` shapes (e.g. two placeholder flags) don't collide.
+    """
+    _db_counter[0] += 1
+    db_path = tmp_root / f"row_{row['id']}_{_db_counter[0]}.db"
+    store = MemoryStore(str(db_path))
+    try:
+        _seed_store(store, row)
+        result_ids = _retrieve_ids(
+            store, row["query"], k, **flag_kwargs,
+        )
+    finally:
+        store.close()
+    return ndcg_at_k(result_ids, row.get("expected_top_k", []), k)
+
+
+def run_per_flag_uplift(
+    rows: list[dict],  # type: ignore[type-arg]
+) -> list[FlagUplift]:
+    """Drive the corpus through retrieve() for each flag on/off.
+
+    Per row, makes one baseline call (all flags off) plus one call per
+    flag turned ON (others off). Mean NDCG@k computed across all
+    rows, per arm.
+    """
+    out: list[FlagUplift] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_root = Path(tmp)
+        for flag, kwargs_fn in FLAG_KWARGS.items():
+            kwargs_on = kwargs_fn()
+            off_total = 0.0
+            on_total = 0.0
+            for row in rows:
+                k = _default_k(row)
+                off_total += _row_ndcg(row, k, {}, tmp_root)
+                on_total += _row_ndcg(row, k, kwargs_on, tmp_root)
+            n = len(rows)
+            out.append(FlagUplift(
+                flag=flag,
+                n_rows=n,
+                mean_ndcg_off=off_total / n if n else 0.0,
+                mean_ndcg_on=on_total / n if n else 0.0,
+            ))
+    return out
+
+
+def _format_table(results: list[FlagUplift]) -> str:
+    lines = [
+        f"{'flag':<28} {'n':>4} {'NDCG_off':>10} {'NDCG_on':>10} {'uplift':>10}",
+        "-" * 66,
+    ]
+    for r in results:
+        lines.append(
+            f"{r.flag:<28} {r.n_rows:>4} "
+            f"{r.mean_ndcg_off:>10.4f} {r.mean_ndcg_on:>10.4f} "
+            f"{r.uplift:>+10.4f}"
+        )
+    return "\n".join(lines)
+
+
+def _load_corpus(corpus_root: Path) -> list[dict]:  # type: ignore[type-arg]
+    mod_dir = corpus_root / "retrieve_uplift"
+    if not mod_dir.is_dir():
+        return []
+    rows: list[dict] = []  # type: ignore[type-arg]
+    for p in sorted(mod_dir.glob("*.jsonl")):
+        with p.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                rows.append(json.loads(line))
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--corpus-root",
+        type=Path,
+        default=Path(os.environ.get("AELFRICE_CORPUS_ROOT", "")) or None,
+        help="Path to a corpus root containing retrieve_uplift/*.jsonl.",
+    )
+    args = parser.parse_args()
+    if args.corpus_root is None:
+        print("AELFRICE_CORPUS_ROOT not set; use --corpus-root", file=sys.stderr)
+        return 2
+    rows = _load_corpus(args.corpus_root)
+    if not rows:
+        print(
+            f"no rows under {args.corpus_root}/retrieve_uplift/",
+            file=sys.stderr,
+        )
+        return 2
+    results = run_per_flag_uplift(rows)
+    print(_format_table(results))
+    # Exit 1 if any flag is net-negative on average — that's the
+    # ship-gate signal: don't flip a flag that regresses NDCG.
+    any_regression = any(r.uplift < 0 for r in results)
+    return 1 if any_regression else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_corpus_schema.py
+++ b/tests/test_corpus_schema.py
@@ -114,6 +114,20 @@ MODULES: dict[str, tuple[set[str], dict[str, str]]] = {
             "k": "int",
         },
     ),
+    # #154 v1.7 default-on flip — per-flag NDCG@k uplift over a graded
+    # ranking. Same beliefs+edges shape as the BFS modules; expected
+    # output is an *ordered* list (top-relevant first) rather than a
+    # set, since NDCG cares about position.
+    "retrieve_uplift": (
+        {"graded"},
+        {
+            "query": "str",
+            "beliefs": "list[belief]",
+            "edges": "list[edge]",
+            "expected_top_k": "list[str]",
+            "k": "int",
+        },
+    ),
     # #389 Track B — `aelf reason` ship gate. Same row structure as
     # bfs_relates_to (the gate measures hit@k uplift over a graph) plus
     # a `query` field for BM25 seed selection on the runtime path.

--- a/tests/test_retrieve_uplift_runner.py
+++ b/tests/test_retrieve_uplift_runner.py
@@ -1,0 +1,82 @@
+"""Unit tests for the #154 retrieve-uplift harness — corpus-free.
+
+Covers the deterministic primitives so the bench-gate test under
+`tests/bench_gate/test_retrieve_uplift.py` (which is corpus-gated and
+skips on public CI) doesn't carry the only assertions about the
+harness shape. NDCG@k arithmetic, FlagUplift derivation, and the
+end-to-end `run_per_flag_uplift` against a one-row synthetic corpus
+all run without `AELFRICE_CORPUS_ROOT`.
+"""
+from __future__ import annotations
+
+from tests.retrieve_uplift_runner import (
+    FLAG_KWARGS,
+    FlagUplift,
+    ndcg_at_k,
+    run_per_flag_uplift,
+)
+
+
+def test_ndcg_perfect_ranking_is_one() -> None:
+    """Hypothesis: when result_ids equals expected_top_k in order,
+    NDCG@k is exactly 1.0. Falsifiable if the metric ever deviates
+    from 1.0 on a perfect ordering."""
+    expected = ["a", "b", "c", "d"]
+    assert ndcg_at_k(expected, expected, k=4) == 1.0
+
+
+def test_ndcg_empty_expected_is_zero() -> None:
+    """Hypothesis: NDCG is 0 when ground truth is empty."""
+    assert ndcg_at_k(["a", "b"], [], k=2) == 0.0
+
+
+def test_ndcg_no_overlap_is_zero() -> None:
+    """Hypothesis: result list disjoint from expected_top_k → NDCG=0."""
+    assert ndcg_at_k(["x", "y", "z"], ["a", "b", "c"], k=3) == 0.0
+
+
+def test_ndcg_partial_overlap_between_zero_and_one() -> None:
+    """Hypothesis: a partial-overlap ordering yields 0 < NDCG < 1.
+    Falsifiable if the metric pegs at the boundaries on partial hits."""
+    score = ndcg_at_k(["a", "x", "b"], ["a", "b", "c"], k=3)
+    assert 0.0 < score < 1.0
+
+
+def test_ndcg_position_matters() -> None:
+    """Hypothesis: putting the top-relevant belief at position 1
+    scores higher than putting it at position 3. Falsifiable if
+    position weighting is broken."""
+    expected = ["a", "b", "c"]
+    front = ndcg_at_k(["a", "x", "y"], expected, k=3)
+    back = ndcg_at_k(["x", "y", "a"], expected, k=3)
+    assert front > back
+
+
+def test_flag_uplift_dataclass_uplift_property() -> None:
+    """Sanity: uplift = on - off."""
+    fu = FlagUplift(flag="x", n_rows=10, mean_ndcg_off=0.4, mean_ndcg_on=0.55)
+    assert abs(fu.uplift - 0.15) < 1e-9
+
+
+def test_run_per_flag_uplift_covers_all_flags() -> None:
+    """Hypothesis: the harness reports one row per registered flag.
+    Falsifiable if a flag is silently dropped."""
+    row = {
+        "id": "ru-test-001",
+        "query": "memory store",
+        "k": 3,
+        "beliefs": [
+            {"id": "b1", "content": "the memory store persists beliefs"},
+            {"id": "b2", "content": "the configuration file lives at /etc"},
+            {"id": "b3", "content": "the memory store uses sqlite"},
+        ],
+        "edges": [],
+        "expected_top_k": ["b1", "b3"],
+    }
+    results = run_per_flag_uplift([row])
+    flags = {r.flag for r in results}
+    assert flags == set(FLAG_KWARGS.keys())
+    for r in results:
+        assert r.n_rows == 1
+        assert 0.0 <= r.mean_ndcg_off <= 1.0
+        assert 0.0 <= r.mean_ndcg_on <= 1.0


### PR DESCRIPTION
Task 1 of [#154](https://github.com/robotrocketscience/aelfrice/issues/154)'s default-on flip workflow. Builds the per-flag retrieve() NDCG@k bench harness; the lab-side run + per-flag flip decisions + README update + v2.0 tag are tasks 2–5 (sequenced after this lands).

## What ships

### Per-flag NDCG@k harness — `tests/retrieve_uplift_runner.py`

Drives a labeled query corpus through `retrieve()` once with all v1.7 flags off (baseline) and once with each flag toggled on (others off). Computes mean NDCG@k per arm and reports per-flag uplift.

Five flags exercised:
- `use_bm25f_anchors` (#148) — wired
- `use_signed_laplacian` (#149) — placeholder; reports uplift=0 until the lane lands
- `use_heat_kernel` (#150) — wired via `heat_kernel_enabled`
- `use_posterior_ranking` (#151) — wired via `posterior_weight=0.5`
- `use_hrr_structural` (#152) — placeholder; same shape as #149

The runner is also a CLI:
```
AELFRICE_CORPUS_ROOT=~/projects/aelfrice-lab/tests/corpus/v2_0 \
    python -m tests.retrieve_uplift_runner
```
Prints a per-flag NDCG table; exits 1 if any flag regresses.

### Bench-gate test — `tests/bench_gate/test_retrieve_uplift.py`

`@pytest.mark.bench_gated`. Asserts no flag regresses NDCG@k against the baseline. Skip-on-no-corpus.

The test deliberately does **NOT** enforce a positive-uplift threshold — per-flag flip thresholds are operator decisions on the resulting evidence table.

### Unit tests — `tests/test_retrieve_uplift_runner.py`

Seven tests cover the NDCG@k arithmetic (perfect ordering = 1.0, empty expected = 0, no overlap = 0, partial overlap in (0,1), position matters) plus the FlagUplift dataclass and an end-to-end one-row synthetic corpus. All run on public CI without `AELFRICE_CORPUS_ROOT`.

### Schema registration

- `tests/test_corpus_schema.py` registers `retrieve_uplift` as a graded module: `{query, beliefs, edges, expected_top_k (ordered), k}`.
- `tests/corpus/v2_0/README.md` updated layout + per-line-shape table. Notes `expected_top_k` is **ordered** (top-relevant first) — distinct from BFS modules' set-shaped `expected_hit_ids` — because NDCG cares about position.

## Out of scope (subsequent #154 tasks)

- **Task 2** — running the bench against a populated lab corpus and posting per-flag NDCG numbers to #154. Lab-side; requires `AELFRICE_CORPUS_ROOT` mounted.
- **Task 3** — per-flag default-on flip PRs based on the resulting evidence.
- **Task 4** — README v1.7 row → `shipped`.
- **Task 5** — v2.0.0 reproducibility-cut tag.

## Test plan

- [x] `uv run pytest tests/test_retrieve_uplift_runner.py -v` — 7 passed.
- [x] `uv run pytest --ignore=tests/bench_gate -q` — 2456 passed (+10 new), 23 skipped.
- [x] `uv run pytest tests/test_corpus_schema.py -q` — 15 skipped (no corpus mounted on public CI; schema entries registered).
- [ ] Lab-side: `AELFRICE_CORPUS_ROOT=... uv run pytest tests/bench_gate/test_retrieve_uplift.py` — runs once a populated corpus lands.

## Summary by Sourcery

Introduce a per-flag NDCG@k benchmark harness and gate for retrieve() v1.7 flags using a graded corpus module.

New Features:
- Add a retrieve_uplift harness that evaluates per-flag NDCG@k uplift for retrieve() over a graded corpus and exposes a CLI for ad-hoc runs.

Enhancements:
- Register the retrieve_uplift graded corpus schema for retrieve() uplift benchmarking.

Documentation:
- Document the new retrieve_uplift graded corpus module and its ordered expected_top_k field in the v2.0 corpus README.

Tests:
- Add corpus-free unit tests for the NDCG@k metric, per-flag uplift aggregation, and harness coverage over registered flags.
- Add a bench-gated test that runs against the retrieve_uplift corpus and fails if any v1.7 flag regresses mean NDCG@k.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retrieve_uplift benchmark testing framework for evaluating feature flag performance improvements.
  * New corpus module for retrieve_uplift regression testing with structured data schema.

* **Tests**
  * Added comprehensive unit tests for performance metric calculations and validation.
  * Added bench-gated regression test to detect performance regressions.

* **Documentation**
  * Updated corpus schema documentation with retrieve_uplift module field specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->