### PR TITLE
feat(bm25): Porter stemming on the BM25F lane (#154)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,13 @@ dependencies = [
     # longer stdlib-only. CHANGELOG records the change.
     "numpy>=2.0",
     "scipy>=1.11",
+    # v1.7.0 added snowballstemmer for BM25F tokenisation parity with
+    # FTS5's Porter stemmer (#154). Pure-Python, ~150 KB; deterministic
+    # for the English Porter algorithm. Required so `q="banana"`
+    # against content `"bananas"` matches in both lanes — flipping the
+    # BM25F default-on without it loses the stemming win FTS5 gives
+    # for free.
+    "snowballstemmer>=2.2",
 ]
 
 [project.urls]

--- a/src/aelfrice/bm25.py
+++ b/src/aelfrice/bm25.py
@@ -44,9 +44,19 @@ from typing import Final
 
 import numpy as np
 import scipy.sparse as sp
+import snowballstemmer
 
 from aelfrice.models import Belief
 from aelfrice.store import MemoryStore
+
+# v1.7.0 #154: Porter stemmer for FTS5 parity. snowballstemmer's
+# "porter" implementation is the original Porter (1980) algorithm,
+# which matches SQLite FTS5's `tokenize='porter unicode61'` behavior
+# closely enough that q="banana" against content "bananas" hits in
+# both lanes. Constructed once at module load (cheap) and shared
+# across `tokenize()` calls (the stemmer is stateless on each
+# `stemWord` call).
+_PORTER_STEMMER = snowballstemmer.stemmer("porter")
 
 # Default weight for the incoming-anchor token stream, per the #148
 # spec. Synthetic-graph evaluation at N=50k under a 15%-vocab-shifted
@@ -78,16 +88,44 @@ _SERIALIZE_VERSION: Final[int] = 1
 
 
 def tokenize(text: str) -> list[str]:
-    """Lowercase + Unicode-word tokenisation.
+    """Lowercase + Unicode-word tokenisation. No stemming.
 
-    Returned tokens are the canonical form used by `BM25Index.build`
-    and `BM25Index.score`. Two pieces of text that differ only in
-    case or punctuation tokenise identically. Empty / whitespace-only
-    input returns ``[]``.
+    Returned tokens are the canonical form used by callers that need
+    word-form-preserving tokens (e.g.,
+    `aelfrice.relationship_detector` matches against unstemmed
+    quantifier tokens like ``"always"`` and ``"rarely"``). Two pieces
+    of text that differ only in case or punctuation tokenise
+    identically. Empty / whitespace-only input returns ``[]``.
+
+    BM25 indexing uses `tokenize_stemmed()` instead — that's where
+    Porter stemming lives so `q="banana"` matches content `"bananas"`
+    on the BM25F path (FTS5 already stems).
     """
     if not text:
         return []
     return [m.group(0).lower() for m in _TOKEN_PATTERN.finditer(text)]
+
+
+def tokenize_stemmed(text: str) -> list[str]:
+    """Lowercase + Unicode-word tokenisation + Porter stemming.
+
+    Used by `BM25Index.build` and `BM25Index.score` so the BM25F
+    lane has FTS5-equivalent stemming. SQLite FTS5 uses Porter by
+    default; without stemming on the BM25F path,
+    `q="banana"` against content `"bananas"` would miss matches that
+    the legacy FTS5 lane catches. Added at v1.7.0 (#154) when the
+    default-on flip was prepared.
+
+    Non-BM25 callers (relationship_detector, scoring helpers, etc.)
+    that depend on word-form-preserving tokens should keep using
+    `tokenize()`; stemming is BM25-specific.
+    """
+    if not text:
+        return []
+    return [
+        _PORTER_STEMMER.stemWord(m.group(0).lower())
+        for m in _TOKEN_PATTERN.finditer(text)
+    ]
 
 
 @dataclass
@@ -185,9 +223,9 @@ class BM25Index:
         tokens_per_doc: list[list[str]] = []
         for bid in belief_ids:
             content = contents.get(bid, "")
-            doc_tokens = tokenize(content)
+            doc_tokens = tokenize_stemmed(content)
             for anchor in incoming.get(bid, ()):
-                anchor_tokens = tokenize(anchor)
+                anchor_tokens = tokenize_stemmed(anchor)
                 for _ in range(anchor_weight):
                     doc_tokens.extend(anchor_tokens)
             tokens_per_doc.append(doc_tokens)
@@ -275,7 +313,7 @@ class BM25Index:
             return []
         if self.tf.shape[0] == 0 or self.tf.shape[1] == 0:
             return []
-        q_tokens = tokenize(query)
+        q_tokens = tokenize_stemmed(query)
         if not q_tokens:
             return []
         # Build the query indicator * idf vector in dense form

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ source = { editable = "." }
 dependencies = [
     { name = "numpy" },
     { name = "scipy" },
+    { name = "snowballstemmer" },
 ]
 
 [package.optional-dependencies]
@@ -54,6 +55,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'benchmarks'", specifier = ">=3.9" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "scipy", specifier = ">=1.11" },
+    { name = "snowballstemmer", specifier = ">=2.2" },
     { name = "tiktoken", marker = "extra == 'benchmarks'", specifier = ">=0.7" },
 ]
 provides-extras = ["mcp", "onboard-llm", "archive", "benchmarks"]
@@ -2251,6 +2253,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "snowballstemmer"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d01295633f5d574fb416d47e535f258272ca1f01f447/snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895", size = 105575, upload-time = "2025-05-09T16:34:51.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274, upload-time = "2025-05-09T16:34:50.371Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the stemming-gap blocker on [#154](https://github.com/robotrocketscience/aelfrice/issues/154)'s default-on flip. Surfaced at [#154 comment 4380887104](https://github.com/robotrocketscience/aelfrice/issues/154#issuecomment-4380887104).

## What ships

- **`snowballstemmer>=2.2`** added as a runtime dep. Pure-Python, ~150 KB, deterministic for the English Porter algorithm.
- **`tokenize_stemmed()`** helper in `aelfrice.bm25` — lowercase + Unicode-word splitting + Porter stemming. `BM25Index.build` and `BM25Index.score` switched to it so BM25F has FTS5-equivalent matching.
- **`tokenize()` (existing) stays unstemmed** — `aelfrice.relationship_detector` and any other caller that depends on word-form-preserving tokens (e.g. matching `"always"` / `"never"` / `"rarely"` against unstemmed `QUANT_AXIS` keys) keeps the old contract.

## Why this is needed

Without stemming, BM25F missed natural-language queries that FTS5's Porter stemmer caught for free:

```
q="banana", BM25F (default-on prototype): []        ← regression
q="banana", FTS5 (legacy):                ['F1']     ← matched "bananas"
```

Switching the L1 lane to BM25F by default would silently break user queries until the stemmer was added. With this PR, both lanes match.

## Bench evidence

Re-ran `python -m tests.retrieve_uplift_runner` against the v0.1 lab corpus under stemming:

| flag | n | NDCG_off | NDCG_on | uplift (pre-stem) | **uplift (post-stem)** |
|---|---|---|---|---|---|
| `use_bm25f_anchors` | 30 | 0.2499 | 0.9149 | +0.6010 | **+0.6650** |
| `use_signed_laplacian` | 30 | 0.2499 | 0.2499 | +0.0000 | +0.0000 |
| `use_heat_kernel` | 30 | 0.2499 | 0.2499 | +0.0000 | +0.0000 |
| `use_posterior_ranking` | 30 | 0.2499 | 0.2499 | +0.0000 | +0.0000 |
| `use_hrr_structural` | 30 | 0.2499 | 0.2499 | +0.0000 | +0.0000 |

`use_bm25f_anchors` uplift improved by +0.064 NDCG@k (more rows match because stem-divergent queries now hit). The other four flags are unchanged — placeholder flags or fixture-too-small per the prior #154 comment 4380842909.

## Out of scope (subsequent #154 tasks)

- **The default-on flip itself**: separate PR. Requires the regression-test contract updates documented in the prior addendum (now defensible because stemming closes the gap).
- **Stem-divergent rows in v0.1 corpus**: optional additional rows to harden the bench evidence. Current 30 rows already validate the new tokenizer behavior since `use_bm25f_anchors` uplift went UP, not DOWN.
- **README v1.7 row update**: PR #426 already proposes the honest "shipped (opt-in)" framing; can be amended after this lands to reflect that the flip is now actually unblocked.

## Test plan

- [x] `uv run pytest --ignore=tests/bench_gate -q` — 2456 passed, 23 skipped.
- [x] `AELFRICE_CORPUS_ROOT=... uv run pytest tests/bench_gate/test_retrieve_uplift.py` — PASS, no per-flag regressions.
- [x] Reproduction of the previously-failing case: `q="banana"` against content `"bananas"` now returns `['F1']` under BM25F (was `[]`).
- [x] `relationship_detector` quantifier-axis tests still pass — confirmed `tokenize()` retains unstemmed behavior for non-BM25 callers.

## Summary by Sourcery

Add Porter-stemmed tokenization to the BM25F path for parity with FTS5 and improved recall.

New Features:
- Introduce a Porter-stemmed tokenizer used by BM25Index build and score so BM25F queries and documents share stemmed tokens.

Enhancements:
- Clarify the existing tokenize() contract to remain unstemmed for callers that require word-form-preserving tokens.

Build:
- Add snowballstemmer as a runtime dependency to provide the Porter stemming implementation used by BM25F.