### PR TITLE
feat(upgrade UX): #427 — banner reword, /aelf:upgrade-cmd rename, deprecated CLI alias

### DIFF
--- a/docs/SLASH_COMMANDS.md
+++ b/docs/SLASH_COMMANDS.md
@@ -22,7 +22,7 @@ Slash files are not shipped for hidden CLI subcommands (`bench`, `feedback`, `he
 | `/aelf:doctor` | optional `[hooks\|graph]`, `--user-settings`, `--project-root` |
 | `/aelf:ingest-transcript` | path or `--batch DIR` |
 | `/aelf:setup` | optional `--scope`, `--command`, `--transcript-ingest`, etc. |
-| `/aelf:upgrade` | (none) — print pip-upgrade hint |
+| `/aelf:upgrade-cmd` | (none) — print install-method-aware upgrade command (renamed from `/aelf:upgrade` at #427 to read advisory) |
 | `/aelf:uninstall` | one of `--keep-db`, `--archive`, `--purge` |
 | `/aelf:rebuild` | (none) — manually fire the context rebuilder; v1.4.0+ |
 | `/aelf:reason` | keyword query — walks the belief graph from BM25-seeded starting points; v2.0+ (#389) |

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -15,7 +15,7 @@ Commands:
   doctor                           verify hook commands resolve in settings.json
   setup                            install UserPromptSubmit hook in Claude Code
   unsetup                          remove UserPromptSubmit hook from Claude Code
-  upgrade                          print the right pip-upgrade command line
+  upgrade-cmd                      print the right pip-upgrade command line (renamed from `upgrade` at #427)
   uninstall                        tear down aelfrice locally + handle DB
   statusline                       emit Claude Code statusline snippet
   bench                            run the v0.9.0-rc benchmark harness
@@ -2006,6 +2006,25 @@ def _format_multi_install_warning(
     return lines
 
 
+def _cmd_upgrade_deprecated_alias(
+    args: argparse.Namespace, out: object
+) -> int:
+    """Deprecated `aelf upgrade` alias — emit warning then delegate.
+
+    The subcommand was renamed to `aelf upgrade-cmd` at #427 to read
+    advisory rather than imperative. The bare `upgrade` form keeps
+    working for one minor so existing scripts don't break; this
+    handler prepends a one-line stderr deprecation notice before
+    invoking the canonical handler.
+    """
+    print(
+        "warning: `aelf upgrade` was renamed to `aelf upgrade-cmd` (#427); "
+        "the bare alias will be removed in a future release.",
+        file=sys.stderr,
+    )
+    return _cmd_upgrade(args, out)
+
+
 def _cmd_upgrade(args: argparse.Namespace, out: object) -> int:
     """Print the right upgrade command for this install context.
 
@@ -3814,8 +3833,15 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
 
     # Hidden: the orange statusline banner already prompts users when an
     # update is pending — direct CLI invocation is auxiliary.
+    #
+    # Renamed `upgrade` -> `upgrade-cmd` at #427 to read advisory (the
+    # subcommand prints the upgrade command; it does NOT execute the
+    # upgrade itself, since replacing the running package is unreliable).
+    # `upgrade` stays as a deprecated alias for one minor — wired as a
+    # second parser whose `func` prepends a stderr deprecation notice
+    # before delegating to the canonical handler.
     p_upgrade = sub.add_parser(
-        "upgrade",
+        "upgrade-cmd",
         help=argparse.SUPPRESS,
     )
     p_upgrade.add_argument(
@@ -3823,6 +3849,16 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help="only report status, do not print the upgrade command line",
     )
     p_upgrade.set_defaults(func=_cmd_upgrade)
+    # Deprecated alias. Identical args; func wraps with a stderr notice.
+    p_upgrade_alias = sub.add_parser(
+        "upgrade",
+        help=argparse.SUPPRESS,
+    )
+    p_upgrade_alias.add_argument(
+        "--check", action="store_true",
+        help="only report status, do not print the upgrade command line",
+    )
+    p_upgrade_alias.set_defaults(func=_cmd_upgrade_deprecated_alias)
 
     # Hidden: scriptable counterpart to setup. Humans use `aelf uninstall`.
     p_unsetup = sub.add_parser("unsetup", help=argparse.SUPPRESS)
@@ -4007,7 +4043,7 @@ def _add_hook_scope_args(parser: argparse.ArgumentParser) -> None:
 
 
 _UPDATE_CHECK_SKIP_CMDS: Final[frozenset[str]] = frozenset(
-    {"upgrade", "uninstall", "statusline"}
+    {"upgrade-cmd", "upgrade", "uninstall", "statusline"}
 )
 
 

--- a/src/aelfrice/lifecycle.py
+++ b/src/aelfrice/lifecycle.py
@@ -289,16 +289,24 @@ def maybe_check_for_update_async(
 # --- Banner helper -------------------------------------------------------
 
 
-def format_update_banner(latest: str) -> str:
+def format_update_banner(
+    latest: str, *, command: str | None = None
+) -> str:
     """Return the plain (no ANSI) body text for an update-available banner.
 
     Single source of truth for the banner format. Both the statusline
     snippet and the CLI stderr notice derive their text from this
     function so the wording never drifts between the two surfaces.
 
-    Example: '⬆ /aelf:upgrade to v1.5.0'
+    `command` is the install-method-aware shell line the user actually
+    runs to upgrade. Defaults to ``upgrade_advice().command`` so callers
+    that don't care can omit it; tests inject a stable value.
+
+    Example: '⬆ aelfrice 1.5.0 — run: uv tool upgrade aelfrice'
     """
-    return f"⬆ /aelf:upgrade to v{latest}"
+    if command is None:
+        command = upgrade_advice().command
+    return f"⬆ aelfrice {latest} — run: {command}"
 
 
 # --- Upgrade advice -----------------------------------------------------

--- a/src/aelfrice/slash_commands/upgrade-cmd.md
+++ b/src/aelfrice/slash_commands/upgrade-cmd.md
@@ -1,5 +1,5 @@
 ---
-name: aelf:upgrade
+name: aelf:upgrade-cmd
 description: Print the right upgrade command for this aelfrice install context.
 allowed-tools:
   - Bash
@@ -11,12 +11,17 @@ Does NOT execute the upgrade itself: replacing the running package
 mid-process is unreliable on Windows and can leave a broken interpreter.
 The user runs the printed line.
 
+The advisory `-cmd` suffix in the slash-command name is deliberate.
+The previous name `/aelf:upgrade` read as an imperative ("upgrade
+now") even though invocation only prints the shell line. New name
+signals that this surface emits the *command*; the user runs it.
+
 If an update is available, also surfaces the published wheel SHA-256
 and PyPI release URL so the user can hash-pin the install if they want.
 </objective>
 
 <process>
-Run: `uv run aelf upgrade`
+Run: `uv run aelf upgrade-cmd`
 
 Display the output verbatim. Do not add commentary.
 </process>

--- a/src/aelfrice/statusline.py
+++ b/src/aelfrice/statusline.py
@@ -76,9 +76,11 @@ def format_snippet(
     """Return the statusline snippet for the given cache status.
 
     Empty when no update is pending. When an update is pending,
-    returns 'COLOR_ON⬆ aelfrice X.Y.Z available, run: aelf upgrade
+    returns 'COLOR_ON⬆ aelfrice X.Y.Z — run: <install-aware-cmd>
     COLOR_OFF │ '. The trailing ' │ ' is the GSD-style separator
-    so the snippet composes naturally as a leading badge.
+    so the snippet composes naturally as a leading badge. The
+    embedded shell command is `upgrade_advice().command` — see
+    `lifecycle.format_update_banner` for the single source of truth.
     """
     if not status.update_available or not status.latest:
         return ""

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -31,7 +31,11 @@ EXPECTED_COMMANDS = (
     "status",
     "doctor",
     "setup",
-    "upgrade",
+    # Renamed from `upgrade` -> `upgrade-cmd` at #427 to read advisory.
+    # The bare `upgrade` form lives on as a deprecated CLI subparser
+    # alias (see HIDDEN_SUBCOMMANDS) for one minor; the slash command
+    # ships only under the new name.
+    "upgrade-cmd",
     "uninstall",
     "rebuild",
     "tail",
@@ -105,6 +109,10 @@ HIDDEN_SUBCOMMANDS = frozenset({
     "health", "stats", "project-warm", "session-delta",
     "demote", "validate", "resolve", "feedback", "ingest-transcript",
     "sweep-feedback",
+    # #427 deprecated alias — kept callable for one minor so existing
+    # `aelf upgrade` invocations don't break. The slash file ships
+    # only under the canonical `upgrade-cmd` name.
+    "upgrade",
 })
 
 

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -62,7 +62,7 @@ def test_no_color_strips_ansi() -> None:
         _fresh(), env={"NO_COLOR": "", "COLORTERM": "truecolor"}
     )
     assert "\x1b[" not in out
-    assert "/aelf:upgrade to v1.2.3" in out
+    assert "aelfrice 1.2.3 — run:" in out
 
 
 def test_no_color_set_to_anything_strips_ansi() -> None:
@@ -77,7 +77,7 @@ def test_snippet_includes_upgrade_command() -> None:
     out = statusline.format_snippet(
         _fresh(), env={"COLORTERM": "truecolor"}
     )
-    assert "/aelf:upgrade to v" in out
+    assert "aelfrice 1.2.3 — run:" in out
     assert statusline.ICON in out
 
 

--- a/tests/test_upgrade_ux.py
+++ b/tests/test_upgrade_ux.py
@@ -46,18 +46,54 @@ def test_installed_version_fallback_on_package_not_found(
 # ---------------------------------------------------------------------------
 
 
-def test_format_update_banner_text() -> None:
-    """Banner text matches the canonical shortened format."""
+def test_format_update_banner_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Banner embeds the install-method-aware command from upgrade_advice."""
+    monkeypatch.setattr(
+        lifecycle,
+        "upgrade_advice",
+        lambda: lifecycle.UpgradeAdvice(
+            command="uv tool upgrade aelfrice", context="uv_tool"
+        ),
+    )
     banner = lifecycle.format_update_banner("1.5.0")
-    assert banner == "⬆ /aelf:upgrade to v1.5.0"
+    assert banner == "⬆ aelfrice 1.5.0 — run: uv tool upgrade aelfrice"
 
 
-def test_format_update_banner_contains_slash_command() -> None:
-    assert "/aelf:upgrade" in lifecycle.format_update_banner("2.0.0")
+def test_format_update_banner_explicit_command_kwarg() -> None:
+    """Caller-supplied `command` overrides upgrade_advice() lookup."""
+    banner = lifecycle.format_update_banner(
+        "2.0.0", command="pipx upgrade aelfrice"
+    )
+    assert banner == "⬆ aelfrice 2.0.0 — run: pipx upgrade aelfrice"
 
 
-def test_statusline_snippet_uses_banner_helper() -> None:
+def test_format_update_banner_no_slash_command_advisory() -> None:
+    """Banner must not phrase a slash command as the upgrade action.
+
+    Regression for #427: the previous shape `'⬆ /aelf:upgrade to v…'`
+    read as an imperative pointing at a slash command that is itself
+    advisory, leading users to believe the slash command performed the
+    upgrade. The banner must surface the actual shell line instead.
+    """
+    banner = lifecycle.format_update_banner(
+        "1.5.0", command="uv tool upgrade aelfrice"
+    )
+    assert "/aelf:upgrade" not in banner
+
+
+def test_statusline_snippet_uses_banner_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """statusline.format_snippet embeds the output of format_update_banner."""
+    monkeypatch.setattr(
+        lifecycle,
+        "upgrade_advice",
+        lambda: lifecycle.UpgradeAdvice(
+            command="uv tool upgrade aelfrice", context="uv_tool"
+        ),
+    )
     status = lifecycle.UpdateStatus(
         update_available=True,
         installed="1.0.0",
@@ -77,11 +113,18 @@ def test_banner_shared_substring_in_statusline_and_cli(
 ) -> None:
     """Both call sites derive text from format_update_banner.
 
-    This test verifies they share the '/aelf:upgrade to v' substring,
+    This test verifies they share the 'aelfrice <ver> — run:' substring,
     ensuring the two surfaces can never drift from each other.
     """
     import io
 
+    monkeypatch.setattr(
+        lifecycle,
+        "upgrade_advice",
+        lambda: lifecycle.UpgradeAdvice(
+            command="uv tool upgrade aelfrice", context="uv_tool"
+        ),
+    )
     status = lifecycle.UpdateStatus(
         update_available=True,
         installed="1.0.0",
@@ -92,7 +135,7 @@ def test_banner_shared_substring_in_statusline_and_cli(
     # Statusline path. Pass installed="" so the running package version
     # does not auto-suppress the snippet.
     snippet = statusline.format_snippet(status, env={}, installed="")
-    assert "/aelf:upgrade to v" in snippet
+    assert "aelfrice 1.5.0 — run:" in snippet
 
     # CLI stderr banner path — monkeypatch the cache reader.
     import aelfrice.cli as cli_mod
@@ -107,7 +150,7 @@ def test_banner_shared_substring_in_statusline_and_cli(
     monkeypatch.setattr(sys, "stderr", buf)
     cli_mod._maybe_emit_update_banner("search")
     stderr_out = buf.getvalue()
-    assert "/aelf:upgrade to v" in stderr_out
+    assert "aelfrice 1.5.0 — run:" in stderr_out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_upgrade_ux.py
+++ b/tests/test_upgrade_ux.py
@@ -154,6 +154,63 @@ def test_banner_shared_substring_in_statusline_and_cli(
 
 
 # ---------------------------------------------------------------------------
+# #427 — `aelf upgrade` deprecated alias for `aelf upgrade-cmd`
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_alias_warns_and_delegates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`aelf upgrade` (deprecated alias) emits a stderr deprecation
+    notice mentioning `upgrade-cmd` and delegates to the canonical
+    handler so existing scripts continue to function."""
+    import io
+
+    import aelfrice.cli as cli_mod
+
+    captured: dict[str, object] = {}
+
+    def _fake_canonical(args: object, out: object) -> int:
+        captured["args"] = args
+        captured["out"] = out
+        return 0
+
+    monkeypatch.setattr(cli_mod, "_cmd_upgrade", _fake_canonical)
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", buf)
+
+    sentinel_args = object()
+    sentinel_out = object()
+    rc = cli_mod._cmd_upgrade_deprecated_alias(
+        sentinel_args, sentinel_out  # type: ignore[arg-type]
+    )
+
+    assert rc == 0
+    assert captured["args"] is sentinel_args
+    assert captured["out"] is sentinel_out
+    stderr_text = buf.getvalue()
+    assert "aelf upgrade" in stderr_text
+    assert "upgrade-cmd" in stderr_text
+    assert "#427" in stderr_text
+
+
+def test_upgrade_alias_registered_in_parser() -> None:
+    """Both `upgrade-cmd` (canonical) and `upgrade` (deprecated alias)
+    must be present as CLI subparsers so existing scripts still work."""
+    from aelfrice.cli import build_parser
+
+    parser = build_parser()
+    sub_actions = [
+        a
+        for a in parser._subparsers._actions  # type: ignore[union-attr]
+        if a.__class__.__name__ == "_SubParsersAction"
+    ]
+    cli_names = set(sub_actions[0].choices.keys())  # type: ignore[attr-defined]
+    assert "upgrade-cmd" in cli_names
+    assert "upgrade" in cli_names
+
+
+# ---------------------------------------------------------------------------
 # install-method detection — each branch
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #427.

## What ships (per spec recommended option 2 + 1)

### Banner reword (option 2)

`format_update_banner(latest, command=...)` now embeds the install-method-aware shell command from `upgrade_advice()`. The previous shape `"⬆ /aelf:upgrade to v1.5.0"` read as an imperative pointing at a slash command that is itself advisory — the operator misread it as "click `/aelf:upgrade` to upgrade." New shape:

```
⬆ aelfrice 1.5.0 — run: uv tool upgrade aelfrice
```

Both call sites (statusline snippet + CLI stderr banner) inherit the new shape from the helper. Tests pin the new contract and a regression assertion verifies no slash-command name leaks into the banner.

### Slash command + CLI subparser rename (option 1)

- `/aelf:upgrade` → `/aelf:upgrade-cmd` (file rename + front matter `name:`)
- `aelf upgrade` → `aelf upgrade-cmd` (canonical CLI subparser)
- `aelf upgrade` stays as a deprecated alias (separate parser; `func` wraps `_cmd_upgrade` with a stderr deprecation notice). Removal targeted for one minor after this lands.
- `EXPECTED_COMMANDS` test fixture updates to `upgrade-cmd`; `HIDDEN_SUBCOMMANDS` gains `upgrade` for the deprecated alias so the parser-vs-bundle drift assertion stays green.
- Existing user installs with cached `~/.claude/commands/aelf/upgrade.md` get the stale file pruned automatically on next `aelf setup` run.

## Out of scope

- Cache-staleness logic (#214 territory).
- Install-method detection (#242 territory; this PR consumes the existing `upgrade_advice()` helper).
- Replacing the running package mid-process — intentionally avoided by the original design and not changed here.

## Test plan

- `uv run pytest --ignore=tests/bench_gate -q` — 2459 passed, 23 skipped (vs 2457 baseline; +2 new tests for deprecated alias + parser registration).
- `uv run pytest tests/test_upgrade_ux.py tests/test_statusline.py tests/test_slash_commands.py tests/test_cli_setup.py -q` — 152 passed.

## Summary by Sourcery

Reword the upgrade banner and statusline snippet to show an install-method-aware shell command and rename the upgrade slash/CLI command while keeping a deprecated alias for backward compatibility.

New Features:
- Expose an install-method-aware upgrade shell command in the update banner and statusline snippet via a shared helper.
- Introduce the `upgrade-cmd` slash command and canonical CLI subcommand as the primary interface for upgrade guidance.

Bug Fixes:
- Prevent the update banner from implying that the slash command itself performs the package upgrade by surfacing the actual shell command instead.

Enhancements:
- Add a deprecated `aelf upgrade` CLI alias that warns and delegates to `upgrade-cmd` to avoid breaking existing scripts.
- Expand upgrade UX tests to cover the new banner format, statusline integration, and deprecated alias behavior.
- Update slash command metadata and documentation to reflect the `upgrade-cmd` rename and clarify its advisory nature.

Tests:
- Add tests for the new banner format, including explicit command overrides and regression coverage ensuring no slash-command name appears as the upgrade action.
- Add tests verifying the deprecated `aelf upgrade` alias emits a deprecation warning, delegates correctly, and remains registered alongside `upgrade-cmd` in the CLI parser.
- Update statusline tests to assert the new banner wording and shared text between statusline and CLI stderr surfaces.