### PR TITLE
ci(replay-soak-gate): scope to #264-touching paths only

### DIFF
--- a/.github/workflows/replay-soak-gate.yml
+++ b/.github/workflows/replay-soak-gate.yml
@@ -5,11 +5,34 @@ name: Replay Soak Gate
 # `replay-soak / consecutive-green ≥ 7d`. Per the 2026-05-04
 # ratification, that name is added to the branch ruleset's
 # required_status_checks list (admin step, separate from this PR).
+#
+# Path scope: only fires on PRs that touch the derivation contract
+# surface (the actual #264 risk surface), the soak fixture, the soak
+# runner / streak scripts, or the soak workflows themselves. Out-of-
+# scope PRs (retrieval, BM25F, edge rerank, contradiction detector,
+# UX, docs) don't see this check at all — keeps the gate honest to
+# its stated intent rather than firing on every PR. Residual risk:
+# additive edits to `store.py` / `models.py` that touch the
+# derivation contract aren't soak-gated; the regular pytest matrix
+# (`replay_full_equality` tests) catches those, and any drift
+# surfaces on the next daily cron entry on main.
 
 on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
+    paths:
+      - 'src/aelfrice/derivation.py'
+      - 'src/aelfrice/derivation_worker.py'
+      - 'src/aelfrice/replay.py'
+      - 'src/aelfrice/ingest.py'
+      - 'src/aelfrice/scanner.py'
+      - 'tests/replay_soak_runner.py'
+      - 'tests/corpus/replay_soak/**'
+      - 'scripts/replay_soak_run.py'
+      - 'scripts/replay_soak_streak.py'
+      - '.github/workflows/replay-soak.yml'
+      - '.github/workflows/replay-soak-gate.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Adds a `paths:` filter to `.github/workflows/replay-soak-gate.yml` so the gate fires only on PRs that touch the derivation-contract surface (the actual #264 risk surface), the soak fixture, the runner/streak scripts, or the soak workflows themselves.

## Why

The gate's own docstring says it gates *"#264-touching merges"* but the trigger had no path filter, so every open PR shows a red `consecutive-green ≥ 7d` check — including six unrelated PRs in flight today (#426, #428, #429, #430, #431, #432) covering retrieval, BM25F, edge rerank, contradiction detector, UX, and docs. None of those touch the derivation contract; the gate firing on them is noise.

The check is **not** in the branch ruleset's `required_status_checks` list (verified via `gh api .../rules/branches/main`), so the red state is advisory rather than blocking. But it's misleading to reviewers and makes `mergeStateStatus: BLOCKED` appear in `gh pr view`.

## Path scope

Files where a change can plausibly affect `replay_full_equality`:

- `src/aelfrice/derivation.py` — `derive()` itself
- `src/aelfrice/derivation_worker.py` — synchronous worker after each batch
- `src/aelfrice/replay.py` — replay logic
- `src/aelfrice/ingest.py` — ingest entry points that write to `ingest_log`
- `src/aelfrice/scanner.py` — onboard path that calls `record_ingest`
- `tests/replay_soak_runner.py` — the harness invoked by the cron
- `tests/corpus/replay_soak/**` — the v0.1 fixture
- `scripts/replay_soak_run.py` / `scripts/replay_soak_streak.py`
- `.github/workflows/replay-soak.yml` / `replay-soak-gate.yml`

This PR itself is in scope (it edits `replay-soak-gate.yml`), so the gate fires on it — and currently the streak is 0 so the check fails. That is fine: the failure is advisory, not blocking, since the check is not in `required_status_checks`.

## Residual risk

Additive edits to `store.py` / `models.py` that *do* affect the derivation contract aren't soak-gated by this filter. Mitigations:

1. The regular pytest matrix runs `replay_full_equality` tests on every PR via the `replay_full_equality` probe shipped at v1.6.0 (#262 / #304). That catches schema and write-path drift before merge.
2. The daily cron on main appends a new entry every 04:00 UTC. Drift introduced by a `store.py` change surfaces within 24h on the next entry; subsequent PRs see streak reset to 0.

If a particular `store.py` PR is high-risk for derivation drift (e.g. `record_ingest` rewrite), the operator can manually invoke the gate by pushing a no-op edit to one of the in-scope files alongside the change.

## Out of scope

- The `Replay Soak` cron workflow itself — keep firing daily on main regardless of touched paths; the cron is the source of streak truth.
- Lowering the `7d` threshold — separate question; this PR doesn't touch the threshold.
- Adding the gate to `required_status_checks` — explicitly deferred per `replay-soak-gate.yml` docstring (\"admin step, separate from this PR\"). Not relevant until the threshold is operationally satisfiable.

## Test plan

- [x] YAML syntax-checked locally — `yaml.safe_load` parses cleanly.
- [x] Conventional-commits prefix (`ci:`) — passes the `commit-msg-prefix` check.
- [x] Commit SSH-signed (`git log --format=%G?` → `G`).
- [ ] Once merged: verify the gate stops appearing on PR pages of out-of-scope PRs (#426, #428, #429, #430, #431, #432).

## Refs

- Workflow shipped at #403 deliverable C (commit 94ac68a).
- Gate's stated intent: #264 (derivation worker) — not all merges.

## Summary by Sourcery

CI:
- Restrict the replay-soak-gate workflow trigger to specific derivation, ingest, replay, soak fixture, runner scripts, and workflow paths so the gate only runs on relevant PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Replay Soak Gate testing workflow to include more targeted execution configuration for pull requests targeting `main`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->