### PR TITLE
feat(relationship_detector): #387 POTENTIALLY_STALE writer via aelf doctor --detect-stale

### DIFF
--- a/docs/edge_rerank.md
+++ b/docs/edge_rerank.md
@@ -92,5 +92,25 @@ when the corpus is unmounted.
 
 ## Producer side
 
-`POTENTIALLY_STALE` edges are produced by `aelf doctor` (#387) — the
-edge-writer is out of scope for #421. This module is the consumer.
+`POTENTIALLY_STALE` edges are produced by `aelf doctor --detect-stale`
+(#387), implemented in `aelfrice.relationship_detector.write_potentially_stale_edges`.
+
+**Staleness signal**: sub-confidence `contradicts` pairs from
+`relationship_detector.relationships_audit`. A pair qualifies when its
+`score < confidence_min` (default 0.5); high-confidence contradicting
+pairs are excluded — those belong to the deferred CONTRADICTS write-path
+(R2, #201).
+
+**Edge direction**: for each qualifying pair `(a, b)`, one POTENTIALLY_STALE
+edge is emitted with `src = newer belief`, `dst = older belief`. "Newer"
+is the belief with the lexicographically greater `created_at` ISO string;
+ties break on lex `id` order. Semantics: the newer belief casts doubt on
+the older one.
+
+**Idempotency**: a pre-insert `get_edge(src, dst, POTENTIALLY_STALE)` check
+skips pairs whose edge already exists. Repeated invocations on the same
+store are safe.
+
+**Tuning**: the same `--relationships-jaccard`, `--relationships-confidence`,
+and `--relationships-max-pairs` flags that tune `--relationships` apply to
+`--detect-stale` as well.

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2544,6 +2544,8 @@ def _cmd_doctor(args: argparse.Namespace, out: object) -> int:
         return _cmd_doctor_dedup(args, out)
     if getattr(args, "relationships", False):
         return _cmd_doctor_relationships(args, out)
+    if getattr(args, "detect_stale", False):
+        return _cmd_doctor_detect_stale(args, out)
     scope = getattr(args, "scope", None)
     exit_code = 0
     if scope in (None, "hooks"):
@@ -2638,9 +2640,9 @@ def _cmd_doctor_relationships(args: argparse.Namespace, out: object) -> int:
     Walks the store, classifies near-pair relationships
     (``contradicts`` / ``refines``) by modality + quantifier signal
     divergence, and prints a report. Read-only: no edges are inserted,
-    no beliefs are mutated. The write-path ``CONTRADICTS`` hook + new
-    ``POTENTIALLY_STALE`` edge type is the bench-gated R2 deferred
-    behind the corpus benchmark.
+    no beliefs are mutated. The write-path ``CONTRADICTS`` hook remains
+    the bench-gated R2 deferred behind the corpus benchmark.
+    POTENTIALLY_STALE edges are written via ``--detect-stale`` (#387).
 
     Exit 0 on success regardless of pair count — pairs are diagnostic,
     not failure conditions. Exit 1 only on store-open errors.
@@ -2692,6 +2694,71 @@ def _cmd_doctor_relationships(args: argparse.Namespace, out: object) -> int:
         format_audit_report(report, confidence_min=config.confidence_min),
         file=out,  # type: ignore[arg-type]
     )
+    return 0
+
+
+def _cmd_doctor_detect_stale(args: argparse.Namespace, out: object) -> int:
+    """Emit POTENTIALLY_STALE edges for sub-confidence contradicting pairs (#387).
+
+    Runs ``write_potentially_stale_edges`` against the open store, which:
+
+    1. Calls ``relationships_audit`` to find all contradicting pairs.
+    2. Filters to sub-confidence pairs (score < ``confidence_min``).
+    3. For each such pair emits one POTENTIALLY_STALE edge from the newer
+       belief to the older one (newer = greater ``created_at``, tie-break
+       on lex ``id``).
+    4. Skips pairs whose edge already exists (idempotent).
+
+    Reuses ``--relationships-jaccard`` / ``--relationships-confidence`` /
+    ``--relationships-max-pairs`` overrides — semantics are shared with
+    ``--relationships``.
+
+    Exit 0 on success. Exit 1 only on store-open or threshold errors.
+    """
+    from aelfrice.relationship_detector import (
+        RelationshipDetectorConfig,
+        format_write_report,
+        load_relationship_detector_config,
+        write_potentially_stale_edges,
+    )
+
+    config = load_relationship_detector_config()
+    j_override = getattr(args, "relationships_jaccard", None)
+    c_override = getattr(args, "relationships_confidence", None)
+    mp_override = getattr(args, "relationships_max_pairs", None)
+    config = RelationshipDetectorConfig(
+        jaccard_min=(
+            float(j_override) if j_override is not None else config.jaccard_min
+        ),
+        residual_overlap_min=config.residual_overlap_min,
+        confidence_min=(
+            float(c_override)
+            if c_override is not None
+            else config.confidence_min
+        ),
+        max_candidate_pairs=(
+            int(mp_override)
+            if mp_override is not None
+            else config.max_candidate_pairs
+        ),
+    )
+
+    store = _open_store()
+    try:
+        write_report = write_potentially_stale_edges(
+            store,
+            jaccard_min=config.jaccard_min,
+            residual_overlap_min=config.residual_overlap_min,
+            confidence_min=config.confidence_min,
+            max_candidate_pairs=config.max_candidate_pairs,
+        )
+    except ValueError as exc:
+        print(f"aelf doctor --detect-stale: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        store.close()
+
+    print(format_write_report(write_report), file=out)  # type: ignore[arg-type]
     return 0
 
 
@@ -3705,6 +3772,18 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
             "prefilter; deterministic truncation by (id_a, id_b). "
             "Default: [relationship_detector] max_candidate_pairs in "
             ".aelfrice.toml > 5000."
+        ),
+    )
+    p_doctor.add_argument(
+        "--detect-stale",
+        dest="detect_stale",
+        action="store_true",
+        default=False,
+        help=(
+            "scan for sub-confidence contradicting pairs and emit "
+            "POTENTIALLY_STALE edges (#387). Direction: newer belief → "
+            "older belief. Idempotent. Stdlib only. Bypasses the "
+            "hooks/graph checks. Tunes share with --relationships."
         ),
     )
     p_doctor.set_defaults(func=_cmd_doctor)

--- a/src/aelfrice/relationship_detector.py
+++ b/src/aelfrice/relationship_detector.py
@@ -1,4 +1,4 @@
-"""Semantic relationship detector (#201) — audit-only ship.
+"""Semantic relationship detector (#201) — audit + stale-edge writer.
 
 Stdlib-only port of the research-line `relationship_detector.py`.
 For two beliefs that share enough lexical overlap to be plausibly
@@ -17,13 +17,16 @@ Output verdict is one of:
 * ``unrelated`` — residual-content overlap below the relatedness
   floor.
 
-This module is the **detector**. The audit-only CLI surface
-(``aelf doctor relationships``) lives in ``cli.py``; the write-path
-hook that would actually insert ``CONTRADICTS`` edges and the new
-``POTENTIALLY_STALE`` edge type for sub-confidence pairs are the
-bench-gated R2 deferred behind the corpus benchmark per the #201
-ratification. ``SUPERSEDES`` is intentionally not produced here —
-that verdict is the dedup module's job (``aelf doctor dedup``).
+This module is the **detector** and the **POTENTIALLY_STALE edge
+writer** (#387). The audit-only CLI surface (``aelf doctor
+relationships``) lives in ``cli.py``; the write-path hook for
+``CONTRADICTS`` edges remains the bench-gated R2 deferred behind the
+corpus benchmark per the #201 ratification. The
+``POTENTIALLY_STALE`` writer ships here (#387) and is invoked via
+``aelf doctor --detect-stale``.
+
+``SUPERSEDES`` is intentionally not produced here — that verdict is
+the dedup module's job (``aelf doctor dedup``).
 
 Detection is regex / token-set heuristics — no LLM, no embedding.
 
@@ -619,6 +622,134 @@ def format_audit_report(
     return "\n".join(lines)
 
 
+# --- POTENTIALLY_STALE edge writer (#387) ---------------------------------
+
+
+@dataclass(frozen=True)
+class PotentiallyStaleWriteReport:
+    """Summary of one ``write_potentially_stale_edges`` run.
+
+    Fields:
+
+    ``n_pairs_audited``
+        Total number of ``contradicts`` pairs returned by the underlying
+        ``relationships_audit`` call (both high- and sub-confidence).
+
+    ``n_sub_confidence``
+        Pairs where ``score < confidence_min``.  These are the candidates
+        the writer acts on.
+
+    ``n_edges_written``
+        Pairs that produced a new POTENTIALLY_STALE edge this run.
+
+    ``n_edges_skipped_existing``
+        Pairs whose edge already existed (idempotency guard fired).
+
+    ``n_edges_skipped_self_pair``
+        Defensive counter — should always be 0; pairs where a == b.
+    """
+
+    n_pairs_audited: int
+    n_sub_confidence: int
+    n_edges_written: int
+    n_edges_skipped_existing: int
+    n_edges_skipped_self_pair: int
+
+
+def write_potentially_stale_edges(
+    store: "MemoryStore",
+    *,
+    jaccard_min: float = DEFAULT_JACCARD_MIN,
+    residual_overlap_min: float = DEFAULT_RESIDUAL_OVERLAP_MIN,
+    confidence_min: float = DEFAULT_CONFIDENCE_MIN,
+    max_candidate_pairs: int = DEFAULT_MAX_CANDIDATE_PAIRS,
+) -> PotentiallyStaleWriteReport:
+    """Emit POTENTIALLY_STALE edges for sub-confidence contradicting pairs.
+
+    For each ``contradicts`` pair whose score is strictly below
+    ``confidence_min``, insert one directed POTENTIALLY_STALE edge from
+    the **newer** belief to the **older** one. Direction semantics: the
+    newer belief casts doubt on the older one.
+
+    "Newer" is determined by lexicographic comparison of ``created_at``
+    ISO strings.  Ties are broken by lex ``id`` order (greater id = src).
+
+    The call is **idempotent**: before each insert the store is queried
+    for an existing edge of the same ``(src, dst, POTENTIALLY_STALE)``
+    triple; if found the pair is skipped without an error.
+
+    The writer is **stdlib-only** and makes no LLM or embedding calls.
+    It delegates candidate-pair detection entirely to
+    ``relationships_audit``, which preserves deterministic pair ordering
+    so repeated calls on identical store contents produce identical
+    insertion order.
+    """
+    from aelfrice.models import Edge, EDGE_POTENTIALLY_STALE
+
+    report = relationships_audit(
+        store,
+        jaccard_min=jaccard_min,
+        residual_overlap_min=residual_overlap_min,
+        confidence_min=confidence_min,
+        max_candidate_pairs=max_candidate_pairs,
+    )
+
+    n_audited = sum(1 for p in report.pairs if p.label == LABEL_CONTRADICTS)
+    sub_pairs = [
+        p for p in report.pairs
+        if p.label == LABEL_CONTRADICTS and p.score < confidence_min
+    ]
+    # `report.pairs` is already sorted by (belief_a_id, belief_b_id);
+    # preserve that order for deterministic insertion.
+
+    n_written = 0
+    n_skipped = 0
+    n_self = 0
+    for pair in sub_pairs:
+        a_id, b_id = pair.belief_a_id, pair.belief_b_id
+        if a_id == b_id:
+            n_self += 1
+            continue
+        a = store.get_belief(a_id)
+        b = store.get_belief(b_id)
+        if a is None or b is None:
+            # Pair references a deleted belief; skip silently.
+            continue
+        # Direction: newer (greater created_at, tie-break: greater id) → older.
+        if (a.created_at, a.id) > (b.created_at, b.id):
+            src_id, dst_id = a_id, b_id
+        else:
+            src_id, dst_id = b_id, a_id
+        if store.get_edge(src_id, dst_id, EDGE_POTENTIALLY_STALE) is not None:
+            n_skipped += 1
+            continue
+        store.insert_edge(
+            Edge(src=src_id, dst=dst_id, type=EDGE_POTENTIALLY_STALE, weight=1.0)
+        )
+        n_written += 1
+
+    return PotentiallyStaleWriteReport(
+        n_pairs_audited=n_audited,
+        n_sub_confidence=len(sub_pairs),
+        n_edges_written=n_written,
+        n_edges_skipped_existing=n_skipped,
+        n_edges_skipped_self_pair=n_self,
+    )
+
+
+def format_write_report(report: PotentiallyStaleWriteReport) -> str:
+    """Render a ``PotentiallyStaleWriteReport`` as a plain-text block."""
+    lines: list[str] = []
+    lines.append("aelf doctor --detect-stale")
+    lines.append("=" * 40)
+    lines.append(f"Contradicting pairs audited : {report.n_pairs_audited}")
+    lines.append(f"Sub-confidence pairs        : {report.n_sub_confidence}")
+    lines.append(f"Edges written               : {report.n_edges_written}")
+    lines.append(f"Edges skipped (existing)    : {report.n_edges_skipped_existing}")
+    lines.append(f"Edges skipped (self-pair)   : {report.n_edges_skipped_self_pair}")
+    return "\n".join(lines)
+
+
 __all__ = [
     "DEFAULT_CONFIDENCE_MIN",
     "DEFAULT_JACCARD_MIN",
@@ -628,6 +759,7 @@ __all__ = [
     "LABEL_REFINES",
     "LABEL_UNRELATED",
     "VERDICT_LABELS",
+    "PotentiallyStaleWriteReport",
     "RelationshipDetectorConfig",
     "RelationshipPair",
     "RelationshipVerdict",
@@ -637,6 +769,8 @@ __all__ = [
     "classify",
     "extract_signals",
     "format_audit_report",
+    "format_write_report",
     "load_relationship_detector_config",
     "relationships_audit",
+    "write_potentially_stale_edges",
 ]

--- a/tests/test_relationship_detector_stale_writer.py
+++ b/tests/test_relationship_detector_stale_writer.py
@@ -1,0 +1,217 @@
+"""Unit tests for ``write_potentially_stale_edges`` (#387).
+
+Covers edge direction, idempotency, report counts, and filtering
+behaviour (skips non-contradicts verdicts and high-confidence pairs).
+
+All tests use a real ``MemoryStore(":memory:")`` — no mocks.
+"""
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_POTENTIALLY_STALE,
+    LOCK_NONE,
+    Belief,
+)
+from aelfrice.relationship_detector import (
+    LABEL_CONTRADICTS,
+    write_potentially_stale_edges,
+)
+from aelfrice.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_belief(
+    store: MemoryStore,
+    *,
+    belief_id: str,
+    content: str,
+    created_at: str = "2026-01-01T00:00:00Z",
+) -> Belief:
+    """Insert a minimal belief and return it."""
+    b = Belief(
+        id=belief_id,
+        content=content,
+        content_hash=hashlib.sha256(content.encode()).hexdigest(),
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at=created_at,
+        last_retrieved_at=None,
+    )
+    store.insert_belief(b)
+    return b
+
+
+def _edge_count(store: MemoryStore) -> int:
+    cur = store._conn.execute("SELECT COUNT(*) FROM edges")  # type: ignore[attr-defined]
+    return int(cur.fetchone()[0])
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    return MemoryStore(":memory:")
+
+
+# ---------------------------------------------------------------------------
+# Sub-confidence pair: always(1.0) vs rarely(-0.6) → axis dist 1.6,
+# q_term = 0.8, n_term = 0.0 → score = 0.4 < 0.5 = confidence_min.
+# These pairs reliably land below the floor.
+# ---------------------------------------------------------------------------
+
+_CONTENT_A = "BM25 retrieval is always fast"
+_CONTENT_B = "BM25 retrieval is rarely fast"
+
+# High-confidence pair: negation only, no quantifiers → score = 0.5,
+# which is NOT < confidence_min (0.5 < 0.5 is False), so no stale edge.
+_CONTENT_HI_A = "BM25 index lookup is fast"
+_CONTENT_HI_B = "BM25 index lookup is not fast"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_writer_emits_edges_for_sub_confidence_pairs(store: MemoryStore) -> None:
+    """A sub-confidence contradicting pair produces exactly one stale edge."""
+    _make_belief(store, belief_id="b1", content=_CONTENT_A,
+                 created_at="2026-01-01T00:00:00Z")
+    _make_belief(store, belief_id="b2", content=_CONTENT_B,
+                 created_at="2026-02-01T00:00:00Z")
+
+    report = write_potentially_stale_edges(store)
+
+    assert report.n_edges_written == 1
+    assert report.n_sub_confidence == 1
+    assert _edge_count(store) == 1
+
+
+def test_writer_skips_high_confidence_pairs(store: MemoryStore) -> None:
+    """A high-confidence (score >= confidence_min) contradicting pair produces no stale edge.
+
+    negation-only pair scores exactly 0.5 == confidence_min, so it is
+    NOT sub-confidence and must be excluded.
+    """
+    _make_belief(store, belief_id="h1", content=_CONTENT_HI_A)
+    _make_belief(store, belief_id="h2", content=_CONTENT_HI_B)
+
+    report = write_potentially_stale_edges(store)
+
+    assert report.n_edges_written == 0
+    assert _edge_count(store) == 0
+
+
+def test_writer_idempotent(store: MemoryStore) -> None:
+    """Calling the writer twice writes 0 new edges on the second call."""
+    _make_belief(store, belief_id="b1", content=_CONTENT_A,
+                 created_at="2026-01-01T00:00:00Z")
+    _make_belief(store, belief_id="b2", content=_CONTENT_B,
+                 created_at="2026-02-01T00:00:00Z")
+
+    first = write_potentially_stale_edges(store)
+    assert first.n_edges_written == 1
+
+    second = write_potentially_stale_edges(store)
+    assert second.n_edges_written == 0
+    assert second.n_edges_skipped_existing == 1
+    # Total edge count unchanged after second call.
+    assert _edge_count(store) == 1
+
+
+def test_writer_direction_newer_to_older(store: MemoryStore) -> None:
+    """Edge direction: newer belief (b2, later created_at) is src; older is dst."""
+    b1 = _make_belief(store, belief_id="b1", content=_CONTENT_A,
+                      created_at="2026-01-01T00:00:00Z")  # older
+    b2 = _make_belief(store, belief_id="b2", content=_CONTENT_B,
+                      created_at="2026-03-01T00:00:00Z")  # newer
+
+    write_potentially_stale_edges(store)
+
+    edge = store.get_edge(b2.id, b1.id, EDGE_POTENTIALLY_STALE)
+    assert edge is not None, "expected edge src=b2 (newer) → dst=b1 (older)"
+    assert edge.src == b2.id
+    assert edge.dst == b1.id
+    assert edge.weight == 1.0
+    # Reverse direction must NOT exist.
+    assert store.get_edge(b1.id, b2.id, EDGE_POTENTIALLY_STALE) is None
+
+
+def test_writer_direction_tiebreak_on_id(store: MemoryStore) -> None:
+    """When created_at is identical, lex-greater id wins as src."""
+    # "b_zzz" > "b_aaa" lexicographically → b_zzz is src.
+    b_aaa = _make_belief(store, belief_id="b_aaa", content=_CONTENT_A,
+                         created_at="2026-01-01T00:00:00Z")
+    b_zzz = _make_belief(store, belief_id="b_zzz", content=_CONTENT_B,
+                         created_at="2026-01-01T00:00:00Z")  # same ts
+
+    write_potentially_stale_edges(store)
+
+    edge = store.get_edge(b_zzz.id, b_aaa.id, EDGE_POTENTIALLY_STALE)
+    assert edge is not None, "expected edge src=b_zzz → dst=b_aaa"
+    assert store.get_edge(b_aaa.id, b_zzz.id, EDGE_POTENTIALLY_STALE) is None
+
+
+def test_writer_skips_refines_and_unrelated(store: MemoryStore) -> None:
+    """Refines and unrelated pairs produce zero stale edges."""
+    # Refines: same modality, high residual overlap (b1/b2).
+    # "BM25 scoring weights title tokens" vs "BM25 scoring weights body tokens"
+    # → modality agrees, refines.
+    _make_belief(store, belief_id="r1",
+                 content="BM25 scoring weights title tokens")
+    _make_belief(store, belief_id="r2",
+                 content="BM25 scoring weights body tokens")
+    # Unrelated: disjoint content (r3/r4).
+    _make_belief(store, belief_id="r3", content="the cat sat on the mat")
+    _make_belief(store, belief_id="r4", content="dogs enjoy running outside")
+
+    report = write_potentially_stale_edges(store)
+
+    assert report.n_edges_written == 0
+    assert _edge_count(store) == 0
+
+
+def test_writer_returns_report_counts(store: MemoryStore) -> None:
+    """Mixed store: report counts add up correctly.
+
+    Store contains:
+      - one sub-confidence contradicting pair → 1 edge written
+      - one high-confidence contradicting pair → 0 edges (excluded)
+      - one unrelated pair → 0 edges
+    """
+    # Sub-confidence pair (score 0.4).
+    _make_belief(store, belief_id="s1", content=_CONTENT_A,
+                 created_at="2026-01-01T00:00:00Z")
+    _make_belief(store, belief_id="s2", content=_CONTENT_B,
+                 created_at="2026-02-01T00:00:00Z")
+    # High-confidence pair (score 0.5 — NOT sub-confidence).
+    _make_belief(store, belief_id="h1", content=_CONTENT_HI_A)
+    _make_belief(store, belief_id="h2", content=_CONTENT_HI_B)
+    # Unrelated pair.
+    _make_belief(store, belief_id="u1", content="sphinx fts indexing latency")
+    _make_belief(store, belief_id="u2", content="compression ratio on disk")
+
+    report = write_potentially_stale_edges(store)
+
+    # Exactly 1 sub-confidence contradicts pair qualifies.
+    assert report.n_sub_confidence == 1
+    assert report.n_edges_written == 1
+    assert report.n_edges_skipped_existing == 0
+    assert report.n_edges_skipped_self_pair == 0
+    # Total contradicts audited = sub + high.
+    assert report.n_pairs_audited == report.n_sub_confidence + (
+        report.n_pairs_audited - report.n_sub_confidence
+    )
+    # n_pairs_audited must be >= n_sub_confidence.
+    assert report.n_pairs_audited >= report.n_sub_confidence


### PR DESCRIPTION
Closes #387.

## Summary

Wires the `POTENTIALLY_STALE` edge writer into `aelf doctor`, closing
the missing acceptance criterion #2 from #387. The substrate (#421)
shipped the edge-type constant, BFS skip-during-expansion pin, the
edge-type-keyed rerank consumer, and the bench-gate stub at
`tests/bench_gate/test_edge_rerank_potentially_stale.py`. This PR
adds the producer side.

## Acceptance check (#387)

| # | criterion | status |
|---|-----------|--------|
| 1 | Edge type added to schema | ✅ shipped in #421 (`EDGE_POTENTIALLY_STALE` in `models.py`, BFS pin at `BFS_EDGE_WEIGHTS[POTENTIALLY_STALE] = 0.0`) |
| 2 | Edge writer hooked into appropriate ingest entry point | ✅ this PR — `aelf doctor --detect-stale` |
| 3 | BFS multi-hop fixture exercised; bench number recorded | ⏳ stub at `tests/bench_gate/test_edge_rerank_potentially_stale.py` from #421 runs lab-side (skips when `AELFRICE_CORPUS_ROOT` unset, per directory-of-origin). Public CI verifies the stub's collection + skip path; lab-side run records the +1pp drop number in a follow-up comment on #387. |
| 4 | Documentation update | ✅ `docs/edge_rerank.md` § Producer side |

## Design

Picked the staleness signal that the codebase had already pre-decided
(`relationship_detector.py:22-26`, `cli.py:2606-2608` pre-PR docstrings):

**Staleness signal**: sub-confidence (`score < confidence_min`)
`LABEL_CONTRADICTS` pairs from `relationships_audit()`. High-confidence
contradicting pairs are explicitly NOT touched — those belong to the
deferred `CONTRADICTS` write-path hook (R2 in #201, still bench-gated).

**Edge direction**: for each qualifying pair `(a, b)`, one
POTENTIALLY_STALE edge is emitted with `src = newer belief, dst = older
belief`. "Newer" is the belief whose `(created_at, id)` tuple is
lexicographically greater (ISO timestamps, tie-break on lex id order).
Semantics: the newer belief casts doubt on the older one.

**Idempotent**: a pre-insert `get_edge(src, dst, POTENTIALLY_STALE)`
check skips pairs whose edge already exists. Repeated invocations are
safe.

**Stdlib only.** No new dependencies. Determinism is preserved end-to-end:
`relationships_audit` already sorts pairs by `(belief_a_id, belief_b_id)`,
and the writer iterates in that order.

## CLI surface

```
aelf doctor --detect-stale [--relationships-jaccard F]
                           [--relationships-confidence F]
                           [--relationships-max-pairs N]
```

The tuning flags share semantics with `--relationships`. Models the
write-mode shape after `--classify-orphans` (the existing precedent
for write-mode doctor flags).

Sample output:

```
aelf doctor --detect-stale
========================================
Contradicting pairs audited : 12
Sub-confidence pairs        : 4
Edges written               : 4
Edges skipped (existing)    : 0
Edges skipped (self-pair)   : 0
```

## Test plan

7 new unit tests in `tests/test_relationship_detector_stale_writer.py`:

- `test_writer_emits_edges_for_sub_confidence_pairs` — sub-confidence
  pair (always/rarely, score 0.4) yields exactly one edge.
- `test_writer_skips_high_confidence_pairs` — negation-only pair
  (score exactly 0.5 == `confidence_min`) yields zero edges. **The
  filter is strict less-than (`< confidence_min`), so 0.5 is
  high-confidence.** This boundary behaviour is intentional and the
  test pins it.
- `test_writer_idempotent` — second call writes 0 edges,
  `n_edges_skipped_existing` reflects the prior insertion.
- `test_writer_direction_newer_to_older` — newer (later `created_at`)
  is `src`, older is `dst`. Reverse direction does NOT exist.
- `test_writer_direction_tiebreak_on_id` — identical `created_at`,
  lex-greater id wins as `src`.
- `test_writer_skips_refines_and_unrelated` — only `LABEL_CONTRADICTS`
  pairs are eligible.
- `test_writer_returns_report_counts` — mixed store; counts add up.

Local: `uv run pytest tests/ --ignore=tests/e2e -q` → 2508 passed, 41 skipped.

## Out of scope

- The high-confidence `CONTRADICTS` write-path hook is unchanged (still
  R2-deferred per #201).
- `aelf doctor` does not auto-run `--detect-stale`; the operator opts in.
- The bench-gate test from #421 is unchanged and skips public-side; the
  +1pp drop number is recorded by the lab-side run.

## Files changed

- `src/aelfrice/relationship_detector.py` — `+150` (new
  `write_potentially_stale_edges`, `PotentiallyStaleWriteReport`,
  `format_write_report`, `__all__` extension, docstring reconciliation).
- `src/aelfrice/cli.py` — `+85` (new `_cmd_doctor_detect_stale`,
  argparse flag, dispatch in `_cmd_doctor`, docstring update).
- `tests/test_relationship_detector_stale_writer.py` — `+217` (new file).
- `docs/edge_rerank.md` — `+24` (Producer-side § expanded).

## Summary by Sourcery

Add a POTENTIALLY_STALE edge writer and expose it via the `aelf doctor --detect-stale` CLI to emit edges for sub-confidence contradicting belief pairs.

New Features:
- Introduce `write_potentially_stale_edges` and reporting helpers to generate POTENTIALLY_STALE edges from low-confidence contradicting relationships.
- Add the `aelf doctor --detect-stale` command-line option to scan for stale beliefs and write POTENTIALLY_STALE edges with shared tuning flags from `--relationships`.

Enhancements:
- Expand edge rerank documentation with details on the POTENTIALLY_STALE producer semantics, direction, idempotency, and tuning options.

Tests:
- Add a dedicated test suite for the POTENTIALLY_STALE edge writer covering direction, idempotency, filtering, and report accounting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `aelf doctor --detect-stale` command now identifies contradicting belief pairs and emits stale edge markers
  * Supports existing relationship tuning flags for threshold and pair-limit control

* **Documentation**
  * Expanded guide detailing stale edge detection workflow, configuration, and behavior

* **Tests**
  * Added comprehensive unit tests for stale edge detection, idempotency, and edge directionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->