### PR TITLE
ci: switch CI to paths-filter so pytest reports on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,14 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    # #413 — docs-only PRs skip pytest. paths-ignore is a UNION filter:
-    # the workflow runs unless every changed file matches an ignored path.
-    # A mixed PR (e.g. src/foo.py + docs/x.md) still runs full CI.
-    # TODO(post-public-flip): once branch protection requires this check,
-    # migrate to a dorny/paths-filter detection job so the workflow always
-    # runs and reports a status, with downstream jobs gated by `if:`.
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - 'LICENSE'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/PULL_REQUEST_TEMPLATE.md'
+    # No paths-ignore: the workflow must always run so the
+    # `pytest (3.12)` and `pytest (3.13)` required status checks
+    # report on every PR — including docs-only ones. Path detection
+    # happens inside the job via `dorny/paths-filter`; non-code PRs
+    # short-circuit the install + test steps and report success.
+    # Per #413/#427 follow-up: replaces the previous `paths-ignore`
+    # filter that silently dropped the pytest check on docs-only PRs
+    # and blocked them under `required_status_checks`.
 
 permissions:
   contents: read
@@ -34,10 +30,25 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/ci.yml'
+      - if: steps.filter.outputs.code == 'true'
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - run: uv sync --frozen --group dev --extra archive
-      - run: uv run pytest tests/ --ignore=tests/e2e -q
+      - if: steps.filter.outputs.code == 'true'
+        run: uv sync --frozen --group dev --extra archive
+      - if: steps.filter.outputs.code == 'true'
+        run: uv run pytest tests/ --ignore=tests/e2e -q
+      - if: steps.filter.outputs.code != 'true'
+        run: echo "No code paths changed; reporting pass for docs-only PR."


### PR DESCRIPTION
Unblocks #426 (and any future docs-only PR).

## Problem

`required_status_checks` ruleset on main requires `pytest (3.12)` and `pytest (3.13)` to pass. The CI workflow's `paths-ignore: ['docs/**', '**/*.md', ...]` causes the entire workflow to skip on docs-only PRs, so those checks never report — main rejects the FF push with `2 of 5 required status checks expected`.

Caught while attempting to land #426 (README v1.7 row → shipped) as part of the v2.0 reproducibility-cut sequence.

## Fix

Per the existing TODO note in `.github/workflows/ci.yml`: replace the workflow-level `paths-ignore` with an in-job `dorny/paths-filter@v3` step. The job always runs (so the required check always reports a status) but the install + test steps are conditional on `code` paths having actually changed. Docs-only PRs short-circuit and report a green check.

## Test plan

- [x] Self-test: this PR is itself a CI / non-docs change, so it triggers the new pytest invocation. CI must remain green for `pytest (3.12)` and `pytest (3.13)`.
- [ ] Post-merge: re-rebase #426 onto new main and verify pytest reports green via the docs-only short-circuit.
- [ ] Post-merge: any future docs-only PR sees the same short-circuit pass.

## Refs

- TODO note: previous \`.github/workflows/ci.yml:9-11\` ("migrate to a \`dorny/paths-filter\` detection job so the workflow always runs and reports a status, with downstream jobs gated by \`if:\`").
- Originally surfaced under #413; deferred until branch protection started enforcing the check.
- Blocking: #426 (#154 task 4 — README v1.7 row → shipped).
- Sister: #443 (paths-filter on the *soak-gate* workflow; orthogonal — that one trims advisory noise, this one unblocks the required-check rule).

## Summary by Sourcery

Ensure CI pytest jobs always run and report status while short-circuiting on non-code changes.

CI:
- Replace workflow-level paths-ignore with in-job dorny/paths-filter usage to detect code vs non-code changes.
- Gate environment setup and pytest steps on code path changes so docs-only PRs report a passing required check without running tests.