### PR TITLE
release: v2.0.0 (stacked on #447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-05-07
+
+Reproducibility cut. v2.0 closes the v1.5–v1.7 feature-parity wave with a single tagged release. No additional product surface beyond v1.7.0 — same wheel content, same retrieval defaults, same CLI surface. v2.0.0 is the canonical reproducibility tag for the v2.0 corpus + bench evidence cut: operators who want a stable pin for the BM25F default-on flip (#154, +0.6650 NDCG@k on the v0.1 retrieve_uplift fixture) plus the v1.7.0 detector wave (#264 worker refactor, #421/#387 edge-type rerank + stale writer, #422 value-comparison, #441 confirm, #197/#201 dedup + contradiction, #228 wonder-consolidation, #383-388 edge-type ship gates) should pin `aelfrice==2.0.0` rather than `aelfrice==1.7.0`. README roadmap rows for v1.7 and v2.0 both flip to `shipped` with this tag.
+
 ## [1.7.0] - 2026-05-07
 
 Two structural changes drive v1.7.0: BM25F anchor-text retrieval flips default-on, and every ingest entry point now routes through a single `derivation_worker` that treats the append-only `ingest_log` as the source of truth. On top of that lands the v2.0 detector wave (dedup, semantic contradiction, value-comparison, sentiment-from-prose, wonder-consolidation), four new CLI verbs (`reason`, `wonder`, `confirm`, `delete`), the `unlock`/`promote` lock-management surface, and a wave of edge-type ship gates.
@@ -677,7 +681,8 @@ Foundation milestone — store, models, config.
 - Initial repo scaffold: pyproject, README, GitHub Actions workflows,
   scan configs (commit `67b4343`).
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/robotrocketscience/aelfrice/compare/v1.7.0...v2.0.0
 [1.7.0]: https://github.com/robotrocketscience/aelfrice/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/robotrocketscience/aelfrice/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/robotrocketscience/aelfrice/compare/v1.5.0...v1.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "1.7.0"
+version = "2.0.0"
 description = "Persistent memory for AI agents. Set up once. Stays out of your way. Local SQLite, auditable, no GPU, no network."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "1.7.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
v2.0.0 reproducibility cut. **Stacked on #447** — needs v1.7.0 to land first; this PR's diff currently shows the v1.7.0 commits too. Once #447 lands, this branch rebases automatically to a single \`release: v2.0.0\` commit.

## Theme

Reproducibility cut. v2.0 closes the v1.5–v1.7 feature-parity wave with a single tagged release that bundles the BM25F default-on flip (#154 bench evidence: \`+0.6650 NDCG@k\` on the v0.1 retrieve_uplift fixture) and the v1.7 components.

The v2.0 release does not introduce additional product surface beyond v1.7.0; it is the canonical reproducibility tag for the v2.0 corpus + bench evidence cut.

## Tag flow

Per CLAUDE.md release process:
1. Merge #447 (v1.7.0) first.
2. Tag \`v1.7.0\` and push (operator step).
3. Rebase this PR onto new main; reduces to a single bump commit.
4. Merge this PR.
5. Tag \`v2.0.0\` and push.
6. \`.github/workflows/publish.yml\` triggers on \`v*\` tags and publishes to PyPI via Trusted Publishing — note CLAUDE.md flags the PyPI Trusted Publishing setup as deferred until v1.0.0; verify it is wired before tagging.

## Test plan

- [x] \`uv lock\` refreshed; \`aelfrice v1.7.0 -> v2.0.0\` resolved cleanly.
- [x] CHANGELOG \`[2.0.0]\` section added describing the reproducibility cut.
- [ ] CI matrix green.
- [ ] FF-merge to main after #447.
- [ ] Tag \`v2.0.0\` and push (operator step; CLAUDE.md release rule).

## Refs

- v1.7.0 release: #447 (parent).
- README roadmap row: README.md "## Roadmap".
- Bench harness: #425 (already landed).

## Summary by Sourcery

Cut the v2.0.0 reproducibility release and align project metadata with the new version.

Build:
- Bump the package version to 2.0.0 and refresh the uv.lock dependency lockfile for the new release.

Documentation:
- Document the v2.0.0 reproducibility cut and backfill the 1.7.0 release notes in CHANGELOG.md, including CI gating and roadmap status notes.

Chores:
- Mark roadmap items for v1.7 and v2.0 as shipped via the release notes to serve as the canonical tag for the v2.0 corpus and benchmarks.