### PR TITLE
feat(health): aelf health per-edge-type breakdown + --json (#452)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -33,7 +33,7 @@ DB resolves from `$AELFRICE_DB`, then `<git-common-dir>/aelfrice/memory.db` when
 | Command | What it does |
 |---|---|
 | `stats` | Belief / thread / lock / feedback counts. |
-| `health` | Structural auditor: orphan threads, FTS5 sync, locked contradictions, corpus volume. Exits 1 on structural failure; corpus-volume warnings are informational. |
+| `health [--json]` | Structural auditor: orphan threads, FTS5 sync, locked contradictions, corpus volume. Includes a per-edge-type count breakdown (sorted by count desc, then alphabetically); empty store prints `no edges yet`. `--json` emits `{"audit": {...}, "features": {"edges_by_type": {...}}}`. Exits 1 on structural failure; corpus-volume warnings are informational. |
 | `status` | Alias for `health`. |
 | `regime` | The v1.0 regime classifier output (`supersede` / `ignore` / `mixed` / `insufficient_data`). Informational; always exits 0. |
 | `doctor` | Verify hook + statusline commands resolve. Inspects `bash <script>` wrappers, flags `2>/dev/null \|\| true` patterns. Surfaces empty-store warning. Exits 1 on broken hooks. v1.6+ flags: `--gc-orphan-feedback` (delete `feedback_history` rows whose `belief_id` no longer exists, #223); `--promote-retention` (one-shot reclassification pass over low-prior beliefs based on accumulated retrieval / corroboration evidence, #290 phase-3). |

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -56,6 +56,7 @@ from aelfrice.migrate import (
 from aelfrice.health import (
     REGIME_INSUFFICIENT_DATA,
     assess_health,
+    compute_features,
     regime_description,
 )
 from aelfrice.models import (
@@ -2160,8 +2161,12 @@ def _cmd_health(args: argparse.Namespace, out: object) -> int:
     The corpus-volume check (added in #116) warns when an established
     project has too few beliefs but is informational — it does not
     affect the exit code.
+
+    --json: emit a single JSON object with keys "audit" and "features".
+    "features.edges_by_type" carries the per-edge-type count dict.
+    Exit code unchanged: 1 on auditor failure, 0 otherwise.
     """
-    _ = args
+    use_json = getattr(args, "json", False)
     corpus_min = _resolve_corpus_min()
     project_age = _git_first_commit_age_days()
     store = _open_store()
@@ -2171,8 +2176,35 @@ def _cmd_health(args: argparse.Namespace, out: object) -> int:
             corpus_min=corpus_min,
             project_age_days=project_age,
         )
+        features = compute_features(store)
     finally:
         store.close()
+
+    if use_json:
+        # Serialise auditor findings + metrics as plain dicts; features via
+        # edges_by_type only (regime fields are not part of this contract).
+        findings_list = [
+            {
+                "check": f.check,
+                "severity": f.severity,
+                "count": f.count,
+                "detail": f.detail,
+            }
+            for f in report.findings
+        ]
+        payload = {
+            "audit": {
+                "findings": findings_list,
+                "metrics": dict(report.metrics),
+                "failed": report.failed,
+            },
+            "features": {
+                "edges_by_type": features.edges_by_type,
+            },
+        }
+        print(json.dumps(payload), file=out)  # type: ignore[arg-type]
+        return 1 if report.failed else 0
+
     print("audit:", file=out)  # type: ignore[arg-type]
     for f in report.findings:
         if f.severity == AUDIT_SEVERITY_FAIL:
@@ -2193,6 +2225,18 @@ def _cmd_health(args: argparse.Namespace, out: object) -> int:
         else:
             display = str(value)
         print(f"  {key:24s} {display}", file=out)  # type: ignore[arg-type]
+    print("", file=out)  # type: ignore[arg-type]
+    # Per-edge-type breakdown (sorted by count desc, then alphabetically).
+    print("edges by type:", file=out)  # type: ignore[arg-type]
+    if not any(features.edges_by_type.values()):
+        print("  no edges yet", file=out)  # type: ignore[arg-type]
+    else:
+        sorted_entries = sorted(
+            features.edges_by_type.items(),
+            key=lambda kv: (-kv[1], kv[0]),
+        )
+        for edge_type, count in sorted_entries:
+            print(f"  {edge_type:24s} {count}", file=out)  # type: ignore[arg-type]
     print("", file=out)  # type: ignore[arg-type]
     sentiment_state, sentiment_count = _sentiment_from_prose_state()
     if sentiment_state == "enabled":
@@ -3513,6 +3557,12 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
 
     # Deprecated alias of `doctor graph`. Hidden from --help; deleted at v1.4.
     p_health = sub.add_parser("health", help=argparse.SUPPRESS)
+    p_health.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="emit JSON: {audit: {...}, features: {edges_by_type: {...}}}",
+    )
     p_health.set_defaults(func=_cmd_health)
 
     # Hidden: research output, not a daily verb.

--- a/src/aelfrice/health.py
+++ b/src/aelfrice/health.py
@@ -26,9 +26,10 @@ output can phrase the regime as "leaning X" rather than committing.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Final
 
+from aelfrice.models import EDGE_POTENTIALLY_STALE, EDGE_TYPES
 from aelfrice.store import MemoryStore
 
 # E43: minimum belief count below which the classifier reports
@@ -74,6 +75,11 @@ class HealthFeatures:
     mass_mean: float
     lock_per_1000: float
     edge_per_belief: float
+    # Per-edge-type count breakdown; keys are every member of EDGE_TYPES ∪
+    # {EDGE_POTENTIALLY_STALE} so the shape is stable across stores (absent
+    # types appear with value 0).  Not fed into the regime classifier —
+    # additive observability field only.
+    edges_by_type: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -103,6 +109,20 @@ def _median(sorted_values: list[float]) -> float:
     return (sorted_values[n // 2 - 1] + sorted_values[n // 2]) / 2.0
 
 
+def _zero_padded_edge_counts(raw: dict[str, int]) -> dict[str, int]:
+    """Merge *raw* (SQL result, may omit zero-count types) into a dict
+    initialised over the full registry: EDGE_TYPES ∪ {EDGE_POTENTIALLY_STALE}.
+
+    POTENTIALLY_STALE is stored in the same `edges` table as the structural
+    edge types (confirmed in #387) so the single `count_edges_by_type` query
+    captures it automatically.
+    """
+    full: dict[str, int] = {t: 0 for t in EDGE_TYPES}
+    full[EDGE_POTENTIALLY_STALE] = 0
+    full.update(raw)
+    return full
+
+
 def compute_features(store: MemoryStore) -> HealthFeatures:
     """Roll up the store into the five-feature vector the classifier
     consumes. Pure function of the current store state.
@@ -111,6 +131,7 @@ def compute_features(store: MemoryStore) -> HealthFeatures:
     surface `insufficient_data`.
     """
     n_beliefs = store.count_beliefs()
+    edges_by_type = _zero_padded_edge_counts(store.count_edges_by_type())
     if n_beliefs == 0:
         return HealthFeatures(
             n_beliefs=0,
@@ -119,6 +140,7 @@ def compute_features(store: MemoryStore) -> HealthFeatures:
             mass_mean=0.0,
             lock_per_1000=0.0,
             edge_per_belief=0.0,
+            edges_by_type=edges_by_type,
         )
 
     pairs = store.alpha_beta_pairs()
@@ -135,6 +157,7 @@ def compute_features(store: MemoryStore) -> HealthFeatures:
         mass_mean=sum(masses) / n_beliefs,
         lock_per_1000=(n_locked / n_beliefs) * 1000.0,
         edge_per_belief=n_edges / n_beliefs,
+        edges_by_type=edges_by_type,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,13 +9,18 @@ property each, per the deterministic-atomic-short policy.
 from __future__ import annotations
 
 import io
+import json
 import subprocess
 from pathlib import Path
 
 import pytest
 
 from aelfrice.cli import DEFAULT_DB_DIR, DEFAULT_DB_FILENAME, db_path, main
-from aelfrice.models import LOCK_USER
+from aelfrice.models import (
+    EDGE_POTENTIALLY_STALE,
+    EDGE_TYPES,
+    LOCK_USER,
+)
 from aelfrice.store import MemoryStore
 
 
@@ -495,6 +500,82 @@ def test_health_exits_nonzero_when_audit_fails(isolated_db: Path) -> None:
     code, out = _run("health")
     assert code == 1
     assert "FAIL" in out
+
+
+# --- aelf health per-edge-type block (#452) -----------------------------
+
+
+def test_health_emits_edges_by_type_block(isolated_db: Path) -> None:
+    """Text output includes the 'edges by type:' header."""
+    code, out = _run("health")
+    assert code == 0
+    assert "edges by type:" in out
+
+
+def test_health_empty_store_no_edges_yet(isolated_db: Path) -> None:
+    """Empty store: 'no edges yet' appears in the edge-type block."""
+    code, out = _run("health")
+    assert code == 0
+    assert "no edges yet" in out
+
+
+# --- aelf health --json shape contract (#452) ---------------------------
+
+_FULL_EDGE_REGISTRY: frozenset[str] = EDGE_TYPES | {EDGE_POTENTIALLY_STALE}
+
+
+def test_health_json_flag_produces_valid_json(isolated_db: Path) -> None:
+    """--json flag emits a single line of valid JSON."""
+    code, out = _run("health", "--json")
+    assert code == 0
+    data = json.loads(out)
+    assert isinstance(data, dict)
+
+
+def test_health_json_has_audit_and_features_keys(isolated_db: Path) -> None:
+    """JSON top-level keys are 'audit' and 'features'."""
+    _code, out = _run("health", "--json")
+    data = json.loads(out)
+    assert "audit" in data
+    assert "features" in data
+
+
+def test_health_json_features_edges_by_type_all_keys_present(
+    isolated_db: Path,
+) -> None:
+    """features.edges_by_type contains every key from EDGE_TYPES ∪ {POTENTIALLY_STALE}."""
+    _code, out = _run("health", "--json")
+    data = json.loads(out)
+    ebt = data["features"]["edges_by_type"]
+    assert set(ebt.keys()) == _FULL_EDGE_REGISTRY
+
+
+def test_health_json_features_edges_by_type_values_are_ints(
+    isolated_db: Path,
+) -> None:
+    """features.edges_by_type values are integers (not floats or strings)."""
+    _code, out = _run("health", "--json")
+    data = json.loads(out)
+    ebt = data["features"]["edges_by_type"]
+    for k, v in ebt.items():
+        assert isinstance(v, int), f"key {k!r} has non-int value {v!r}"
+
+
+def test_health_json_audit_has_findings_and_metrics(isolated_db: Path) -> None:
+    """audit block carries 'findings', 'metrics', and 'failed' keys."""
+    _code, out = _run("health", "--json")
+    data = json.loads(out)
+    audit = data["audit"]
+    assert "findings" in audit
+    assert "metrics" in audit
+    assert "failed" in audit
+
+
+def test_health_json_exit_code_mirrors_text(isolated_db: Path) -> None:
+    """--json exit code matches text mode (0 on clean store)."""
+    code_text, _ = _run("health")
+    code_json, _ = _run("health", "--json")
+    assert code_text == code_json == 0
 
 
 # --- regime (v1.0 classifier preserved) --------------------------------

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -7,6 +7,9 @@ deterministic regime_description framing (no alarm copy).
 """
 from __future__ import annotations
 
+import io
+import json
+
 from aelfrice.health import (
     MIN_BELIEFS,
     REGIME_IGNORE,
@@ -22,7 +25,17 @@ from aelfrice.health import (
 )
 from aelfrice.models import (
     BELIEF_FACTUAL,
+    EDGE_CITES,
+    EDGE_CONTRADICTS,
+    EDGE_DERIVED_FROM,
+    EDGE_IMPLEMENTS,
+    EDGE_POTENTIALLY_STALE,
+    EDGE_RELATES_TO,
+    EDGE_SUPERSEDES,
     EDGE_SUPPORTS,
+    EDGE_TEMPORAL_NEXT,
+    EDGE_TESTS,
+    EDGE_TYPES,
     LOCK_NONE,
     LOCK_USER,
     Belief,
@@ -344,3 +357,87 @@ def test_mixed_description_returned_for_mixed() -> None:
 def test_insufficient_data_description_directs_user_to_onboard() -> None:
     desc = regime_description(REGIME_INSUFFICIENT_DATA).lower()
     assert "onboard" in desc
+
+
+# --- edges_by_type: new field on HealthFeatures (#452) -------------------
+
+# Full registry that edges_by_type must enumerate.
+_FULL_EDGE_REGISTRY: frozenset[str] = EDGE_TYPES | {EDGE_POTENTIALLY_STALE}
+
+
+def test_empty_store_edges_by_type_zero_padded() -> None:
+    """Empty store: edges_by_type present with 0 for every registered type."""
+    s = MemoryStore(":memory:")
+    f = compute_features(s)
+    assert isinstance(f.edges_by_type, dict)
+    assert set(f.edges_by_type.keys()) == _FULL_EDGE_REGISTRY
+    assert all(v == 0 for v in f.edges_by_type.values())
+
+
+def test_seeded_store_edges_by_type_counts_correctly() -> None:
+    """Seeded store with one edge of each type: counts must be 1 each."""
+    s = MemoryStore(":memory:")
+    # Provide enough beliefs for all edges.
+    belief_ids = [f"b{i}" for i in range(20)]
+    for bid in belief_ids:
+        s.insert_belief(_mk(bid, 1.0, 1.0))
+
+    edge_iter = iter(zip(belief_ids, belief_ids[1:]))
+    one_of_each = [
+        (EDGE_SUPPORTS, *next(edge_iter)),
+        (EDGE_CITES, *next(edge_iter)),
+        (EDGE_CONTRADICTS, *next(edge_iter)),
+        (EDGE_SUPERSEDES, *next(edge_iter)),
+        (EDGE_RELATES_TO, *next(edge_iter)),
+        (EDGE_DERIVED_FROM, *next(edge_iter)),
+        (EDGE_IMPLEMENTS, *next(edge_iter)),
+        (EDGE_TEMPORAL_NEXT, *next(edge_iter)),
+        (EDGE_TESTS, *next(edge_iter)),
+        (EDGE_POTENTIALLY_STALE, *next(edge_iter)),
+    ]
+    for etype, src, dst in one_of_each:
+        s.insert_edge(Edge(src=src, dst=dst, type=etype, weight=1.0))
+
+    f = compute_features(s)
+    assert set(f.edges_by_type.keys()) == _FULL_EDGE_REGISTRY
+    for etype, _src, _dst in one_of_each:
+        assert f.edges_by_type[etype] == 1, f"expected 1 for {etype}"
+
+
+def test_edges_by_type_multiple_of_same_type() -> None:
+    """Multiple edges of one type sum correctly; others remain 0."""
+    s = MemoryStore(":memory:")
+    for i in range(5):
+        s.insert_belief(_mk(f"x{i}", 1.0, 1.0))
+    # Insert 3 SUPPORTS edges.
+    s.insert_edge(Edge(src="x0", dst="x1", type=EDGE_SUPPORTS, weight=1.0))
+    s.insert_edge(Edge(src="x1", dst="x2", type=EDGE_SUPPORTS, weight=1.0))
+    s.insert_edge(Edge(src="x2", dst="x3", type=EDGE_SUPPORTS, weight=1.0))
+    f = compute_features(s)
+    assert f.edges_by_type[EDGE_SUPPORTS] == 3
+    assert f.edges_by_type[EDGE_CITES] == 0
+
+
+def test_edges_by_type_not_in_per_feature_scores() -> None:
+    """edges_by_type must not appear in per_feature_scores (not a classifier input)."""
+    s = MemoryStore(":memory:")
+    for i in range(MIN_BELIEFS):
+        s.insert_belief(_mk(f"b{i}", 4.0, 1.0))
+    r = classify_regime(compute_features(s))
+    assert "edges_by_type" not in r.per_feature_scores
+
+
+def test_classify_regime_per_feature_scores_unchanged() -> None:
+    """Regime classifier still produces exactly the original five feature keys."""
+    expected_keys = {
+        "confidence_mean",
+        "confidence_median",
+        "mass_mean",
+        "lock_per_1000",
+        "edge_per_belief",
+    }
+    s = MemoryStore(":memory:")
+    for i in range(MIN_BELIEFS):
+        s.insert_belief(_mk(f"b{i}", 4.0, 1.0))
+    r = classify_regime(compute_features(s))
+    assert set(r.per_feature_scores.keys()) == expected_keys


### PR DESCRIPTION
Closes #452 — Track C, `aelf health` per-edge-type breakdown.

Track A gate (≥2 Track A edges shipped) is satisfied 6× — all six edge types from #383–#388 are in `EDGE_TYPES` ∪ `{POTENTIALLY_STALE}`.

## What ships

1. `HealthFeatures.edges_by_type: dict[str, int]` — additive field. Stable shape across stores: every key in `EDGE_TYPES ∪ {EDGE_POTENTIALLY_STALE}` is present, zero-padded if no edges of that type exist. Not fed into the regime classifier (additive observability only — `per_feature_scores` keys are unchanged).
2. `aelf health` text — new "edges by type:" block under the metrics block, sorted by count desc, alphabetical tiebreak. Empty store prints `no edges yet`.
3. `aelf health --json` — new flag. Shape: `{"audit": {"findings": [...], "metrics": {...}, "failed": bool}, "features": {"edges_by_type": {...}}}`. Exit code unchanged.
4. `docs/COMMANDS.md` row 36 updated.

## Substrate reused (no new store API needed)

- `MemoryStore.count_edges_by_type()` already existed at `src/aelfrice/store.py:2266` (used by `auditor.py` and `telemetry.py`). `compute_features` in `health.py` zero-pads the SQL result over the full registry.
- `POTENTIALLY_STALE` lives in the `edges` table (per #387) so the single SQL query captures it; documented inline.

## Reconciliation

- vs. acceptance #2 (issue body) — *"New `MemoryStore.count_edges_by_type()`"*. The store method already shipped earlier. This PR wires it into `health.py` and the CLI; no duplicate method.
- Regime classifier — `edges_by_type` is excluded from `_FEATURE_ANCHORS`. Test `test_classify_regime_per_feature_scores_unchanged` pins the original five-key invariant.

## Test plan

- [x] Discretion grep on diff vs `github/main` — clean.
- [x] All 4 commits SSH-signed (`G`).
- [x] `pytest tests/`: 2545 passed, 41 skipped.
- [x] New tests: empty-store zero-padding, one-of-each seeded counts, multi-edge counts, exclusion from per_feature_scores, five-key regime invariant; CLI text block, "no edges yet", JSON shape contract, all-keys-present, int values, audit sub-keys.
- [ ] CI matrix green.
- [ ] Reviewer: confirm JSON shape (`audit` + `features` top-level) is the right contract; sanity-check that `_zero_padded_edge_counts` is the right place for the registry merge.

## Refs

- Issue: #452.
- Umbrella: #382 (Track C sub-issue).
- Track A landings: #383, #384, #385, #386, #387, #388.
- Existing consumers of `count_edges_by_type`: `src/aelfrice/auditor.py:189`, `src/aelfrice/telemetry.py:239`.

## Summary by Sourcery

Add per-edge-type health metrics to the health computation and CLI, including a JSON output mode for machine-readable audit and feature data.

New Features:
- Expose per-edge-type edge counts as a new edges_by_type field on HealthFeatures, zero-padded over the full edge type registry.
- Extend the aelf health command with a per-edge-type breakdown block in text output and add a --json flag returning structured audit and feature data.

Enhancements:
- Preserve the existing regime classifier feature set while wiring edge-type counts into the health feature computation.

Documentation:
- Document the updated aelf health command, including the per-edge-type breakdown and the --json response shape, in COMMANDS.md.

Tests:
- Add unit tests for edges_by_type computation, classifier invariants, health text output, and the aelf health --json shape and exit-code behavior.