### PR TITLE
refactor(#264 slice 2): route remaining entry points through derivation worker

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -70,6 +70,20 @@ The principled response is to add aggregative-query routing at the structural-an
 
 One DB at a time. Beliefs from project A do not surface in project B (different `.git/` directories). Use `AELFRICE_DB` to scope per-project explicitly.
 
+## Derivation worker (v2.x)
+
+The `ingest_log` → `beliefs` derivation worker (#264) is **synchronous and in-process** at v2.x. Every ingest entry point (`scan_repo`, `ingest_turn`, `accept_classifications`, `aelf lock`, MCP `aelf:lock`, `triple_extractor.ingest_triples`) appends one unstamped log row per raw input and invokes `run_worker(store)` once at end-of-batch in the same Python process. The "worker" name is aspirational — there is no daemon, no async queue, no background thread.
+
+What this implies for v2.x users:
+
+- **No async / daemon mode.** Long ingest batches block the caller. Async / daemon mode is parked for v3.
+- **Crash recovery requires an operator action.** If the process dies between `record_ingest` and `run_worker`, the canonical store is left with `ingest_log` rows whose `derived_belief_ids` is NULL. The next ingest call's end-of-batch worker pass picks them up automatically — but until then, `beliefs` is missing rows for those raw inputs. The escape hatch is `aelf doctor --derive-pending`, which forces a worker pass without requiring another ingest. Auto-derive-on-startup (so `_open_store` would do it implicitly on every CLI invocation) is the broader Decision-2 ratification from the slice plan and is deferred to a follow-up.
+- **Multi-rule-set re-derivation is not wired.** The worker uses the *current* rule set. Re-deriving every belief under a different classifier requires `aelf doctor --replay` + a manual rebuild from log; there is no `aelf doctor --rederive --rule-set <hash>` surface yet. (`aelf doctor --replay` is the drift detector, not the rebuild path.)
+- **Two non-canonical paths remain.** The scanner's LLM-classify path (`aelf onboard --llm-classify`, classifier_version-stamped) still writes to `beliefs` directly via the parallel-write pattern — its alpha/beta/origin/audit_source are not yet representable in `raw_meta` for the worker to reconstruct. The `aelf validate` / `aelf promote` lock-upgrade subpaths mutate `beliefs` directly (no log row) because they are not ingest events. `aelf doctor --replay` reports both as `canonical_orphan` and excludes them from the drift count — these are spec-allowed outliers, not bugs.
+- **`record_ingest + run_worker` is not wrapped in a single SQLite transaction.** Decision D1 in the slice plan calls for this (so a partial-stamp window after `record_ingest` returns and before `run_worker` finishes is closed). Today the two are sequential; SQLite's WAL + autocommit semantics mean an intervening writer between them sees the unstamped row briefly. The `--derive-pending` escape hatch + `--replay` drift detector together cover this; the explicit single-tx wrap is deferred behind operational evidence that the partial-stamp window matters in practice.
+
+The view-flip (#265) — making `beliefs` a derived view of `ingest_log` and stopping the parallel write — is the next step in the chain. Until that lands, both writes happen and are kept consistent by the worker.
+
 ## Compatibility
 
 - Python 3.12 or 3.13.

--- a/src/aelfrice/classification.py
+++ b/src/aelfrice/classification.py
@@ -483,9 +483,18 @@ def accept_classifications(
     skipped_existing = 0
     skipped_unclassified = 0
 
-    # Lazy import: derivation imports classify_sentence from this module;
-    # importing at module-load would form a cycle.
-    from aelfrice.derivation import DerivationInput, derive  # noqa: PLC0415
+    # #264 slice 2: route through the derivation worker. The host's
+    # belief-type verdict rides in `raw_meta.override_belief_type` so
+    # the worker reconstructs the same DerivationInput on replay.
+    # Pre-existing beliefs at the same id surface as `skipped_existing`
+    # via post-worker stamp inspection rather than an inline
+    # `get_belief` short-circuit — every host verdict appends a log row,
+    # so replay sees the full ingest history (#205 parallel-write
+    # becomes canonical).
+    from aelfrice.derivation_worker import run_worker  # noqa: PLC0415
+
+    ids_before: set[str] = set(store.list_belief_ids())
+    log_ids: list[str] = []
 
     for sd in sentences_data:
         idx = int(sd["index"])
@@ -498,36 +507,39 @@ def accept_classifications(
         if not c.persist:
             skipped_non_persisting += 1
             continue
-        out = derive(DerivationInput(
-            raw_text=text,
-            source_kind=INGEST_SOURCE_FILESYSTEM,
-            source_path=source,
-            ts=timestamp,
-            session_id=session_id,
-            override_belief_type=c.belief_type,
-        ))
-        # override_belief_type always produces a belief (persist=True
-        # is the caller's responsibility; checked above).
-        assert out.belief is not None
-        bid = out.belief.id
-        if store.get_belief(bid) is not None:
-            skipped_existing += 1
-            continue
-        # v2.0 #205 parallel-write: log the host-classified text.
-        store.record_ingest(
+        log_id = store.record_ingest(
             source_kind=INGEST_SOURCE_FILESYSTEM,
             source_path=source,
             raw_text=text,
-            derived_belief_ids=[bid],
             session_id=session_id,
             ts=timestamp,
+            raw_meta={
+                "call_site": CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+                "override_belief_type": c.belief_type,
+            },
         )
-        _, was_inserted = store.insert_or_corroborate(
-            out.belief,
-            source_type=CORROBORATION_SOURCE_FILESYSTEM_INGEST,
-        )
-        if was_inserted:
-            inserted += 1
+        log_ids.append(log_id)
+
+    if log_ids:
+        run_worker(store)
+        for log_id in log_ids:
+            entry = store.get_ingest_log_entry(log_id)
+            if entry is None:
+                continue
+            ids = entry.get("derived_belief_ids") or []
+            if not isinstance(ids, list) or not ids:
+                # `override_belief_type` forces persist=True in derive();
+                # an empty list here means the row failed to materialize.
+                # Surface as skipped_non_persisting so the count is
+                # observable rather than silently lost.
+                skipped_non_persisting += 1
+                continue
+            bid = str(ids[0])
+            if bid in ids_before:
+                skipped_existing += 1
+            else:
+                inserted += 1
+                ids_before.add(bid)  # convergent dupes within this batch
 
     store.complete_onboard_session(session_id, timestamp)
     return AcceptOnboardResult(

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2565,6 +2565,8 @@ def _cmd_doctor(args: argparse.Namespace, out: object) -> int:
         return _cmd_doctor_relationships(args, out)
     if getattr(args, "detect_stale", False):
         return _cmd_doctor_detect_stale(args, out)
+    if getattr(args, "derive_pending", False):
+        return _cmd_doctor_derive_pending(args, out)
     scope = getattr(args, "scope", None)
     exit_code = 0
     if scope in (None, "hooks"):
@@ -2811,6 +2813,46 @@ def _cmd_doctor_replay(args: argparse.Namespace, out: object) -> int:
     drift_total = report.mismatched + report.derived_orphan
     threshold = max(0, max_drift) if max_drift is not None else 0
     return 0 if drift_total <= threshold else 1
+
+
+def _cmd_doctor_derive_pending(
+    args: argparse.Namespace, out: object,  # noqa: ARG001
+) -> int:
+    """Run the derivation worker over orphan ingest_log rows (#264).
+
+    Manual escape per the slice-2 plan: when the worker dies between
+    batches (e.g. process killed mid-`aelf onboard`), the next ingest
+    invocation would normally pick up the orphan rows on its own
+    end-of-batch worker pass — but until then the canonical store has
+    drift between `ingest_log` (rows present, derived_belief_ids NULL)
+    and `beliefs` (no row materialized). `aelf doctor --derive-pending`
+    forces the catch-up pass without requiring another ingest.
+
+    Idempotent: re-running over an already-stamped store no-ops every
+    row. Exit 0 when no unstamped rows remain after the run; exit 1
+    when the store still has orphan rows (caller should investigate
+    why `derive()` returned no belief for those raw inputs).
+    """
+    from aelfrice.derivation_worker import run_worker  # noqa: PLC0415
+
+    store = _open_store()
+    try:
+        before = len(store.list_unstamped_ingest_log())
+        result = run_worker(store)
+        after = len(store.list_unstamped_ingest_log())
+    finally:
+        store.close()
+
+    print("derive-pending report", file=out)  # type: ignore[arg-type]
+    print("---------------------", file=out)  # type: ignore[arg-type]
+    print(f"unstamped before:        {before}", file=out)  # type: ignore[arg-type]
+    print(f"rows scanned:            {result.rows_scanned}", file=out)  # type: ignore[arg-type]
+    print(f"beliefs inserted:        {result.beliefs_inserted}", file=out)  # type: ignore[arg-type]
+    print(f"beliefs corroborated:    {result.beliefs_corroborated}", file=out)  # type: ignore[arg-type]
+    print(f"rows stamped:            {result.rows_stamped}", file=out)  # type: ignore[arg-type]
+    print(f"rows skipped no belief:  {result.rows_skipped_no_belief}", file=out)  # type: ignore[arg-type]
+    print(f"unstamped after:         {after}", file=out)  # type: ignore[arg-type]
+    return 0 if after == 0 else 1
 
 
 def _cmd_doctor_classify_orphans(
@@ -3654,6 +3696,20 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
             "every non-legacy ingest_log row and compare to canonical "
             "beliefs. Exits 0 when mismatched + derived_orphan == 0 "
             "(or <= --max-drift N). Bypasses the hooks/graph checks."
+        ),
+    )
+    p_doctor.add_argument(
+        "--derive-pending",
+        dest="derive_pending",
+        action="store_true",
+        default=False,
+        help=(
+            "run the derivation worker over orphan ingest_log rows "
+            "(#264): the manual escape when an ingest batch's "
+            "end-of-batch worker pass died and left log rows with "
+            "NULL derived_belief_ids. Idempotent. Exits 0 if every "
+            "row is stamped after the run; exit 1 if any row remains "
+            "orphan. Bypasses the hooks/graph checks."
         ),
     )
     p_doctor.add_argument(

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -1046,6 +1046,13 @@ def _cmd_lock(args: argparse.Namespace, out: object) -> int:
             getattr(args, "session_id", None),
             surface_name="aelf lock",
         )
+        # #264 slice 2: route through the derivation worker, mirroring
+        # mcp_server.tool_lock. We pre-derive only to compute the
+        # prospective belief id for the re-lock semantic — the actual
+        # write goes through the worker so the canonical log records
+        # every `aelf lock` invocation.
+        from aelfrice.derivation_worker import run_worker  # noqa: PLC0415
+
         derived = derive(DerivationInput(
             raw_text=args.statement,
             source_kind=INGEST_SOURCE_CLI_REMEMBER,
@@ -1054,33 +1061,45 @@ def _cmd_lock(args: argparse.Namespace, out: object) -> int:
         ))
         # cli_remember always produces a belief.
         assert derived.belief is not None
-        bid = derived.belief.id
-        existing = store.get_belief(bid)
-        if existing is None:
-            # v2.0 #205 parallel-write.
-            store.record_ingest(
-                source_kind=INGEST_SOURCE_CLI_REMEMBER,
-                raw_text=args.statement,
-                derived_belief_ids=[bid],
-                session_id=sid,
-                ts=now,
-            )
-            actual_id, was_inserted = store.insert_or_corroborate(
-                derived.belief,
-                source_type=CORROBORATION_SOURCE_CLI_REMEMBER,
-                session_id=sid,
-            )
-            if was_inserted:
-                print(f"locked: {actual_id}", file=out)  # type: ignore[arg-type]
-            else:
-                print(f"locked: {actual_id} (corroborated existing)", file=out)  # type: ignore[arg-type]
+        lock_bid = derived.belief.id
+        pre_existing_at_lock_id = store.get_belief(lock_bid) is not None
+        ids_before: set[str] = set(store.list_belief_ids())
+        log_id = store.record_ingest(
+            source_kind=INGEST_SOURCE_CLI_REMEMBER,
+            raw_text=args.statement,
+            session_id=sid,
+            ts=now,
+            raw_meta={"call_site": CORROBORATION_SOURCE_CLI_REMEMBER},
+        )
+        run_worker(store)
+        entry = store.get_ingest_log_entry(log_id)
+        derived_ids = (
+            entry.get("derived_belief_ids") if entry is not None else None
+        )
+        if not isinstance(derived_ids, list) or not derived_ids:
+            # cli_remember always derives a belief; an empty stamp here
+            # means something is broken downstream.
+            print("lock failed: derivation produced no belief", file=sys.stderr)
+            return 1
+        actual_id = str(derived_ids[0])
+        if pre_existing_at_lock_id and actual_id == lock_bid:
+            # Re-lock of an existing lock-id belief: apply lock-upgrade
+            # (the worker's insert_or_corroborate just records corroboration).
+            existing = store.get_belief(actual_id)
+            if existing is not None:
+                existing.lock_level = LOCK_USER
+                existing.locked_at = now
+                existing.demotion_pressure = 0
+                existing.origin = ORIGIN_USER_STATED
+                store.update_belief(existing)
+            print(f"upgraded existing belief to lock: {actual_id}", file=out)  # type: ignore[arg-type]
+        elif actual_id in ids_before:
+            # content_hash collision with a different-source belief: the
+            # worker corroborated it; preserve pre-#264 'corroborated'
+            # output for parity with the prior CLI surface.
+            print(f"locked: {actual_id} (corroborated existing)", file=out)  # type: ignore[arg-type]
         else:
-            existing.lock_level = LOCK_USER
-            existing.locked_at = now
-            existing.demotion_pressure = 0
-            existing.origin = ORIGIN_USER_STATED
-            store.update_belief(existing)
-            print(f"upgraded existing belief to lock: {bid}", file=out)  # type: ignore[arg-type]
+            print(f"locked: {actual_id}", file=out)  # type: ignore[arg-type]
     finally:
         store.close()
     return 0

--- a/src/aelfrice/triple_extractor.py
+++ b/src/aelfrice/triple_extractor.py
@@ -248,58 +248,6 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _resolve_or_create_belief(
-    store: MemoryStore, phrase: str, *,
-    session_id: str | None,
-    created_ids: list[str],
-) -> str:
-    """Return the id of the belief representing `phrase`, creating
-    one with the project default prior (alpha=1.0, beta=1.0) if none
-    exists. The first creator within a call stamps `session_id`.
-
-    When the belief already exists (same id = same normalised phrase),
-    a corroboration row is recorded so the re-assertion is observable.
-    """
-    # derive() id-scheme matches _belief_id_for_phrase; compute once.
-    ts = _now_iso()
-    out = derive(DerivationInput(
-        raw_text=phrase,
-        source_kind=INGEST_SOURCE_GIT,
-        session_id=session_id,
-        ts=ts,
-    ))
-    # INGEST_SOURCE_GIT always produces a belief (no classifier skip).
-    assert out.belief is not None
-    bid = out.belief.id
-    existing = store.get_belief(bid)
-    if existing is not None:
-        store.record_corroboration(
-            bid,
-            source_type=CORROBORATION_SOURCE_COMMIT_INGEST,
-            session_id=session_id,
-        )
-        return bid
-    # v2.0 #205 parallel-write: log the raw phrase before materialization.
-    # source_kind=git because the commit-ingest path emits triples from
-    # commit messages; source_path is unknown at this layer (callers
-    # have it). Future commits could thread the commit SHA through.
-    store.record_ingest(
-        source_kind=INGEST_SOURCE_GIT,
-        raw_text=phrase,
-        derived_belief_ids=[bid],
-        session_id=session_id,
-        ts=ts,
-    )
-    actual_id, was_inserted = store.insert_or_corroborate(
-        out.belief,
-        source_type=CORROBORATION_SOURCE_COMMIT_INGEST,
-        session_id=session_id,
-    )
-    if was_inserted:
-        created_ids.append(actual_id)
-    return actual_id
-
-
 def ingest_triples(
     store: MemoryStore,
     triples: list[Triple],
@@ -307,28 +255,81 @@ def ingest_triples(
 ) -> IngestResult:
     """Persist `triples` to `store`. Idempotent.
 
-    For each triple:
-      1. Resolve / create the subject belief by content hash.
-      2. Resolve / create the object belief.
-      3. Insert an Edge(subject_id -> object_id, type=relation,
+    Under #264 slice 2 each unique phrase appends one unstamped
+    `ingest_log` row; a single `run_worker(store)` invocation at
+    end-of-batch materializes every referenced belief. Edges are
+    constructed against the worker-stamped canonical ids.
+
+    For each triple after the worker runs:
+      1. Resolve subject + object via the stamp on each phrase's
+         log row.
+      2. Insert an Edge(subject_id -> object_id, type=relation,
          anchor_text=triple.anchor_text). Skip if already present.
 
-    Self-edges (subject and object resolve to the same id) are
-    counted under `skipped_no_subject_or_object` and dropped.
+    Self-edges (subject and object resolve to the same id post-worker)
+    are counted under `skipped_no_subject_or_object` and dropped.
     """
+    from aelfrice.derivation_worker import run_worker  # noqa: PLC0415
+
     result = IngestResult()
+    if not triples:
+        return result
+
+    ts = _now_iso()
+    ids_before: set[str] = set(store.list_belief_ids())
+    # One log row per unique phrase. Convergent triples (same subject
+    # across multiple triples) reuse the log_id; the worker's content-
+    # hash UNIQUE path corroborates idempotently anyway, so the dedup
+    # here is just a record-keeping optimisation, not a correctness lever.
+    phrase_to_log_id: dict[str, str] = {}
+    for triple in triples:
+        if not triple.subject or not triple.object:
+            continue
+        for phrase in (triple.subject, triple.object):
+            if phrase in phrase_to_log_id:
+                continue
+            phrase_to_log_id[phrase] = store.record_ingest(
+                source_kind=INGEST_SOURCE_GIT,
+                raw_text=phrase,
+                session_id=session_id,
+                ts=ts,
+                raw_meta={"call_site": CORROBORATION_SOURCE_COMMIT_INGEST},
+            )
+
+    if phrase_to_log_id:
+        run_worker(store)
+
+    # Harvest worker output. `actual_id` may differ from the
+    # deterministically-derived bid when the worker resolves a content-
+    # hash collision against an existing belief from a different source.
+    phrase_to_actual_id: dict[str, str] = {}
+    for phrase, log_id in phrase_to_log_id.items():
+        entry = store.get_ingest_log_entry(log_id)
+        if entry is None:
+            continue
+        ids = entry.get("derived_belief_ids") or []
+        if not isinstance(ids, list) or not ids:
+            continue
+        actual_id = str(ids[0])
+        phrase_to_actual_id[phrase] = actual_id
+        if actual_id not in ids_before:
+            if actual_id not in result.new_beliefs:
+                result.new_beliefs.append(actual_id)
+            ids_before.add(actual_id)
+
     for triple in triples:
         if not triple.subject or not triple.object:
             result.skipped_no_subject_or_object += 1
             continue
-        subj_id = _resolve_or_create_belief(
-            store, triple.subject,
-            session_id=session_id, created_ids=result.new_beliefs,
-        )
-        obj_id = _resolve_or_create_belief(
-            store, triple.object,
-            session_id=session_id, created_ids=result.new_beliefs,
-        )
+        subj_id = phrase_to_actual_id.get(triple.subject)
+        obj_id = phrase_to_actual_id.get(triple.object)
+        if subj_id is None or obj_id is None:
+            # Worker did not stamp this phrase — derive() returned no
+            # belief, an unexpected state for INGEST_SOURCE_GIT. Surface
+            # under skipped_no_subject_or_object so the count is
+            # observable.
+            result.skipped_no_subject_or_object += 1
+            continue
         if subj_id == obj_id:
             result.skipped_no_subject_or_object += 1
             continue

--- a/src/aelfrice/triple_extractor.py
+++ b/src/aelfrice/triple_extractor.py
@@ -28,7 +28,6 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Final
 
-from aelfrice.derivation import DerivationInput, derive
 from aelfrice.models import (
     CORROBORATION_SOURCE_COMMIT_INGEST,
     EDGE_CITES,

--- a/tests/test_classification_via_worker.py
+++ b/tests/test_classification_via_worker.py
@@ -1,0 +1,146 @@
+"""Integration tests for the post-#264 accept_classifications →
+derivation_worker call shape.
+
+`accept_classifications` is the host-LLM onboarding terminus: the host
+classified each sentence in its own context, returned a `belief_type`
+verdict, and now aelfrice materializes the resulting beliefs. Under
+slice 2 the entry point appends one unstamped log row per persisted
+classification (with `raw_meta.override_belief_type` set), then invokes
+`run_worker(store)` once at end-of-batch. Skipped-vs-inserted accounting
+is reconstructed post-worker from the stamped log rows.
+
+These tests anchor the *new* invariants. They will catch any future
+regression that re-introduces an inline `derive()` / `insert_belief()`
+call in the entry point.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from aelfrice.classification import (
+    HostClassification,
+    accept_classifications,
+    start_onboard_session,
+)
+from aelfrice.models import BELIEF_FACTUAL
+from aelfrice.replay import replay_full_equality
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Iterator[MemoryStore]:
+    s = MemoryStore(str(tmp_path / "classification-via-worker.db"))
+    yield s
+    s.close()
+
+
+def _populate_repo(root: Path) -> None:
+    """Drop a single .md file with a couple of factual sentences."""
+    (root / "facts.md").write_text(
+        "The configuration file lives at /etc/aelfrice/conf.\n"
+        "The default port is 8080.\n"
+    )
+
+
+def test_every_log_row_is_stamped_after_accept(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: after accept_classifications returns, no log row
+    remains unstamped — the worker ran end-of-batch and stamped every
+    row. Falsifiable by any row whose `derived_belief_ids IS NULL`."""
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    cls = [
+        HostClassification(index=s.index, belief_type=BELIEF_FACTUAL, persist=True)
+        for s in result.sentences
+    ]
+    accept_classifications(store, result.session_id, cls, now="2026-04-26T01:00:00Z")
+    unstamped = store.list_unstamped_ingest_log()
+    assert unstamped == [], f"unstamped rows: {unstamped}"
+
+
+def test_log_row_carries_call_site_and_override_metadata(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: each persisted classification produces a log row
+    whose `raw_meta` carries both `call_site=filesystem_ingest` and
+    `override_belief_type=<host's verdict>`. The worker reads
+    override_belief_type to reconstruct the same DerivationInput on
+    replay. Falsifiable if either key is missing."""
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    cls = [
+        HostClassification(index=s.index, belief_type=BELIEF_FACTUAL, persist=True)
+        for s in result.sentences
+    ]
+    accept_classifications(store, result.session_id, cls, now="2026-04-26T01:00:00Z")
+    rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT raw_meta FROM ingest_log WHERE source_path IS NOT NULL"
+    ).fetchall()
+    assert rows
+    import json
+    for row in rows:
+        meta = json.loads(row["raw_meta"]) if row["raw_meta"] else None
+        assert isinstance(meta, dict)
+        assert meta.get("call_site") == "filesystem_ingest"
+        assert meta.get("override_belief_type") == BELIEF_FACTUAL
+
+
+def test_non_persisting_classification_writes_no_log_row(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: a HostClassification with persist=False is dropped
+    before record_ingest — no log row is appended. The host's verdict
+    is "this isn't worth persisting" and the canonical log shouldn't
+    record it. Falsifiable if a log row appears for that index."""
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    if not result.sentences:
+        pytest.skip("fixture produced no sentences")
+    cls = [HostClassification(
+        index=result.sentences[0].index,
+        belief_type=BELIEF_FACTUAL,
+        persist=False,
+    )]
+    outcome = accept_classifications(
+        store, result.session_id, cls, now="2026-04-26T01:00:00Z",
+    )
+    assert outcome.skipped_non_persisting == 1
+    assert outcome.inserted == 0
+    n_rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT COUNT(*) AS n FROM ingest_log",
+    ).fetchone()["n"]
+    assert n_rows == 0
+
+
+def test_replay_full_equality_passes_after_accept(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis (CI gate): after a representative accept run, the
+    full-equality replay probe reports zero drift — every log row
+    re-derives to a shape-equal canonical belief, including the
+    host-supplied override_belief_type that rides in raw_meta.
+
+    Falsifiable by any non-zero drift counter."""
+    _populate_repo(tmp_path)
+    result = start_onboard_session(store, tmp_path, now="2026-04-26T00:00:00Z")
+    cls = [
+        HostClassification(index=s.index, belief_type=BELIEF_FACTUAL, persist=True)
+        for s in result.sentences
+    ]
+    accept_classifications(store, result.session_id, cls, now="2026-04-26T01:00:00Z")
+    report = replay_full_equality(store)
+    assert report.total_log_rows > 0
+    assert report.matched == report.total_log_rows, (
+        f"replay drift: matched={report.matched}, "
+        f"mismatched={report.mismatched}, "
+        f"derived_orphan={report.derived_orphan}, "
+        f"canonical_orphan={report.canonical_orphan}, "
+        f"examples={report.drift_examples}"
+    )
+    assert report.mismatched == 0
+    assert report.derived_orphan == 0
+    assert report.canonical_orphan == 0

--- a/tests/test_cli_lock_via_worker.py
+++ b/tests/test_cli_lock_via_worker.py
@@ -1,0 +1,112 @@
+"""Integration tests for the post-#264 `aelf lock` → derivation_worker
+call shape.
+
+Mirrors test_ingest_via_worker.py for the CLI lock entry point. After
+slice 2 ships, every `aelf lock <statement>` invocation appends one
+unstamped log row (with `raw_meta.call_site = cli_remember`) and
+invokes `run_worker(store)` once at end-of-call. Re-lock semantics
+(applying lock-upgrade to a pre-existing lock-id belief) are layered
+on top of the worker's stamped output, not used as a parallel-write
+short-circuit.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from aelfrice.cli import main as cli_main
+from aelfrice.replay import replay_full_equality
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture
+def isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[Path]:
+    """Fresh DB per test under tmp_path."""
+    db_path = tmp_path / "lock-via-worker.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db_path))
+    monkeypatch.setenv("AELFRICE_SESSION_ID", "sess-test")
+    yield db_path
+
+
+def _open_store(db_path: Path) -> MemoryStore:
+    return MemoryStore(str(db_path))
+
+
+def test_every_log_row_is_stamped_after_lock(isolated_db: Path) -> None:
+    """Hypothesis: after `aelf lock` returns 0, no log row remains
+    unstamped — the worker ran end-of-call. Falsifiable by any row
+    whose `derived_belief_ids IS NULL`."""
+    rc = cli_main(["lock", "we always sign commits with ssh"])
+    assert rc == 0
+    store = _open_store(isolated_db)
+    try:
+        assert store.list_unstamped_ingest_log() == []
+    finally:
+        store.close()
+
+
+def test_log_row_carries_call_site_metadata(isolated_db: Path) -> None:
+    """Hypothesis: `aelf lock` stamps `raw_meta.call_site=cli_remember`
+    so the worker resolves the corroboration source unambiguously.
+    Falsifiable if `raw_meta` is missing or carries a different
+    call_site."""
+    rc = cli_main(["lock", "the canonical port is 8080"])
+    assert rc == 0
+    store = _open_store(isolated_db)
+    try:
+        rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+            "SELECT raw_meta FROM ingest_log"
+        ).fetchall()
+        assert rows
+        import json
+        for row in rows:
+            meta = json.loads(row["raw_meta"]) if row["raw_meta"] else None
+            assert isinstance(meta, dict)
+            assert meta.get("call_site") == "cli_remember"
+    finally:
+        store.close()
+
+
+def test_re_lock_appends_log_row_and_keeps_lock(isolated_db: Path) -> None:
+    """Hypothesis: re-locking the same statement appends a second log
+    row (canonical history shows both invocations) AND re-applies
+    lock-upgrade semantics (the belief stays LOCK_USER with refreshed
+    timestamp). Falsifiable if the second invocation drops the row OR
+    leaves the belief in a non-LOCK_USER state."""
+    cli_main(["lock", "atomic commits beat batched commits"])
+    rc = cli_main(["lock", "atomic commits beat batched commits"])
+    assert rc == 0
+    store = _open_store(isolated_db)
+    try:
+        rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+            "SELECT COUNT(*) AS n FROM ingest_log",
+        ).fetchone()
+        assert rows["n"] == 2
+        # Still exactly one locked belief (no double-insert).
+        assert store.count_locked() == 1
+    finally:
+        store.close()
+
+
+def test_replay_full_equality_passes_after_lock(isolated_db: Path) -> None:
+    """Hypothesis (CI gate): after a representative lock invocation,
+    the full-equality replay probe reports zero drift. Falsifiable by
+    any non-zero drift counter — the `cli_remember` call site must
+    re-derive to the same canonical belief on replay."""
+    cli_main(["lock", "the dashboard runs on port 8080"])
+    cli_main(["lock", "always use uv to manage python envs"])
+    store = _open_store(isolated_db)
+    try:
+        report = replay_full_equality(store)
+        assert report.total_log_rows > 0
+        assert report.matched == report.total_log_rows, (
+            f"replay drift: matched={report.matched}, "
+            f"mismatched={report.mismatched}, "
+            f"derived_orphan={report.derived_orphan}, "
+            f"canonical_orphan={report.canonical_orphan}, "
+            f"examples={report.drift_examples}"
+        )
+    finally:
+        store.close()

--- a/tests/test_doctor_derive_pending.py
+++ b/tests/test_doctor_derive_pending.py
@@ -1,0 +1,128 @@
+"""Tests for `aelf doctor --derive-pending` (#264 slice 2).
+
+The manual escape for orphan ingest_log rows: when a worker died
+between batches and left rows with NULL derived_belief_ids, the next
+ingest call would normally pick them up — but until then, the operator
+can force a catch-up pass.
+"""
+from __future__ import annotations
+
+import io
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from aelfrice.cli import main as cli_main
+from aelfrice.derivation_worker import run_worker
+from aelfrice.ingest import ingest_turn
+from aelfrice.models import INGEST_SOURCE_FILESYSTEM
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture
+def isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[Path]:
+    db_path = tmp_path / "doctor-derive-pending.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db_path))
+    monkeypatch.setenv("AELFRICE_SESSION_ID", "sess-test")
+    yield db_path
+
+
+def _capture(*argv: str) -> tuple[int, str]:
+    buf = io.StringIO()
+    import contextlib
+    with contextlib.redirect_stdout(buf):
+        rc = cli_main(list(argv))
+    return rc, buf.getvalue()
+
+
+def test_derive_pending_on_clean_store_returns_zero(isolated_db: Path) -> None:
+    """Hypothesis: a store with no orphan log rows (the steady-state
+    after every well-behaved ingest) reports zero scanned and exits 0.
+    Falsifiable if exit code is non-zero or any "rows scanned" is
+    non-zero."""
+    rc, out = _capture("doctor", "--derive-pending")
+    assert rc == 0
+    assert "unstamped before:        0" in out
+    assert "rows scanned:            0" in out
+    assert "unstamped after:         0" in out
+
+
+def test_derive_pending_stamps_orphan_log_row(isolated_db: Path) -> None:
+    """Hypothesis: an orphan log row inserted directly to ingest_log
+    (simulating the 'worker died mid-batch' scenario) is stamped after
+    --derive-pending runs. Exit 0 on success.
+
+    Falsifiable if `derived_belief_ids` remains NULL OR if the worker
+    counters don't reflect the recovery (rows_scanned == 0)."""
+    store = MemoryStore(str(isolated_db))
+    try:
+        store.record_ingest(
+            source_kind=INGEST_SOURCE_FILESYSTEM,
+            source_path="orphan.md",
+            raw_text="The orphan port is 9090.",
+            session_id="sess-orphan",
+            ts="2026-04-26T00:00:00Z",
+            raw_meta={"call_site": "filesystem_ingest"},
+        )
+        # confirm orphan state
+        assert len(store.list_unstamped_ingest_log()) == 1
+    finally:
+        store.close()
+
+    rc, out = _capture("doctor", "--derive-pending")
+    assert rc == 0
+    assert "unstamped before:        1" in out
+    assert "rows scanned:            1" in out
+    assert "rows stamped:            1" in out
+    assert "unstamped after:         0" in out
+
+    store = MemoryStore(str(isolated_db))
+    try:
+        assert store.list_unstamped_ingest_log() == []
+    finally:
+        store.close()
+
+
+def test_derive_pending_idempotent(isolated_db: Path) -> None:
+    """Hypothesis: running --derive-pending twice over the same store
+    produces a no-op on the second invocation (rows scanned == 0 the
+    second time). Falsifiable if the second run touches any rows."""
+    # Seed with an ingest so there's data, then verify no orphans.
+    store = MemoryStore(str(isolated_db))
+    try:
+        ingest_turn(store, "Atomic commits beat batched commits.", source="user")
+    finally:
+        store.close()
+
+    rc1, out1 = _capture("doctor", "--derive-pending")
+    rc2, out2 = _capture("doctor", "--derive-pending")
+    assert rc1 == 0
+    assert rc2 == 0
+    # Second run: nothing to do.
+    assert "unstamped before:        0" in out2
+    assert "rows scanned:            0" in out2
+
+
+def test_run_worker_returns_aggregate_counts(isolated_db: Path) -> None:
+    """Hypothesis: run_worker's WorkerResult correctly aggregates
+    counts across multiple orphan rows. Falsifiable by any counter
+    mismatch."""
+    store = MemoryStore(str(isolated_db))
+    try:
+        for i in range(3):
+            store.record_ingest(
+                source_kind=INGEST_SOURCE_FILESYSTEM,
+                source_path=f"orphan-{i}.md",
+                raw_text=f"Distinct fact number {i}.",
+                session_id="sess-orphan",
+                ts="2026-04-26T00:00:00Z",
+                raw_meta={"call_site": "filesystem_ingest"},
+            )
+        result = run_worker(store)
+        assert result.rows_scanned == 3
+        assert result.rows_stamped == 3
+        assert result.beliefs_inserted == 3
+        assert result.beliefs_corroborated == 0
+    finally:
+        store.close()

--- a/tests/test_onboard_handshake.py
+++ b/tests/test_onboard_handshake.py
@@ -285,8 +285,14 @@ def test_accept_skips_existing_beliefs_inserted_after_session_started(
     # session A starts, session B starts and completes for the same
     # tree, A's accept must skip rather than collide.
     bid = _derive_id_for_sentence(s0.text, s0.source)
+    # Use the canonical content_hash so the race-belief looks identical
+    # to what derive() would produce — under the worker-routed path
+    # (#264 slice 2) classification appends a log row unconditionally
+    # and lets `insert_or_corroborate`'s content_hash UNIQUE constraint
+    # detect the prior insert.
+    from aelfrice.derivation import _content_hash  # noqa: PLC0415
     store.insert_belief(Belief(
-        id=bid, content=s0.text, content_hash="precomputed",
+        id=bid, content=s0.text, content_hash=_content_hash(s0.text),
         alpha=1.0, beta=1.0, type=BELIEF_FACTUAL,
         lock_level=LOCK_NONE, locked_at=None, demotion_pressure=0,
         created_at="2026-04-26T00:30:00Z", last_retrieved_at=None,

--- a/tests/test_triple_extractor_via_worker.py
+++ b/tests/test_triple_extractor_via_worker.py
@@ -1,0 +1,133 @@
+"""Integration tests for the post-#264 ingest_triples → derivation_worker
+call shape.
+
+`ingest_triples` is the commit-ingest terminus: triples extracted from
+commit messages get materialized as belief pairs + edges. Under slice 2
+the entry point appends one unstamped log row per unique phrase (with
+`raw_meta.call_site = commit_ingest`), invokes `run_worker(store)` once
+at end-of-batch, then constructs edges against the worker-stamped
+canonical ids.
+
+These tests anchor the *new* invariants. They catch any future
+regression that re-introduces an inline `derive()` / `insert_belief()`
+call in the entry point.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from aelfrice.replay import replay_full_equality
+from aelfrice.store import MemoryStore
+from aelfrice.triple_extractor import Triple, ingest_triples
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Iterator[MemoryStore]:
+    s = MemoryStore(str(tmp_path / "triples-via-worker.db"))
+    yield s
+    s.close()
+
+
+def _t(subj: str, rel: str, obj: str, anchor: str = "") -> Triple:
+    return Triple(subject=subj, relation=rel, object=obj, anchor_text=anchor or f"{subj} {rel} {obj}")
+
+
+def test_every_log_row_is_stamped_after_ingest_triples(
+    store: MemoryStore,
+) -> None:
+    """Hypothesis: after ingest_triples returns, no log row remains
+    unstamped — the worker ran end-of-batch. Falsifiable by any row
+    whose `derived_belief_ids IS NULL`."""
+    triples = [
+        _t("the scheduler", "supports", "the worker"),
+        _t("the worker", "implements", "derivation"),
+    ]
+    ingest_triples(store, triples, session_id="commit-abc")
+    assert store.list_unstamped_ingest_log() == []
+
+
+def test_log_row_carries_call_site_metadata(store: MemoryStore) -> None:
+    """Hypothesis: each unique phrase stamps `raw_meta.call_site=commit_ingest`
+    so the worker resolves the corroboration source unambiguously.
+    Falsifiable if `raw_meta` is missing or carries a different
+    call_site."""
+    ingest_triples(store, [_t("alpha", "depends_on", "beta")], session_id="c1")
+    rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT raw_meta FROM ingest_log"
+    ).fetchall()
+    assert rows
+    import json
+    for row in rows:
+        meta = json.loads(row["raw_meta"]) if row["raw_meta"] else None
+        assert isinstance(meta, dict)
+        assert meta.get("call_site") == "commit_ingest"
+
+
+def test_unique_phrase_per_log_row(store: MemoryStore) -> None:
+    """Hypothesis: convergent triples (same phrase appearing as the
+    subject across multiple triples) reuse one log row per phrase.
+    Falsifiable if `ingest_log` row count exceeds the unique-phrase
+    count for the batch."""
+    triples = [
+        _t("the scheduler", "supports", "the worker"),
+        _t("the scheduler", "supports", "the dashboard"),  # subj reused
+    ]
+    ingest_triples(store, triples, session_id="c2")
+    n_rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT COUNT(*) AS n FROM ingest_log"
+    ).fetchone()["n"]
+    # 3 unique phrases: "the scheduler", "the worker", "the dashboard".
+    assert n_rows == 3
+
+
+def test_ingest_triples_idempotent_on_re_run(store: MemoryStore) -> None:
+    """Hypothesis: re-ingesting the same triple batch is idempotent on
+    the canonical belief and edge sets, even though the log appends
+    new rows. Falsifiable if a duplicate edge appears OR if
+    new_beliefs is non-empty on the second call."""
+    triples = [_t("the cache", "supports", "the api")]
+    r1 = ingest_triples(store, triples, session_id="c3")
+    edges_after_first = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT COUNT(*) AS n FROM edges"
+    ).fetchone()["n"]
+    r2 = ingest_triples(store, triples, session_id="c3")
+    assert r2.new_beliefs == []
+    assert r2.new_edges == []
+    edges_after_second = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT COUNT(*) AS n FROM edges"
+    ).fetchone()["n"]
+    assert edges_after_first == edges_after_second
+    # And both invocations created log rows (canonical history).
+    n_rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT COUNT(*) AS n FROM ingest_log"
+    ).fetchone()["n"]
+    assert n_rows == 4  # 2 unique phrases × 2 invocations
+    assert r1.new_beliefs  # sanity: first call did create beliefs
+
+
+def test_replay_full_equality_passes_after_triples(store: MemoryStore) -> None:
+    """Hypothesis (CI gate): after a representative ingest_triples run,
+    the full-equality replay probe reports zero drift. Falsifiable by
+    any non-zero drift counter — triples that bypass the worker would
+    show up as canonical_orphan immediately."""
+    triples = [
+        _t("the scheduler", "supports", "the worker"),
+        _t("the worker", "implements", "derivation"),
+        _t("the api", "depends_on", "the cache"),
+    ]
+    ingest_triples(store, triples, session_id="c4")
+    report = replay_full_equality(store)
+    assert report.total_log_rows > 0
+    assert report.matched == report.total_log_rows, (
+        f"replay drift: matched={report.matched}, "
+        f"mismatched={report.mismatched}, "
+        f"derived_orphan={report.derived_orphan}, "
+        f"canonical_orphan={report.canonical_orphan}, "
+        f"examples={report.drift_examples}"
+    )
+    assert report.mismatched == 0
+    assert report.derived_orphan == 0
+    assert report.canonical_orphan == 0


### PR DESCRIPTION
## Summary

Closes #264 slice 2 — routes the four remaining ingest entry points through `derivation_worker.run_worker`, ships the `aelf doctor --derive-pending` manual escape, and updates `docs/LIMITATIONS.md`. Slice 1 (worker module) shipped at #399; slice 2 work for `scanner.py`, `ingest.py`, and `mcp_server.py` already shipped on main; this PR is the remainder.

Refers #264. Soak window from #262 closure (2026-04-29 → 2026-05-06) is met per the calendar test in prior release messages on the issue.

## What lands

- `accept_classifications` (`classification.py`) — worker-routed; host's belief_type rides in `raw_meta.override_belief_type`.
- `_cmd_lock` (`cli.py`) — mirrors `mcp_server.tool_lock`. Re-lock now also appends a log row.
- `ingest_triples` (`triple_extractor.py`) — batched two-phase shape (one log row per unique phrase, one worker pass, then edge construction).
- `aelf doctor --derive-pending` — runs the worker over orphan ingest_log rows. Idempotent. Exit 0 when fully stamped, 1 if any rows remain orphan.
- `docs/LIMITATIONS.md` — new "Derivation worker (v2.x)" section documenting synchronous-only, crash recovery via `--derive-pending`, two non-canonical paths still on direct write, no single-tx wrap.

## Behavior changes (deliberate, called out per Setr's plan)

- Every persisted host classification appends an ingest_log row, even when the resulting belief id already exists. Pre-existing-id beliefs are recorded as `skipped_existing` from the post-worker stamp instead of an inline `get_belief` short-circuit.
- Every `aelf lock` invocation appends a log row, including the lock-upgrade case (previously only the parallel-write branch logged).
- `triple_extractor.ingest_triples` records corroborations through the worker's `insert_or_corroborate` (content_hash UNIQUE) path rather than directly via `record_corroboration`. Net effect on `belief_corroborations` rows is the same.

`test_accept_skips_existing_beliefs_inserted_after_session_started` switches its precomputed-race belief from a fake `content_hash="precomputed"` to the canonical `_content_hash(text)` so the worker's content_hash UNIQUE path detects the prior insert. Same race, real hash; behavior unchanged from the test's stated intent.

## Deferred to follow-ups

- Auto-derive-on-startup (D2 broader ratification) — wiring `run_worker` inside `_open_store` with a `--no-auto-derive-on-startup` opt-out. Documented in LIMITATIONS as a deferred concern; the manual escape (`--derive-pending`) is the v2.x recovery path.
- Single SQLite transaction wrapping `record_ingest + run_worker` (D1) — documented in LIMITATIONS. Today the two are sequential.
- Multi-rule-set re-derivation surface — documented in LIMITATIONS.

## Verification

- `uv run pytest -q -x -k 'not bench'` — 2512 passed, 24 skipped, 37 deselected.
- Ruff clean on every changed file.
- `aelf doctor --derive-pending` smoke-tested on a clean store and on a store with synthetic orphan rows; both paths report correctly and exit with the expected code.

## Test plan

- [x] Per-entry-point integration test (one per file: classification, cli lock, triple_extractor) anchoring the post-#264 invariants (every log row stamped, raw_meta carries call_site, replay_full_equality reports zero drift).
- [x] `--derive-pending` test for clean store / orphan recovery / idempotency / aggregate counter sanity.
- [x] Existing onboard-handshake suite extended with the canonical content_hash for the precomputed-race test.
- [x] Full pytest matrix — 2512 passed.

## Summary by Sourcery

Route remaining ingest entry points through the derivation worker and add a manual recovery command for unstamped ingest_log rows.

New Features:
- Add `aelf doctor --derive-pending` to run the derivation worker over orphan ingest_log rows and report aggregate processing stats.

Enhancements:
- Refactor `accept_classifications` to log host classifications and rely on the derivation worker for belief materialization while preserving skip/insert accounting.
- Refactor CLI `aelf lock` to always append ingest_log rows, delegate belief creation to the derivation worker, and maintain re-lock semantics via post-worker inspection.
- Refactor `triple_extractor.ingest_triples` to batch ingest via ingest_log and a single worker pass, then build edges from worker-stamped belief IDs.
- Document current v2.x derivation worker behavior, limitations, and remaining direct-write paths in `docs/LIMITATIONS.md`.

Documentation:
- Expand LIMITATIONS with a section describing the synchronous derivation worker model, crash-recovery via `--derive-pending`, and deferred improvements.

Tests:
- Add integration tests that assert worker-routed behavior and replay invariants for `accept_classifications`, `aelf lock`, and `ingest_triples`.
- Extend onboarding handshake and doctor tests to cover canonical content_hash races and the `--derive-pending` recovery and idempotency behavior.