### PR TITLE
ci(replay-soak): write soak status to dedicated branch (#461)

### DIFF
--- a/.github/workflows/replay-soak-gate.yml
+++ b/.github/workflows/replay-soak-gate.yml
@@ -15,7 +15,11 @@ name: Replay Soak Gate
 # additive edits to `store.py` / `models.py` that touch the
 # derivation contract aren't soak-gated; the regular pytest matrix
 # (`replay_full_equality` tests) catches those, and any drift
-# surfaces on the next daily cron entry on main.
+# surfaces on the next daily cron entry on the soak branch.
+#
+# The soak file lives on the dedicated `replay-soak-status` branch
+# (#461), not `main` — the main ruleset blocks the cron's bot push.
+# This workflow checks out that branch to read the file.
 
 on:
   pull_request:
@@ -53,19 +57,38 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          # Need main's `.replay-soak-status.json`, not the PR branch's.
-          # The cron only writes on main, so PR branches by default don't
-          # carry fresh entries. Fetch main and read the file from there.
-          ref: main
+          # Read the soak file from the dedicated `replay-soak-status`
+          # branch (#461). The cron pushes there because the `main`
+          # ruleset rejects unsigned bot pushes; the dedicated branch
+          # is unconstrained and is the authoritative location.
+          ref: replay-soak-status
           fetch-depth: 1
           persist-credentials: false
+          # If the branch doesn't exist yet (fresh bootstrap window),
+          # checkout would fail; allow the workflow to continue and
+          # the streak script's missing-file path treats it as 0.
+          # Note: actions/checkout has no `continue-on-error` field;
+          # the orphan branch is bootstrapped before this workflow
+          # ever runs (operator one-shot at #461 PR merge).
+
+      - name: Fetch streak script from main
+        # `replay-soak-status` is an orphan content branch — only
+        # `.replay-soak-status.json` lives there. Pull the streak
+        # script out of `main` so we don't have to duplicate it on
+        # the status branch.
+        run: |
+          set -euo pipefail
+          git fetch origin main:refs/remotes/origin/main --depth=1
+          mkdir -p scripts
+          git show origin/main:scripts/replay_soak_streak.py > scripts/replay_soak_streak.py
+          chmod +x scripts/replay_soak_streak.py
 
       - name: Compute streak
         id: streak
         run: |
           set -euo pipefail
           if [ ! -f .replay-soak-status.json ]; then
-            echo "::warning::.replay-soak-status.json does not exist on main yet; treating streak as 0"
+            echo "::warning::.replay-soak-status.json does not exist on replay-soak-status yet; treating streak as 0"
             n=0
           else
             n=$(python3 scripts/replay_soak_streak.py --quiet)
@@ -78,7 +101,7 @@ jobs:
           set -euo pipefail
           n="${{ steps.streak.outputs.streak }}"
           if [ "$n" -lt 7 ]; then
-            echo "::error::replay-soak streak is $n; threshold is 7. The soak gate blocks #264-touching merges. Wait for the daily cron on main to extend the green streak, or investigate the most recent fail entry."
+            echo "::error::replay-soak streak is $n; threshold is 7. The soak gate blocks #264-touching merges. Wait for the daily cron to extend the green streak on replay-soak-status, or investigate the most recent fail entry."
             exit 1
           fi
           echo "replay-soak streak $n ≥ 7 — gate satisfied"

--- a/.github/workflows/replay-soak.yml
+++ b/.github/workflows/replay-soak.yml
@@ -2,11 +2,20 @@ name: Replay Soak
 
 # v2.x replay-equality soak gate (#403 deliverable A).
 #
-# Runs daily on `main` against the public v0.1 corpus under
+# Runs daily against the public v0.1 corpus under
 # `tests/corpus/replay_soak/v0.1/`. Appends one row to
-# `.replay-soak-status.json` (append-only JSONL, despite the .json
-# suffix) per the 2026-05-04 ratification on #403. The PR check that
-# enforces "≥ 7 consecutive green days" reads from this file (#403 C).
+# `.replay-soak-status.json` on the dedicated `replay-soak-status`
+# branch — append-only JSONL despite the `.json` suffix per the
+# 2026-05-04 ratification on #403. The PR check that enforces "≥ 7
+# consecutive green days" reads from that branch (#403 C / #461).
+#
+# Why a dedicated branch (not `main`):
+# the `main` ruleset blocks unsigned bot pushes (`required_signatures`)
+# and forbids direct pushes (`pull_request` rule). The ruleset is
+# scoped to `refs/heads/main` only; `replay-soak-status` is
+# unconstrained, which lets the cron commit and push under the
+# default workflow token without a long-lived signing key or a
+# bypass-roster expansion. See `docs/feature-replay-soak-bot.md`.
 
 on:
   schedule:
@@ -20,9 +29,10 @@ on:
 
 permissions:
   contents: write
-  # `contents: write` so the cron job can commit the status-file
-  # update back to `main`. PR runs do not need it; this workflow
-  # only runs on schedule + dispatch (no `pull_request` trigger).
+  # `contents: write` so the cron job can push the status entry to
+  # the dedicated `replay-soak-status` branch. PR runs do not need
+  # it; this workflow only runs on schedule + dispatch (no
+  # `pull_request` trigger).
 
 concurrency:
   # Serialize across schedule + dispatch so two runs can't append
@@ -42,6 +52,8 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          # Default `main` checkout: brings the corpus, the runner
+          # script, and the aelfrice source the runner imports.
           fetch-depth: 0
           # Use the workflow token; default is read-only on schedule
           # but `permissions.contents: write` above flips it.
@@ -56,10 +68,26 @@ jobs:
       - name: Install dev group
         run: uv sync --frozen --group dev
 
+      - name: Fetch replay-soak-status branch into a side worktree
+        # The cron commit lands on the dedicated `replay-soak-status`
+        # branch (which is not ruleset-protected). A side worktree
+        # keeps the main checkout (corpus + code) intact so the
+        # runner has everything it needs to import.
+        run: |
+          set -euo pipefail
+          git fetch origin replay-soak-status:refs/remotes/origin/replay-soak-status
+          git worktree add .soak-status-branch \
+            -B replay-soak-status origin/replay-soak-status
+
       - name: Run replay-soak runner
         id: soak
         run: |
-          uv run python scripts/replay_soak_run.py
+          # Append into the side-worktree's status file. The runner
+          # ensures parent dirs exist; on first run after bootstrap
+          # the file is empty (one orphan commit, single zero-byte
+          # `.replay-soak-status.json`).
+          uv run python scripts/replay_soak_run.py \
+            --status-file .soak-status-branch/.replay-soak-status.json
         # Exit code 1 on drift; the workflow still commits the entry
         # (the streak ends; the PR check reads the result). The job
         # itself fails so an alert fires.
@@ -67,17 +95,20 @@ jobs:
 
       - name: Show appended entry
         run: |
-          tail -n 1 .replay-soak-status.json
+          tail -n 1 .soak-status-branch/.replay-soak-status.json
 
-      - name: Commit status update
+      - name: Commit + push to replay-soak-status
         env:
-          # Bot identity for the audit-trail commits.
+          # Bot identity for the audit-trail commits. Unsigned —
+          # `replay-soak-status` is not subject to the main ruleset's
+          # `required_signatures` rule.
           GIT_AUTHOR_NAME: aelfrice-soak-bot
           GIT_AUTHOR_EMAIL: aelfrice-soak-bot@users.noreply.github.com
           GIT_COMMITTER_NAME: aelfrice-soak-bot
           GIT_COMMITTER_EMAIL: aelfrice-soak-bot@users.noreply.github.com
         run: |
           set -euo pipefail
+          cd .soak-status-branch
           if git diff --quiet .replay-soak-status.json; then
             echo "no soak-status delta to commit"
             exit 0
@@ -85,7 +116,7 @@ jobs:
           today=$(date -u +%Y-%m-%d)
           git add .replay-soak-status.json
           git commit -m "audit(replay-soak): ${today} entry"
-          git push origin HEAD:main
+          git push origin HEAD:replay-soak-status
 
       - name: Fail job if drift
         if: steps.soak.outcome == 'failure'

--- a/docs/feature-replay-soak-bot.md
+++ b/docs/feature-replay-soak-bot.md
@@ -1,0 +1,123 @@
+# Spec: replay-soak-bot push path — dedicated branch
+
+Spec for issue [#461](https://github.com/robotrocketscience/aelfrice/issues/461). The replay-soak cron landed in [#403 deliverable A](https://github.com/robotrocketscience/aelfrice/issues/403) cannot write its status entry; the PR-level gate (`replay-soak / consecutive-green ≥ 7d`, [#403 C](https://github.com/robotrocketscience/aelfrice/issues/403)) therefore blocks every #264-touching merge with `streak < 7`. This memo records the design decision and implementation plan.
+
+## Live-ruleset facts (verified 2026-05-06)
+
+Single ruleset on `robotrocketscience/aelfrice`, scoped to `refs/heads/main` only:
+
+- `deletion`, `non_fast_forward`, `required_linear_history`
+- `required_signatures`
+- `pull_request` — `required_approving_review_count: 0`, `allowed_merge_methods: ["rebase"]`
+- `required_status_checks`: `secrets-scan`, `pattern-scan`, `history-scan`, `pytest (3.12)`, `pytest (3.13)`
+- `current_user_can_bypass: never`
+
+Two of these block the cron's current `git push origin HEAD:main`:
+1. `required_signatures` — workflow token's commit is unsigned;
+2. `pull_request` — direct push to `main` is forbidden regardless of signing.
+
+The `pull_request` rule is the harder constraint: even a deploy-key-signed bot commit would still be rejected. **Option 1 in the issue body ("sign the bot commit, push direct") does not work standalone** against the live ruleset — it would have to be paired with a bypass actor for the `pull_request` rule, at which point it has collapsed into option 4.
+
+## Decision: option 3, dedicated branch (`refs/heads/replay-soak-status`)
+
+### Why
+
+The ruleset's `conditions.ref_name.include` is `["refs/heads/main"]`. **Any other branch is unconstrained.** A long-lived branch dedicated to soak-status updates therefore needs no signing key, no bypass actor, and no PR machinery — the cron pushes straight to it as the workflow token's default identity. The PR-level gate workflow already does a fresh checkout to read the file; pointing it at the dedicated branch's ref instead of `main` is a one-line change.
+
+The issue body's stated concern about option 3 — "artifact retention windows apply (90 days default) — would need a long-retention bucket or a dedicated branch" — applies only to the *Actions-artifacts* variant. **A dedicated branch has no retention window.** Branch tips persist indefinitely; the audit trail is git-native (a real, fetchable, blameable history of soak entries) and survives the same way `main` does.
+
+### Why not the alternatives
+
+| Option | Verdict | Reason |
+|---|---|---|
+| **1.** Sign + push direct to main | reject | `pull_request` rule blocks regardless of signature; only viable paired with option 4 |
+| **2.** PR-per-soak with auto-merge | reject | Adds ~365 PRs/year (one open + one merge + one close every day) plus ~5 min × 365 = ~30 hr/year of CI on the full pytest matrix per soak. The status-file delta is one JSONL row; the audit trail it produces is the same regardless of whether the commit lands via PR or direct branch push. The PR machinery is pure overhead here. |
+| **3.** Dedicated branch | **pick** | Smallest workflow diff; no new long-lived signing key on a public repo; no bypass-roster expansion; git-native audit trail; no retention window. |
+| **4.** Ruleset bypass for `aelfrice-soak-bot` | reject | Expands the public repo's bypass roster, which the project has been deliberate about keeping narrow. A compromised bot credential would land unreviewed code on `main`. The benefit (smallest workflow diff) is marginal vs. option 3, and the security-surface cost is real. |
+
+The #403 design recommendation said the soak file should be "git-native, doesn't depend on artifact retention windows, and the soak history becomes part of the audit trail." A dedicated branch satisfies all three; that recommendation does not require the file to live on `main` specifically.
+
+## Implementation plan
+
+### Files changed
+
+1. **`.github/workflows/replay-soak.yml`** — push to `replay-soak-status` instead of `main`. Use `git worktree add` to keep the corpus + code checkout (from `main`) separate from the status-branch worktree (where the commit lands).
+
+2. **`.github/workflows/replay-soak-gate.yml`** — change the `actions/checkout` step's `ref:` from `main` to `replay-soak-status`. Treat a missing branch as `streak = 0` (already the existing fall-through path when `.replay-soak-status.json` does not exist).
+
+3. **One-time bootstrap** — push an empty orphan branch `replay-soak-status` to `github` containing only an empty `.replay-soak-status.json`. No ruleset rules apply; this is a normal `git push`. Done as part of this session before merging.
+
+4. **(Cosmetic, in same PR)** — remove the 0-byte `.replay-soak-status.json` from `main`. The file's authoritative location is now the dedicated branch; leaving the stub on `main` invites future confusion.
+
+### Workflow shape
+
+```yaml
+- uses: actions/checkout@…           # main checkout: corpus + code
+  with: { fetch-depth: 0, persist-credentials: true }
+
+- name: uv sync
+  run: uv sync --frozen --group dev
+
+- name: Fetch replay-soak-status branch into a side worktree
+  run: |
+    git fetch origin replay-soak-status:refs/remotes/origin/replay-soak-status
+    git worktree add .soak-status-branch \
+      -B replay-soak-status origin/replay-soak-status
+
+- name: Run replay-soak runner
+  id: soak
+  run: |
+    uv run python scripts/replay_soak_run.py \
+      --status-file .soak-status-branch/.replay-soak-status.json
+  continue-on-error: true
+
+- name: Commit + push to replay-soak-status
+  env:
+    GIT_AUTHOR_NAME:     aelfrice-soak-bot
+    GIT_AUTHOR_EMAIL:    aelfrice-soak-bot@users.noreply.github.com
+    GIT_COMMITTER_NAME:  aelfrice-soak-bot
+    GIT_COMMITTER_EMAIL: aelfrice-soak-bot@users.noreply.github.com
+  run: |
+    set -euo pipefail
+    cd .soak-status-branch
+    if git diff --quiet .replay-soak-status.json; then
+      echo "no soak-status delta to commit"; exit 0
+    fi
+    git add .replay-soak-status.json
+    git commit -m "audit(replay-soak): $(date -u +%Y-%m-%d) entry"
+    git push origin HEAD:replay-soak-status
+```
+
+The commit on `replay-soak-status` is **not** signed (the rule does not apply to that ref). The audit trail is preserved by branch history; if signing-everything is desired later, a separate hardening pass can add a deploy key without changing the design.
+
+### Gate workflow shape
+
+```yaml
+- uses: actions/checkout@…
+  with:
+    ref: replay-soak-status        # was: main
+    fetch-depth: 1
+    persist-credentials: false
+```
+
+Rest unchanged. The existing `if [ ! -f .replay-soak-status.json ]; then n=0` path covers the brief window between PR merge and the first cron run on the new branch.
+
+## Acceptance trace
+
+- [x] Path picked and rationale recorded.  *(this memo)*
+- [ ] `replay-soak.yml` updated; next scheduled run (or a `workflow_dispatch`) lands an entry on `replay-soak-status`.
+- [ ] `.replay-soak-status.json` on `replay-soak-status` accumulates ≥1 row.
+- [ ] (After 7 daily runs) `scripts/replay_soak_streak.py --quiet` returns ≥7; `replay-soak / consecutive-green ≥ 7d` PR check passes on a no-op derivation-touching PR.
+- [ ] #264 claim becomes unblocked.
+
+## Risks and rollback
+
+- **Branch deletion** — anyone with write access can delete `replay-soak-status`, which would reset the streak. The branch is not ruleset-protected. Mitigation: the cron's first commit after deletion re-creates an empty file and the streak rebuilds. If this becomes a real problem, add a separate ruleset entry that includes `refs/heads/replay-soak-status` with `deletion` blocked — independent of this PR.
+- **Force-push** — same risk class. Same mitigation if needed.
+- **Rollback this PR** — revert the two workflow files and (if it landed) the `main`-side stub deletion. Soak entries already on `replay-soak-status` remain valid history but stop being read by the gate; the streak reverts to 0 until the next on-`main` cron entry succeeds (which it cannot, by the same root cause).
+
+## Out of scope
+
+- Implementing #264. This issue ships the gate plumbing; #264 lands behind it.
+- Changing the threshold from 7. The 2026-05-04 ratification on #403 set 7.
+- Hardening signing on `replay-soak-status` (deferred — not required for the gate to function).


### PR DESCRIPTION
Closes #461.

Picks design option 3 (dedicated branch) and implements it. Spec memo at `docs/feature-replay-soak-bot.md` records the rationale and rejects the other three options against the live ruleset.

## What changed

- **`docs/feature-replay-soak-bot.md`** (new) — spec memo. Decision + tradeoff matrix + implementation plan.
- **`.github/workflows/replay-soak.yml`** — cron now pushes the daily entry to `refs/heads/replay-soak-status` instead of `main`. A side worktree (`.soak-status-branch/`) keeps the `main` checkout (corpus + code) intact so the runner imports cleanly.
- **`.github/workflows/replay-soak-gate.yml`** — gate checks out `replay-soak-status` to read the soak file. Adds a step to fetch the streak script out of `main` so we don't have to duplicate it on the orphan branch.
- **`.replay-soak-status.json`** — 0-byte stub on `main` removed. The file's authoritative location is now the dedicated branch.
- **Bootstrap (already pushed)** — `refs/heads/replay-soak-status` exists with one orphan root commit `audit(replay-soak): branch init for #461` containing only an empty `.replay-soak-status.json`. SSH-signed.

## Why option 3

The single ruleset on `robotrocketscience/aelfrice` is scoped to `refs/heads/main` only. Two of its rules block the cron's current `git push origin HEAD:main`:

- `required_signatures` (workflow-token commits are unsigned), and
- `pull_request` (direct push to main forbidden, irrespective of signing).

Option 1 (sign + direct push) **doesn't actually work standalone** — the `pull_request` rule rejects regardless. To make it work, you'd need to add a bypass actor for that rule, at which point it has collapsed into option 4.

Picking option 3 (dedicated branch) avoids: a long-lived signing key on a public repo (option 1 cost), a bypass-roster expansion (option 4 cost), and ~365 PRs/year of CI noise (option 2 cost). The issue body's stated concern about retention windows applies only to the Actions-artifacts variant of option 3 — a dedicated branch has no retention window and gives a git-native audit trail equivalent to the `main` variant.

Full tradeoff matrix in the spec memo.

## Verification

- Live ruleset confirmed via `gh api repos/.../rulesets/15575532` — `conditions.ref_name.include = ["refs/heads/main"]`. Other branches unconstrained.
- Local sim of the workflow shape ran clean: `git worktree add .soak-status-branch -B replay-soak-status github/replay-soak-status` → `replay_soak_run.py --status-file .soak-status-branch/.replay-soak-status.json` → produces a valid JSONL row in the side worktree.
- Streak script reads correctly from the alternate path (`scripts/replay_soak_streak.py --status-file ...` returns the right count).
- All three commits on this branch are SSH-signed (`G`).
- Discretion grep clean on the full diff vs `github/main`.
- Bootstrap commit on `replay-soak-status` is also SSH-signed (`G`).

## Acceptance trace (per #461)

- [x] Path picked and rationale recorded — `docs/feature-replay-soak-bot.md`.
- [ ] `replay-soak.yml` updated; next scheduled run lands an entry. **Verifies in this PR's CI:** the gate workflow will fire on this PR (paths filter matches), check out `replay-soak-status`, see the bootstrap empty-file, and report streak 0. The `replay-soak / consecutive-green ≥ 7d` check is not in the ruleset's `required_status_checks` list yet (per the issue body, that's a separate admin step), so the streak-0 result does not block merge of this PR. After merge, the daily cron writes its first real entry tomorrow at 04:00 UTC.
- [ ] `.replay-soak-status.json` accumulates ≥1 row — happens on first cron run after merge.
- [ ] Streak ≥ 7 → gate passes — 7 daily runs after merge.
- [ ] #264 unblocks — same.

## Out of scope

- Implementing #264. This PR ships the gate plumbing; #264 lands behind it.
- Adding `replay-soak-status` to a separate ruleset entry to block deletion / force-push. Mitigation noted in the spec memo's risks section; deferrable.
- Hardening the bot commit on `replay-soak-status` with a signing key. Defensible without it; can add later if desired.

## Rollback

Revert the two workflow yamls and the stub deletion. Soak entries already on `replay-soak-status` remain valid history but stop being read by the gate.

## Summary by Sourcery

Route replay soak status writes to a dedicated orphan branch instead of main, and update the gate workflow and docs accordingly.

Enhancements:
- Change the replay soak cron workflow to write status entries to the replay-soak-status branch via a side worktree instead of committing to main.
- Update the replay soak gate workflow to read the status file from the replay-soak-status branch and fetch the streak script from main.
- Add a design memo documenting the replay-soak bot branch decision, rationale, and implementation plan.
- Remove the obsolete zero-byte .replay-soak-status.json stub from main, making the dedicated branch the authoritative source of soak status.

CI:
- Adjust CI workflows to respect the main branch ruleset by avoiding direct bot pushes to main while preserving the soak gate behavior.

Documentation:
- Introduce a spec document describing the replay-soak bot push-path design and tradeoffs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specification documentation for replay-soak automation workflow.

* **Chores**
  * Updated continuous integration workflows to improve status tracking and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->