### PR TITLE
feat(directive_detection): Path A intent-prefix filter (#374)

### DIFF
--- a/src/aelfrice/directive_detector.py
+++ b/src/aelfrice/directive_detector.py
@@ -89,6 +89,35 @@ _WH_QUESTION_LEADING = re.compile(
     re.IGNORECASE,
 )
 
+# Path A intent-prefix filter (issue #374, ratified 2026-05-07). Imperative
+# coding-task verbs in head position read as one-shot session tasks
+# ("Refactor X so it never blocks", "Add a test that ensures …"), not durable
+# rules. They short-circuit to False even when a downstream imperative-verb
+# match would otherwise fire.
+_CODING_TASK_PREFIX_VERBS: tuple[str, ...] = (
+    "refactor", "add", "implement", "write", "create", "update",
+    "fix", "make", "build", "remove", "rename", "extract",
+    "merge", "split", "move", "delete",
+)
+_CODING_TASK_PREFIX_PATTERN = re.compile(
+    r"^\s*(?:" + "|".join(_CODING_TASK_PREFIX_VERBS) + r")\b",
+    re.IGNORECASE,
+)
+
+# Rule-marker connectives — re-enable directive classification when a
+# coding-task prefix is present but the sentence still encodes a durable rule
+# ("Refactor X so it never blocks as a rule"). Empty per the #374 ratification:
+# the prefix always wins on first iteration; expand only with corpus evidence.
+_RULE_MARKER_CONNECTIVES: tuple[str, ...] = ()
+_RULE_MARKER_PATTERN: re.Pattern[str] | None = (
+    re.compile(
+        r"\b(?:" + "|".join(re.escape(c) for c in _RULE_MARKER_CONNECTIVES) + r")\b",
+        re.IGNORECASE,
+    )
+    if _RULE_MARKER_CONNECTIVES
+    else None
+)
+
 
 def detect_directive(text: str) -> bool:
     """Return True if `text` reads as a durable imperative directive.
@@ -98,7 +127,8 @@ def detect_directive(text: str) -> bool:
       2. Questions (leading interrogative or trailing '?') → False.
       3. Reported-speech / habitual narration ("I never X when Y") → False.
       4. Hedged statements ("maybe", "I think", …) → False.
-      5. Otherwise: True iff any imperative verb appears.
+      5. Coding-task imperative prefix without a rule-marker connective → False.
+      6. Otherwise: True iff any imperative verb appears.
     """
     if not text or not text.strip():
         return False
@@ -111,4 +141,7 @@ def detect_directive(text: str) -> bool:
         return False
     if _HEDGE_PATTERN.search(stripped):
         return False
+    if _CODING_TASK_PREFIX_PATTERN.match(stripped):
+        if _RULE_MARKER_PATTERN is None or not _RULE_MARKER_PATTERN.search(stripped):
+            return False
     return _VERB_PATTERN.search(stripped) is not None

--- a/tests/test_directive_detector.py
+++ b/tests/test_directive_detector.py
@@ -45,3 +45,50 @@ def test_directive_positives(text: str) -> None:
 )
 def test_directive_negatives(text: str) -> None:
     assert detect_directive(text) is False
+
+
+# Path A: head-position coding-task prefix short-circuits to False even when
+# a downstream imperative verb would otherwise fire. Each row embeds a verb
+# from the imperative bank ("never", "ensure", "must", "only", "avoid", …)
+# so the test would pass under the old detector if Path A weren't applied —
+# making the test load-bearing for the new branch.
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Refactor X so it never blocks",
+        "Add a test that ensures the gate fires",
+        "Implement the parser so it must reject empty input",
+        "Write a guard that always returns False on the empty case",
+        "Create a wrapper that should not propagate exceptions",
+        "Update the README so it only mentions the public API",
+        "Fix the pre-push hook to avoid bypassing on rebase",
+        "Make the worker shutdown ensure no half-flushed batches",
+        "Build a fixture that requires the v0.1 corpus path",
+        "Remove the dead branch before merging",
+        "Rename _emit so it cannot collide with _emit_core",
+        "Extract the helper unless the call site needs inlining",
+        "Merge the two threads after the gate passes",
+        "Split the test so each case must check exactly one signal",
+        "Move the docstring before the type annotations",
+        "Delete the cache whenever the schema bumps",
+    ],
+)
+def test_directive_coding_task_prefix_short_circuits(text: str) -> None:
+    assert detect_directive(text) is False
+
+
+# Regression: leading deontic anchors and durable rules where the head verb
+# is NOT in the coding-task bank still classify True. The prefix filter is
+# case-insensitive but positional, and only fires on the head verb.
+@pytest.mark.parametrize(
+    "text",
+    [
+        "always update the changelog before tagging",
+        "never delete a worktree without releasing the claim first",
+        "must rename the temp file before commit",
+        "only merge after the gate passes",
+        "before merging, ensure CI is green",
+    ],
+)
+def test_directive_prefix_filter_does_not_swallow_rules(text: str) -> None:
+    assert detect_directive(text) is True


### PR DESCRIPTION
## What

Implements the Path A intent-prefix filter ratified on issue #374 (2026-05-07). Adds a head-position lexical pre-filter to `detect_directive()` so imperative coding-task verbs short-circuit to `False` unless a rule-marker connective is also present. Targets the monolithic FP cluster identified against lab corpus v0.1 (P=0.664 / R=0.937) — imperative-grammar one-shot coding tasks like "Refactor X so it never blocks" that the 29-verb regex misclassifies.

## Why

The H1 enforcement gate is `P ≥ 0.80 ∧ R ≥ 0.60 ∧ n ≥ 200`. Current measurement is below the precision floor with 23 percentage points of recall headroom — the iteration is a precision problem. Failure-mode analysis on the 45 FPs showed a single dominant cluster: imperatives the user issues to the agent for the immediate session, not durable rules. Path A isolates that cluster on a structural property (head-verb position) without weakening the imperative bank or breaking determinism.

## Changes

- **`src/aelfrice/directive_detector.py`** (+34, -1)
  - Add `_CODING_TASK_PREFIX_VERBS` (16 verbs) and `_CODING_TASK_PREFIX_PATTERN` (anchored regex).
  - Add `_RULE_MARKER_CONNECTIVES` (empty per #374 decision) and `_RULE_MARKER_PATTERN` (precompiled to `None` when the list is empty so the hot path skips the search).
  - Insert filter step 5 in `detect_directive()` between hedge check and verb check; short-circuit to `False` when prefix matches and no connective is registered or present.
  - Update docstring to enumerate the new filter step.
- **`tests/test_directive_detector.py`** (+47)
  - `test_directive_coding_task_prefix_short_circuits` — 16 rows, one per head-position verb. Each embeds a downstream imperative-bank verb so the row would pass under the pre-Path-A detector if the short-circuit weren't applied; load-bearing for the new branch.
  - `test_directive_prefix_filter_does_not_swallow_rules` — regression: rules with a non-coding-task head verb (always, never, must, only, before) still classify True.

## Decision provenance

All four iteration-spec asks ratified on the issue thread (2026-05-07):

| Ask | Resolution |
|-----|------------|
| Iteration target | Path A |
| Verb bank (16) | Confirmed as proposed |
| Rule-marker connectives | Empty list — coding-task prefix always wins |
| Lab corpus v0.1 → lab `main` | Done |

## Verification

- Sanity tests: `uv run pytest tests/test_directive_detector.py` — 39 passed.
- Full suite: `uv run pytest` — 2616 passed, 41 skipped, no regressions.
- Two atomic signed commits (`feat(directive_detection):` + `test(directive_detection):`).
- Discretion grep on the diff: clean.

## Out of scope

- `process_directive`, the TODO lifecycle, the repetition counter, the escalation table, hook wiring. All gated on the bench gate passing per `docs/v2_enforcement.md` § H1.
- Corpus authoring (lab-side per directory-of-origin rules).
- Verb-bank expansion in the existing 29-imperative regex. Path A composes with it; this PR does not modify it.

## Closes / refs

Refs #374, #199 (umbrella). **Does not close #374** — that requires a passing bench-gate run against `AELFRICE_CORPUS_ROOT/directive_detection/v0_1.jsonl` (now landed on lab `main`) demonstrating P ≥ 0.80 ∧ R ≥ 0.60 ∧ n ≥ 200. Lab-side closing PR strikes the H1 row from `docs/V2_REENTRY_QUEUE.md` and posts the bench numbers in the PR body.

## Summary by Sourcery

Introduce a head-position coding-task prefix filter to improve directive detection precision while preserving durable rule detection.

New Features:
- Add a coding-task intent-prefix filter in directive detection that short-circuits one-shot coding commands even when downstream imperative verbs are present.

Enhancements:
- Document the new prefix-filter step in the directive detector workflow and keep rule-marker connective wiring in place for future iterations.

Tests:
- Add parametrized tests ensuring coding-task prefix phrases no longer classify as directives and that non-coding-task deontic rule statements continue to be detected as directives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved directive detection to exclude common coding-task imperatives (such as "Refactor," "Add," "Write," "Build") at the beginning of sentences from being classified as directives unless specific rule markers are present.

* **Tests**
  * Added comprehensive test coverage for the updated directive detection logic, including case-insensitive prefix filtering and regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->