### PR TITLE
feat(view-flip): WRITE_LOG_AUTHORITATIVE flag reader (#265 PR-A)

### DIFF
--- a/src/aelfrice/derivation_worker.py
+++ b/src/aelfrice/derivation_worker.py
@@ -40,7 +40,9 @@ Design properties:
 """
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
+from typing import Final
 
 from aelfrice.derivation import DerivationInput, derive
 from aelfrice.models import (
@@ -73,6 +75,30 @@ _CORROBORATION_BY_SOURCE_KIND: dict[str, str] = {
 _META_CALL_SITE: str = "call_site"
 _META_OVERRIDE_BELIEF_TYPE: str = "override_belief_type"
 _META_SOURCE_PATH_HASH: str = "source_path_hash"
+
+# v2.x #265 view-flip flag. Default off. When on, `beliefs` becomes a
+# materialized view of `ingest_log` and direct `insert_belief()` calls
+# from outside the derivation worker raise. The flag itself is wired
+# here in PR-A and consumed by PR-B (insert_belief gating) + PR-C
+# (`aelf rebuild` re-derive). Reading inline matches the pattern used
+# by AELFRICE_BFS / AELFRICE_BM25F / AELFRICE_HEAT_KERNEL in retrieval.py.
+ENV_WRITE_LOG_AUTHORITATIVE: Final[str] = "AELFRICE_WRITE_LOG_AUTHORITATIVE"
+_ENV_TRUTHY: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+
+
+def is_write_log_authoritative(env: dict[str, str] | None = None) -> bool:
+    """Return True iff `AELFRICE_WRITE_LOG_AUTHORITATIVE` is set truthy.
+
+    Two-state (vs the tri-state pattern used by AELFRICE_BFS) because
+    no kwarg / TOML precedence layer exists for this flag — env is the
+    only signal. Default off; any unset / unrecognised value is off.
+    `env` is `os.environ`-like; `None` reads the live process env.
+    """
+    src = os.environ if env is None else env
+    raw = src.get(ENV_WRITE_LOG_AUTHORITATIVE)
+    if raw is None:
+        return False
+    return raw.strip().lower() in _ENV_TRUTHY
 
 
 @dataclass(frozen=True)

--- a/tests/test_write_log_authoritative_flag.py
+++ b/tests/test_write_log_authoritative_flag.py
@@ -1,0 +1,54 @@
+"""Tests for the v2.x #265 view-flip flag reader.
+
+PR-A scope: the flag is read deterministically and defaults off. No
+behavior is gated yet. Subsequent PRs (B/C/D) consume the flag to
+gate `insert_belief()` direct calls, drive `aelf rebuild`, and
+surface `aelf doctor --explain` lineage.
+
+Each test is a falsifiable hypothesis about flag resolution:
+
+- unset env → off (default of "off" is the rollback path)
+- truthy values ("1", "true", "yes", "on") → on (case-insensitive)
+- falsy values ("0", "false", "no", "off") → off
+- unrecognised values → off (conservative; does not silently flip)
+- whitespace tolerated
+"""
+from __future__ import annotations
+
+import pytest
+
+from aelfrice.derivation_worker import (
+    ENV_WRITE_LOG_AUTHORITATIVE,
+    is_write_log_authoritative,
+)
+
+
+def test_unset_env_returns_false() -> None:
+    assert is_write_log_authoritative(env={}) is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE", "On", " yes "])
+def test_truthy_values_return_true(value: str) -> None:
+    assert is_write_log_authoritative(env={ENV_WRITE_LOG_AUTHORITATIVE: value}) is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "FALSE", "Off"])
+def test_falsy_values_return_false(value: str) -> None:
+    assert is_write_log_authoritative(env={ENV_WRITE_LOG_AUTHORITATIVE: value}) is False
+
+
+@pytest.mark.parametrize("value", ["", "maybe", "2", "yesno"])
+def test_unrecognised_values_return_false(value: str) -> None:
+    """Conservative: only the defined truthy set flips. Anything else
+    stays off so a typo never silently flips authority."""
+    assert is_write_log_authoritative(env={ENV_WRITE_LOG_AUTHORITATIVE: value}) is False
+
+
+def test_live_env_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Read live process env when no kwarg passed."""
+    monkeypatch.delenv(ENV_WRITE_LOG_AUTHORITATIVE, raising=False)
+    assert is_write_log_authoritative() is False
+    monkeypatch.setenv(ENV_WRITE_LOG_AUTHORITATIVE, "1")
+    assert is_write_log_authoritative() is True
+    monkeypatch.setenv(ENV_WRITE_LOG_AUTHORITATIVE, "off")
+    assert is_write_log_authoritative() is False


### PR DESCRIPTION
Closes part of #265 (PR-A of the view-flip series).

Adds `is_write_log_authoritative()` to `src/aelfrice/derivation_worker.py`, reading `AELFRICE_WRITE_LOG_AUTHORITATIVE` from the environment. Default off. No behavior change.

This is the foundation flag for the v2.x view-flip. Subsequent PRs in the series consume it:

- **PR-B** — when on, `insert_belief()` raises for callers outside the derivation worker. Migrates the 5 known bypass call sites (`scanner.py:280`, `wonder/simulator.py:170`, `benchmark.py:165`, `migrate.py:173`, `store.insert_beliefs()` bulk wrapper) through the worker. A scanner-call-site memo is written before this lands.
- **PR-C** — `aelf rebuild` CLI: drop canonical, re-derive from log under current rule set; idempotent. `--as-of <ts>` for time-travel.
- **PR-D** — `aelf doctor --explain <belief_id>`: print `ingest_log` lineage. CHANGELOG entry naming flag + rollback path + CLI.

Each PR merges independently behind the default-off flag, so the soak window starts when this PR lands and runs across B/C/D.

## Design decisions

- **Inline `os.environ` read, not a new `aelfrice.config` module.** Matches the existing per-module pattern (`AELFRICE_BFS`, `AELFRICE_BM25F`, `AELFRICE_HEAT_KERNEL` in `retrieval.py`; `AELFRICE_DB`, `AELFRICE_CORPUS_MIN` in `cli.py`). Issue text said `aelfrice.config.WRITE_LOG_AUTHORITATIVE` but no such module exists; minimum-scope option chosen.
- **Two-state (vs the BFS-style tri-state) because env is the only precedence layer for this flag.** Conservative-off avoids silent authority flips on typos.
- **Lives in `derivation_worker.py`** because that module is the conceptual home of the worker that PR-B will gate.

## Tests

`tests/test_write_log_authoritative_flag.py` — 19 cases covering unset / truthy / falsy / unrecognised / case-insensitive / whitespace-tolerant / live-env paths. Existing 5 worker tests unchanged.

## Rollback

Revert this commit. The flag reader becomes nonexistent; nothing depends on it yet (PR-B onward depend on this PR landing first).

## Summary by Sourcery

Introduce an environment-driven feature flag for write-log authoritative mode in the derivation worker, defaulting to off, and covered by dedicated tests.

New Features:
- Add is_write_log_authoritative helper to read the AELFRICE_WRITE_LOG_AUTHORITATIVE environment flag with a default-off behavior.

Tests:
- Add a focused test suite validating flag resolution for unset, truthy, falsy, unrecognised, and live-environment cases for the write-log authoritative flag reader.