### PR TITLE
ci(staging-gate): skip pattern-scan on dependabot PRs

### DIFF
--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -29,6 +29,14 @@ jobs:
           GITLEAKS_CONFIG: .gitleaks.toml
 
   pattern-scan:
+    # Skip on dependabot PRs: GitHub does not pass repository Actions secrets
+    # to dependabot-triggered runs (supply-chain protection), so SCAN_RULES_B64
+    # is empty and this job has no patterns to scan against. Dependabot diffs
+    # only touch dependency manifests (pyproject.toml / uv.lock), which carry
+    # no PII vector worth gating on. Other staging-gate jobs (secrets-scan,
+    # history-scan, commit-msg-prefix, pr-body-issue-link) still run and
+    # provide the actual security gates for dep updates.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0


### PR DESCRIPTION
## Summary

GitHub does not pass repository Actions secrets to dependabot-triggered runs (supply-chain protection), so \`secrets.SCAN_RULES_B64\` is empty on dependabot PRs and the pattern-scan step fails immediately with \`SCAN_RULES_B64 not configured\`. This blocks every dependabot PR under the current ruleset, since pattern-scan is on the required-status-checks list.

PR #464 (python-multipart 0.0.26 → 0.0.27 bump) is the currently-visible instance.

## Fix

Add \`if: github.actor != 'dependabot[bot]'\` to the \`pattern-scan\` job in \`staging-gate.yml\`. Other staging-gate jobs still run on dependabot PRs and cover the real security surface for dep updates:

- \`secrets-scan\` (gitleaks)
- \`history-scan\` (gitleaks history)
- \`commit-msg-prefix\` (conventional-commit gate)
- \`pr-body-issue-link\` / \`pr-title-prefix\`
- typos, deptry, vulture
- pytest matrix

Dependabot diffs only modify dependency manifests (\`pyproject.toml\`, \`uv.lock\`); no PII vector is plausible there.

## Alternative considered

Granting \`SCAN_RULES_B64\` to dependabot via \`gh api PUT /repos/.../dependabot/secrets/SCAN_RULES_B64\`. Rejected: the repo Actions secret value cannot be read back by the API (write-only by design), so the user would need to re-supply it from their secret store. Skipping is operationally simpler and equally defensible for the dependabot-only scope.

## Test plan

- [ ] CI runs and pattern-scan job is skipped (not failed) on this PR (this PR is human-authored, so pattern-scan should still run — the skip kicks in only when \`github.actor == 'dependabot[bot]'\`)
- [ ] After merge, re-run CI on #464 and verify pattern-scan is skipped, all other checks pass
- [ ] Land #464

Refs #464.

## Summary by Sourcery

CI:
- Skip the pattern-scan job in the staging-gate workflow when the GitHub actor is dependabot[bot] to avoid secret-related failures while keeping other checks intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to optimize job execution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->