### PR TITLE
feat(view-flip): #265 PR-B — scanner→worker migration + insert_belief gate

### DIFF
--- a/docs/design/v2_view_flip_scanner_call_site.md
+++ b/docs/design/v2_view_flip_scanner_call_site.md
@@ -1,0 +1,164 @@
+# Scanner call-site migration for the view-flip (#265 PR-B)
+
+**Status:** memo — written before PR-B implementation per PR-A's body.
+**Scope:** `src/aelfrice/scanner.py` only. The other four bypass call sites
+named in PR-A (`wonder/simulator.py`, `benchmark.py`, `migrate.py`, the
+`store.insert_beliefs()` bulk wrapper) are mechanical migrations and do not
+require a memo.
+
+## Why scanner is the hard one
+
+The regex path was already migrated to the worker in #264 part 2
+(scanner.py:312-335). The remaining bypass is the **LLM-classify path**
+(scanner.py:262-310). The inline comment at scanner.py:230-232 names the
+blocker:
+
+> The LLM path remains direct-write — its alpha/beta/origin/audit_source
+> are not yet representable in `raw_meta` for the worker to reconstruct.
+
+The router emits per-candidate `LLMRoute(belief_type, origin, persist, alpha,
+beta, audit_source)` (scanner.py:128-142). `derive()` produces these fields
+from deterministic classification — it does not know about the router's
+output. Routing through the worker today would silently drop the router's
+decisions on the floor.
+
+## What must flow from scanner → ingest_log → worker
+
+Five fields the deterministic `derive()` cannot reconstruct:
+
+| Field          | Source                        | Where it lands today                |
+|----------------|-------------------------------|-------------------------------------|
+| `belief_type`  | LLM classifier                | `Belief.type`                       |
+| `origin`       | LLM classifier                | `Belief.origin`                     |
+| `alpha`        | LLM classifier (confidence)   | `Belief.alpha`                      |
+| `beta`         | LLM classifier (confidence)   | `Belief.beta`                       |
+| `audit_source` | LLM classifier (fallback tag) | `feedback_history` row, post-insert |
+
+`persist=False` is consumed before any state change — it does not need to
+flow through the log. Skip the `record_ingest` call entirely.
+
+## Decision: extend `raw_meta` with a `route_overrides` sub-dict
+
+Two existing patterns live in `raw_meta`: `call_site` (string sentinel) and
+`override_belief_type` (string sentinel, read by
+`derivation_worker._derivation_input_from_row`). Adding more
+top-level sentinel keys (`override_origin`, `override_alpha`, …) bloats the
+flat namespace and makes audit logs noisy. Group them.
+
+```python
+raw_meta = {
+    "call_site": CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+    "route_overrides": {
+        "belief_type": "factual",
+        "origin": "agent_inferred",
+        "alpha": 1.4,
+        "beta": 0.6,
+        "audit_source": "llm_router_v1",  # optional
+    },
+}
+```
+
+When `route_overrides` is absent (the default — regex path, transcript
+ingest, etc.), the worker's behavior is byte-identical to today.
+
+## Worker contract change
+
+`_derivation_input_from_row` already forwards `override_belief_type` from
+`raw_meta` to `DerivationInput` (derivation_worker.py:140-168). Extend it to
+also forward `route_overrides` as a typed sub-field on `DerivationInput`,
+e.g. `DerivationInput.route_overrides: RouteOverrides | None`.
+
+`derive()` then applies the overrides on its output `Belief` when present.
+The override semantics are **post-derivation splice**, not a different
+codepath: `derive()` runs as today, then if `route_overrides` is set, the
+output belief's `(type, origin, alpha, beta)` are replaced. This keeps the
+deterministic classifier's edge-emission and other side-channel logic
+intact — only the fields the LLM owns are overridden.
+
+`audit_source` is not a `Belief` field. The worker emits a
+`feedback_events` row (using the existing `insert_feedback_event` API)
+for the canonical belief_id when `route_overrides.audit_source` is set
+and the belief was newly inserted (not corroborated). This collapses the
+scanner.py:304-310 logic into the worker.
+
+## Scanner shape after migration
+
+```python
+for idx, candidate in enumerate(filtered):
+    created_at = candidate.commit_date or timestamp
+    raw_meta: dict[str, Any] = {
+        "call_site": CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+    }
+    if routes is not None:
+        route = routes[idx]
+        if not route.persist:
+            skipped_non_persisting += 1
+            continue
+        raw_meta["route_overrides"] = {
+            "belief_type": route.belief_type,
+            "origin": route.origin,
+            "alpha": route.alpha,
+            "beta": route.beta,
+        }
+        if route.audit_source is not None:
+            raw_meta["route_overrides"]["audit_source"] = route.audit_source
+    log_id = store.record_ingest(
+        source_kind=INGEST_SOURCE_FILESYSTEM,
+        source_path=candidate.source,
+        raw_text=candidate.text,
+        session_id=sid,
+        ts=created_at,
+        raw_meta=raw_meta,
+    )
+    log_ids.append(log_id)
+
+if log_ids:
+    run_worker(store)
+    # back-fill ScanResult counters from stamped rows (existing logic)
+```
+
+The two-path `routes is not None` / regex split collapses into one loop.
+The LLM-route-vs-regex distinction lives in `raw_meta` only.
+
+## `aelf rebuild` interaction (PR-C concern, flagged here)
+
+`route_overrides` are **frozen at ingest time** and re-applied on every
+rebuild. Rationale: the LLM router's decision was the ground-truth ingest
+event for that row — replaying the log under a new rule-set should not
+re-roll it (we have no LLM available at rebuild time, and even if we did,
+non-determinism would break replay equality). Document in PR-C:
+`route_overrides` survives `aelf rebuild`; only fields `derive()`
+reconstructs deterministically participate in rule-set replay.
+
+## Out of scope for PR-B
+
+- Changing `derive()` semantics for non-overridden fields.
+- Eliminating the `LLMRoute` dataclass — kept as the in-memory shape
+  the router emits before scanner serializes it into `raw_meta`.
+- Migrating the four simpler call sites
+  (`wonder/simulator.py`, `benchmark.py`, `migrate.py`, bulk `insert_beliefs`)
+  — they don't need the route-override machinery; they get a private
+  `_insert_belief_unchecked()` path. Detail in PR-B itself.
+
+## Acceptance for the scanner slice
+
+1. `RouteOverrides` typed dataclass added to `aelfrice.derivation` (or a
+   new `route_overrides` module).
+2. `_derivation_input_from_row` reads `raw_meta["route_overrides"]`.
+3. `derive()` (or a post-derive splice) applies overrides to the output
+   belief's `(type, origin, alpha, beta)` when set.
+4. Worker emits the `feedback_events` audit row when
+   `route_overrides.audit_source` is set and the belief was newly
+   inserted.
+5. Scanner LLM-classify path uses `record_ingest` + `run_worker` only;
+   no `insert_or_corroborate` or `insert_belief` call survives outside
+   the worker.
+6. Tests:
+   - regex-path scan unchanged (byte-identical canonical output flag-on
+     and flag-off).
+   - LLM-route scan with flag-off: same belief content as today.
+   - LLM-route scan with flag-on: same belief content as flag-off,
+     `derived_belief_ids` populated on log rows, `feedback_events` audit
+     row written when `audit_source` is set.
+   - `replay_full_equality` (#262) returns zero drift after an LLM-route
+     scan with flag-on.

--- a/src/aelfrice/derivation.py
+++ b/src/aelfrice/derivation.py
@@ -46,6 +46,34 @@ _TRIPLE_BELIEF_SOURCE: Final[str] = "triple"
 
 
 @dataclass(frozen=True)
+class RouteOverrides:
+    """LLM-router post-derivation splice (#265 PR-B).
+
+    The scanner's LLM-classify path produces a per-candidate decision
+    that the deterministic `derive()` cannot reconstruct from raw text.
+    Carrying these fields on the `DerivationInput` lets the worker apply
+    them as a post-derivation splice on the classifier-path output: the
+    `(type, origin, alpha, beta)` of the produced belief are replaced
+    with router-supplied values; everything else (id, content_hash,
+    edges) flows through `derive()` unchanged.
+
+    `audit_source` is not a `Belief` field. The worker inspects it
+    after insert and emits a `feedback_history` row when set and the
+    belief was newly inserted (not corroborated). Mirrors today's
+    direct-write scanner audit at `scanner.py:304-310`.
+
+    Frozen at ingest time per the #265 ratification: rebuilds replay
+    these values verbatim rather than re-rolling the LLM router.
+    """
+
+    belief_type: str
+    origin: str
+    alpha: float
+    beta: float
+    audit_source: str | None = None
+
+
+@dataclass(frozen=True)
 class DerivationInput:
     """Everything `derive()` needs; no store references.
 
@@ -71,6 +99,12 @@ class DerivationInput:
     # handshake). When set, `derive()` skips `classify_sentence` and uses
     # this type to look up the source-adjusted prior.
     override_belief_type: str | None = None
+    # Optional LLM-router post-derivation splice (#265 PR-B). Applied
+    # only on the classifier path (filesystem / python_ast). On the
+    # lock/remember and triple-extraction paths the deterministic
+    # output is the contract; route_overrides is silently ignored
+    # there.
+    route_overrides: RouteOverrides | None = None
 
 
 @dataclass(frozen=True)
@@ -242,6 +276,33 @@ def derive(inp: DerivationInput) -> DerivationOutput:
             last_retrieved_at=None,
             session_id=inp.session_id,
             origin=ORIGIN_AGENT_INFERRED,
+            retention_class=retention_class_for_source(inp.source_kind),
+        )
+        return DerivationOutput(belief=belief, edges=[])
+
+    if inp.route_overrides is not None:
+        # LLM-router path: skip the regex classifier entirely. The
+        # router has already produced (type, origin, alpha, beta);
+        # `derive()`'s job is to mint the deterministic id +
+        # content_hash and assemble the Belief shell. `persist=False`
+        # routes are filtered upstream (scanner.py) before reaching
+        # the worker, so we can assume persist=True here.
+        ro = inp.route_overrides
+        bid = _belief_id(raw, source)
+        belief = Belief(
+            id=bid,
+            content=raw,
+            content_hash=_content_hash(raw),
+            alpha=ro.alpha,
+            beta=ro.beta,
+            type=ro.belief_type,
+            lock_level=LOCK_NONE,
+            locked_at=None,
+            demotion_pressure=0,
+            created_at=ts,
+            last_retrieved_at=None,
+            session_id=inp.session_id,
+            origin=ro.origin,
             retention_class=retention_class_for_source(inp.source_kind),
         )
         return DerivationOutput(belief=belief, edges=[])

--- a/src/aelfrice/derivation_worker.py
+++ b/src/aelfrice/derivation_worker.py
@@ -44,7 +44,7 @@ import os
 from dataclasses import dataclass
 from typing import Final
 
-from aelfrice.derivation import DerivationInput, derive
+from aelfrice.derivation import DerivationInput, RouteOverrides, derive
 from aelfrice.models import (
     CORROBORATION_SOURCE_CLI_REMEMBER,
     CORROBORATION_SOURCE_COMMIT_INGEST,
@@ -75,6 +75,19 @@ _CORROBORATION_BY_SOURCE_KIND: dict[str, str] = {
 _META_CALL_SITE: str = "call_site"
 _META_OVERRIDE_BELIEF_TYPE: str = "override_belief_type"
 _META_SOURCE_PATH_HASH: str = "source_path_hash"
+# #265 PR-B route_overrides sub-dict — group-keyed so the LLM-router's
+# per-candidate fields don't pollute the flat raw_meta namespace.
+_META_ROUTE_OVERRIDES: str = "route_overrides"
+_RO_BELIEF_TYPE: str = "belief_type"
+_RO_ORIGIN: str = "origin"
+_RO_ALPHA: str = "alpha"
+_RO_BETA: str = "beta"
+_RO_AUDIT_SOURCE: str = "audit_source"
+
+# Valence written on the worker-emitted audit row when an LLM route
+# carries an `audit_source`. Matches the scanner's pre-migration value
+# at scanner.py:307 — no semantic shift, just relocation.
+_AUDIT_VALENCE: float = 0.0
 
 # v2.x #265 view-flip flag. Default off. When on, `beliefs` becomes a
 # materialized view of `ingest_log` and direct `insert_belief()` calls
@@ -137,6 +150,46 @@ def _resolve_corroboration_source(row: dict[str, object]) -> str:
     )
 
 
+def _route_overrides_from_raw_meta(
+    raw_meta: dict[str, object] | None,
+) -> RouteOverrides | None:
+    """Reconstruct a `RouteOverrides` from `raw_meta["route_overrides"]`.
+
+    Returns `None` when the sub-dict is absent or malformed; the caller
+    treats `None` as "no override" and lets `derive()` run its
+    deterministic path. Strict on types (#265 ratification: schema is
+    fixed) — silently dropping a malformed sub-dict beats partial
+    application.
+    """
+    if not isinstance(raw_meta, dict):
+        return None
+    block = raw_meta.get(_META_ROUTE_OVERRIDES)
+    if not isinstance(block, dict):
+        return None
+    belief_type = block.get(_RO_BELIEF_TYPE)
+    origin = block.get(_RO_ORIGIN)
+    alpha = block.get(_RO_ALPHA)
+    beta = block.get(_RO_BETA)
+    if not (
+        isinstance(belief_type, str) and belief_type
+        and isinstance(origin, str) and origin
+        and isinstance(alpha, (int, float))
+        and isinstance(beta, (int, float))
+    ):
+        return None
+    audit_source = block.get(_RO_AUDIT_SOURCE)
+    return RouteOverrides(
+        belief_type=belief_type,
+        origin=origin,
+        alpha=float(alpha),
+        beta=float(beta),
+        audit_source=(
+            audit_source if isinstance(audit_source, str) and audit_source
+            else None
+        ),
+    )
+
+
 def _derivation_input_from_row(row: dict[str, object]) -> DerivationInput:
     raw_meta_obj = row.get("raw_meta")
     raw_meta: dict[str, object] | None = (
@@ -147,6 +200,7 @@ def _derivation_input_from_row(row: dict[str, object]) -> DerivationInput:
         ov = raw_meta.get(_META_OVERRIDE_BELIEF_TYPE)
         if isinstance(ov, str) and ov:
             override = ov
+    route_overrides = _route_overrides_from_raw_meta(raw_meta)
     source_path = row.get("source_path")
     session_id = row.get("session_id")
     classifier_version = row.get("classifier_version")
@@ -165,6 +219,7 @@ def _derivation_input_from_row(row: dict[str, object]) -> DerivationInput:
             rule_set_hash if isinstance(rule_set_hash, str) else None
         ),
         override_belief_type=override,
+        route_overrides=route_overrides,
     )
 
 
@@ -221,6 +276,23 @@ def _process_row(
         session_id=inp.session_id,
         source_path_hash=source_path_hash,
     )
+
+    # #265 PR-B: relocate scanner's post-insert audit row into the
+    # worker. Only fires when the LLM router stamped an `audit_source`
+    # AND the belief was newly inserted (matches scanner.py:301-310's
+    # `if was_inserted` guard intent — corroborations don't need a
+    # second audit row).
+    if (
+        was_inserted
+        and inp.route_overrides is not None
+        and inp.route_overrides.audit_source is not None
+    ):
+        store.insert_feedback_event(
+            belief_id=actual_id,
+            valence=_AUDIT_VALENCE,
+            source=inp.route_overrides.audit_source,
+            created_at=inp.ts,
+        )
 
     derived_edge_ids: list[tuple[str, str, str]] = []
     for edge in out.edges:

--- a/src/aelfrice/replay.py
+++ b/src/aelfrice/replay.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from aelfrice.derivation import DerivationInput, derive
+from aelfrice.derivation_worker import _route_overrides_from_raw_meta
 from aelfrice.models import INGEST_SOURCE_LEGACY_UNKNOWN
 from aelfrice.store import MemoryStore
 
@@ -232,11 +233,18 @@ def replay_full_equality(
         rule_set_hash = row["rule_set_hash"]
         log_row_id = str(row["id"])
 
-        # Reconstruct override_belief_type from raw_meta when present —
-        # mirrors derivation_worker._derivation_input_from_row so replay
-        # equality holds for #264 slice 2 host-classified onboard rows.
+        # Reconstruct override_belief_type and route_overrides from
+        # raw_meta when present — mirrors
+        # derivation_worker._derivation_input_from_row so replay equality
+        # holds for #264 slice 2 host-classified rows AND for #265 PR-B
+        # LLM-routed rows. `route_overrides` are frozen at ingest time
+        # per the memo at docs/design/v2_view_flip_scanner_call_site.md;
+        # replay must re-apply them verbatim, otherwise the canonical
+        # belief (which carries the router's fields) drifts from the
+        # re-derived shell (which would carry derive()'s defaults).
         raw_meta_blob = row["raw_meta"]
         override_belief_type: str | None = None
+        meta_obj: object | None = None
         if raw_meta_blob:
             try:
                 meta_obj = _json.loads(raw_meta_blob)
@@ -246,6 +254,9 @@ def replay_full_equality(
                 ov = meta_obj.get(_META_OVERRIDE_BELIEF_TYPE)
                 if isinstance(ov, str) and ov:
                     override_belief_type = ov
+        route_overrides = _route_overrides_from_raw_meta(
+            meta_obj if isinstance(meta_obj, dict) else None,
+        )
         inp = DerivationInput(
             raw_text=raw_text,
             source_kind=source_kind,
@@ -256,6 +267,7 @@ def replay_full_equality(
             classifier_version=classifier_version if classifier_version is not None else None,
             rule_set_hash=rule_set_hash if rule_set_hash is not None else None,
             override_belief_type=override_belief_type,
+            route_overrides=route_overrides,
         )
 
         out = derive(inp)

--- a/src/aelfrice/scanner.py
+++ b/src/aelfrice/scanner.py
@@ -23,16 +23,13 @@ import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 
 from aelfrice.derivation_worker import run_worker
 from aelfrice.inedible import is_inedible
 from aelfrice.models import (
     CORROBORATION_SOURCE_FILESYSTEM_INGEST,
     INGEST_SOURCE_FILESYSTEM,
-    LOCK_NONE,
-    Belief,
-    retention_class_for_source,
 )
 from aelfrice.noise_filter import NoiseConfig, is_noise
 from aelfrice.store import MemoryStore
@@ -221,17 +218,22 @@ def scan_repo(
     skipped_non_persisting = 0
     skipped_noise = 0
 
-    # #264 part 2: regex path defers belief materialization to
-    # `derivation_worker.run_worker`. Each regex candidate appends one
+    # Both paths defer belief materialization to
+    # `derivation_worker.run_worker` (#264 part 2 for regex; #265 PR-B
+    # for the LLM-classify path). Each persistable candidate appends one
     # unstamped row to `ingest_log`; one worker invocation at end-of-scan
     # stamps every row, dedup-or-corroborates against `beliefs`, and
     # writes edges. Snapshot the canonical id set up front so we can
     # back-fill scanner accounting from log entries after the worker
-    # runs (preserves the public ScanResult contract). The LLM path
-    # remains direct-write — its alpha/beta/origin/audit_source are not
-    # yet representable in `raw_meta` for the worker to reconstruct.
+    # runs (preserves the public ScanResult contract).
+    #
+    # The LLM-vs-regex distinction lives in `raw_meta["route_overrides"]`:
+    # when present, the worker post-splices the router's
+    # type/origin/alpha/beta onto derive()'s output and emits the
+    # audit_source feedback row on insert. When absent, the worker runs
+    # the deterministic classifier and writes no audit row.
     ids_before: set[str] = set(store.list_belief_ids())
-    regex_log_ids: list[str] = []
+    log_ids: list[str] = []
 
     # Two-pass when an llm_router is supplied: first collect the
     # noise-filtered candidates, then route them all through the
@@ -258,72 +260,34 @@ def scan_repo(
 
     for idx, candidate in enumerate(filtered):
         created_at = candidate.commit_date or timestamp
-
+        raw_meta: dict[str, Any] = {
+            "call_site": CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+        }
         if routes is not None:
-            # LLM-classify path: router already derived type/origin/alpha/beta.
             route = routes[idx]
             if not route.persist:
+                # persist=False is consumed before any state change —
+                # no log row, no worker work. Counted for visibility.
                 skipped_non_persisting += 1
                 continue
-            belief_id = _derive_belief_id(candidate.text, candidate.source)
-            if store.get_belief(belief_id) is not None:
-                skipped_existing += 1
-                continue
-            store.record_ingest(
-                source_kind=INGEST_SOURCE_FILESYSTEM,
-                source_path=candidate.source,
-                raw_text=candidate.text,
-                derived_belief_ids=[belief_id],
-                session_id=sid,
-                ts=created_at,
-            )
-            _, was_inserted = store.insert_or_corroborate(
-                Belief(
-                    id=belief_id,
-                    content=candidate.text,
-                    content_hash=_content_hash(candidate.text),
-                    alpha=route.alpha,
-                    beta=route.beta,
-                    type=route.belief_type,
-                    lock_level=LOCK_NONE,
-                    locked_at=None,
-                    demotion_pressure=0,
-                    created_at=created_at,
-                    last_retrieved_at=None,
-                    session_id=sid,
-                    origin=route.origin,
-                    retention_class=retention_class_for_source(
-                        INGEST_SOURCE_FILESYSTEM,
-                    ),
-                ),
-                source_type=CORROBORATION_SOURCE_FILESYSTEM_INGEST,
-            )
-            if was_inserted:
-                inserted += 1
-            # Audit row for fallback insertions (spec § 7.2 step 3).
+            overrides: dict[str, Any] = {
+                "belief_type": route.belief_type,
+                "origin": route.origin,
+                "alpha": route.alpha,
+                "beta": route.beta,
+            }
             if route.audit_source is not None:
-                store.insert_feedback_event(
-                    belief_id=belief_id,
-                    valence=0.0,
-                    source=route.audit_source,
-                    created_at=timestamp,
-                )
-        else:
-            # Regex path: append one unstamped log row. The worker
-            # invocation after this loop calls derive() + writes the
-            # canonical belief via insert_or_corroborate + stamps the
-            # row. `call_site` disambiguates the corroboration audit
-            # since INGEST_SOURCE_FILESYSTEM is shared with other
-            # entry points (transcript ingest, hook commit ingest).
-            log_id = store.record_ingest(
-                source_kind=INGEST_SOURCE_FILESYSTEM,
-                source_path=candidate.source,
-                raw_text=candidate.text,
-                session_id=sid,
-                ts=created_at,
-                raw_meta={"call_site": CORROBORATION_SOURCE_FILESYSTEM_INGEST},
-            )
-            regex_log_ids.append(log_id)
+                overrides["audit_source"] = route.audit_source
+            raw_meta["route_overrides"] = overrides
+        log_id = store.record_ingest(
+            source_kind=INGEST_SOURCE_FILESYSTEM,
+            source_path=candidate.source,
+            raw_text=candidate.text,
+            session_id=sid,
+            ts=created_at,
+            raw_meta=raw_meta,
+        )
+        log_ids.append(log_id)
 
     # End-of-batch worker invocation. Idempotent: scans every unstamped
     # row in the store, including any orphaned by a crashed prior scan.
@@ -331,7 +295,7 @@ def scan_repo(
     # and stamps each with `derived_belief_ids`. Calling once per scan
     # rather than per candidate keeps the cost O(unstamped) instead of
     # O(unstamped × candidates).
-    if regex_log_ids:
+    if log_ids:
         run_worker(store)
 
         # Back-fill scanner accounting from the stamped log rows. Three
@@ -344,7 +308,7 @@ def scan_repo(
         #     most once per id so two log rows that converge on the
         #     same belief still report inserted=1.
         seen_new: set[str] = set()
-        for log_id in regex_log_ids:
+        for log_id in log_ids:
             entry = store.get_ingest_log_entry(log_id)
             if entry is None:
                 continue
@@ -362,7 +326,7 @@ def scan_repo(
                     inserted += 1
                 else:
                     # Same belief id already counted in this scan
-                    # (two regex log rows hashed to the same id).
+                    # (two log rows hashed to the same id).
                     skipped_existing += 1
 
     return ScanResult(
@@ -428,8 +392,6 @@ _GIT_LOG_TIMEOUT_SECONDS: Final[float] = 5.0
 
 _PY_EXTENSION: Final[str] = ".py"
 
-_BELIEF_ID_HEX_LEN: Final[int] = 16
-
 
 @dataclass
 class ScanResult:
@@ -452,19 +414,6 @@ class ScanResult:
     skipped_non_persisting: int
     total_candidates: int
     skipped_noise: int = 0
-
-
-def _derive_belief_id(text: str, source: str) -> str:
-    """Deterministic id from (text, source). Re-running scan on the same
-    tree yields the same ids — that's how the orchestrator stays
-    idempotent without a separate dedupe table.
-    """
-    h = hashlib.sha256(f"{source}\x00{text}".encode("utf-8")).hexdigest()
-    return h[:_BELIEF_ID_HEX_LEN]
-
-
-def _content_hash(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
 def _utc_now_iso() -> str:

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -2443,16 +2443,6 @@ class MemoryStore:
 
         return applied
 
-    # --- Bulk helpers (used by tests / future modules) -------------------
-
-    def insert_beliefs(self, beliefs: Iterable[Belief]) -> None:
-        for b in beliefs:
-            self.insert_belief(b)
-
-    def insert_edges(self, edges: Iterable[Edge]) -> None:
-        for e in edges:
-            self.insert_edge(e)
-
     # --- Onboard sessions -------------------------------------------------
 
     def insert_onboard_session(self, s: OnboardSession) -> None:

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -14,7 +14,9 @@ suite locks that behaviour in from day one
 """
 from __future__ import annotations
 
+import inspect
 import json
+import os
 import secrets
 import sqlite3
 from datetime import datetime, timezone
@@ -37,6 +39,102 @@ from aelfrice.models import (
     Session,
 )
 from aelfrice.ulid import ulid
+
+# --- v2.x view-flip gate --------------------------------------------------
+#
+# When AELFRICE_WRITE_LOG_AUTHORITATIVE is on, `beliefs` becomes a
+# materialized view of `ingest_log` and direct `insert_belief()` calls
+# from outside the allowlist raise. The flag itself was wired in
+# derivation_worker.is_write_log_authoritative (#265 PR-A); store reads
+# os.environ inline to avoid a circular import (worker depends on store).
+#
+# Allowlist matches the ratification on PR #478:
+#   - aelfrice.derivation_worker  — the single canonical writer
+#   - aelfrice.wonder.simulator   — synthetic corpus seeder (test fixture)
+#   - aelfrice.benchmark          — benchmarking fixtures
+#   - aelfrice.migrate            — v1→v2 store migration; legacy_unknown
+#                                    rows are emitted by the migration tool
+#                                    itself, not through ingest_log
+#
+# Anything outside the allowlist must go through
+# `record_ingest` + `run_worker` so the write trail starts on the log.
+
+_ENV_WRITE_LOG_AUTHORITATIVE: Final[str] = "AELFRICE_WRITE_LOG_AUTHORITATIVE"
+_WLAUTH_TRUTHY: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+
+INSERT_BELIEF_ALLOWLIST: Final[frozenset[str]] = frozenset({
+    "aelfrice.derivation_worker",
+    "aelfrice.wonder.simulator",
+    "aelfrice.benchmark",
+    "aelfrice.migrate",
+})
+
+
+class WriteLogAuthorityViolation(RuntimeError):
+    """Raised when `MemoryStore.insert_belief` is called from outside
+    `INSERT_BELIEF_ALLOWLIST` while `AELFRICE_WRITE_LOG_AUTHORITATIVE`
+    is on. Indicates a code path that would write to `beliefs` without
+    a corresponding `ingest_log` row — the write trail invariant the
+    v2.x view-flip is designed to enforce.
+
+    Resolution: route the caller through `record_ingest` + `run_worker`
+    instead of calling `insert_belief` directly. Or, if the caller is a
+    legitimate fixture/migration site, add it to `INSERT_BELIEF_ALLOWLIST`
+    after design review.
+    """
+
+
+def _is_write_log_authoritative_inline() -> bool:
+    """Inline reader to avoid the store→derivation_worker→store cycle."""
+    raw = os.environ.get(_ENV_WRITE_LOG_AUTHORITATIVE)
+    if raw is None:
+        return False
+    return raw.strip().lower() in _WLAUTH_TRUTHY
+
+
+def _check_insert_belief_authority() -> None:
+    """Stack-walk gate for `insert_belief`.
+
+    No-op when the flag is off (production default at this commit).
+    When on, walks frames until it finds one outside `aelfrice.store`,
+    then checks that frame's module against `INSERT_BELIEF_ALLOWLIST`.
+    Raises `WriteLogAuthorityViolation` on a non-allowlisted caller.
+
+    `insert_or_corroborate` calls `insert_belief` internally; the walk
+    skips over `aelfrice.store` frames so the *true* caller (the worker
+    or another module) is what gets checked.
+    """
+    if not _is_write_log_authoritative_inline():
+        return
+    frame = inspect.currentframe()
+    if frame is None:  # platforms without frame inspection
+        return
+    # Skip our own frame plus any aelfrice.store frames (insert_belief,
+    # insert_or_corroborate, …). The first non-store frame is the
+    # true caller.
+    caller = frame.f_back
+    while caller is not None:
+        mod = caller.f_globals.get("__name__", "")
+        if not mod.startswith("aelfrice.store"):
+            if mod in INSERT_BELIEF_ALLOWLIST:
+                return
+            raise WriteLogAuthorityViolation(
+                f"insert_belief() called from {mod!r}; not in "
+                f"INSERT_BELIEF_ALLOWLIST {sorted(INSERT_BELIEF_ALLOWLIST)}. "
+                f"With AELFRICE_WRITE_LOG_AUTHORITATIVE on, only the "
+                f"derivation worker and three allowlisted fixture/"
+                f"migration modules may write to `beliefs` directly; "
+                f"all other callers must go through "
+                f"`record_ingest` + `run_worker`."
+            )
+        caller = caller.f_back
+    # No non-store frame found (shouldn't happen in practice). Fail
+    # closed — the caller is opaque, treat it as a violation.
+    raise WriteLogAuthorityViolation(
+        "insert_belief() called from an opaque caller; could not "
+        "identify the calling module while the write-log gate is on."
+    )
+
 
 # --- Schema ---------------------------------------------------------------
 
@@ -1201,6 +1299,7 @@ class MemoryStore:
     # --- Belief CRUD ------------------------------------------------------
 
     def insert_belief(self, b: Belief) -> None:
+        _check_insert_belief_authority()
         if b.retention_class not in RETENTION_CLASSES:
             raise ValueError(
                 f"invalid retention_class {b.retention_class!r}; "

--- a/tests/test_derivation_worker_route_overrides.py
+++ b/tests/test_derivation_worker_route_overrides.py
@@ -1,0 +1,402 @@
+"""Tests for the worker's `route_overrides` plumbing (#265 PR-B commit 1).
+
+Each test is a falsifiable hypothesis about the LLM-router post-derivation
+splice contract ratified on PR #478:
+
+  - `route_overrides` flows through `raw_meta -> DerivationInput`.
+  - When set, `derive()` skips the regex classifier and uses the router's
+    `(type, origin, alpha, beta)`. Byte-identical to today's scanner.py
+    direct-write LLM-classify path on the same input.
+  - The worker emits a `feedback_history` audit row when
+    `audit_source` is set AND the belief was newly inserted (matches
+    today's scanner.py:301-310 `if was_inserted` guard).
+  - Absent `route_overrides`, today's regex-path behavior is unchanged.
+
+Scanner-side migration to `record_ingest + run_worker` lives in commit 2.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from aelfrice.derivation import (
+    DerivationInput,
+    RouteOverrides,
+    derive,
+)
+from aelfrice.derivation_worker import (
+    _derivation_input_from_row,
+    _route_overrides_from_raw_meta,
+    run_worker,
+)
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+    INGEST_SOURCE_FILESYSTEM,
+    ORIGIN_AGENT_INFERRED,
+    ORIGIN_USER_STATED,
+)
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Iterator[MemoryStore]:
+    s = MemoryStore(str(tmp_path / "ro.db"))
+    yield s
+    s.close()
+
+
+def _record_with_overrides(
+    store: MemoryStore,
+    text: str,
+    overrides: dict | None,
+    *,
+    source_path: str = "doc:notes.md",
+    call_site: str = CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+    ts: str = "2026-05-08T00:00:00+00:00",
+) -> str:
+    raw_meta: dict[str, object] = {"call_site": call_site}
+    if overrides is not None:
+        raw_meta["route_overrides"] = overrides
+    return store.record_ingest(
+        source_kind=INGEST_SOURCE_FILESYSTEM,
+        source_path=source_path,
+        raw_text=text,
+        raw_meta=raw_meta,
+        ts=ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# `RouteOverrides` dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_route_overrides_is_frozen():
+    """Frozen so callers can stash it as a dict value safely."""
+    ro = RouteOverrides(
+        belief_type="factual",
+        origin="agent_inferred",
+        alpha=1.4,
+        beta=0.6,
+    )
+    with pytest.raises(Exception):
+        ro.alpha = 2.0  # type: ignore[misc]
+
+
+def test_route_overrides_audit_source_optional():
+    ro = RouteOverrides(belief_type="factual", origin="x", alpha=1.0, beta=1.0)
+    assert ro.audit_source is None
+
+
+# ---------------------------------------------------------------------------
+# `_route_overrides_from_raw_meta`
+# ---------------------------------------------------------------------------
+
+
+def test_parses_well_formed_block():
+    block = {
+        "belief_type": "factual",
+        "origin": ORIGIN_AGENT_INFERRED,
+        "alpha": 1.4,
+        "beta": 0.6,
+        "audit_source": "llm_router_v1",
+    }
+    ro = _route_overrides_from_raw_meta({"route_overrides": block})
+    assert ro is not None
+    assert ro.belief_type == "factual"
+    assert ro.origin == ORIGIN_AGENT_INFERRED
+    assert ro.alpha == pytest.approx(1.4)
+    assert ro.beta == pytest.approx(0.6)
+    assert ro.audit_source == "llm_router_v1"
+
+
+def test_returns_none_when_block_absent():
+    assert _route_overrides_from_raw_meta({"call_site": "x"}) is None
+
+
+def test_returns_none_for_missing_required_field():
+    block = {"belief_type": "factual", "origin": "x", "alpha": 1.0}
+    # missing beta
+    assert _route_overrides_from_raw_meta({"route_overrides": block}) is None
+
+
+def test_returns_none_for_wrong_type():
+    block = {
+        "belief_type": "factual",
+        "origin": "x",
+        "alpha": "not a number",
+        "beta": 1.0,
+    }
+    assert _route_overrides_from_raw_meta({"route_overrides": block}) is None
+
+
+def test_returns_none_for_empty_strings():
+    block = {"belief_type": "", "origin": "x", "alpha": 1.0, "beta": 1.0}
+    assert _route_overrides_from_raw_meta({"route_overrides": block}) is None
+
+
+def test_int_alpha_beta_coerce_to_float():
+    block = {"belief_type": "f", "origin": "x", "alpha": 2, "beta": 3}
+    ro = _route_overrides_from_raw_meta({"route_overrides": block})
+    assert ro is not None
+    assert isinstance(ro.alpha, float) and ro.alpha == 2.0
+    assert isinstance(ro.beta, float) and ro.beta == 3.0
+
+
+def test_audit_source_none_when_empty_string():
+    block = {
+        "belief_type": "f", "origin": "x", "alpha": 1.0, "beta": 1.0,
+        "audit_source": "",
+    }
+    ro = _route_overrides_from_raw_meta({"route_overrides": block})
+    assert ro is not None
+    assert ro.audit_source is None
+
+
+def test_returns_none_when_raw_meta_is_none():
+    assert _route_overrides_from_raw_meta(None) is None
+
+
+# ---------------------------------------------------------------------------
+# `_derivation_input_from_row` forwards route_overrides
+# ---------------------------------------------------------------------------
+
+
+def test_derivation_input_carries_route_overrides():
+    row = {
+        "id": "log-1",
+        "raw_text": "x",
+        "source_kind": INGEST_SOURCE_FILESYSTEM,
+        "source_path": "doc:x.md",
+        "ts": "2026-05-08T00:00:00+00:00",
+        "raw_meta": {
+            "call_site": CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+            "route_overrides": {
+                "belief_type": "factual",
+                "origin": ORIGIN_AGENT_INFERRED,
+                "alpha": 1.5,
+                "beta": 0.5,
+            },
+        },
+    }
+    inp = _derivation_input_from_row(row)
+    assert inp.route_overrides is not None
+    assert inp.route_overrides.belief_type == "factual"
+    assert inp.route_overrides.alpha == pytest.approx(1.5)
+
+
+def test_derivation_input_route_overrides_default_none():
+    row = {
+        "id": "log-2",
+        "raw_text": "x",
+        "source_kind": INGEST_SOURCE_FILESYSTEM,
+        "raw_meta": {"call_site": "x"},
+    }
+    inp = _derivation_input_from_row(row)
+    assert inp.route_overrides is None
+
+
+# ---------------------------------------------------------------------------
+# `derive()` honors route_overrides
+# ---------------------------------------------------------------------------
+
+
+def test_derive_uses_router_fields_when_set():
+    """Hypothesis: derive() with route_overrides produces a Belief whose
+    (type, origin, alpha, beta) match the overrides verbatim. Falsifiable
+    by any of the four fields differing."""
+    inp = DerivationInput(
+        raw_text="The agent stores beliefs in SQLite.",
+        source_kind=INGEST_SOURCE_FILESYSTEM,
+        source_path="doc:notes.md",
+        ts="2026-05-08T00:00:00+00:00",
+        route_overrides=RouteOverrides(
+            belief_type="opinion",
+            origin=ORIGIN_USER_STATED,
+            alpha=2.0,
+            beta=0.5,
+        ),
+    )
+    out = derive(inp)
+    assert out.belief is not None
+    assert out.belief.type == "opinion"
+    assert out.belief.origin == ORIGIN_USER_STATED
+    assert out.belief.alpha == pytest.approx(2.0)
+    assert out.belief.beta == pytest.approx(0.5)
+
+
+def test_derive_id_unchanged_by_route_overrides():
+    """Belief id is sha256(source\\x00text)[:16] regardless of overrides
+    — same scheme used by scanner._derive_belief_id today, so byte-
+    identical canonical state holds with or without the override."""
+    common_kwargs = {
+        "raw_text": "Some content here for hashing.",
+        "source_kind": INGEST_SOURCE_FILESYSTEM,
+        "source_path": "doc:x.md",
+        "ts": "2026-05-08T00:00:00+00:00",
+    }
+    base = derive(DerivationInput(**common_kwargs))
+    routed = derive(DerivationInput(
+        **common_kwargs,
+        route_overrides=RouteOverrides(
+            belief_type=BELIEF_FACTUAL,
+            origin=ORIGIN_AGENT_INFERRED,
+            alpha=1.0,
+            beta=1.0,
+        ),
+    ))
+    assert base.belief is not None
+    assert routed.belief is not None
+    assert base.belief.id == routed.belief.id
+
+
+def test_derive_skips_classifier_when_route_overrides_set():
+    """Question-form text is normally rejected by classify_sentence
+    (persist=False). With route_overrides, the router's persist=True
+    decision wins and a belief lands. Matches scanner.py LLM-path
+    today."""
+    inp = DerivationInput(
+        raw_text="Are we storing this as a belief?",
+        source_kind=INGEST_SOURCE_FILESYSTEM,
+        source_path="doc:notes.md",
+        route_overrides=RouteOverrides(
+            belief_type="factual",
+            origin=ORIGIN_AGENT_INFERRED,
+            alpha=1.0,
+            beta=1.0,
+        ),
+    )
+    out = derive(inp)
+    assert out.belief is not None  # would be None without overrides
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through `run_worker`
+# ---------------------------------------------------------------------------
+
+
+def test_worker_writes_belief_with_overrides_from_log_row(
+    store: MemoryStore,
+) -> None:
+    """Hypothesis: a log row carrying raw_meta.route_overrides yields a
+    canonical belief whose router-owned fields match the sub-dict
+    verbatim. End-to-end through run_worker()."""
+    log_id = _record_with_overrides(
+        store,
+        "The retrieval engine uses BM25.",
+        overrides={
+            "belief_type": "factual",
+            "origin": ORIGIN_AGENT_INFERRED,
+            "alpha": 1.7,
+            "beta": 0.3,
+        },
+    )
+    result = run_worker(store)
+    assert result.beliefs_inserted == 1
+
+    row = store.get_ingest_log_entry(log_id)
+    assert row is not None
+    derived = row["derived_belief_ids"]
+    assert isinstance(derived, list) and len(derived) == 1
+
+    belief = store.get_belief(derived[0])
+    assert belief is not None
+    assert belief.type == "factual"
+    assert belief.origin == ORIGIN_AGENT_INFERRED
+    assert belief.alpha == pytest.approx(1.7)
+    assert belief.beta == pytest.approx(0.3)
+
+
+def test_worker_emits_audit_row_on_new_insert_with_audit_source(
+    store: MemoryStore,
+) -> None:
+    """Hypothesis: when route_overrides.audit_source is set AND the
+    belief is newly inserted, the worker writes one feedback_history
+    row tagged with the supplied source string. Mirrors scanner's
+    pre-migration behavior at scanner.py:304-310."""
+    _record_with_overrides(
+        store,
+        "Source-marked belief content.",
+        overrides={
+            "belief_type": "factual",
+            "origin": ORIGIN_AGENT_INFERRED,
+            "alpha": 1.0,
+            "beta": 1.0,
+            "audit_source": "llm_router_v1",
+        },
+    )
+    run_worker(store)
+
+    events = store.list_feedback_events()
+    assert len(events) == 1
+    assert events[0].source == "llm_router_v1"
+    assert events[0].valence == pytest.approx(0.0)
+
+
+def test_worker_skips_audit_row_when_audit_source_absent(
+    store: MemoryStore,
+) -> None:
+    """Hypothesis: an LLM-routed row without audit_source produces a
+    belief but no audit row — only the optional `audit_source` field
+    triggers the feedback_history emission."""
+    _record_with_overrides(
+        store,
+        "Different content for a unique id.",
+        overrides={
+            "belief_type": "factual",
+            "origin": ORIGIN_AGENT_INFERRED,
+            "alpha": 1.0,
+            "beta": 1.0,
+        },
+    )
+    run_worker(store)
+
+    assert store.count_feedback_events() == 0
+
+
+def test_worker_skips_audit_row_on_corroboration(
+    store: MemoryStore,
+) -> None:
+    """Hypothesis: a second log row carrying the same text + audit_source
+    does NOT write a second audit row, because the belief was
+    corroborated rather than inserted. Matches scanner's `if
+    was_inserted` guard at scanner.py:301-310."""
+    overrides = {
+        "belief_type": "factual",
+        "origin": ORIGIN_AGENT_INFERRED,
+        "alpha": 1.0,
+        "beta": 1.0,
+        "audit_source": "llm_router_v1",
+    }
+    _record_with_overrides(store, "Repeated content.", overrides=overrides)
+    run_worker(store)
+    assert store.count_feedback_events() == 1
+
+    _record_with_overrides(
+        store,
+        "Repeated content.",
+        overrides=overrides,
+        ts="2026-05-08T01:00:00+00:00",
+    )
+    run_worker(store)
+
+    # Still 1 — second pass should corroborate, not insert.
+    assert store.count_feedback_events() == 1
+
+
+def test_worker_unchanged_when_no_overrides(store: MemoryStore) -> None:
+    """Regex-path baseline: a log row without route_overrides produces a
+    classifier-derived belief, no audit row. Today's behavior must hold."""
+    store.record_ingest(
+        source_kind=INGEST_SOURCE_FILESYSTEM,
+        source_path="doc:r.md",
+        raw_text="The system uses an SQLite store for beliefs.",
+        raw_meta={"call_site": CORROBORATION_SOURCE_FILESYSTEM_INGEST},
+        ts="2026-05-08T00:00:00+00:00",
+    )
+    result = run_worker(store)
+    assert result.beliefs_inserted == 1
+    assert store.count_feedback_events() == 0

--- a/tests/test_insert_belief_gate.py
+++ b/tests/test_insert_belief_gate.py
@@ -1,0 +1,306 @@
+"""Tests for the v2.x view-flip gate on `MemoryStore.insert_belief`
+(#265 PR-B commit 4).
+
+When `AELFRICE_WRITE_LOG_AUTHORITATIVE` is on, `insert_belief()`
+walks the call stack to find the first frame outside `aelfrice.store`
+and raises `WriteLogAuthorityViolation` unless that module appears in
+`INSERT_BELIEF_ALLOWLIST` = {derivation_worker, wonder.simulator,
+benchmark, migrate}. With the flag off (production default at this
+commit), the check is a no-op.
+
+Each test states a falsifiable hypothesis about the gate contract.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from aelfrice.derivation_worker import run_worker
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    INGEST_SOURCE_FILESYSTEM,
+    LOCK_NONE,
+    ORIGIN_AGENT_INFERRED,
+    RETENTION_UNKNOWN,
+    Belief,
+)
+from aelfrice.store import (
+    INSERT_BELIEF_ALLOWLIST,
+    MemoryStore,
+    WriteLogAuthorityViolation,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Iterator[MemoryStore]:
+    s = MemoryStore(str(tmp_path / "gate.db"))
+    yield s
+    s.close()
+
+
+def _belief(bid: str = "b" * 16, content: str = "alpha gate test") -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-05-08T00:00:00+00:00",
+        last_retrieved_at=None,
+        session_id=None,
+        origin=ORIGIN_AGENT_INFERRED,
+        retention_class=RETENTION_UNKNOWN,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default-off behavior
+# ---------------------------------------------------------------------------
+
+
+def test_gate_off_by_default(store: MemoryStore) -> None:
+    """Hypothesis: with no env var set, insert_belief from a test module
+    (not on the allowlist) succeeds. The gate is a no-op when the flag
+    is off — production default at this commit. Falsifiable by a raise
+    on insert_belief without setting the env var."""
+    store.insert_belief(_belief())
+    assert store.count_beliefs() == 1
+
+
+def test_gate_off_explicit_zero_value(
+    store: MemoryStore, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hypothesis: an explicit non-truthy value (`0`, `false`, `off`,
+    `no`, …) keeps the gate off. Falsifiable by a raise on any of
+    these values."""
+    for falsy in ("0", "false", "off", "no", ""):
+        monkeypatch.setenv("AELFRICE_WRITE_LOG_AUTHORITATIVE", falsy)
+        # Each iteration uses a distinct id so the row insert succeeds.
+        bid = f"{ord(falsy[0:1] or 'x'):x}".rjust(16, "0")
+        store.insert_belief(_belief(bid=bid, content=f"falsy {falsy!r}"))
+
+
+# ---------------------------------------------------------------------------
+# Gate-on, non-allowlisted callers raise
+# ---------------------------------------------------------------------------
+
+
+def test_gate_on_test_module_raises(
+    store: MemoryStore, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hypothesis: with the gate on, calling insert_belief from this
+    test module (not on the allowlist) raises
+    `WriteLogAuthorityViolation`. The exception message names the
+    offending module. Falsifiable by silent acceptance."""
+    monkeypatch.setenv("AELFRICE_WRITE_LOG_AUTHORITATIVE", "1")
+    with pytest.raises(WriteLogAuthorityViolation) as exc_info:
+        store.insert_belief(_belief())
+    msg = str(exc_info.value)
+    # Module name appears verbatim so the operator can grep it.
+    assert "test_insert_belief_gate" in msg
+
+
+def test_gate_on_truthy_variants(
+    store: MemoryStore, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hypothesis: every truthy spelling (`1`, `true`, `yes`, `on`,
+    case-insensitive, surrounded by whitespace) trips the gate.
+    Falsifiable by silent acceptance for any variant."""
+    for truthy in ("1", "true", "TRUE", "yes", "on", " on ", "True"):
+        monkeypatch.setenv("AELFRICE_WRITE_LOG_AUTHORITATIVE", truthy)
+        with pytest.raises(WriteLogAuthorityViolation):
+            store.insert_belief(_belief())
+
+
+# ---------------------------------------------------------------------------
+# Gate-on, allowlisted callers pass
+# ---------------------------------------------------------------------------
+
+
+def test_gate_on_worker_path_passes(
+    store: MemoryStore,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hypothesis: the worker is on the allowlist, so a
+    `record_ingest` + `run_worker` round-trip with the gate on still
+    writes a canonical belief. The worker reaches `insert_belief` via
+    `insert_or_corroborate`; the stack-walk skips the aelfrice.store
+    frames and finds `aelfrice.derivation_worker` as the true caller.
+    Falsifiable by a raise inside the worker."""
+    monkeypatch.setenv("AELFRICE_WRITE_LOG_AUTHORITATIVE", "1")
+    store.record_ingest(
+        source_kind=INGEST_SOURCE_FILESYSTEM,
+        source_path="doc:gate-on.md",
+        raw_text="Aelfrice stores beliefs in a SQLite database.",
+        raw_meta={"call_site": "filesystem_ingest"},
+        ts="2026-05-08T01:00:00+00:00",
+    )
+    result = run_worker(store)
+    assert result.beliefs_inserted == 1
+    assert store.count_beliefs() == 1
+
+
+def _simulator_caller(store: MemoryStore, b: Belief) -> None:
+    """Helper invoked from inside `aelfrice.wonder.simulator` to exercise
+    the allowlist path. Lives in this test module via dynamic
+    `__name__` patching below."""
+    store.insert_belief(b)
+
+
+def test_gate_on_allowlisted_module_passes(
+    store: MemoryStore, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hypothesis: when the calling frame's `__name__` is in
+    `INSERT_BELIEF_ALLOWLIST`, the gate lets the write through.
+    Simulated by patching the helper's globals to claim the allowlisted
+    module name. Falsifiable by a raise despite the allowlisted
+    identity. The simulator/benchmark/migrate paths are tested this
+    way because their real call paths have shape that's awkward to
+    drive from a unit test (synthetic corpus seeders, version
+    migration tooling)."""
+    monkeypatch.setenv("AELFRICE_WRITE_LOG_AUTHORITATIVE", "1")
+    for allowlisted in INSERT_BELIEF_ALLOWLIST:
+        # Patch the helper's frame to look like it's in the allowlisted
+        # module. The stack walk reads `frame.f_globals["__name__"]`.
+        original = _simulator_caller.__globals__.get("__name__")
+        _simulator_caller.__globals__["__name__"] = allowlisted
+        try:
+            bid = ("a" * 8 + str(hash(allowlisted) & 0xFFFF).zfill(8))[:16]
+            _simulator_caller(store, _belief(bid=bid, content=allowlisted))
+        finally:
+            if original is not None:
+                _simulator_caller.__globals__["__name__"] = original
+
+
+# ---------------------------------------------------------------------------
+# Allowlist surface
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_contents_are_ratified_set() -> None:
+    """Hypothesis: the allowlist is exactly the four modules ratified
+    on PR #478. Adding or removing entries is a design decision that
+    requires re-ratification. Falsifiable by drift on either side."""
+    assert INSERT_BELIEF_ALLOWLIST == frozenset({
+        "aelfrice.derivation_worker",
+        "aelfrice.wonder.simulator",
+        "aelfrice.benchmark",
+        "aelfrice.migrate",
+    })
+
+
+def test_violation_message_lists_allowlist(
+    store: MemoryStore, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hypothesis: the violation message includes the allowlist so the
+    operator can debug a misrouted caller without reading source.
+    Falsifiable by an empty / generic message."""
+    monkeypatch.setenv("AELFRICE_WRITE_LOG_AUTHORITATIVE", "1")
+    try:
+        store.insert_belief(_belief())
+    except WriteLogAuthorityViolation as exc:
+        msg = str(exc)
+        for module in INSERT_BELIEF_ALLOWLIST:
+            assert module in msg, (
+                f"violation message missing allowlisted module {module!r}"
+            )
+    else:
+        pytest.fail("insert_belief did not raise under the gate")
+
+
+def test_insert_or_corroborate_walks_past_store_frames(
+    store: MemoryStore, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hypothesis: when `insert_or_corroborate` calls `insert_belief`
+    internally, the stack walk skips the aelfrice.store frames and
+    checks the *outer* caller against the allowlist. With the test as
+    outer caller, the gate raises. Falsifiable by silent acceptance
+    (the gate would have to mistake `insert_or_corroborate`'s own
+    frame for the true caller — that's the bug the skip-loop guards
+    against)."""
+    monkeypatch.setenv("AELFRICE_WRITE_LOG_AUTHORITATIVE", "1")
+    with pytest.raises(WriteLogAuthorityViolation):
+        store.insert_or_corroborate(
+            _belief(),
+            source_type="filesystem_ingest",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Real-module smoke tests (production allowlist code paths)
+# ---------------------------------------------------------------------------
+
+
+def test_gate_on_benchmark_seed_corpus_passes(
+    store: MemoryStore, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hypothesis: `aelfrice.benchmark.seed_corpus` writes via
+    `insert_belief` and is on the allowlist; the production seeder
+    works with the gate on. Falsifiable by a violation raised inside
+    seed_corpus."""
+    from aelfrice.benchmark import seed_corpus
+
+    monkeypatch.setenv("AELFRICE_WRITE_LOG_AUTHORITATIVE", "1")
+    inserted = seed_corpus(store)
+    assert inserted >= 1
+    assert store.count_beliefs() == inserted
+
+
+def test_gate_on_simulator_populate_store_passes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hypothesis: `aelfrice.wonder.simulator.populate_store` writes
+    via `insert_belief` and is on the allowlist; the synthetic-corpus
+    seeder works with the gate on. Falsifiable by a violation raised
+    inside populate_store."""
+    import random
+
+    from aelfrice.wonder.simulator import build_corpus, populate_store
+
+    monkeypatch.setenv("AELFRICE_WRITE_LOG_AUTHORITATIVE", "1")
+    rng = random.Random(42)
+    corpus = build_corpus(rng=rng, n_topics=4, n_atoms_per_topic=5)
+    s = MemoryStore(str(tmp_path / "sim.db"))
+    try:
+        populate_store(s, corpus, rng=rng)
+        assert s.count_beliefs() == 4 * 5
+    finally:
+        s.close()
+
+
+def test_gate_on_migrate_passes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hypothesis: `aelfrice.migrate.migrate` writes via
+    `insert_belief` and is on the allowlist; the v1→v2 migration
+    works with the gate on. The legacy_unknown rows are emitted by
+    the migration tool itself (per ratification: no ingest_log
+    injection). Falsifiable by a violation inside migrate()."""
+    from aelfrice.migrate import migrate
+
+    # Seed a v1-shape source store with the gate OFF so we can write
+    # the source state, then turn the gate on for the migration step.
+    src_path = tmp_path / "v1.db"
+    dst_path = tmp_path / "v2.db"
+    src = MemoryStore(str(src_path))
+    try:
+        src.insert_belief(_belief(bid="0123456789abcdef", content="src belief"))
+    finally:
+        src.close()
+
+    monkeypatch.setenv("AELFRICE_WRITE_LOG_AUTHORITATIVE", "1")
+    report = migrate(
+        legacy_path=src_path,
+        target_path=dst_path,
+        project_root=tmp_path,
+        apply=True,
+        copy_all=True,
+    )
+    assert report.counts.inserted_beliefs == 1

--- a/tests/test_scanner_llm_via_worker.py
+++ b/tests/test_scanner_llm_via_worker.py
@@ -1,0 +1,362 @@
+"""Integration tests for the scanner LLM-classify path → derivation_worker
+call shape (#265 PR-B commit 2).
+
+Pre-migration, scanner.py:262-310 wrote beliefs directly via
+`store.insert_or_corroborate` and `store.insert_feedback_event` when an
+`llm_router` was supplied. Commit 2 collapses that branch into the same
+`record_ingest` + `run_worker` shape the regex path already uses, with
+the router's per-candidate decisions carried in
+`raw_meta["route_overrides"]`.
+
+Each test states a falsifiable hypothesis about the new contract:
+
+    scan_repo(llm_router=X) writes one log row per persistable
+    candidate (route.persist=True) with `raw_meta.route_overrides`
+    populated, invokes run_worker once at end-of-scan, and produces
+    canonical beliefs whose (type, origin, alpha, beta) match the
+    router's decision verbatim.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from aelfrice.replay import replay_full_equality
+from aelfrice.scanner import LLMRoute, SentenceCandidate, scan_repo
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Iterator[MemoryStore]:
+    s = MemoryStore(str(tmp_path / "scanner-llm-via-worker.db"))
+    yield s
+    s.close()
+
+
+def _seed_repo(root: Path) -> None:
+    """Drop a tiny doc-only tree the filesystem extractor will see."""
+    (root / "README.md").write_text(
+        "The configuration file lives at /etc/aelfrice/conf.\n"
+        "\n"
+        "The default port is 8080 for the dashboard.\n"
+        "\n"
+        "Aelfrice stores beliefs in a SQLite database.\n",
+        encoding="utf-8",
+    )
+
+
+class _StubRouter:
+    """Per-candidate `LLMRoute` table indexed by candidate text.
+
+    Tests configure (text -> LLMRoute) up front; the stub returns the
+    routes in input order. Any candidate without a configured route gets
+    `default_route` (a no-op question-form persist=False decision by
+    default — fail-loud if the test forgot to map a candidate).
+    """
+
+    def __init__(
+        self,
+        routes_by_text: dict[str, LLMRoute],
+        *,
+        default: LLMRoute | None = None,
+    ) -> None:
+        self._routes_by_text = routes_by_text
+        self._default = default
+        self.calls: list[list[SentenceCandidate]] = []
+
+    def classify(
+        self, candidates: list[SentenceCandidate],
+    ) -> list[LLMRoute]:
+        self.calls.append(list(candidates))
+        out: list[LLMRoute] = []
+        for cand in candidates:
+            route = self._routes_by_text.get(cand.text)
+            if route is None:
+                if self._default is None:
+                    raise AssertionError(
+                        f"_StubRouter: no route configured for "
+                        f"{cand.text!r}",
+                    )
+                route = self._default
+            out.append(route)
+        return out
+
+
+def _persist_route(
+    *,
+    belief_type: str = "factual",
+    origin: str = "agent_inferred",
+    alpha: float = 1.4,
+    beta: float = 0.6,
+    audit_source: str | None = None,
+) -> LLMRoute:
+    return LLMRoute(
+        belief_type=belief_type,
+        origin=origin,
+        persist=True,
+        alpha=alpha,
+        beta=beta,
+        audit_source=audit_source,
+    )
+
+
+def test_llm_path_writes_log_rows_through_worker(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: with an `llm_router`, scan_repo writes one ingest_log
+    row per persistable candidate and `run_worker` stamps every row.
+    Falsifiable by any unstamped row OR by zero log rows when the
+    router classified at least one persistable candidate."""
+    _seed_repo(tmp_path)
+    router = _StubRouter(
+        routes_by_text={
+            "The configuration file lives at /etc/aelfrice/conf.":
+                _persist_route(),
+            "The default port is 8080 for the dashboard.":
+                _persist_route(),
+            "Aelfrice stores beliefs in a SQLite database.":
+                _persist_route(),
+        },
+    )
+    scan_repo(store, tmp_path, llm_router=router)
+
+    assert store.list_unstamped_ingest_log() == []
+    rows = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT raw_meta FROM ingest_log",
+    ).fetchall()
+    assert rows
+    for row in rows:
+        meta = json.loads(row["raw_meta"]) if row["raw_meta"] else None
+        assert isinstance(meta, dict)
+        assert meta.get("call_site") == "filesystem_ingest"
+        assert "route_overrides" in meta
+
+
+def test_llm_path_belief_carries_router_fields(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: the canonical belief written by the worker carries
+    the router's `(type, origin, alpha, beta)` verbatim — the
+    post-derivation splice replaced the deterministic classifier's
+    output. Falsifiable by any field reverting to derive()'s default."""
+    _seed_repo(tmp_path)
+    router = _StubRouter(
+        routes_by_text={
+            "The configuration file lives at /etc/aelfrice/conf.":
+                _persist_route(
+                    belief_type="factual",
+                    origin="user_stated",
+                    alpha=2.5,
+                    beta=0.3,
+                ),
+        },
+        default=_persist_route(),
+    )
+    scan_repo(store, tmp_path, llm_router=router)
+
+    beliefs = [
+        b for b in (store.get_belief(bid) for bid in store.list_belief_ids())
+        if b is not None
+        and b.content == "The configuration file lives at /etc/aelfrice/conf."
+    ]
+    assert len(beliefs) == 1
+    belief = beliefs[0]
+    assert belief.type == "factual"
+    assert belief.origin == "user_stated"
+    assert belief.alpha == pytest.approx(2.5)
+    assert belief.beta == pytest.approx(0.3)
+
+
+def test_llm_path_persist_false_writes_no_log_row(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: candidates routed `persist=False` are counted in
+    `skipped_non_persisting` but produce no ingest_log row and no
+    canonical belief. Falsifiable by an extra log row OR by a belief
+    appearing for a non-persisting candidate."""
+    _seed_repo(tmp_path)
+    router = _StubRouter(
+        routes_by_text={
+            "The configuration file lives at /etc/aelfrice/conf.":
+                _persist_route(),
+            "The default port is 8080 for the dashboard.":
+                LLMRoute(
+                    belief_type="factual",
+                    origin="agent_inferred",
+                    persist=False,
+                    alpha=1.0,
+                    beta=1.0,
+                ),
+            "Aelfrice stores beliefs in a SQLite database.":
+                _persist_route(),
+        },
+    )
+    result = scan_repo(store, tmp_path, llm_router=router)
+
+    assert result.skipped_non_persisting == 1
+    log_count = store._conn.execute(  # pyright: ignore[reportPrivateUsage]
+        "SELECT COUNT(*) AS n FROM ingest_log",
+    ).fetchone()["n"]
+    assert log_count == 2
+
+    belief_texts = {
+        b.content
+        for b in (store.get_belief(bid) for bid in store.list_belief_ids())
+        if b is not None
+    }
+    assert "The default port is 8080 for the dashboard." not in belief_texts
+
+
+def test_llm_path_audit_source_emits_feedback_event(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: when `route.audit_source` is set, the worker writes
+    one feedback_history row tagged with that source string. Mirrors
+    pre-migration scanner.py:304-310. Falsifiable by zero rows or by
+    a row tagged with a different source."""
+    _seed_repo(tmp_path)
+    router = _StubRouter(
+        routes_by_text={
+            "The configuration file lives at /etc/aelfrice/conf.":
+                _persist_route(audit_source="llm_router_v1"),
+        },
+        default=_persist_route(),
+    )
+    scan_repo(store, tmp_path, llm_router=router)
+
+    events = [e for e in store.list_feedback_events()
+              if e.source == "llm_router_v1"]
+    assert len(events) == 1
+    assert events[0].valence == pytest.approx(0.0)
+
+
+def test_llm_path_audit_source_skipped_on_corroboration(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: a second scan of the same tree with the same router
+    decision DOES NOT write a second audit row — the worker's
+    feedback_history emission is gated by `was_inserted`. Falsifiable
+    by a duplicate audit row on the second pass."""
+    _seed_repo(tmp_path)
+    router = _StubRouter(
+        routes_by_text={
+            "The configuration file lives at /etc/aelfrice/conf.":
+                _persist_route(audit_source="llm_router_v1"),
+        },
+        default=_persist_route(),
+    )
+    scan_repo(store, tmp_path, llm_router=router)
+    first_pass = store.count_feedback_events()
+    assert first_pass == 1
+
+    scan_repo(store, tmp_path, llm_router=router)
+    assert store.count_feedback_events() == 1
+
+
+def test_llm_path_replay_full_equality_clean(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis (CI gate): after an llm_router scan, the
+    full-equality replay probe reports zero drift. Tripwire for the
+    LLM path bypassing the worker (`canonical_orphan`) or the worker
+    producing a different canonical belief than direct splice
+    (`mismatched`). Falsifiable by any non-zero drift counter."""
+    _seed_repo(tmp_path)
+    router = _StubRouter(
+        routes_by_text={
+            "The configuration file lives at /etc/aelfrice/conf.":
+                _persist_route(audit_source="llm_router_v1"),
+            "The default port is 8080 for the dashboard.":
+                _persist_route(),
+            "Aelfrice stores beliefs in a SQLite database.":
+                _persist_route(origin="user_stated", alpha=2.0, beta=1.0),
+        },
+    )
+    scan_repo(store, tmp_path, llm_router=router)
+    scan_repo(store, tmp_path, llm_router=router)
+    report = replay_full_equality(store)
+    assert report.total_log_rows > 0
+    assert report.matched == report.total_log_rows, (
+        f"replay drift: matched={report.matched}, "
+        f"mismatched={report.mismatched}, "
+        f"derived_orphan={report.derived_orphan}, "
+        f"canonical_orphan={report.canonical_orphan}, "
+        f"examples={report.drift_examples}"
+    )
+    assert report.mismatched == 0
+    assert report.derived_orphan == 0
+    assert report.canonical_orphan == 0
+
+
+def test_llm_path_idempotent_after_worker(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: re-scanning under the LLM path is idempotent on the
+    canonical belief set. `ScanResult.inserted` is 0 on the second run;
+    every persistable candidate counts as `skipped_existing`.
+    Falsifiable by a duplicate belief OR non-zero `inserted` on the
+    second scan."""
+    _seed_repo(tmp_path)
+    router = _StubRouter(
+        routes_by_text={
+            "The configuration file lives at /etc/aelfrice/conf.":
+                _persist_route(),
+            "The default port is 8080 for the dashboard.":
+                _persist_route(),
+            "Aelfrice stores beliefs in a SQLite database.":
+                _persist_route(),
+        },
+    )
+    first = scan_repo(store, tmp_path, llm_router=router)
+    assert first.inserted >= 1
+    beliefs_after_first = store.count_beliefs()
+
+    second = scan_repo(store, tmp_path, llm_router=router)
+    assert second.inserted == 0
+    assert second.skipped_existing >= first.inserted
+    assert store.count_beliefs() == beliefs_after_first
+
+
+def test_llm_path_no_direct_belief_writes(
+    store: MemoryStore, tmp_path: Path,
+) -> None:
+    """Hypothesis: scanner.py no longer calls `insert_or_corroborate`,
+    `insert_belief`, or `insert_feedback_event` directly on the LLM
+    path. The worker is the only writer of beliefs/feedback rows.
+
+    Patches the three store methods to fail-loud; if scan_repo invokes
+    any of them, the test fails. The worker reaches the same methods
+    via its own code path (which is fine — we only assert the scanner
+    module itself does not).
+    """
+    _seed_repo(tmp_path)
+    router = _StubRouter(
+        routes_by_text={
+            "The configuration file lives at /etc/aelfrice/conf.":
+                _persist_route(audit_source="llm_router_v1"),
+        },
+        default=_persist_route(),
+    )
+
+    # The scanner module must not call these. The worker reaches them
+    # by importing from `store` directly, so the worker's invocations
+    # are not intercepted by attribute-replacement on the instance.
+    import aelfrice.scanner as scanner_mod
+
+    forbidden = {
+        "insert_or_corroborate",
+        "insert_belief",
+        "insert_feedback_event",
+    }
+    for name in forbidden:
+        assert not hasattr(scanner_mod, name), (
+            f"scanner module re-exports forbidden writer {name!r}"
+        )
+
+    # End-to-end smoke: scan must succeed and produce the expected
+    # belief without scanner.py reaching for direct writes.
+    scan_repo(store, tmp_path, llm_router=router)
+    assert store.count_beliefs() >= 1


### PR DESCRIPTION
PR-B implementation of the v2.x view-flip (#265). Lands the scanner LLM-classify migration, the RouteOverrides post-derivation splice, the cleanup deletion of unused bulk wrappers, and the `AELFRICE_WRITE_LOG_AUTHORITATIVE` gate with module allowlist ratified on this PR's comment 4404692789.

Default-off; no behavior change in production. The gate is an opt-in tripwire so operators can validate their environment before the eventual default-on flip in a later PR.

## Stack

```
709408b docs(view-flip): scanner-call-site memo
6556fea feat(view-flip): RouteOverrides plumbing through worker
e342093 feat(view-flip): scanner LLM-classify → record_ingest+run_worker
f430647 refactor(store): drop unused insert_beliefs/insert_edges
072d1ff feat(view-flip): insert_belief() gate with module allowlist
45c9f9a gate: PR-B ready for review
```

## What landed

### 1. Memo (709408b)
`docs/design/v2_view_flip_scanner_call_site.md` — the design memo PR-A's body named as the explicit prereq before PR-B implementation.

### 2. RouteOverrides plumbing through worker (6556fea)
- `RouteOverrides` frozen dataclass on `aelfrice.derivation` carrying `(belief_type, origin, alpha, beta, audit_source?)`. Frozen at ingest time per the rebuild policy.
- `DerivationInput.route_overrides` plumbed through; `derive()` skips classify_sentence when set, mints the deterministic id, assembles the Belief shell from the router's fields.
- Worker reads `raw_meta["route_overrides"]` via `_route_overrides_from_raw_meta` (strict typing, malformed blocks fall through to the deterministic path).
- Worker emits one `feedback_history` row when `audit_source` is set AND the belief was newly inserted.

### 3. Scanner migration (e342093)
- Collapses `scanner.py:262-310`'s two-branch loop into the unified `record_ingest` + `run_worker` shape the regex path already uses. The LLM-vs-regex distinction now lives only in `raw_meta["route_overrides"]`.
- Removes scanner-side direct writers: no `insert_or_corroborate`, no `insert_belief`, no `insert_feedback_event` reachable from `scanner.py`.
- `replay_full_equality` reconstructs `route_overrides` from `raw_meta` so canonical-vs-rederived comparison holds (frozen-at-ingest semantic).

### 4. Bulk wrapper cleanup (f430647)
- `MemoryStore.insert_beliefs` and `insert_edges` were defined but unused. Deleted. Removes one of the four "mechanical migration" sites named in PR-A's body.

### 5. The gate (072d1ff)
- `MemoryStore.insert_belief` walks the call stack when `AELFRICE_WRITE_LOG_AUTHORITATIVE` is on; raises `WriteLogAuthorityViolation` for callers outside `INSERT_BELIEF_ALLOWLIST`.
- `INSERT_BELIEF_ALLOWLIST = {derivation_worker, wonder.simulator, benchmark, migrate}` — exactly the ratified set from this PR's comment 4404692789.
- Stack-walk skips `aelfrice.store` frames so `insert_or_corroborate`'s internal `insert_belief` call is checked against the *outer* caller (the worker), not against `store` itself.

## Verification

- pytest **2765 passed**, 39 skipped (gate-off, production default)
- pytest **2765 passed** with `AELFRICE_WRITE_LOG_AUTHORITATIVE=1` flipped on the three real allowlisted modules:
  - `aelfrice.benchmark.seed_corpus` — bench corpus seeder
  - `aelfrice.wonder.simulator.populate_store` — synthetic corpus
  - `aelfrice.migrate.migrate` — v1→v2 store migration
- `replay_full_equality` clean after a `route_overrides` scan, idempotent on re-scan
- Discretion grep on full branch diff: clean

## Decisions ratified on this PR

Per [comment 4404692789](https://github.com/robotrocketscience/aelfrice/pull/478#issuecomment-4404692789):

1. **Gate mechanism** — stack-check on `insert_belief()` + module allowlist `{derivation_worker, simulator, benchmark, migrate}`.
2. **`route_overrides` schema** — sub-dict under `raw_meta.route_overrides` carrying `{belief_type, origin, alpha, beta, audit_source?}`.
3. **`aelf rebuild` semantic** — frozen-at-ingest-time, replay verbatim. Implemented in `replay_full_equality` and the worker.
4. **Audit-source contract** — worker emits the `feedback_events` row on insert; scanner drops `scanner.py:304-310`.

## Out of scope (deferred)

- `aelf rebuild` CLI surface — PR-C concern.
- Default-on flip of `AELFRICE_WRITE_LOG_AUTHORITATIVE` — separate PR after operator validation.

Closes #265's PR-B slice.

## Summary by Sourcery

Migrate the scanner’s LLM-classify path to use the ingest_log + derivation worker pipeline and introduce a guarded, allowlisted insert_belief path as part of the v2.x view-flip preparation.

New Features:
- Add RouteOverrides metadata flow from scanner raw_meta through DerivationInput into derive(), allowing the worker to apply LLM router decisions when materializing beliefs.
- Introduce an environment-gated insert_belief authority check with a module allowlist to enforce that beliefs are written via the ingest log and worker.
- Add a design memo documenting the scanner call-site migration and route_overrides semantics for the v2.x view-flip.

Enhancements:
- Unify scanner regex and LLM-classify ingestion through a common record_ingest + run_worker shape, removing scanner-side direct writes to beliefs and feedback events.
- Teach the derivation worker and replay logic to reconstruct and honor route_overrides from raw_meta, ensuring replay_full_equality holds and LLM decisions are frozen at ingest time.
- Remove unused bulk store helpers for inserting beliefs and edges to simplify the store API surface.

Tests:
- Add comprehensive tests for route_overrides plumbing through the worker and derive(), including audit emission behavior and replay equality invariants.
- Add integration tests for the scanner LLM path to verify ingest_log usage, worker behavior, idempotency, and absence of direct belief writes from scanner.
- Add tests for the insert_belief gate to validate default-off behavior, allowlisted modules, violation messaging, and compatibility with benchmark, simulator, and migrate flows.