### PR TITLE
fix(retrieval): temporal_sort kwarg + half-life decay (#473)

### DIFF
--- a/benchmarks/structmemeval_adapter.py
+++ b/benchmarks/structmemeval_adapter.py
@@ -258,8 +258,10 @@ def ingest_case(store: MemoryStore, case: Case) -> int:
 def query_aelfrice(store: MemoryStore, question: str, budget: int = 2000) -> str:
     """Query aelfrice and return retrieved belief content.
 
-    Uses temporal_sort=True so beliefs are presented newest-first,
-    which helps the reader identify the current state vs historical states.
+    Uses temporal_sort=True (#473): post-rerank multiplicative half-life
+    decay on `created_at`, so recent beliefs are surfaced over older
+    historical states without a hard `created_at DESC` sort. Locked
+    (L0) beliefs stay pinned at the head and are not re-ordered.
     """
     result = retrieve(
         store=store,

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -53,6 +53,7 @@ import os
 import re
 from collections import OrderedDict
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO, Any, Final
 import sys
@@ -159,6 +160,17 @@ ENV_HRR_STRUCTURAL: Final[str] = "AELFRICE_HRR_STRUCTURAL"
 # layer (kwarg → TOML → DEFAULT_POSTERIOR_WEIGHT) and trace to
 # stderr. Same shape as `_read_toml_flag_for` tolerance.
 ENV_POSTERIOR_WEIGHT: Final[str] = "AELFRICE_POSTERIOR_WEIGHT"
+# v2.1 #473 temporal-decay half-life env override. Float seconds.
+# Empty / non-numeric values fall through (kwarg → TOML → default).
+ENV_TEMPORAL_HALF_LIFE: Final[str] = "AELFRICE_TEMPORAL_HALF_LIFE_SECONDS"
+# `[retrieval] temporal_half_life_seconds` TOML key (#473).
+TEMPORAL_HALF_LIFE_FLAG: Final[str] = "temporal_half_life_seconds"
+# v2.1 #473 default half-life: 7 days. Ratified A1=A by the operator
+# (issue #473 comment IC_kwDOSM7PXc8AAAABBokOsA). Conservative default
+# tunable via `[retrieval] temporal_half_life_seconds` in
+# `.aelfrice.toml`. A bench-evidence sweep harness is queued as a
+# follow-up issue (A3=A).
+DEFAULT_TEMPORAL_HALF_LIFE_SECONDS: Final[float] = 7.0 * 24.0 * 3600.0
 # Number of decimal places used to round `posterior_weight` before
 # inclusion in the cache key. Two callers passing weights that
 # differ by less than this granularity collapse to the same key.
@@ -469,6 +481,137 @@ def resolve_posterior_weight(
     if weight < 0.0:
         return 0.0
     return weight
+
+
+def _env_temporal_half_life() -> float | None:
+    """Return AELFRICE_TEMPORAL_HALF_LIFE_SECONDS as a positive float,
+    or None when unset / non-numeric / non-positive.
+
+    Non-numeric and non-positive values trace to stderr and fall through
+    (same fail-soft contract as `_env_posterior_weight`). A half-life of
+    zero or negative is structurally meaningless for an exponential
+    decay, so we reject rather than clamp.
+    """
+    raw = os.environ.get(ENV_TEMPORAL_HALF_LIFE)
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    try:
+        value = float(stripped)
+    except ValueError:
+        print(
+            f"aelfrice retrieval: ignoring {ENV_TEMPORAL_HALF_LIFE}={raw!r} "
+            f"(expected float)",
+            file=sys.stderr,
+        )
+        return None
+    if value <= 0.0:
+        print(
+            f"aelfrice retrieval: ignoring {ENV_TEMPORAL_HALF_LIFE}={raw!r} "
+            f"(must be > 0)",
+            file=sys.stderr,
+        )
+        return None
+    return value
+
+
+def resolve_temporal_half_life(
+    explicit: float | None = None,
+    *,
+    start: Path | None = None,
+) -> float:
+    """Resolve the temporal-decay half-life (seconds) per v2.1 #473:
+
+      1. AELFRICE_TEMPORAL_HALF_LIFE_SECONDS env var (positive float).
+      2. Explicit `explicit` kwarg from the caller.
+      3. `[retrieval] temporal_half_life_seconds` in `.aelfrice.toml`.
+      4. Default: DEFAULT_TEMPORAL_HALF_LIFE_SECONDS (7 days).
+
+    Non-positive values at any layer fall through to the next layer.
+    The decay is `2 ** (-age_seconds / half_life)` so half_life=0 is
+    undefined; treat it as missing.
+    """
+    env = _env_temporal_half_life()
+    if env is not None:
+        return env
+    if explicit is not None and explicit > 0.0:
+        return float(explicit)
+    toml_value = _read_toml_float_for(TEMPORAL_HALF_LIFE_FLAG, start)
+    if toml_value is not None and toml_value > 0.0:
+        return float(toml_value)
+    return DEFAULT_TEMPORAL_HALF_LIFE_SECONDS
+
+
+def _belief_age_seconds(b: Belief, now: datetime) -> float:
+    """Seconds between `now` and `b.created_at` (clamped at 0).
+
+    `created_at` is an ISO-8601 string (`datetime.now(timezone.utc)
+    .isoformat()` per `store.insert_belief`). Malformed timestamps fall
+    through as age=0 — no decay penalty rather than a hard crash. This
+    matches the rest of `retrieval.py`'s fail-soft posture on user data.
+    """
+    raw = b.created_at
+    if not raw:
+        return 0.0
+    try:
+        ts = datetime.fromisoformat(raw)
+    except ValueError:
+        return 0.0
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    delta = (now - ts).total_seconds()
+    return delta if delta > 0.0 else 0.0
+
+
+def _apply_temporal_decay(
+    beliefs: list[Belief],
+    half_life_seconds: float,
+    *,
+    now: datetime | None = None,
+) -> list[Belief]:
+    """Re-rank `beliefs` by an exponential recency decay.
+
+    Locked beliefs (lock_level != LOCK_NONE) are pinned at the head of
+    the output in their original relative order — L0 is user-asserted
+    ground truth and is never re-ordered by recency.
+
+    The remaining beliefs are scored by `(1 / (rank + 1)) * 2 ** (-age
+    / half_life)`, where `rank` is the belief's pre-decay position in
+    `beliefs` and `age` is the seconds since `created_at`. Sort is
+    stable on the proxy score: ties keep the upstream pipeline's order.
+
+    The proxy `1 / (rank + 1)` is a borderline design call (issue #473
+    closing comment): `retrieve_v2` does not surface per-belief scores
+    out of `retrieve_with_tiers`, so the wrapper has only the merged
+    order to work from. Treating rank-position as the proxy score keeps
+    the decay multiplicative on a meaningful baseline (1.0 at the head,
+    diminishing) while leaving the upstream pipeline as the score
+    authority.
+    """
+    if not beliefs or half_life_seconds <= 0.0:
+        return list(beliefs)
+    when = now if now is not None else datetime.now(timezone.utc)
+    locked: list[Belief] = []
+    rest: list[tuple[int, Belief]] = []
+    for i, b in enumerate(beliefs):
+        if b.lock_level != LOCK_NONE:
+            locked.append(b)
+        else:
+            rest.append((i, b))
+    if not rest:
+        return list(beliefs)
+
+    def keyfn(item: tuple[int, Belief]) -> float:
+        i, b = item
+        rank_score = 1.0 / float(i + 1)
+        age = _belief_age_seconds(b, when)
+        decay = 2.0 ** (-age / half_life_seconds)
+        return rank_score * decay
+
+    rest_sorted = sorted(rest, key=keyfn, reverse=True)
+    return locked + [b for _, b in rest_sorted]
 
 
 def is_entity_index_enabled(
@@ -1259,6 +1402,8 @@ def retrieve_v2(
     posterior_weight: float | None = None,
     use_bm25f: bool | None = None,
     bm25f_cache: BM25IndexCache | None = None,
+    temporal_sort: bool = False,
+    temporal_half_life_seconds: float | None = None,
 ) -> RetrievalResult:
     """Lab-compatible retrieval wrapper for academic-suite adapters.
 
@@ -1282,6 +1427,21 @@ def retrieve_v2(
     - `bfs_max_depth`, `bfs_nodes_per_hop`, `bfs_total_budget_nodes`,
       `bfs_min_path_score` — pass-through tuning knobs for the L3
       tier. Defaults match `bfs_multihop.DEFAULT_*`.
+    - `temporal_sort` (v2.1 #473) — when True, applies a multiplicative
+      half-life decay to the merged output as a final re-rank pass
+      (post-BM25F + posterior + edge-type rerank). Default False keeps
+      the v1.3-v1.7 ordering byte-identical for adapters that don't opt
+      in. Locked (L0) beliefs are pinned at the head and never re-
+      ordered. The decay is `2 ** (-age / half_life)` against
+      `created_at`. Half-life resolution: explicit kwarg →
+      `AELFRICE_TEMPORAL_HALF_LIFE_SECONDS` env →
+      `[retrieval] temporal_half_life_seconds` in `.aelfrice.toml` →
+      `DEFAULT_TEMPORAL_HALF_LIFE_SECONDS` (7 days, ratified per
+      issue #473 A1=A).
+    - `temporal_half_life_seconds` (v2.1 #473) — explicit override for
+      the half-life when `temporal_sort=True`. None falls through to
+      `resolve_temporal_half_life()`'s precedence chain. Ignored when
+      `temporal_sort=False`.
     - Returns a `RetrievalResult` wrapper so adapters can read
       `result.beliefs` (and stub diagnostics fields, plus the new
       v1.3 `entity_hits` and `bfs_chains`).
@@ -1310,6 +1470,9 @@ def retrieve_v2(
         beliefs = out
     else:
         beliefs = [b for b in out if b.lock_level == LOCK_NONE]
+    if temporal_sort:
+        half_life = resolve_temporal_half_life(temporal_half_life_seconds)
+        beliefs = _apply_temporal_decay(beliefs, half_life)
     return RetrievalResult(
         beliefs=beliefs,
         entity_hits=l25_ids_list,

--- a/tests/test_retrieve_v2_temporal_sort.py
+++ b/tests/test_retrieve_v2_temporal_sort.py
@@ -1,0 +1,284 @@
+"""Tests for retrieve_v2 temporal_sort kwarg + half-life resolver (#473)."""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.retrieval import (
+    DEFAULT_TEMPORAL_HALF_LIFE_SECONDS,
+    ENV_TEMPORAL_HALF_LIFE,
+    _apply_temporal_decay,
+    _belief_age_seconds,
+    resolve_temporal_half_life,
+    retrieve_v2,
+)
+from aelfrice.store import MemoryStore
+
+
+# A fixed reference epoch used by all temporal-decay assertions, so
+# absolute "now" drift between test invocations cannot perturb results.
+NOW = datetime(2026, 5, 8, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _belief(
+    *,
+    idx: int,
+    content: str,
+    age_seconds: float,
+    locked: bool = False,
+) -> Belief:
+    created = NOW - timedelta(seconds=age_seconds)
+    return Belief(
+        id=f"b{idx}",
+        content=content,
+        content_hash=f"h{idx}",
+        alpha=2.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_USER if locked else LOCK_NONE,
+        locked_at=created.isoformat() if locked else None,
+        demotion_pressure=0,
+        created_at=created.isoformat(),
+        last_retrieved_at=None,
+    )
+
+
+# --- _belief_age_seconds boundaries ---------------------------------------
+
+
+def test_belief_age_zero_when_created_at_now() -> None:
+    b = _belief(idx=1, content="x", age_seconds=0.0)
+    assert _belief_age_seconds(b, NOW) == pytest.approx(0.0)
+
+
+def test_belief_age_clamped_at_zero_for_future_timestamps() -> None:
+    b = _belief(idx=1, content="x", age_seconds=-3600.0)
+    assert _belief_age_seconds(b, NOW) == 0.0
+
+
+def test_belief_age_returns_zero_for_malformed_timestamp() -> None:
+    b = _belief(idx=1, content="x", age_seconds=0.0)
+    b.created_at = "not-an-iso-timestamp"
+    assert _belief_age_seconds(b, NOW) == 0.0
+
+
+def test_belief_age_returns_zero_for_empty_timestamp() -> None:
+    b = _belief(idx=1, content="x", age_seconds=0.0)
+    b.created_at = ""
+    assert _belief_age_seconds(b, NOW) == 0.0
+
+
+def test_belief_age_treats_naive_timestamp_as_utc() -> None:
+    b = _belief(idx=1, content="x", age_seconds=0.0)
+    b.created_at = (NOW - timedelta(seconds=120)).replace(tzinfo=None).isoformat()
+    assert _belief_age_seconds(b, NOW) == pytest.approx(120.0)
+
+
+# --- _apply_temporal_decay shape + invariants -----------------------------
+
+
+def test_decay_empty_input_returns_empty() -> None:
+    assert _apply_temporal_decay([], 604800.0, now=NOW) == []
+
+
+def test_decay_zero_half_life_returns_input_unchanged() -> None:
+    bs = [_belief(idx=i, content=str(i), age_seconds=i * 3600.0) for i in range(3)]
+    assert _apply_temporal_decay(bs, 0.0, now=NOW) == bs
+    assert _apply_temporal_decay(bs, -1.0, now=NOW) == bs
+
+
+def test_decay_pins_locked_at_head() -> None:
+    locked = _belief(
+        idx=0, content="locked-old", age_seconds=10 * 24 * 3600.0, locked=True
+    )
+    fresh = _belief(idx=1, content="fresh", age_seconds=60.0)
+    older = _belief(idx=2, content="older", age_seconds=3 * 24 * 3600.0)
+    out = _apply_temporal_decay([locked, fresh, older], 86400.0, now=NOW)
+    assert out[0].id == "b0"
+
+
+def test_decay_recent_outranks_older_at_same_position() -> None:
+    """When two unlocked beliefs sit at the same upstream rank-proxy
+    (different positions), recency still moves the recent ahead if the
+    decay penalty on the older one is large enough.
+
+    Position 0 (rank_score 1.0) old vs position 1 (rank_score 0.5) recent:
+    at half_life 1d and ages 10d / 0d, scores are 1.0 * 2^-10 ≈ 0.001 and
+    0.5 * 1.0 = 0.5. Recent must win.
+    """
+    very_old = _belief(idx=0, content="old", age_seconds=10 * 86400.0)
+    fresh = _belief(idx=1, content="fresh", age_seconds=0.0)
+    out = _apply_temporal_decay([very_old, fresh], 86400.0, now=NOW)
+    assert [b.id for b in out] == ["b1", "b0"]
+
+
+def test_decay_preserves_order_when_all_same_age() -> None:
+    """Equal ages → same decay multiplier → rank-proxy alone decides.
+    Original head-of-list belief stays at head.
+    """
+    bs = [
+        _belief(idx=0, content="a", age_seconds=3600.0),
+        _belief(idx=1, content="b", age_seconds=3600.0),
+        _belief(idx=2, content="c", age_seconds=3600.0),
+    ]
+    out = _apply_temporal_decay(bs, 86400.0, now=NOW)
+    assert [b.id for b in out] == ["b0", "b1", "b2"]
+
+
+def test_decay_does_not_reorder_locked_among_themselves() -> None:
+    a = _belief(idx=0, content="a", age_seconds=10 * 86400.0, locked=True)
+    b = _belief(idx=1, content="b", age_seconds=86400.0, locked=True)
+    c = _belief(idx=2, content="c", age_seconds=0.0)
+    out = _apply_temporal_decay([a, b, c], 86400.0, now=NOW)
+    assert [x.id for x in out[:2]] == ["b0", "b1"]
+
+
+# --- Decay math at half-life boundaries -----------------------------------
+
+
+def test_decay_factor_at_half_life_is_one_half() -> None:
+    """At age == half_life, decay multiplier should be exactly 0.5.
+
+    We isolate the math by placing the recent belief at upstream rank 1
+    (proxy 0.5) and the at-half-life belief at upstream rank 0 (proxy
+    1.0). After decay: 1.0 * 0.5 = 0.5 vs 0.5 * 1.0 = 0.5 — tie. Stable
+    sort keeps the head-of-list belief first.
+    """
+    half_life = 86400.0
+    at_half = _belief(idx=0, content="half-old", age_seconds=half_life)
+    fresh = _belief(idx=1, content="fresh", age_seconds=0.0)
+    out = _apply_temporal_decay([at_half, fresh], half_life, now=NOW)
+    assert [b.id for b in out] == ["b0", "b1"]
+
+
+def test_decay_factor_at_two_half_lives_is_one_quarter() -> None:
+    """At age == 2 * half_life, decay multiplier is 0.25. Position-0
+    score = 0.25 vs position-1 score = 0.5 * 1.0 = 0.5 → fresh wins.
+    """
+    half_life = 86400.0
+    at_two = _belief(idx=0, content="two-old", age_seconds=2.0 * half_life)
+    fresh = _belief(idx=1, content="fresh", age_seconds=0.0)
+    out = _apply_temporal_decay([at_two, fresh], half_life, now=NOW)
+    assert [b.id for b in out] == ["b1", "b0"]
+
+
+# --- resolve_temporal_half_life precedence --------------------------------
+
+
+def test_resolve_default_when_nothing_set(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv(ENV_TEMPORAL_HALF_LIFE, raising=False)
+    assert resolve_temporal_half_life(start=tmp_path) == DEFAULT_TEMPORAL_HALF_LIFE_SECONDS
+
+
+def test_resolve_env_overrides_explicit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(ENV_TEMPORAL_HALF_LIFE, "3600")
+    assert resolve_temporal_half_life(86400.0, start=tmp_path) == 3600.0
+
+
+def test_resolve_explicit_overrides_toml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv(ENV_TEMPORAL_HALF_LIFE, raising=False)
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[retrieval]\ntemporal_half_life_seconds = 3600\n"
+    )
+    assert resolve_temporal_half_life(7200.0, start=tmp_path) == 7200.0
+
+
+def test_resolve_toml_overrides_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv(ENV_TEMPORAL_HALF_LIFE, raising=False)
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[retrieval]\ntemporal_half_life_seconds = 12345\n"
+    )
+    assert resolve_temporal_half_life(start=tmp_path) == 12345.0
+
+
+def test_resolve_rejects_non_positive_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(ENV_TEMPORAL_HALF_LIFE, "0")
+    assert resolve_temporal_half_life(start=tmp_path) == DEFAULT_TEMPORAL_HALF_LIFE_SECONDS
+
+
+def test_resolve_rejects_non_numeric_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(ENV_TEMPORAL_HALF_LIFE, "not-a-number")
+    assert resolve_temporal_half_life(start=tmp_path) == DEFAULT_TEMPORAL_HALF_LIFE_SECONDS
+
+
+def test_resolve_falls_through_non_positive_kwarg(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv(ENV_TEMPORAL_HALF_LIFE, raising=False)
+    assert (
+        resolve_temporal_half_life(0.0, start=tmp_path)
+        == DEFAULT_TEMPORAL_HALF_LIFE_SECONDS
+    )
+    assert (
+        resolve_temporal_half_life(-1.0, start=tmp_path)
+        == DEFAULT_TEMPORAL_HALF_LIFE_SECONDS
+    )
+
+
+# --- retrieve_v2 integration ----------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Iterator[MemoryStore]:
+    s = MemoryStore(str(tmp_path / "rv2_temporal.db"))
+    yield s
+    s.close()
+
+
+def _insert(store: MemoryStore, idx: int, content: str, age_days: float, locked: bool = False) -> None:
+    store.insert_belief(
+        _belief(idx=idx, content=content, age_seconds=age_days * 86400.0, locked=locked)
+    )
+
+
+def test_retrieve_v2_temporal_sort_off_is_byte_identical(
+    monkeypatch: pytest.MonkeyPatch, store: MemoryStore
+) -> None:
+    """temporal_sort=False (the default) leaves the merged order
+    untouched relative to a call that omits the kwarg entirely."""
+    monkeypatch.delenv(ENV_TEMPORAL_HALF_LIFE, raising=False)
+    _insert(store, 1, "alpha factual statement", age_days=10)
+    _insert(store, 2, "alpha factual paragraph", age_days=1)
+    _insert(store, 3, "alpha factual content", age_days=0)
+    a = retrieve_v2(store, "alpha", budget=10_000)
+    b = retrieve_v2(store, "alpha", budget=10_000, temporal_sort=False)
+    assert [x.id for x in a.beliefs] == [x.id for x in b.beliefs]
+
+
+def test_retrieve_v2_temporal_sort_pins_locked_at_head(
+    monkeypatch: pytest.MonkeyPatch, store: MemoryStore
+) -> None:
+    monkeypatch.delenv(ENV_TEMPORAL_HALF_LIFE, raising=False)
+    _insert(store, 1, "alpha factual statement old locked", age_days=30, locked=True)
+    _insert(store, 2, "alpha factual paragraph fresh", age_days=0)
+    result = retrieve_v2(
+        store,
+        "alpha",
+        budget=10_000,
+        include_locked=True,
+        temporal_sort=True,
+        temporal_half_life_seconds=86400.0,
+    )
+    assert result.beliefs[0].lock_level == LOCK_USER
+
+
+def test_retrieve_v2_temporal_sort_explicit_half_life_kwarg(
+    monkeypatch: pytest.MonkeyPatch, store: MemoryStore
+) -> None:
+    """Explicit kwarg flows through to the decay calculation. With a
+    very short half-life, even a moderately old belief gets crushed
+    relative to a fresh one regardless of upstream rank order."""
+    monkeypatch.delenv(ENV_TEMPORAL_HALF_LIFE, raising=False)
+    _insert(store, 1, "alpha factual statement old", age_days=10)
+    _insert(store, 2, "alpha factual statement new", age_days=0)
+    result = retrieve_v2(
+        store,
+        "alpha factual statement",
+        budget=10_000,
+        temporal_sort=True,
+        temporal_half_life_seconds=3600.0,
+    )
+    ids = [b.id for b in result.beliefs]
+    assert ids.index("b2") < ids.index("b1")


### PR DESCRIPTION
Closes #473.

## What changed

`retrieve_v2()` now accepts:

- `temporal_sort: bool = False`
- `temporal_half_life_seconds: float | None = None`

When `temporal_sort=True`, the merged tier output is re-ranked by a multiplicative half-life decay `2 ** (-age_seconds / half_life)` against `created_at`, applied as a final factor on top of the upstream pipeline's rank order. Locked (L0) beliefs are pinned at the head and never re-ordered.

Half-life resolution mirrors `resolve_posterior_weight`:

1. `AELFRICE_TEMPORAL_HALF_LIFE_SECONDS` env var (positive float)
2. Explicit `temporal_half_life_seconds` kwarg
3. `[retrieval] temporal_half_life_seconds` in `.aelfrice.toml`
4. Default: `DEFAULT_TEMPORAL_HALF_LIFE_SECONDS` (7 days, per #473 A1=A)

Default `temporal_sort=False` means the retrieve_v2 ordering is byte-identical to v1.7.0 for callers that don't opt in — verified by `test_retrieve_v2_temporal_sort_off_is_byte_identical`.

## Why

`benchmarks/structmemeval_adapter.py:264-272` was already calling `retrieve_v2(..., temporal_sort=True)` since #54, but `retrieve_v2`'s signature ended at `bm25f_cache`. The mismatch was masked while `/tmp/StructMemEval` was empty (silent "no cases" return), and surfaced as `TypeError: retrieve_v2() got an unexpected keyword argument 'temporal_sort'` once the data dir was populated. This blocked 4/11 canonical invocations in the #437 calibration pass.

Per the issue ratification (`[gate:ratify]` comment, A1=A / A2=A / A3=A): land the kwarg with conservative 7-day default, post-rerank application point, and ship as-is — sweep harness deferred to a follow-up.

## Tests

`tests/test_retrieve_v2_temporal_sort.py` (23 cases):

- `_belief_age_seconds` boundaries: zero, future timestamp, malformed, empty, naive UTC.
- `_apply_temporal_decay` invariants: empty input, zero/negative half-life, locked pinning, locked-internal order preserved, equal-age stability.
- Decay-math boundaries at `age = half_life` (factor 0.5) and `age = 2 * half_life` (factor 0.25).
- Resolver precedence: env > kwarg > TOML > default; non-positive / non-numeric env falls through; non-positive kwarg falls through.
- `retrieve_v2` integration: off-byte-identical, locked head pin, explicit half-life kwarg flow.

Full pytest suite: 2746 passed, 41 skipped — no regressions on existing retrieval tests.

## Borderline design call

`retrieve_v2` does not surface per-belief scores out of `retrieve_with_tiers`, so the wrapper has only the merged order to work from. I'm using `1 / (rank + 1)` as a proxy "score" that the decay multiplies against. This matches the issue's closing-comment lean toward "multiplies the final score," but flagging it explicitly because:

- A reviewer might prefer threading score back through `retrieve_with_tiers` so the decay multiplies a real composite. That's a larger contract change (touches `retrieve()` + `retrieve_with_tiers` return tuple).
- Alternative: drop the rank-proxy and use a constant 1.0, so decay alone re-orders the tail. Simpler math, but then a fresh L1 hit can outrank a fresh L2.5 entity hit on age delta alone, which feels wrong relative to the upstream pipeline's lane-priority intent.

Currently shipping with the rank-proxy. Push back here if a different shape is wanted.

## Out of scope

- `tests/temporal_blend_sweep.py` bench-evidence harness (A3=A — follow-up issue).
- Adaptive-meta-belief exploration (#480 — separate thread).
- `[retrieval] temporal_half_life_seconds` documentation in `.aelfrice.toml.example` if one exists (didn't find one in tree; can add if pointed at the right file).

## Refs

- Issue: #473
- Calibration blocker: #437
- Adapter call site: `benchmarks/structmemeval_adapter.py:264-272`
- Public surface: `src/aelfrice/retrieval.py::retrieve_v2`

## Summary by Sourcery

Add optional temporal recency re-ranking to retrieve_v2 while keeping default retrieval order unchanged for existing callers.

New Features:
- Introduce temporal_sort and temporal_half_life_seconds options to retrieve_v2 to enable half-life based recency decay on merged retrieval results.
- Expose configuration of temporal half-life via environment variable, TOML config, or explicit kwarg with a 7-day default.

Enhancements:
- Implement temporal half-life resolution helper and recency-based decay scoring that respects locked beliefs and preserves upstream ordering stability.

Tests:
- Add comprehensive tests covering belief age calculation, temporal decay behavior, configuration precedence, and retrieve_v2 integration with temporal_sort enabled and disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added temporal decay-based re-ranking to retrieval results, prioritizing more recent content while maintaining locked items at the top.

* **Documentation**
  * Updated documentation describing temporal sorting behavior with locked item preservation.

* **Tests**
  * Added comprehensive test suite validating temporal re-ranking functionality and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->