### PR TITLE
feat(gate-list): aggregator CLI `aelf gate list` for gate:* issues

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -1492,6 +1492,38 @@ _BENCH_INERT_TARGETS: Final[dict[str, str]] = {
 }
 
 
+def _cmd_gate(args: argparse.Namespace, out: object) -> int:
+    """Aggregate open `gate:*` issues into a single screenful (#475).
+
+    `aelf gate list` (default verb) prints sections for `gate:ratify`,
+    `gate:prereq`, `gate:bench` (label `bench-gated`), `gate:license` —
+    one line per issue with ask-count + age for ratify, plain `#N title`
+    for the rest. `--json` emits the same structure as machine-readable
+    JSON for scripting.
+
+    Repo is auto-detected from cwd's git remote, the same model the rest
+    of the gh-driven tooling uses (aelf-claim.sh, aelf-scan.sh).
+    """
+    from aelfrice import gate_list as _gl
+    verb = (getattr(args, "gate_verb", None) or "list").lower()
+    if verb != "list":
+        print(
+            f"aelf gate: unknown verb {verb!r}. Known: list.",
+            file=out,  # type: ignore[arg-type]
+        )
+        return 2
+    try:
+        report = _gl.collect()
+    except _gl.GhError as e:
+        print(f"aelf gate list: {e}", file=out)  # type: ignore[arg-type]
+        return 1
+    if getattr(args, "gate_json", False):
+        print(_gl.format_json(report), end="", file=out)  # type: ignore[arg-type]
+    else:
+        print(_gl.format_text(report), end="", file=out)  # type: ignore[arg-type]
+    return 0
+
+
 def _cmd_bench(args: argparse.Namespace, out: object) -> int:
     """Run a benchmark target.
 
@@ -4417,6 +4449,17 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
 
     # Hidden: CI regression target. Humans run via `python -m aelfrice.benchmark`
     # if needed.
+    p_gate = sub.add_parser("gate", help=argparse.SUPPRESS)
+    p_gate.add_argument(
+        "gate_verb", nargs="?", default="list",
+        help="verb: list (default). Future: ratify (read/write API).",
+    )
+    p_gate.add_argument(
+        "--json", dest="gate_json", action="store_true",
+        help="emit machine-readable JSON instead of plain text",
+    )
+    p_gate.set_defaults(func=_cmd_gate)
+
     p_bench = sub.add_parser("bench", help=argparse.SUPPRESS)
     p_bench.add_argument(
         "target", nargs="?", default=None,

--- a/src/aelfrice/gate_list.py
+++ b/src/aelfrice/gate_list.py
@@ -1,0 +1,228 @@
+"""Operator-side gate aggregator surface for `aelf gate list` (#475).
+
+Reads open issues with `gate:*` labels via `gh`, counts asks-block lines
+in the most recent `[gate:ratify]` comment per ratify issue, and emits a
+single screenful so the operator can speed-read pending decisions.
+
+The four sections, in print order:
+- gate:ratify   — open design decisions; operator picks an option
+- gate:prereq   — waiting on sister issues to land
+- gate:bench    — waiting on bench evidence (label is `bench-gated`)
+- gate:license  — waiting on legal/license review
+
+Sort: oldest-open-ask-first for ratify (proxy: oldest `[gate:ratify]`
+comment); oldest-issue-first (lowest issue number) for the rest.
+
+Repo is auto-detected from cwd's git remote — the same model as
+`aelf-claim.sh` and the rest of the repo's gh-driven tooling.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+# Each tuple: (label as filtered on gh, header label as printed).
+# `bench-gated` is the existing label; the printed header `gate:bench`
+# matches the four-shape vocabulary in #475's body.
+SECTIONS: tuple[tuple[str, str], ...] = (
+    ("gate:ratify", "gate:ratify"),
+    ("gate:prereq", "gate:prereq"),
+    ("bench-gated", "gate:bench"),
+    ("gate:license", "gate:license"),
+)
+
+_ASKS_RE = re.compile(r"^\*\*Ask (\d+):", re.MULTILINE)
+
+GhRunner = Callable[[Sequence[str]], str]
+
+
+@dataclass
+class GateItem:
+    number: int
+    title: str
+    asks_count: int = 0
+    most_recent_gate_comment_at: datetime | None = None
+
+
+@dataclass
+class GateReport:
+    sections: dict[str, list[GateItem]] = field(default_factory=dict)
+
+
+class GhError(RuntimeError):
+    pass
+
+
+def _default_runner(args: Sequence[str]) -> str:
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except FileNotFoundError as e:
+        raise GhError("gh CLI not found on PATH") from e
+    except subprocess.TimeoutExpired as e:
+        raise GhError(f"gh timed out: {' '.join(args)}") from e
+    if proc.returncode != 0:
+        raise GhError(
+            f"gh exited {proc.returncode}: {proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    return proc.stdout
+
+
+def _parse_iso(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def parse_asks_count(body: str) -> int:
+    """Count `^**Ask N:` headers in a `[gate:ratify]` comment body."""
+    return len(_ASKS_RE.findall(body))
+
+
+def _list_issues(label: str, runner: GhRunner) -> list[dict]:
+    out = runner(
+        [
+            "issue", "list",
+            "--label", label,
+            "--state", "open",
+            "--json", "number,title,createdAt",
+            "--limit", "200",
+        ]
+    )
+    out = out.strip()
+    if not out:
+        return []
+    data = json.loads(out)
+    if not isinstance(data, list):
+        raise GhError(f"unexpected gh issue list payload: {data!r}")
+    return data
+
+
+def _most_recent_gate_comment(num: int, kind: str, runner: GhRunner) -> dict | None:
+    out = runner(["issue", "view", str(num), "--json", "comments"])
+    data = json.loads(out)
+    comments = data.get("comments") or []
+    marker = f"[gate:{kind}]"
+    matches = [c for c in comments if (c.get("body") or "").lstrip().startswith(marker)]
+    if not matches:
+        return None
+    return max(matches, key=lambda c: c["createdAt"])
+
+
+def _gather_ratify(runner: GhRunner) -> list[GateItem]:
+    items: list[GateItem] = []
+    for issue in _list_issues("gate:ratify", runner):
+        comment = _most_recent_gate_comment(issue["number"], "ratify", runner)
+        body = (comment.get("body") if comment else "") or ""
+        items.append(
+            GateItem(
+                number=issue["number"],
+                title=issue["title"],
+                asks_count=parse_asks_count(body),
+                most_recent_gate_comment_at=(
+                    _parse_iso(comment["createdAt"]) if comment else None
+                ),
+            )
+        )
+    # Oldest gate-comment first; comments without one sort last (treat as
+    # "no asks block yet" — the operator should see them after live ones).
+    sentinel = datetime.max.replace(tzinfo=timezone.utc)
+    items.sort(key=lambda x: x.most_recent_gate_comment_at or sentinel)
+    return items
+
+
+def _gather_simple(label: str, runner: GhRunner) -> list[GateItem]:
+    items = [
+        GateItem(number=i["number"], title=i["title"])
+        for i in _list_issues(label, runner)
+    ]
+    items.sort(key=lambda x: x.number)
+    return items
+
+
+def collect(runner: GhRunner | None = None) -> GateReport:
+    r = runner or _default_runner
+    sections: dict[str, list[GateItem]] = {}
+    for label, header in SECTIONS:
+        if header == "gate:ratify":
+            sections[header] = _gather_ratify(r)
+        else:
+            sections[header] = _gather_simple(label, r)
+    return GateReport(sections=sections)
+
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+
+def _humanise_age(now: datetime, ts: datetime | None) -> str:
+    if ts is None:
+        return "no asks-block"
+    delta = now - ts
+    secs = int(delta.total_seconds())
+    if secs < 0:
+        return "just now"
+    if secs < 60:
+        return f"{secs}s"
+    if secs < 3600:
+        return f"{secs // 60}m"
+    if secs < 86400:
+        return f"{secs // 3600}h"
+    return f"{secs // 86400}d"
+
+
+def format_text(report: GateReport, *, now: datetime | None = None) -> str:
+    now = now or datetime.now(timezone.utc)
+    lines: list[str] = []
+    for _, header in SECTIONS:
+        items = report.sections.get(header, [])
+        if header == "gate:ratify":
+            total_asks = sum(i.asks_count for i in items)
+            lines.append(
+                f"{header} ({len(items)} open, {total_asks} total asks):"
+            )
+            if not items:
+                lines.append("  (none)")
+            for it in items:
+                lines.append(
+                    f"  #{it.number}  "
+                    f"{it.asks_count} ask{'s' if it.asks_count != 1 else ''}  "
+                    f"oldest {_humanise_age(now, it.most_recent_gate_comment_at)}        "
+                    f"{it.title}"
+                )
+        else:
+            lines.append(f"{header} ({len(items)} open):")
+            if not items:
+                lines.append("  (none)")
+            for it in items:
+                lines.append(f"  #{it.number}  {it.title}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def format_json(report: GateReport) -> str:
+    payload: dict = {"sections": {}}
+    for _, header in SECTIONS:
+        items = report.sections.get(header, [])
+        payload["sections"][header] = [
+            {
+                "number": i.number,
+                "title": i.title,
+                "asks_count": i.asks_count,
+                "most_recent_gate_comment_at": (
+                    i.most_recent_gate_comment_at.isoformat()
+                    if i.most_recent_gate_comment_at
+                    else None
+                ),
+            }
+            for i in items
+        ]
+    return json.dumps(payload, indent=2) + "\n"

--- a/tests/test_gate_list.py
+++ b/tests/test_gate_list.py
@@ -1,0 +1,357 @@
+"""Unit tests for `aelf gate list` aggregator (#475).
+
+The runner is injected so tests never shell out to gh. Each test passes
+a fake runner that returns canned JSON for `issue list` / `issue view`.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from aelfrice import gate_list as gl
+
+
+def _make_runner(responses: dict[str, str]):
+    """Map keyed-by-args-tuple gh-call → stdout. Unrecognised calls error."""
+    def runner(args):
+        key = tuple(args)
+        if key not in responses:
+            raise AssertionError(f"unexpected gh call: {key}")
+        return responses[key]
+    return runner
+
+
+def _list_call(label: str) -> tuple:
+    return (
+        "issue", "list",
+        "--label", label,
+        "--state", "open",
+        "--json", "number,title,createdAt",
+        "--limit", "200",
+    )
+
+
+def _view_call(num: int) -> tuple:
+    return ("issue", "view", str(num), "--json", "comments")
+
+
+# ---------------------------------------------------------------------------
+# parse_asks_count
+# ---------------------------------------------------------------------------
+
+
+def test_parse_asks_count_typical():
+    body = (
+        "[gate:ratify]\n\nThree asks open.\n\n"
+        "**Ask 1: foo?**\n  A. one.\n\n"
+        "**Ask 2: bar?**\n  A. two.\n\n"
+        "**Ask 3: baz?**\n  A. three.\n"
+    )
+    assert gl.parse_asks_count(body) == 3
+
+
+def test_parse_asks_count_zero_when_empty():
+    assert gl.parse_asks_count("") == 0
+    assert gl.parse_asks_count("[gate:ratify]\nno asks here") == 0
+
+
+def test_parse_asks_count_ignores_inline_mentions():
+    body = "Some prose mentioning Ask 1 inline\n**Ask 1: real header?**\n"
+    assert gl.parse_asks_count(body) == 1
+
+
+def test_parse_asks_count_handles_double_digit():
+    body = "\n".join(f"**Ask {i}: q?**" for i in range(1, 12))
+    assert gl.parse_asks_count(body) == 11
+
+
+# ---------------------------------------------------------------------------
+# collect — section assembly
+# ---------------------------------------------------------------------------
+
+
+def test_collect_empty_sections():
+    runner = _make_runner({
+        _list_call("gate:ratify"): "[]",
+        _list_call("gate:prereq"): "[]",
+        _list_call("bench-gated"): "[]",
+        _list_call("gate:license"): "[]",
+    })
+    report = gl.collect(runner=runner)
+    for header in ("gate:ratify", "gate:prereq", "gate:bench", "gate:license"):
+        assert report.sections[header] == []
+
+
+def test_collect_ratify_counts_asks_and_records_age():
+    issues = [
+        {"number": 473, "title": "StructMemEval temporal_sort",
+         "createdAt": "2026-05-08T07:00:00Z"},
+    ]
+    comments = [
+        {"body": "informational prose; not a gate block",
+         "createdAt": "2026-05-08T07:01:00Z"},
+        {"body": "[gate:ratify]\n\n**Ask 1: a?**\n**Ask 2: b?**\n**Ask 3: c?**",
+         "createdAt": "2026-05-08T07:28:34Z"},
+    ]
+    runner = _make_runner({
+        _list_call("gate:ratify"): json.dumps(issues),
+        _view_call(473): json.dumps({"comments": comments}),
+        _list_call("gate:prereq"): "[]",
+        _list_call("bench-gated"): "[]",
+        _list_call("gate:license"): "[]",
+    })
+    report = gl.collect(runner=runner)
+    rats = report.sections["gate:ratify"]
+    assert len(rats) == 1
+    assert rats[0].number == 473
+    assert rats[0].asks_count == 3
+    assert rats[0].most_recent_gate_comment_at == datetime(
+        2026, 5, 8, 7, 28, 34, tzinfo=timezone.utc
+    )
+
+
+def test_collect_ratify_picks_most_recent_gate_comment():
+    issues = [
+        {"number": 100, "title": "x", "createdAt": "2026-01-01T00:00:00Z"}
+    ]
+    comments = [
+        {"body": "[gate:ratify]\n**Ask 1: stale?**",
+         "createdAt": "2026-01-01T00:00:00Z"},
+        {"body": "[gate:ratify]\n**Ask 1: fresh?**\n**Ask 2: also?**",
+         "createdAt": "2026-05-08T07:30:00Z"},
+        {"body": "[gate:ratify]\n**Ask 1: middle?**",
+         "createdAt": "2026-03-01T00:00:00Z"},
+    ]
+    runner = _make_runner({
+        _list_call("gate:ratify"): json.dumps(issues),
+        _view_call(100): json.dumps({"comments": comments}),
+        _list_call("gate:prereq"): "[]",
+        _list_call("bench-gated"): "[]",
+        _list_call("gate:license"): "[]",
+    })
+    report = gl.collect(runner=runner)
+    item = report.sections["gate:ratify"][0]
+    assert item.asks_count == 2  # asks come from the freshest comment
+    assert item.most_recent_gate_comment_at == datetime(
+        2026, 5, 8, 7, 30, 0, tzinfo=timezone.utc
+    )
+
+
+def test_collect_ratify_handles_no_gate_comment():
+    issues = [
+        {"number": 50, "title": "y", "createdAt": "2026-01-01T00:00:00Z"}
+    ]
+    runner = _make_runner({
+        _list_call("gate:ratify"): json.dumps(issues),
+        _view_call(50): json.dumps({"comments": []}),
+        _list_call("gate:prereq"): "[]",
+        _list_call("bench-gated"): "[]",
+        _list_call("gate:license"): "[]",
+    })
+    report = gl.collect(runner=runner)
+    item = report.sections["gate:ratify"][0]
+    assert item.asks_count == 0
+    assert item.most_recent_gate_comment_at is None
+
+
+def test_collect_ratify_sorted_oldest_first_no_comment_last():
+    issues = [
+        {"number": 10, "title": "no-comment", "createdAt": "2026-01-01T00:00:00Z"},
+        {"number": 20, "title": "fresh", "createdAt": "2026-01-01T00:00:00Z"},
+        {"number": 30, "title": "stale", "createdAt": "2026-01-01T00:00:00Z"},
+    ]
+    runner = _make_runner({
+        _list_call("gate:ratify"): json.dumps(issues),
+        _view_call(10): json.dumps({"comments": []}),
+        _view_call(20): json.dumps({"comments": [
+            {"body": "[gate:ratify]\n**Ask 1: q?**",
+             "createdAt": "2026-05-08T07:30:00Z"},
+        ]}),
+        _view_call(30): json.dumps({"comments": [
+            {"body": "[gate:ratify]\n**Ask 1: q?**",
+             "createdAt": "2026-03-01T00:00:00Z"},
+        ]}),
+        _list_call("gate:prereq"): "[]",
+        _list_call("bench-gated"): "[]",
+        _list_call("gate:license"): "[]",
+    })
+    report = gl.collect(runner=runner)
+    nums = [i.number for i in report.sections["gate:ratify"]]
+    # stale (Mar) before fresh (May), no-comment last
+    assert nums == [30, 20, 10]
+
+
+def test_collect_simple_sections_sorted_by_number():
+    prereqs = [
+        {"number": 365, "title": "close-the-loop", "createdAt": "2026-04-01T00:00:00Z"},
+        {"number": 291, "title": "rebuild redesign", "createdAt": "2026-03-01T00:00:00Z"},
+    ]
+    bench = [
+        {"number": 197, "title": "dedup eval", "createdAt": "2026-02-01T00:00:00Z"},
+    ]
+    runner = _make_runner({
+        _list_call("gate:ratify"): "[]",
+        _list_call("gate:prereq"): json.dumps(prereqs),
+        _list_call("bench-gated"): json.dumps(bench),
+        _list_call("gate:license"): "[]",
+    })
+    report = gl.collect(runner=runner)
+    assert [i.number for i in report.sections["gate:prereq"]] == [291, 365]
+    assert [i.number for i in report.sections["gate:bench"]] == [197]
+
+
+# ---------------------------------------------------------------------------
+# format_text / format_json
+# ---------------------------------------------------------------------------
+
+
+def _fixed_now() -> datetime:
+    return datetime(2026, 5, 8, 11, 28, 34, tzinfo=timezone.utc)
+
+
+def test_format_text_all_sections_present_when_empty():
+    report = gl.GateReport(sections={
+        "gate:ratify": [],
+        "gate:prereq": [],
+        "gate:bench": [],
+        "gate:license": [],
+    })
+    text = gl.format_text(report, now=_fixed_now())
+    assert "gate:ratify (0 open, 0 total asks):" in text
+    assert "gate:prereq (0 open):" in text
+    assert "gate:bench (0 open):" in text
+    assert "gate:license (0 open):" in text
+    # Each empty section prints "(none)" line.
+    assert text.count("(none)") == 4
+
+
+def test_format_text_ratify_line_shape():
+    item = gl.GateItem(
+        number=473,
+        title="StructMemEval temporal_sort",
+        asks_count=3,
+        most_recent_gate_comment_at=datetime(
+            2026, 5, 8, 7, 28, 34, tzinfo=timezone.utc
+        ),
+    )
+    report = gl.GateReport(sections={
+        "gate:ratify": [item],
+        "gate:prereq": [],
+        "gate:bench": [],
+        "gate:license": [],
+    })
+    text = gl.format_text(report, now=_fixed_now())
+    assert "gate:ratify (1 open, 3 total asks):" in text
+    assert "#473" in text
+    assert "3 asks" in text
+    assert "oldest 4h" in text  # 11:28 - 07:28 = 4h
+    assert "StructMemEval temporal_sort" in text
+
+
+def test_format_text_singular_ask_label():
+    item = gl.GateItem(
+        number=999,
+        title="single ask",
+        asks_count=1,
+        most_recent_gate_comment_at=datetime(
+            2026, 5, 8, 11, 28, 34, tzinfo=timezone.utc
+        ),
+    )
+    report = gl.GateReport(sections={
+        "gate:ratify": [item],
+        "gate:prereq": [],
+        "gate:bench": [],
+        "gate:license": [],
+    })
+    text = gl.format_text(report, now=_fixed_now())
+    assert "1 ask " in text  # singular, no trailing 's'
+
+
+def test_format_text_simple_section_line_shape():
+    report = gl.GateReport(sections={
+        "gate:ratify": [],
+        "gate:prereq": [
+            gl.GateItem(number=291, title="rebuild redesign"),
+            gl.GateItem(number=365, title="close-the-loop"),
+        ],
+        "gate:bench": [],
+        "gate:license": [],
+    })
+    text = gl.format_text(report, now=_fixed_now())
+    assert "gate:prereq (2 open):" in text
+    assert "  #291  rebuild redesign" in text
+    assert "  #365  close-the-loop" in text
+
+
+@pytest.mark.parametrize("seconds, expected", [
+    (5, "5s"),
+    (90, "1m"),
+    (3600 * 2, "2h"),
+    (86400 * 3, "3d"),
+])
+def test_humanise_age_buckets(seconds, expected):
+    now = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc)
+    ts = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc).fromtimestamp(
+        now.timestamp() - seconds, tz=timezone.utc
+    )
+    assert gl._humanise_age(now, ts) == expected
+
+
+def test_humanise_age_no_comment_marker():
+    now = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc)
+    assert gl._humanise_age(now, None) == "no asks-block"
+
+
+def test_format_json_round_trips():
+    report = gl.GateReport(sections={
+        "gate:ratify": [
+            gl.GateItem(
+                number=473,
+                title="t",
+                asks_count=3,
+                most_recent_gate_comment_at=datetime(
+                    2026, 5, 8, 7, 28, 34, tzinfo=timezone.utc
+                ),
+            )
+        ],
+        "gate:prereq": [gl.GateItem(number=291, title="p")],
+        "gate:bench": [],
+        "gate:license": [],
+    })
+    payload = json.loads(gl.format_json(report))
+    assert payload["sections"]["gate:ratify"][0]["number"] == 473
+    assert payload["sections"]["gate:ratify"][0]["asks_count"] == 3
+    assert payload["sections"]["gate:ratify"][0]["most_recent_gate_comment_at"] == (
+        "2026-05-08T07:28:34+00:00"
+    )
+    assert payload["sections"]["gate:prereq"][0]["number"] == 291
+    assert payload["sections"]["gate:prereq"][0]["most_recent_gate_comment_at"] is None
+    assert payload["sections"]["gate:bench"] == []
+    assert payload["sections"]["gate:license"] == []
+
+
+# ---------------------------------------------------------------------------
+# Error surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_default_runner_raises_when_gh_missing(monkeypatch):
+    def fake_run(*a, **kw):
+        raise FileNotFoundError("no gh")
+    monkeypatch.setattr("aelfrice.gate_list.subprocess.run", fake_run)
+    with pytest.raises(gl.GhError, match="gh CLI not found"):
+        gl._default_runner(["issue", "list"])
+
+
+def test_default_runner_raises_on_nonzero(monkeypatch):
+    class _R:
+        returncode = 1
+        stdout = ""
+        stderr = "boom"
+    monkeypatch.setattr(
+        "aelfrice.gate_list.subprocess.run", lambda *a, **kw: _R()
+    )
+    with pytest.raises(gl.GhError, match="boom"):
+        gl._default_runner(["issue", "list"])

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -118,6 +118,10 @@ HIDDEN_SUBCOMMANDS = frozenset({
     "health", "stats", "project-warm", "session-delta",
     "demote", "validate", "resolve", "feedback", "ingest-transcript",
     "sweep-feedback",
+    # v2.1 (#475) — operator-side gate aggregator. CLI ships hidden;
+    # slash command shape (`/aelf:gate-list` vs `/aelf:gate`) is a
+    # separate ship.
+    "gate",
     # #427 deprecated alias — kept callable for one minor so existing
     # `aelf upgrade` invocations don't break. The slash file ships
     # only under the canonical `upgrade-cmd` name.


### PR DESCRIPTION
Closes #475.

## What

Hidden CLI subparser `aelf gate list` that aggregates open `gate:*` issues into one screenful so the operator can speed-read pending decisions and batch-respond.

```
$ aelf gate list

gate:ratify (0 open, 0 total asks):
  (none)

gate:prereq (2 open):
  #291  Rebuild redesign: query understanding (entity extraction, intent, term-weighting)
  #365  feat(eval): close-the-loop relevance calibration — spec for #317

gate:bench (6 open):
  #197  Deduplication module (dedup) — v2.0 evaluation
  #433  [v2.0] HRR vocabulary bridge — close vocabulary-gap-recovery claim
  #434  [v2.0] Type-aware compression — tokens-per-belief reduction on retrieved output
  #435  [v2.0] Document / semantic linker — recovery-inventory placeholder
  #436  [v2.0] Intentional clustering — co-locate related beliefs for multi-fact coherence
  #437  [v2.0] Reproducibility harness — `benchmarks/results/v2.0.0.json` is canonical, `uv sync && aelf bench all`

gate:license (1 open):
  #476  [v2.1] PR-smoke fixtures for benchmark adapters — license review required
```

`--json` toggles a structured output for scripting.

## Design notes

- **`bench-gated` → `gate:bench` header.** The label `gate:bench` doesn't exist; the existing label is `bench-gated`. Filtered on `bench-gated`, printed under the four-shape header `gate:bench` per #475's body. If the label gets renamed later, only the `SECTIONS` tuple changes.
- **Sort.** `gate:ratify` sorts by oldest `[gate:ratify]` comment first (proxy for "oldest open ask"); items with no gate-comment sort last with marker `no asks-block`. The other three sort by lowest issue number ascending.
- **Asks-count.** Counts `^**Ask N:` headers in the most recent `[gate:ratify]` comment via `re.compile(r"^\*\*Ask (\d+):", re.MULTILINE)`. Verified against #473's live ratify block — 3 asks parsed.
- **Hidden subparser.** Followed the `bench` precedent; slash-command shape (`/aelf:gate-list` vs `/aelf:gate`) is a separate ship per #475's body ("Slash command `/aelf:gate-list` follows."). The slash file lives outside this PR; can land in a follow-up once the convention solidifies.
- **Repo discovery.** `gh issue list` / `gh issue view` auto-resolve from cwd's git remote, matching `aelf-claim.sh` and the rest of the gh-driven tooling. No `--repo` flag needed for the v1.

## Tests

- 22 unit tests in `tests/test_gate_list.py` covering: asks-counter regex, freshest-comment selection, `(none)` rendering, ratify-sort with no-comment-last, simple-section number-sort, age humanisation buckets, JSON round-trip, and the two `_default_runner` error surfaces (gh missing, gh non-zero).
- Runner is injected (`GhRunner` Callable type), so tests never shell out.
- Added `gate` to `HIDDEN_SUBCOMMANDS` in `tests/test_slash_commands.py` to keep the registry test honest.
- Live smoke: `uv run aelf gate list` and `uv run aelf gate list --json` produce the output above; full suite **2745 passed, 41 skipped**.

## Out of scope

- `aelf gate ratify 473 A1=A` (write-side) — flagged as future verb in `_cmd_gate`'s docstring; would need API write-permission handling.
- `gate:prereq`-comment "Blocked on: #N" line (the example in #475's spec). Convention isn't established yet on any prereq issue, so v1 just lists `#N title`. Trivial to extend the dataclass + parser when the convention lands.

## Summary by Sourcery

Add a hidden `aelf gate` CLI subcommand that aggregates gate-related GitHub issues, with text and JSON output formats, backed by a new gate listing module and unit tests.

New Features:
- Introduce `aelf gate list` hidden CLI subcommand to aggregate open `gate:*` issues into a single report with optional JSON output.

Tests:
- Add comprehensive unit test suite for gate issue aggregation, formatting, and error handling, including fake `gh` runner coverage and CLI registry checks.