### PR TITLE
fix(bench/tolerance): _walk_leaves recurses into bare '_' sentinel

### DIFF
--- a/benchmarks/tolerance.py
+++ b/benchmarks/tolerance.py
@@ -146,12 +146,18 @@ def _walk_leaves(
 
     Skips non-numeric leaves (strings, lists, None) silently — those
     aren't metrics. Skips keys starting with `_` (reserved for
-    metadata like `_status`, `_elapsed_sec`).
+    metadata like `_status`, `_elapsed_sec`) EXCEPT the bare `_`
+    sentinel: `benchmarks/run.py:241` uses `_` as the sub-bucket key
+    for single-invocation adapters (locomo, longmemeval, amabench),
+    so their `output.*` leaves live under
+    `results.<adapter>._.output.*` and must be walked. Recursion
+    re-filters at each level so metadata like `_status` nested
+    inside `_` still gets skipped.
     """
     leaves: list[tuple[tuple[str, ...], float]] = []
     if isinstance(obj, dict):
         for k, v in obj.items():
-            if isinstance(k, str) and k.startswith("_"):
+            if isinstance(k, str) and k.startswith("_") and k != "_":
                 continue
             leaves.extend(_walk_leaves(v, (*path, str(k))))
     elif isinstance(obj, (int, float)) and not isinstance(obj, bool):

--- a/tests/test_bench_tolerance.py
+++ b/tests/test_bench_tolerance.py
@@ -121,6 +121,67 @@ def test_check_report_skips_underscore_prefixed_keys():
     assert checks[0].path == ("mab", "f1")
 
 
+def test_walk_leaves_recurses_into_bare_underscore_sentinel():
+    """`benchmarks/run.py:241` uses `"_"` as the sub-bucket for
+    single-invocation adapters (locomo, longmemeval, amabench).
+    The walker must descend into `_` so `output.*` leaves are
+    visible to the band-checker. Metadata like `_status` nested
+    inside `_` is still skipped by the recursive re-filter.
+    """
+    obj = {
+        "locomo": {
+            "_": {
+                "_status": "ok",
+                "_elapsed_sec": 0.5,
+                "output": {"overall_f1": 0.0212, "avg_latency_ms": 5.55},
+            },
+        },
+    }
+    leaves = dict(tolerance._walk_leaves(obj))
+    assert ("locomo", "_", "output", "overall_f1") in leaves
+    assert leaves[("locomo", "_", "output", "overall_f1")] == pytest.approx(0.0212)
+    assert ("locomo", "_", "output", "avg_latency_ms") in leaves
+    # _status / _elapsed_sec under `_` must still be skipped.
+    assert not any("_status" in p for p, _ in leaves.items())
+    assert not any("_elapsed_sec" in p for p, _ in leaves.items())
+
+
+def test_check_report_band_checks_single_invocation_adapter():
+    """Without the `_` sentinel fix, `_walk_leaves` skipped the
+    bucket and `output.*` leaves were never band-checked. Regression
+    case from #490: locomo / longmemeval / amabench could silently
+    pass on a 100% latency regression.
+    """
+    cano = _canonical({
+        "longmemeval": {"_": {"_status": "ok", "output": {"avg_latency_ms": 5.0}}},
+    })
+    # 100% latency regression — far outside the 25% band for latency
+    obs = _canonical({
+        "longmemeval": {"_": {"_status": "ok", "output": {"avg_latency_ms": 10.0}}},
+    })
+    checks = tolerance.check_report(cano, obs)
+    assert len(checks) == 1
+    assert checks[0].path == ("longmemeval", "_", "output", "avg_latency_ms")
+    assert checks[0].verdict == Verdict.FAIL
+
+
+def test_check_report_passes_inside_band_for_single_invocation_adapter():
+    """Mirror of the FAIL case — confirms band classification works
+    correctly through the `_` sentinel, not just that the path is
+    visible.
+    """
+    cano = _canonical({
+        "amabench": {"_": {"_status": "ok", "output": {"total_qa": 100.0}}},
+    })
+    obs = _canonical({
+        "amabench": {"_": {"_status": "ok", "output": {"total_qa": 100.5}}},
+    })
+    checks = tolerance.check_report(cano, obs)
+    assert len(checks) == 1
+    assert checks[0].path == ("amabench", "_", "output", "total_qa")
+    assert checks[0].verdict == Verdict.PASS
+
+
 def test_summarize_fail_dominates():
     cano = _canonical({"mab": {"split_a": {"f1": 0.5, "exact_match": 0.3}}})
     obs = _canonical({"mab": {"split_a": {"f1": 0.51, "exact_match": 0.99}}})


### PR DESCRIPTION
## Why

`benchmarks/run.py:241` uses `"_"` as the sub-bucket key for single-invocation adapters:

```python
if r.invocation.sub_key is None:
    bucket["_"] = payload   # ← single-invocation sentinel
```

Three adapters route through `_`: **locomo**, **longmemeval**, **amabench**. Their `output.*` metric leaves (`overall_f1`, `avg_latency_ms`, `total_qa`, …) live under `results.<adapter>._.output.*`.

`benchmarks/tolerance._walk_leaves` previously skipped *every* key starting with `_`, so those metrics were never enumerated and the cron's `tolerance.check_report` would silently pass even on a 100% latency regression. Multi-invocation adapters (mab, structmemeval) were unaffected — their sub-keys are e.g. `Conflict_Resolution`, not `_`.

## Fix

One-line change to `_walk_leaves`:

```python
if isinstance(k, str) and k.startswith("_") and k != "_":
    continue
```

Walker recurses into `"_"` and the next level (`output`, `_status`, `_elapsed_sec`) is re-filtered by the same rule, so metadata nested under `"_"` still gets skipped.

## Verification

- existing 19 `test_bench_tolerance.py` tests still pass
- 3 new tests:
  - `test_walk_leaves_recurses_into_bare_underscore_sentinel` — direct `_walk_leaves` test, `_` recursed, `_status`/`_elapsed_sec` inside `_` skipped
  - `test_check_report_band_checks_single_invocation_adapter` — the regression case: 100% latency drift on `longmemeval._.output.avg_latency_ms` now FAILs (instead of silently passing)
  - `test_check_report_passes_inside_band_for_single_invocation_adapter` — confirms band classification works through the sentinel, not just visibility
- full suite **2834 passed**, 41 skipped
- discretion grep clean, sig G

## Out of scope

- No change to `metric_overrides` defaults
- No change to badge-text rendering
- No change to current `v2.0.0.json` canonical (locomo currently has `_status: error` and no `output`; longmemeval / amabench `output` will start being band-checked once cron rebuilds with this fix)

Source: Setr's PR #489 review notes, "Side effects to flag" §1, 2026-05-08.

Closes #490.

## Summary by Sourcery

Ensure benchmark tolerance checking walks metrics under the single-invocation '_' bucket while still skipping underscore-prefixed metadata keys.

Bug Fixes:
- Fix omission of single-invocation adapter metrics under the '_' sentinel from tolerance band checks so regressions are detected correctly.

Tests:
- Add tests covering _walk_leaves recursion into the '_' sentinel and band-check behavior for single-invocation adapters across regression and within-band cases.