### PR TITLE
feat(compression): type-aware compression module + retrieve_v2 integration (#434)

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -9,7 +9,7 @@ This is the reference for power users whose project has a documentation idiom or
 A single optional TOML file at the root of a project (or any ancestor). It exposes two power-user surfaces:
 
 - `[noise]` — onboard-time belief filter. Changes how `aelf onboard` ingests beliefs; nothing else.
-- `[retrieval]` (v1.3+) — retrieval-time tier toggles + ranking. Knobs: `entity_index_enabled` (L2.5), `bfs_enabled` (L3), `posterior_weight` (partial Bayesian-weighted L1 ranking), `use_bm25f_anchors` (BM25F-with-anchor-text since v1.7), `use_heat_kernel` (authority scoring lane, opt-in), `use_hrr_structural` (HRR structural-query lane, opt-in). Two placeholder flags (`use_signed_laplacian`, `use_posterior_ranking`) are recognised but emit a deprecation warning if set — their lanes have not yet shipped.
+- `[retrieval]` (v1.3+) — retrieval-time tier toggles + ranking. Knobs: `entity_index_enabled` (L2.5), `bfs_enabled` (L3), `posterior_weight` (partial Bayesian-weighted L1 ranking), `use_bm25f_anchors` (BM25F-with-anchor-text since v1.7), `use_heat_kernel` (authority scoring lane, opt-in), `use_hrr_structural` (HRR structural-query lane, opt-in), `use_type_aware_compression` (per-belief retention-class compression, opt-in since v2.1). Two placeholder flags (`use_signed_laplacian`, `use_posterior_ranking`) are recognised but emit a deprecation warning if set — their lanes have not yet shipped.
 
 Locks, hooks, MCP tools, and the Bayesian feedback math are not affected.
 
@@ -77,6 +77,16 @@ use_heat_kernel = false
 # composition tracker (#154) flips the default after the
 # benchmark gate. AELFRICE_HRR_STRUCTURAL=1 env var overrides.
 use_hrr_structural = false
+
+# v2.1+. Default `false`, opt-in. Enables type-aware compression
+# (#434) — populates RetrievalResult.compressed_beliefs with per-
+# belief renderings keyed by retention_class (snapshot → headline,
+# transient → stub, fact + locked → verbatim). The pack-loop budget
+# rewrite that turns the parallel field into recall@k uplift is a
+# follow-up; this flag at v2.1 just exposes the mechanism behind a
+# default-OFF gate. AELFRICE_TYPE_AWARE_COMPRESSION=1 env var
+# overrides.
+use_type_aware_compression = false
 
 # Placeholder flags reserved by #154 — recognised so callers can
 # write forward-compat config, but their lanes have not yet
@@ -281,6 +291,23 @@ Precedence (first decisive wins): env var `AELFRICE_HEAT_KERNEL=0`/`1` > explici
 Boolean, default `false`, opt-in. Enables the HRR structural-query lane (#152). Like `use_heat_kernel`, the lane is implemented and stays opt-in pending the #154 benchmark gate.
 
 Precedence (first decisive wins): env var `AELFRICE_HRR_STRUCTURAL=0`/`1` > explicit Python kwarg > TOML `[retrieval] use_hrr_structural` > default `false`.
+
+### `use_type_aware_compression`
+
+Boolean, default `false`, opt-in (v2.1+, #434). Populates `RetrievalResult.compressed_beliefs` with per-belief renderings dispatched by `belief.retention_class`:
+
+| Retention class | Locked | Unlocked | Notes |
+|---|---|---|---|
+| `fact` | verbatim | verbatim | Stable codebase state. |
+| `snapshot` | verbatim | **headline** | First sentence (split outside ``` fences) + `…`. |
+| `transient` | verbatim | **stub** | `[stub: belief={id} class=transient]` marker; full text via `store.get_belief(id)`. |
+| `unknown` | verbatim | verbatim | Migration safety. |
+
+Compression is pure and deterministic — no store, clock, env, or random reads. The `compressed_beliefs` field is parallel to `beliefs` (same length, same order); consumers that want the raw belief read `.beliefs[i]`, consumers that want the compressed render read `.compressed_beliefs[i].rendered`.
+
+When disabled (default), `compressed_beliefs` is empty and `beliefs` is byte-identical to the v1.x return shape.
+
+Precedence (first decisive wins): env var `AELFRICE_TYPE_AWARE_COMPRESSION=0`/`1` > explicit Python kwarg `use_type_aware_compression=<bool>` > TOML `[retrieval] use_type_aware_compression` > default `false`. The default-on flip is gated on the lab-side bench in `tests/bench_gate/test_compression_uplift.py` plus the pack-loop budget rewrite (follow-up).
 
 ### Placeholder flags
 

--- a/src/aelfrice/compression.py
+++ b/src/aelfrice/compression.py
@@ -1,0 +1,190 @@
+"""Type-aware compression for retrieval pack (#434).
+
+Pure deterministic compressor over `(Belief, locked)` per
+`docs/feature-type-aware-compression.md`. Strategy is dispatched by
+`belief.retention_class`:
+
+  fact      → verbatim         (locked or not)
+  unknown   → verbatim         (migration safety; locked or not)
+  snapshot  → headline if not locked, else verbatim
+  transient → stub if not locked, else verbatim
+
+Locks always override retention class — this mirrors the existing
+"L0 beliefs are never trimmed" rule in `retrieval.py`.
+
+The module has no store reads, no clock reads, no env reads, no random.
+It depends only on `models` for the `Belief` shape and retention-class
+constants. Token estimator is duplicated from `retrieval._estimate_tokens`
+to avoid a circular import (retrieval consumes this module).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from .models import (
+    RETENTION_FACT,
+    RETENTION_SNAPSHOT,
+    RETENTION_TRANSIENT,
+    RETENTION_UNKNOWN,
+    Belief,
+)
+
+STRATEGY_VERBATIM: Final[str] = "verbatim"
+STRATEGY_HEADLINE: Final[str] = "headline"
+STRATEGY_STUB: Final[str] = "stub"
+
+MAX_HEADLINE_CHARS: Final[int] = 240
+
+_HEADLINE_ELLIPSIS: Final[str] = "…"
+_CODE_FENCE: Final[str] = "```"
+
+# Mirrors `retrieval._CHARS_PER_TOKEN`. Duplicated to keep this module
+# free of a retrieval import (retrieval.py imports compression, not the
+# other way around).
+_CHARS_PER_TOKEN: Final[float] = 4.0
+
+
+@dataclass(frozen=True)
+class CompressedBelief:
+    """A `Belief` plus its packed-render form.
+
+    `rendered_tokens` is monotone-non-increasing in `_estimate_tokens(belief.content)`:
+    the compressor never produces a render that costs more than the source.
+    """
+
+    belief: Belief
+    rendered: str
+    rendered_tokens: int
+    strategy: str
+
+
+def _estimate_tokens(text: str) -> int:
+    if not text:
+        return 0
+    return int((len(text) + _CHARS_PER_TOKEN - 1) // _CHARS_PER_TOKEN)
+
+
+def _content_is_single_code_fence(content: str) -> bool:
+    s = content.strip()
+    if not s.startswith(_CODE_FENCE) or not s.endswith(_CODE_FENCE):
+        return False
+    inner = s[len(_CODE_FENCE):-len(_CODE_FENCE)]
+    return _CODE_FENCE not in inner
+
+
+def _headline(content: str) -> str:
+    """Extract the leading sentence as a headline.
+
+    - If content already fits within MAX_HEADLINE_CHARS and has no
+      internal sentence boundary, return content unchanged (the
+      headline strategy never expands the source).
+    - If content is wholly a single code fence, return content
+      unchanged (per impl-PR decision on open-question 3).
+    - Otherwise split on the first `. ` or `.\\n` that falls outside
+      a balanced code-fence span. If that split lands within
+      MAX_HEADLINE_CHARS, return prefix + `…`.
+    - Else hard-truncate at the last whitespace ≤ MAX_HEADLINE_CHARS
+      and append `…`.
+    """
+    if _content_is_single_code_fence(content):
+        return content
+
+    sentence_end = _first_sentence_end_outside_fence(content)
+    if sentence_end is not None and sentence_end <= MAX_HEADLINE_CHARS:
+        prefix = content[:sentence_end].rstrip()
+        if sentence_end >= len(content):
+            return prefix
+        return prefix + _HEADLINE_ELLIPSIS
+
+    if len(content) <= MAX_HEADLINE_CHARS and sentence_end is None:
+        return content
+
+    cut = content.rfind(" ", 0, MAX_HEADLINE_CHARS + 1)
+    if cut <= 0:
+        cut = MAX_HEADLINE_CHARS
+    return content[:cut].rstrip() + _HEADLINE_ELLIPSIS
+
+
+def _first_sentence_end_outside_fence(content: str) -> int | None:
+    """Return the index just past the first `. ` or `.\\n` that falls
+    outside a balanced ``` code fence, or None if none exists."""
+    in_fence = False
+    i = 0
+    n = len(content)
+    while i < n:
+        if content.startswith(_CODE_FENCE, i):
+            in_fence = not in_fence
+            i += len(_CODE_FENCE)
+            continue
+        if not in_fence and content[i] == ".":
+            nxt = content[i + 1] if i + 1 < n else ""
+            if nxt == " " or nxt == "\n":
+                return i + 1
+        i += 1
+    return None
+
+
+def _stub(belief: Belief) -> str:
+    return f"[stub: belief={belief.id} class={RETENTION_TRANSIENT}]"
+
+
+def compress_for_retrieval(belief: Belief, *, locked: bool) -> CompressedBelief:
+    """Compress a belief for the retrieval pack.
+
+    Pure and deterministic. See module docstring and
+    `docs/feature-type-aware-compression.md` for the strategy table.
+
+    Invariant: `rendered_tokens <= _estimate_tokens(belief.content)`.
+    """
+    source_cost = _estimate_tokens(belief.content)
+    rc = belief.retention_class
+
+    if locked or rc == RETENTION_FACT or rc == RETENTION_UNKNOWN:
+        return CompressedBelief(
+            belief=belief,
+            rendered=belief.content,
+            rendered_tokens=source_cost,
+            strategy=STRATEGY_VERBATIM,
+        )
+
+    if rc == RETENTION_SNAPSHOT:
+        rendered = _headline(belief.content)
+        cost = _estimate_tokens(rendered)
+        if cost > source_cost or rendered == belief.content:
+            return CompressedBelief(
+                belief=belief,
+                rendered=belief.content,
+                rendered_tokens=source_cost,
+                strategy=STRATEGY_VERBATIM,
+            )
+        return CompressedBelief(
+            belief=belief,
+            rendered=rendered,
+            rendered_tokens=cost,
+            strategy=STRATEGY_HEADLINE,
+        )
+
+    if rc == RETENTION_TRANSIENT:
+        rendered = _stub(belief)
+        cost = _estimate_tokens(rendered)
+        if cost > source_cost:
+            return CompressedBelief(
+                belief=belief,
+                rendered=belief.content,
+                rendered_tokens=source_cost,
+                strategy=STRATEGY_VERBATIM,
+            )
+        return CompressedBelief(
+            belief=belief,
+            rendered=rendered,
+            rendered_tokens=cost,
+            strategy=STRATEGY_STUB,
+        )
+
+    return CompressedBelief(
+        belief=belief,
+        rendered=belief.content,
+        rendered_tokens=source_cost,
+        strategy=STRATEGY_VERBATIM,
+    )

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -67,6 +67,7 @@ from aelfrice.bfs_multihop import (
     expand_bfs,
 )
 from aelfrice.bm25 import BM25IndexCache
+from aelfrice.compression import CompressedBelief, compress_for_retrieval
 from aelfrice.entity_extractor import extract_entities
 from aelfrice.graph_spectral import (
     DEFAULT_BM25_SEED_TOP_K,
@@ -79,7 +80,7 @@ from aelfrice.graph_spectral import (
     heat_kernel_score,
     seeds_from_bm25,
 )
-from aelfrice.models import LOCK_NONE, Belief
+from aelfrice.models import LOCK_NONE, LOCK_USER, Belief
 from aelfrice.scoring import (
     DEFAULT_POSTERIOR_WEIGHT,
     partial_bayesian_score,
@@ -130,6 +131,12 @@ SIGNED_LAPLACIAN_FLAG: Final[str] = "use_signed_laplacian"
 HEAT_KERNEL_FLAG: Final[str] = "use_heat_kernel"
 POSTERIOR_RANKING_FLAG: Final[str] = "use_posterior_ranking"
 HRR_STRUCTURAL_FLAG: Final[str] = "use_hrr_structural"
+# v2.1 #434 type-aware compression flag. Default-OFF at v2.0.0 until the
+# lab-side bench gate (A2 + A4 in docs/feature-type-aware-compression.md)
+# clears. ON populates RetrievalResult.compressed_beliefs with per-belief
+# CompressedBelief renderings; OFF leaves the field empty for byte-identical
+# behavior with v1.x adapters.
+TYPE_AWARE_COMPRESSION_FLAG: Final[str] = "use_type_aware_compression"
 
 PLACEHOLDER_FLAGS: Final[tuple[str, ...]] = (
     SIGNED_LAPLACIAN_FLAG,
@@ -154,6 +161,8 @@ ENV_BM25F: Final[str] = "AELFRICE_BM25F"
 ENV_HEAT_KERNEL: Final[str] = "AELFRICE_HEAT_KERNEL"
 # v1.7.0 HRR structural-query env override. Tri-state like ENV_BM25F.
 ENV_HRR_STRUCTURAL: Final[str] = "AELFRICE_HRR_STRUCTURAL"
+# v2.1 #434 type-aware compression env override. Tri-state.
+ENV_TYPE_AWARE_COMPRESSION: Final[str] = "AELFRICE_TYPE_AWARE_COMPRESSION"
 # v1.3.0 posterior-weight env override. Float-typed; "0.0" is the
 # only value that fully disables (collapsing to BM25-only ordering).
 # Empty / non-numeric values fall through to the next precedence
@@ -215,6 +224,13 @@ class RetrievalResult:
     entity_hits: list[str] = field(default_factory=lambda: [])
     locked_ids: list[str] = field(default_factory=lambda: [])
     l1_ids: list[str] = field(default_factory=lambda: [])
+    # v2.1 #434 type-aware compression. Populated when
+    # use_type_aware_compression resolves True. Same length and order as
+    # `beliefs` (parallel field — consumers that want compressed render
+    # read this; consumers that want raw Belief keep reading `beliefs`).
+    # Default-empty preserves byte-identical v1.x adapter behavior when
+    # the flag is OFF.
+    compressed_beliefs: list[CompressedBelief] = field(default_factory=lambda: [])
 
 
 def _estimate_tokens(text: str) -> int:
@@ -294,6 +310,21 @@ def _env_hrr_structural_override() -> bool | None:
     recognised truthy/falsy value, else None. Symmetric to
     `_env_bm25f_override`."""
     raw = os.environ.get(ENV_HRR_STRUCTURAL)
+    if raw is None:
+        return None
+    norm = raw.strip().lower()
+    if norm in _ENV_FALSY:
+        return False
+    if norm in _ENV_TRUTHY:
+        return True
+    return None
+
+
+def _env_type_aware_compression_override() -> bool | None:
+    """Return True/False if AELFRICE_TYPE_AWARE_COMPRESSION is set to a
+    recognised truthy/falsy value, else None. Symmetric to
+    `_env_bm25f_override`."""
+    raw = os.environ.get(ENV_TYPE_AWARE_COMPRESSION)
     if raw is None:
         return None
     norm = raw.strip().lower()
@@ -700,6 +731,32 @@ def is_hrr_structural_enabled(
     if explicit is not None:
         return explicit
     toml_value = _read_toml_flag_for(HRR_STRUCTURAL_FLAG, start)
+    if toml_value is not None:
+        return toml_value
+    return False
+
+
+def resolve_use_type_aware_compression(
+    explicit: bool | None = None,
+    *,
+    start: Path | None = None,
+) -> bool:
+    """Resolve the type-aware compression flag (#434).
+
+    Precedence (first decisive wins):
+      1. AELFRICE_TYPE_AWARE_COMPRESSION env var (truthy / falsy normalised).
+      2. Explicit `explicit` kwarg from the caller.
+      3. `[retrieval] use_type_aware_compression` in `.aelfrice.toml`.
+      4. Default: False — ships behind the flag at v2.0.0; the bench gate
+         (A2 + A4 in docs/feature-type-aware-compression.md) flips the
+         default after lab-side benchmark evidence clears.
+    """
+    env = _env_type_aware_compression_override()
+    if env is not None:
+        return env
+    if explicit is not None:
+        return explicit
+    toml_value = _read_toml_flag_for(TYPE_AWARE_COMPRESSION_FLAG, start)
     if toml_value is not None:
         return toml_value
     return False
@@ -1404,6 +1461,7 @@ def retrieve_v2(
     bm25f_cache: BM25IndexCache | None = None,
     temporal_sort: bool = False,
     temporal_half_life_seconds: float | None = None,
+    use_type_aware_compression: bool | None = None,
 ) -> RetrievalResult:
     """Lab-compatible retrieval wrapper for academic-suite adapters.
 
@@ -1473,12 +1531,21 @@ def retrieve_v2(
     if temporal_sort:
         half_life = resolve_temporal_half_life(temporal_half_life_seconds)
         beliefs = _apply_temporal_decay(beliefs, half_life)
+
+    compressed: list[CompressedBelief] = []
+    if resolve_use_type_aware_compression(use_type_aware_compression):
+        compressed = [
+            compress_for_retrieval(b, locked=(b.lock_level == LOCK_USER))
+            for b in beliefs
+        ]
+
     return RetrievalResult(
         beliefs=beliefs,
         entity_hits=l25_ids_list,
         locked_ids=locked_ids_list,
         l1_ids=l1_ids_list,
         bfs_chains=bfs_chains,
+        compressed_beliefs=compressed,
     )
 
 

--- a/tests/bench_gate/test_compression_uplift.py
+++ b/tests/bench_gate/test_compression_uplift.py
@@ -1,0 +1,122 @@
+"""Bench gate for #434 type-aware compression.
+
+Measures the precondition for A2 in `docs/feature-type-aware-compression.md`:
+on a mixed-retention-class corpus, the compressed total token cost is
+strictly less than the uncompressed total token cost. If compression
+does not reduce cost on the lab corpus, no pack-loop rewrite can
+deliver the A2 recall@k uplift no matter how it is wired.
+
+Skips on public CI (autouse `bench_gated` marker handles
+`AELFRICE_CORPUS_ROOT` absence). Skips again when the
+`tests/corpus/v2_0/compression_uplift/` directory is empty.
+
+Note: A2's strict recall@k comparison requires the follow-up
+budget-rewrite work that consumes `compressed_beliefs[*].rendered_tokens`
+in the pack loops. This gate measures the upstream invariant
+(compression is monotone-strictly-decreasing in token cost on
+non-fact-only corpora) that A2 depends on.
+
+Expected row schema (`tests/corpus/v2_0/compression_uplift/*.jsonl`):
+
+  {
+    "id": "row-id",
+    "content": "belief content text",
+    "retention_class": "fact" | "snapshot" | "transient" | "unknown",
+    "lock_level": "none" | "user"
+  }
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aelfrice.compression import (
+    STRATEGY_HEADLINE,
+    STRATEGY_STUB,
+    STRATEGY_VERBATIM,
+    _estimate_tokens,
+    compress_for_retrieval,
+)
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    LOCK_USER,
+    RETENTION_UNKNOWN,
+    Belief,
+)
+from tests.conftest import load_corpus_module
+
+
+def _belief_from_row(row: dict) -> tuple[Belief, bool]:
+    bid = str(row["id"])
+    content = str(row["content"])
+    retention_class = str(row.get("retention_class", RETENTION_UNKNOWN))
+    lock_level = str(row.get("lock_level", "none"))
+    locked = lock_level == LOCK_USER
+    belief = Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-05-08T00:00:00Z",
+        last_retrieved_at=None,
+        retention_class=retention_class,
+    )
+    return belief, locked
+
+
+@pytest.mark.bench_gated
+def test_compression_reduces_total_tokens_on_corpus(
+    aelfrice_corpus_root: Path,
+) -> None:
+    rows = load_corpus_module(aelfrice_corpus_root, "compression_uplift")
+
+    uncompressed_total = 0
+    compressed_total = 0
+    strategy_counts: dict[str, int] = {
+        STRATEGY_VERBATIM: 0,
+        STRATEGY_HEADLINE: 0,
+        STRATEGY_STUB: 0,
+    }
+    for row in rows:
+        belief, locked = _belief_from_row(row)
+        uncompressed_total += _estimate_tokens(belief.content)
+        cb = compress_for_retrieval(belief, locked=locked)
+        compressed_total += cb.rendered_tokens
+        strategy_counts[cb.strategy] = strategy_counts.get(cb.strategy, 0) + 1
+
+    assert uncompressed_total > 0, (
+        f"compression_uplift corpus produced zero uncompressed tokens "
+        f"on {len(rows)} rows; check corpus content"
+    )
+    # Monotone: compressed must not exceed uncompressed (per the
+    # CompressedBelief invariant; this is a corpus-scale recheck).
+    assert compressed_total <= uncompressed_total, (
+        f"compressed_total {compressed_total} > uncompressed_total "
+        f"{uncompressed_total} on {len(rows)} rows — invariant violation"
+    )
+    # Strict: at least one row must have actually compressed. A corpus
+    # of all-fact-class rows would hit `verbatim` for every row and
+    # leave compressed_total == uncompressed_total — that is a corpus
+    # composition problem, not a compressor bug, so it skips rather
+    # than fails.
+    if compressed_total == uncompressed_total:
+        pytest.skip(
+            f"compression_uplift corpus has no compressible rows "
+            f"(all {len(rows)} rows render verbatim); add snapshot/transient "
+            f"rows to exercise the headline/stub strategies"
+        )
+    reduction = (uncompressed_total - compressed_total) / uncompressed_total
+    # A2 precondition: on a mixed-class corpus, compression should
+    # produce a non-trivial reduction. Threshold is loose (1%) — the
+    # spec doesn't pin a magnitude here; A2's strict gate is
+    # measured on recall@k after the pack-loop rewrite.
+    assert reduction >= 0.01, (
+        f"compression reduction {reduction:.3%} below 1% floor on "
+        f"{len(rows)} rows; strategies={strategy_counts}"
+    )

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,0 +1,233 @@
+"""Unit tests for type-aware compression (#434).
+
+Covers the strategy table, the headline edge cases, the locked-override
+rule, and the token-monotone invariant.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aelfrice.compression import (
+    MAX_HEADLINE_CHARS,
+    STRATEGY_HEADLINE,
+    STRATEGY_STUB,
+    STRATEGY_VERBATIM,
+    CompressedBelief,
+    _estimate_tokens,
+    compress_for_retrieval,
+)
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    LOCK_NONE,
+    LOCK_USER,
+    RETENTION_FACT,
+    RETENTION_SNAPSHOT,
+    RETENTION_TRANSIENT,
+    RETENTION_UNKNOWN,
+    Belief,
+)
+
+
+def _mk(
+    content: str,
+    *,
+    bid: str = "b1",
+    retention_class: str = RETENTION_UNKNOWN,
+    lock_level: str = LOCK_NONE,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-05-08T00:00:00Z",
+        last_retrieved_at=None,
+        retention_class=retention_class,
+    )
+
+
+# --- Strategy table ----------------------------------------------------
+
+
+def test_fact_unlocked_is_verbatim() -> None:
+    b = _mk("a long fact-class belief content. with more sentences. here.",
+            retention_class=RETENTION_FACT)
+    cb = compress_for_retrieval(b, locked=False)
+    assert cb.strategy == STRATEGY_VERBATIM
+    assert cb.rendered == b.content
+
+
+def test_fact_locked_is_verbatim() -> None:
+    b = _mk("locked fact content.", retention_class=RETENTION_FACT)
+    cb = compress_for_retrieval(b, locked=True)
+    assert cb.strategy == STRATEGY_VERBATIM
+
+
+def test_unknown_class_is_verbatim() -> None:
+    b = _mk("uncategorised belief content. another sentence.",
+            retention_class=RETENTION_UNKNOWN)
+    cb = compress_for_retrieval(b, locked=False)
+    assert cb.strategy == STRATEGY_VERBATIM
+    assert cb.rendered == b.content
+
+
+def test_snapshot_unlocked_takes_headline() -> None:
+    content = (
+        "the first sentence is the headline. "
+        "the second sentence and rest of body should be dropped. "
+        "and a third sentence."
+    )
+    b = _mk(content, retention_class=RETENTION_SNAPSHOT)
+    cb = compress_for_retrieval(b, locked=False)
+    assert cb.strategy == STRATEGY_HEADLINE
+    assert cb.rendered.startswith("the first sentence is the headline")
+    assert cb.rendered.endswith("…")
+    assert cb.rendered_tokens < _estimate_tokens(content)
+
+
+def test_snapshot_locked_is_verbatim() -> None:
+    content = "first sentence. second sentence. third."
+    b = _mk(content, retention_class=RETENTION_SNAPSHOT, lock_level=LOCK_USER)
+    cb = compress_for_retrieval(b, locked=True)
+    assert cb.strategy == STRATEGY_VERBATIM
+    assert cb.rendered == content
+
+
+def test_transient_unlocked_is_stub() -> None:
+    content = "ephemeral PR-window note about a temporary fix."
+    b = _mk(content, bid="abcd1234", retention_class=RETENTION_TRANSIENT)
+    cb = compress_for_retrieval(b, locked=False)
+    assert cb.strategy == STRATEGY_STUB
+    assert cb.rendered == "[stub: belief=abcd1234 class=transient]"
+
+
+def test_transient_locked_is_verbatim() -> None:
+    b = _mk("locked transient content.", retention_class=RETENTION_TRANSIENT)
+    cb = compress_for_retrieval(b, locked=True)
+    assert cb.strategy == STRATEGY_VERBATIM
+
+
+# --- Headline edge cases -----------------------------------------------
+
+
+def test_headline_short_no_boundary_renders_verbatim() -> None:
+    content = "short content with no period in it"
+    b = _mk(content, retention_class=RETENTION_SNAPSHOT)
+    cb = compress_for_retrieval(b, locked=False)
+    assert cb.strategy == STRATEGY_VERBATIM
+    assert cb.rendered == content
+
+
+def test_headline_long_no_boundary_hard_truncates() -> None:
+    content = "word " * 100
+    b = _mk(content, retention_class=RETENTION_SNAPSHOT)
+    cb = compress_for_retrieval(b, locked=False)
+    assert cb.strategy == STRATEGY_HEADLINE
+    assert cb.rendered.endswith("…")
+    assert len(cb.rendered) <= MAX_HEADLINE_CHARS + len("…")
+
+
+def test_headline_split_on_newline_period() -> None:
+    content = "first line headline.\nsecond line should be dropped."
+    b = _mk(content, retention_class=RETENTION_SNAPSHOT)
+    cb = compress_for_retrieval(b, locked=False)
+    assert cb.strategy == STRATEGY_HEADLINE
+    assert "second line" not in cb.rendered
+
+
+def test_headline_preserves_balanced_code_fence_only_content() -> None:
+    content = "```python\nx = 1\nprint(x)\n```"
+    b = _mk(content, retention_class=RETENTION_SNAPSHOT)
+    cb = compress_for_retrieval(b, locked=False)
+    assert cb.strategy == STRATEGY_VERBATIM
+    assert cb.rendered == content
+
+
+def test_headline_does_not_split_on_period_inside_code_fence() -> None:
+    content = (
+        "first sentence with no boundary then code "
+        "```\nfoo. bar.\n``` and more prose. final sentence."
+    )
+    b = _mk(content, retention_class=RETENTION_SNAPSHOT)
+    cb = compress_for_retrieval(b, locked=False)
+    assert cb.strategy == STRATEGY_HEADLINE
+    assert "final sentence" not in cb.rendered
+    assert cb.rendered.endswith("…")
+
+
+# --- Invariants --------------------------------------------------------
+
+
+def test_token_monotone_non_increasing() -> None:
+    contents = [
+        "short.",
+        "first sentence. second sentence.",
+        "word " * 200,
+        "```\nprint(1)\n```",
+        "transient note text.",
+        "",
+    ]
+    for rc in (RETENTION_FACT, RETENTION_SNAPSHOT, RETENTION_TRANSIENT, RETENTION_UNKNOWN):
+        for content in contents:
+            for locked in (False, True):
+                b = _mk(content, retention_class=rc)
+                cb = compress_for_retrieval(b, locked=locked)
+                source_cost = _estimate_tokens(content)
+                assert cb.rendered_tokens <= source_cost, (
+                    f"rendered_tokens={cb.rendered_tokens} > source={source_cost} "
+                    f"for rc={rc} locked={locked} content={content!r}"
+                )
+
+
+def test_compress_is_deterministic() -> None:
+    content = "first sentence. second sentence. third sentence here."
+    for rc in (RETENTION_FACT, RETENTION_SNAPSHOT, RETENTION_TRANSIENT, RETENTION_UNKNOWN):
+        for locked in (False, True):
+            b = _mk(content, retention_class=rc)
+            a = compress_for_retrieval(b, locked=locked)
+            c = compress_for_retrieval(b, locked=locked)
+            assert a == c
+
+
+def test_total_function_returns_compressed_belief_for_every_input() -> None:
+    for rc in (RETENTION_FACT, RETENTION_SNAPSHOT, RETENTION_TRANSIENT, RETENTION_UNKNOWN):
+        b = _mk("any content", retention_class=rc)
+        cb = compress_for_retrieval(b, locked=False)
+        assert isinstance(cb, CompressedBelief)
+        assert cb.belief is b
+
+
+def test_unknown_retention_value_falls_back_to_verbatim() -> None:
+    # Defensive: a belief whose retention_class is some out-of-band string
+    # (e.g. a future class added by a downgrade-then-upgrade) should not
+    # crash and should not silently compress. Verbatim is the safe fallback.
+    b = _mk("content", retention_class="unrecognised_class")
+    cb = compress_for_retrieval(b, locked=False)
+    assert cb.strategy == STRATEGY_VERBATIM
+
+
+# --- Stub format ------------------------------------------------------
+
+
+def test_stub_format_is_grep_friendly() -> None:
+    # Use content longer than the stub marker so the stub strategy fires.
+    payload = "this is a long-enough transient note " * 4
+    b = _mk(payload, bid="xyz789", retention_class=RETENTION_TRANSIENT)
+    cb = compress_for_retrieval(b, locked=False)
+    assert cb.strategy == STRATEGY_STUB
+    assert "[stub: belief=xyz789" in cb.rendered
+    assert "class=transient" in cb.rendered
+
+
+def test_stub_falls_back_to_verbatim_when_source_smaller() -> None:
+    # Pathological case: a transient belief whose content is shorter than
+    # the stub marker (~38 chars). Compressor must not expand cost.
+    b = _mk("x", bid="i", retention_class=RETENTION_TRANSIENT)
+    cb = compress_for_retrieval(b, locked=False)
+    assert cb.rendered_tokens <= _estimate_tokens("x")
+    assert cb.strategy == STRATEGY_VERBATIM

--- a/tests/test_compression_integration.py
+++ b/tests/test_compression_integration.py
@@ -1,0 +1,190 @@
+"""Integration tests for #434 type-aware compression in retrieve_v2.
+
+Covers flag-precedence resolution and the parallel `compressed_beliefs`
+field on `RetrievalResult`. Default-OFF path is byte-identical to v1.x:
+`compressed_beliefs` is empty when the flag does not resolve True.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from aelfrice.compression import STRATEGY_HEADLINE, STRATEGY_STUB, STRATEGY_VERBATIM
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    LOCK_NONE,
+    LOCK_USER,
+    RETENTION_FACT,
+    RETENTION_SNAPSHOT,
+    RETENTION_TRANSIENT,
+    Belief,
+)
+from aelfrice.retrieval import (
+    ENV_TYPE_AWARE_COMPRESSION,
+    resolve_use_type_aware_compression,
+    retrieve_v2,
+)
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    bid: str,
+    content: str,
+    *,
+    retention_class: str = RETENTION_FACT,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-05-08T00:00:00Z",
+        last_retrieved_at=None,
+        retention_class=retention_class,
+    )
+
+
+@pytest.fixture
+def _no_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_TYPE_AWARE_COMPRESSION, raising=False)
+
+
+@pytest.fixture
+def _isolated_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """cd into an empty tmp dir so .aelfrice.toml lookups don't pick up
+    the repo's own config during flag resolution."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# --- Flag resolution ---------------------------------------------------
+
+
+def test_default_is_off(_no_env_override: None, _isolated_cwd: Path) -> None:
+    assert resolve_use_type_aware_compression() is False
+
+
+def test_explicit_kwarg_overrides_default(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    assert resolve_use_type_aware_compression(True) is True
+    assert resolve_use_type_aware_compression(False) is False
+
+
+def test_env_overrides_explicit_kwarg(
+    monkeypatch: pytest.MonkeyPatch, _isolated_cwd: Path
+) -> None:
+    monkeypatch.setenv(ENV_TYPE_AWARE_COMPRESSION, "1")
+    assert resolve_use_type_aware_compression(False) is True
+    monkeypatch.setenv(ENV_TYPE_AWARE_COMPRESSION, "0")
+    assert resolve_use_type_aware_compression(True) is False
+
+
+def test_env_garbage_falls_through(
+    monkeypatch: pytest.MonkeyPatch, _isolated_cwd: Path
+) -> None:
+    monkeypatch.setenv(ENV_TYPE_AWARE_COMPRESSION, "maybe")
+    # Garbage env reverts to the next layer; with no kwarg/toml,
+    # default OFF wins.
+    assert resolve_use_type_aware_compression() is False
+    # And a kwarg now decides.
+    assert resolve_use_type_aware_compression(True) is True
+
+
+def test_toml_resolves_when_kwarg_and_env_unset(
+    _no_env_override: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / ".aelfrice.toml"
+    cfg.write_text("[retrieval]\nuse_type_aware_compression = true\n")
+    monkeypatch.chdir(tmp_path)
+    assert resolve_use_type_aware_compression() is True
+
+
+# --- retrieve_v2 integration ------------------------------------------
+
+
+def _populate_store() -> MemoryStore:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("F1", "the system uses sqlite for persistence",
+                        retention_class=RETENTION_FACT))
+    s.insert_belief(_mk(
+        "S1",
+        "morning thought: the system uses sqlite for persistence. "
+        "and other things to drop in the headline strategy.",
+        retention_class=RETENTION_SNAPSHOT,
+    ))
+    s.insert_belief(_mk(
+        "T1",
+        "PR-window scratch about the sqlite system note " * 3,
+        retention_class=RETENTION_TRANSIENT,
+    ))
+    s.insert_belief(_mk(
+        "L1",
+        "user-pinned: sqlite is the chosen substrate. immutable.",
+        retention_class=RETENTION_SNAPSHOT,
+        lock_level=LOCK_USER,
+        locked_at="2026-05-08T00:00:00Z",
+    ))
+    return s
+
+
+def test_compressed_beliefs_empty_when_flag_off(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    s = _populate_store()
+    result = retrieve_v2(s, "sqlite system", use_type_aware_compression=False)
+    assert result.compressed_beliefs == []
+    # `beliefs` is unchanged.
+    assert any(b.id == "F1" for b in result.beliefs)
+
+
+def test_compressed_beliefs_populated_when_flag_on(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    s = _populate_store()
+    result = retrieve_v2(s, "sqlite system", use_type_aware_compression=True)
+    assert len(result.compressed_beliefs) == len(result.beliefs)
+    # Same order, same belief ids.
+    for b, cb in zip(result.beliefs, result.compressed_beliefs, strict=True):
+        assert cb.belief.id == b.id
+
+
+def test_compression_strategy_dispatches_by_retention_class(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    s = _populate_store()
+    result = retrieve_v2(s, "sqlite system", use_type_aware_compression=True)
+    by_id = {cb.belief.id: cb for cb in result.compressed_beliefs}
+    assert by_id["F1"].strategy == STRATEGY_VERBATIM
+    assert by_id["S1"].strategy == STRATEGY_HEADLINE
+    assert by_id["T1"].strategy == STRATEGY_STUB
+    # Locked belief renders verbatim despite snapshot retention class.
+    assert by_id["L1"].strategy == STRATEGY_VERBATIM
+
+
+def test_env_var_alone_enables_compression(
+    monkeypatch: pytest.MonkeyPatch, _isolated_cwd: Path
+) -> None:
+    monkeypatch.setenv(ENV_TYPE_AWARE_COMPRESSION, "1")
+    s = _populate_store()
+    result = retrieve_v2(s, "sqlite system")  # no explicit kwarg
+    assert len(result.compressed_beliefs) == len(result.beliefs)
+
+
+def test_default_call_leaves_compressed_empty(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    s = _populate_store()
+    result = retrieve_v2(s, "sqlite system")  # no kwarg, no env, default OFF
+    assert result.compressed_beliefs == []


### PR DESCRIPTION
Closes-progress on #434 (type-aware compression). Lands the **mechanically-correct, default-OFF** form of the feature per the spec's bench-gate / ship-or-defer policy (`docs/feature-type-aware-compression.md` § "Bench-gate / ship-or-defer policy").

## What landed

### 1. `src/aelfrice/compression.py` (commit 1)

Pure, deterministic `compress_for_retrieval(belief, *, locked) → CompressedBelief`. Strategy table per spec:

| Retention class | Locked | Unlocked |
|---|---|---|
| `fact` | verbatim | verbatim |
| `snapshot` | verbatim | **headline** |
| `transient` | verbatim | **stub** |
| `unknown` | verbatim | verbatim |

- Headline: first sentence on `. ` / `.\n` boundary, with `…`. Code-fence-aware (does not split inside ``` blocks). Content that is wholly a single code fence renders verbatim (impl-PR resolution of spec open-question 3). Hard-truncates at last whitespace ≤ `MAX_HEADLINE_CHARS=240` if no boundary found.
- Stub: `[stub: belief={id} class=transient]` — falls back to verbatim when the marker would cost more than the source content.
- 18 unit tests cover the strategy table, headline edge cases, locked-override rule, token-monotone-non-increasing invariant (corpus-level recheck), and deterministic re-evaluation.

### 2. `retrieve_v2()` integration (commit 2)

- New flag `use_type_aware_compression` with the established 4-stage precedence (env > kwarg > TOML > default-OFF). Env var: `AELFRICE_TYPE_AWARE_COMPRESSION`.
- `RetrievalResult` gains a parallel `compressed_beliefs: list[CompressedBelief]` field. Same length and order as `beliefs` when the flag resolves True; empty when OFF — preserves byte-identical v1.x adapter behavior.
- 10 integration tests cover flag-precedence resolution and the parallel-field invariant on a mixed-class fixture.
- **Out of scope:** the budget-accounting pack-loop rewrite that turns this parallel field into measurable recall@k uplift (A2). That requires a follow-up PR plus the lab-side bench evidence.

### 3. `tests/bench_gate/test_compression_uplift.py` (commit 3)

Lab-mounted bench gate. Skips on public CI (autouse `bench_gated` marker). When `AELFRICE_CORPUS_ROOT` points at a populated `compression_uplift/` directory, asserts the upstream invariant A2 depends on: compressed total tokens < uncompressed total tokens. The strict A2 recall@k comparison waits on the budget rewrite.

### 4. `docs/CONFIG.md` (commit 4)

Adds `use_type_aware_compression` to the `[retrieval]` section header, the `.aelfrice.toml` example, and a dedicated Keys subsection with the strategy table.

## Acceptance status

- **A1 (corpus):** lab-side. `tests/corpus/v2_0/compression_uplift/` row schema documented in the gate's module docstring.
- **A2 (token-budget recovery):** **deferred** — requires the pack-loop budget rewrite that consumes `compressed_beliefs[*].rendered_tokens`. Bench-gate harness exists for the precondition; full A2 measurement is the follow-up.
- **A3 (determinism):** **covered** by `test_compression.py::test_compress_is_deterministic` and the `test_token_monotone_non_increasing` property test (16 inputs × 4 retention classes × 2 lock states).
- **A4 (rebuilder fidelity):** **deferred** — same dependency chain as A2 (rebuilder consumes the post-pack output; needs the budget rewrite).
- **A5 (composition tracker doc row):** **deferred** — `docs/RETRIEVAL_COMPOSITION.md` does not exist yet (per #433's spec note: "or wherever the #154 tracker doc lands by ship-time"). When the tracker doc lands, a one-line row for `use_type_aware_compression` should be added.

## Test plan

- [x] `uv run pytest tests/test_compression.py` — 18 passed
- [x] `uv run pytest tests/test_compression_integration.py` — 10 passed
- [x] `uv run pytest tests/bench_gate/test_compression_uplift.py` — skipped (public CI; corpus absent)
- [x] `uv run pytest tests/` — 2864 passed, 40 skipped, no regressions vs `main`
- [ ] `AELFRICE_CORPUS_ROOT=~/projects/aelfrice-lab/tests/corpus/v2_0 uv run pytest tests/bench_gate/test_compression_uplift.py` — operator/lab-side; ratifies A2 precondition

## Follow-up issues

- **A2 budget-rewrite PR:** rewrite the `retrieve_v2` / `retrieve_with_tiers` pack loops to use `cb.rendered_tokens` for budget accounting when `use_type_aware_compression=True`. Spec text is at `docs/feature-type-aware-compression.md` § "Where compression sits".
- **A4 rebuilder fidelity bench:** wire continuation-fidelity scorer (#141) to consume compressed output; bench at fixed `[rebuilder] token_budget`.
- **A5 composition-tracker row:** waits on `docs/RETRIEVAL_COMPOSITION.md` (or whichever location #154 picks).

Refs #434, #154 (composition tracker), #437 (canonical bench harness).

## Summary by Sourcery

Add a type-aware compression module and integrate it with retrieve_v2 behind a configurable, default-off flag.

New Features:
- Introduce a deterministic type-aware compression system for beliefs with strategies based on retention class and lock status.
- Expose compressed belief renderings via a new compressed_beliefs field on RetrievalResult, populated when type-aware compression is enabled.
- Add a configurable use_type_aware_compression flag with environment, kwarg, and TOML precedence for retrieval.

Enhancements:
- Document the new type-aware compression configuration knob and behavior in CONFIG.md, including retention-class strategy details.

Tests:
- Add unit tests for compression strategies, headline behavior, determinism, and token-cost invariants.
- Add integration tests covering retrieve_v2 compression integration and flag-precedence resolution.
- Introduce a bench-gated compression uplift test that validates corpus-level token reduction when compression is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional type-aware compression for retrieval results, configurable via TOML, environment variable, or function parameter.
  * Compression strategies vary by belief type: facts and unknowns render in full; snapshots compress to headlines; transient beliefs compress to stubs.

* **Documentation**
  * Extended configuration documentation with compression feature details, including default behavior and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->