### PR TITLE
feat(retrieval): pack-loop budget uses compressed cost when flag ON (#434)

### DIFF
--- a/docs/feature-type-aware-compression.md
+++ b/docs/feature-type-aware-compression.md
@@ -1,6 +1,6 @@
 # Feature spec: Type-aware compression (#434)
 
-**Status:** spec, no implementation
+**Status:** implemented behind default-OFF flag; pack-loop budget rewrite landed; lab bench A2 / A4 pending
 **Issue:** #434
 **Recovery-inventory line:** [`docs/ROADMAP.md`](ROADMAP.md) — *"Type-aware compression | v2.0.0"*
 **Substrate prereqs:** #290 (retention class column + per-source defaults, shipped v1.6.0), #141 (context rebuilder, shipped v1.4.0)

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -1380,6 +1380,7 @@ def retrieve_with_tiers(
     bm25f_cache: BM25IndexCache | None = None,
     heat_kernel_enabled: bool | None = None,
     eigenbasis_cache: GraphEigenbasisCache | None = None,
+    use_type_aware_compression: bool | None = None,
 ) -> tuple[
     list[Belief], list[str], list[str], list[str], list[list[str]],
 ]:
@@ -1394,6 +1395,12 @@ def retrieve_with_tiers(
     L3-tier expansion belief in `merged_output` (empty list when
     BFS is off / produced nothing / bfs hits collide with prior
     tiers).
+
+    When `use_type_aware_compression` resolves True (#434 v2.1), the
+    pack loops account for L2.5/L1/BFS beliefs at their compressed
+    `rendered_tokens` rather than `_belief_tokens(b)`. Locks always
+    render verbatim per the strategy table, so locked accounting is
+    unchanged. Default-OFF preserves byte-identical output.
     """
     global _LAST_TELEMETRY
     enabled = is_entity_index_enabled(entity_index_enabled)
@@ -1401,7 +1408,20 @@ def retrieve_with_tiers(
     bm25f_on = resolve_use_bm25f_anchors(use_bm25f_anchors)
     weight = resolve_posterior_weight(posterior_weight)
     heat_on = is_heat_kernel_enabled(heat_kernel_enabled)
+    compress_on = resolve_use_type_aware_compression(
+        use_type_aware_compression,
+    )
     warn_placeholder_flags()
+
+    def _cost(b: Belief) -> int:
+        """Per-belief pack cost. Compressed render when flag ON,
+        else raw token estimate. Locks render verbatim either way."""
+        if not compress_on:
+            return _belief_tokens(b)
+        cb = compress_for_retrieval(
+            b, locked=(b.lock_level == LOCK_USER),
+        )
+        return cb.rendered_tokens
 
     locked: list[Belief] = store.list_locked_beliefs()
     locked_ids_list: list[str] = [b.id for b in locked]
@@ -1443,12 +1463,12 @@ def retrieve_with_tiers(
             if b.id not in locked_ids and b.id not in l25_ids
         ]
 
-    used: int = locked_used + sum(_belief_tokens(b) for b in l25)
+    used: int = locked_used + sum(_cost(b) for b in l25)
     out: list[Belief] = list(locked) + list(l25)
     l1_ids_list: list[str] = []
     l1_packed: list[Belief] = []
     for b in l1:
-        cost: int = _belief_tokens(b)
+        cost: int = _cost(b)
         if used + cost > effective_budget:
             break
         out.append(b)
@@ -1474,7 +1494,7 @@ def retrieve_with_tiers(
             for hop in hops:
                 if hop.belief.id in seen_ids:
                     continue
-                cost = _belief_tokens(hop.belief)
+                cost = _cost(hop.belief)
                 if used + cost > effective_budget:
                     break
                 out.append(hop.belief)
@@ -1599,6 +1619,7 @@ def retrieve_v2(
         posterior_weight=posterior_weight,
         use_bm25f_anchors=use_bm25f,
         bm25f_cache=bm25f_cache,
+        use_type_aware_compression=use_type_aware_compression,
     )
     if include_locked:
         beliefs = out

--- a/tests/test_compression_integration.py
+++ b/tests/test_compression_integration.py
@@ -188,3 +188,97 @@ def test_default_call_leaves_compressed_empty(
     s = _populate_store()
     result = retrieve_v2(s, "sqlite system")  # no kwarg, no env, default OFF
     assert result.compressed_beliefs == []
+
+
+# --- Pack-loop budget rewrite (#434 phase 2) ---------------------------
+#
+# With the flag ON, pack accounting consumes `cb.rendered_tokens` — so a
+# tight budget that fit only the fact-class belief at raw cost can now
+# admit the transient-class beliefs whose stub render is ~10 tokens each.
+
+
+def _populate_pack_widening_store() -> MemoryStore:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk(
+        "F1",
+        "the system uses sqlite for persistence",
+        retention_class=RETENTION_FACT,
+    ))
+    for i in range(5):
+        s.insert_belief(_mk(
+            f"T{i}",
+            "scratch about sqlite system token " * 30,
+            retention_class=RETENTION_TRANSIENT,
+        ))
+    return s
+
+
+def test_pack_widens_when_flag_on(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    s = _populate_pack_widening_store()
+    off = retrieve_v2(
+        s, "sqlite system",
+        budget=80,
+        use_entity_index=False,
+        use_type_aware_compression=False,
+    )
+    on = retrieve_v2(
+        s, "sqlite system",
+        budget=80,
+        use_entity_index=False,
+        use_type_aware_compression=True,
+    )
+    assert len(on.beliefs) > len(off.beliefs)
+
+
+def test_pack_byte_identical_when_flag_off(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    """Flag OFF reproduces pre-#434-phase-2 selection at the same budget.
+
+    Two calls — explicit OFF vs default OFF — must agree byte-for-byte
+    on the merged belief id list. This is the byte-identity invariant
+    that makes the pack-loop change safe to land default-OFF.
+    """
+    s = _populate_pack_widening_store()
+    explicit_off = retrieve_v2(
+        s, "sqlite system",
+        budget=80,
+        use_entity_index=False,
+        use_type_aware_compression=False,
+    )
+    default_off = retrieve_v2(
+        s, "sqlite system",
+        budget=80,
+        use_entity_index=False,
+    )
+    assert [b.id for b in explicit_off.beliefs] \
+        == [b.id for b in default_off.beliefs]
+
+
+def test_pack_locked_unchanged_when_flag_on(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    """Locks render verbatim, so locked accounting is identical OFF vs ON."""
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk(
+        "L1",
+        "user-pinned: sqlite is the chosen substrate. immutable.",
+        retention_class=RETENTION_SNAPSHOT,
+        lock_level=LOCK_USER,
+        locked_at="2026-05-08T00:00:00Z",
+    ))
+    off = retrieve_v2(
+        s, "sqlite",
+        use_entity_index=False,
+        use_type_aware_compression=False,
+    )
+    on = retrieve_v2(
+        s, "sqlite",
+        use_entity_index=False,
+        use_type_aware_compression=True,
+    )
+    assert [b.id for b in off.beliefs] == [b.id for b in on.beliefs]
+    # Locked render is verbatim under compression.
+    assert on.compressed_beliefs[0].strategy == STRATEGY_VERBATIM


### PR DESCRIPTION
Phase 2 of #434 — pack-loop budget rewrite. Phase 1 (compress_for_retrieval module + flag wiring + RetrievalResult.compressed_beliefs) shipped at a6f1582. This PR closes the A2 wider-pack precondition: at fixed budget, ON admits more beliefs than OFF.

## Change

`retrieve_with_tiers()` accepts `use_type_aware_compression: bool | None`. When ON, pack accounting for L2.5 / L1 / BFS uses `compress_for_retrieval(b, locked=...).rendered_tokens` instead of `_belief_tokens(b)`. Locked beliefs always render verbatim, so locked accounting is unchanged.

`retrieve_v2()` threads its existing flag through. The post-pack `compressed_beliefs` field is unchanged.

## Default-OFF byte-identity

`_cost(b)` collapses to `_belief_tokens(b)` when `compress_on` resolves False, so the OFF-path arithmetic is identical to pre-#434-phase-2. Covered by `test_pack_byte_identical_when_flag_off` and the unmodified existing 2864-test baseline (now 2897 / 43 skipped, full suite green).

## ON widens

`test_pack_widens_when_flag_on` at `budget=80` against fact + 5×transient: OFF packs 1 belief (fact at ~30 tokens), ON packs ≥ 2 (fact + ≥1 transient at ~10-token stub). Strict inequality.

## Acceptance against spec

- A1 (corpus): lab-side; this PR is public-side only
- A2 (recall@k uplift): pack-loop precondition closed here. Strict-recall@k bench still requires `AELFRICE_CORPUS_ROOT` lab cut
- A3 (determinism): unchanged from phase 1
- A4 (rebuilder fidelity): blocked on A2 lab cut
- A5 (composition tracker row): waits on #154

## Refs

- Spec: `docs/feature-type-aware-compression.md` § "Where compression sits"
- Phase 1: a6f1582 / 8b08021 / 0e357ea / 17e74db / a6f1582
- Substrate: #290 retention class, #141 context rebuilder

Closes A2-precondition for #434. Issue stays open as umbrella for the lab-side bench cut.

## Summary by Sourcery

Update retrieval pack-loop budgeting to optionally use type-aware compression while preserving default behavior.

New Features:
- Allow retrieval_with_tiers and retrieve_v2 to account for belief pack costs using type-aware compression when the corresponding flag is enabled.

Enhancements:
- Ensure locked beliefs are always treated with verbatim cost accounting regardless of compression settings.
- Preserve byte-identical retrieval output when type-aware compression is disabled, maintaining backward compatibility.

Documentation:
- Mark type-aware compression as implemented behind a default-off flag and note the pack-loop budget rewrite in the feature spec.

Tests:
- Add integration tests verifying wider packing under compression, byte-identical behavior when the flag is off, and unchanged handling of locked beliefs.