### PR TITLE
feat(retrieval): wire intentional clustering into retrieve_v2 (#436 Phase 2)

### DIFF
--- a/docs/feature-intentional-clustering.md
+++ b/docs/feature-intentional-clustering.md
@@ -1,6 +1,6 @@
 # Feature spec: Intentional clustering (#436)
 
-**Status:** module shipped (`src/aelfrice/clustering.py`); retrieval-side wiring + bench-gate evidence are the next gates
+**Status:** wired into `retrieve_v2` behind `use_intentional_clustering` (default-OFF at v2.0.0); bench-gate evidence (A2) is the gate to flip the default
 **Issue:** #436
 **Recovery-inventory line:** [`docs/ROADMAP.md`](ROADMAP.md) — *"Intentional clustering | v2.0.0"*
 **Substrate prereqs:** edge graph (foundation), `dedup.DuplicateCluster` union-find pattern (`src/aelfrice/dedup.py:155-185`, shipped #197), heat kernel authority (#150, shipped v1.7.0), BFS multi-hop (#143, shipped v1.3.0)

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -67,6 +67,12 @@ from aelfrice.bfs_multihop import (
     expand_bfs,
 )
 from aelfrice.bm25 import BM25IndexCache
+from aelfrice.clustering import (
+    DEFAULT_CLUSTER_DIVERSITY_TARGET,
+    DEFAULT_CLUSTER_EDGE_FLOOR,
+    cluster_candidates,
+    pack_with_clusters,
+)
 from aelfrice.compression import CompressedBelief, compress_for_retrieval
 from aelfrice.vocab_bridge import VocabBridge, VocabBridgeCache
 from aelfrice.entity_extractor import extract_entities
@@ -143,6 +149,14 @@ TYPE_AWARE_COMPRESSION_FLAG: Final[str] = "use_type_aware_compression"
 # When ON, retrieve_v2 builds (or fetches a cached) VocabBridge against
 # the store and rewrites the query before lane fan-out.
 VOCAB_BRIDGE_FLAG: Final[str] = "use_vocab_bridge"
+# v2.0 #436 intentional-clustering flag. Default-OFF at v2.0.0 until the
+# lab-side bench gate (A2 in docs/feature-intentional-clustering.md)
+# clears. When ON, the L1 pack loop is replaced with a diversity-aware
+# greedy fill that biases the top-K toward distinct graph-connected
+# clusters; locked + L2.5 are pre-included unchanged. Mutually exclusive
+# with use_type_aware_compression at v2.0.0 — the cluster pack uses raw
+# token cost, composing it with compressed cost is a v2.x follow-up.
+INTENTIONAL_CLUSTERING_FLAG: Final[str] = "use_intentional_clustering"
 
 PLACEHOLDER_FLAGS: Final[tuple[str, ...]] = (
     SIGNED_LAPLACIAN_FLAG,
@@ -171,6 +185,8 @@ ENV_HRR_STRUCTURAL: Final[str] = "AELFRICE_HRR_STRUCTURAL"
 ENV_TYPE_AWARE_COMPRESSION: Final[str] = "AELFRICE_TYPE_AWARE_COMPRESSION"
 # v2.1 #433 vocabulary-bridge env override. Tri-state.
 ENV_VOCAB_BRIDGE: Final[str] = "AELFRICE_VOCAB_BRIDGE"
+# v2.0 #436 intentional-clustering env override. Tri-state.
+ENV_INTENTIONAL_CLUSTERING: Final[str] = "AELFRICE_INTENTIONAL_CLUSTERING"
 # v1.3.0 posterior-weight env override. Float-typed; "0.0" is the
 # only value that fully disables (collapsing to BM25-only ordering).
 # Empty / non-numeric values fall through to the next precedence
@@ -348,6 +364,21 @@ def _env_type_aware_compression_override() -> bool | None:
     recognised truthy/falsy value, else None. Symmetric to
     `_env_bm25f_override`."""
     raw = os.environ.get(ENV_TYPE_AWARE_COMPRESSION)
+    if raw is None:
+        return None
+    norm = raw.strip().lower()
+    if norm in _ENV_FALSY:
+        return False
+    if norm in _ENV_TRUTHY:
+        return True
+    return None
+
+
+def _env_intentional_clustering_override() -> bool | None:
+    """Return True/False if AELFRICE_INTENTIONAL_CLUSTERING is set to a
+    recognised truthy/falsy value, else None. Symmetric to
+    `_env_bm25f_override`."""
+    raw = os.environ.get(ENV_INTENTIONAL_CLUSTERING)
     if raw is None:
         return None
     norm = raw.strip().lower()
@@ -780,6 +811,32 @@ def resolve_use_type_aware_compression(
     if explicit is not None:
         return explicit
     toml_value = _read_toml_flag_for(TYPE_AWARE_COMPRESSION_FLAG, start)
+    if toml_value is not None:
+        return toml_value
+    return False
+
+
+def resolve_use_intentional_clustering(
+    explicit: bool | None = None,
+    *,
+    start: Path | None = None,
+) -> bool:
+    """Resolve the intentional-clustering flag (#436).
+
+    Precedence (first decisive wins):
+      1. AELFRICE_INTENTIONAL_CLUSTERING env var (truthy / falsy normalised).
+      2. Explicit `explicit` kwarg from the caller.
+      3. `[retrieval] use_intentional_clustering` in `.aelfrice.toml`.
+      4. Default: False — ships behind the flag at v2.0.0; the bench gate
+         (A2 in docs/feature-intentional-clustering.md) flips the default
+         after lab-side benchmark evidence clears.
+    """
+    env = _env_intentional_clustering_override()
+    if env is not None:
+        return env
+    if explicit is not None:
+        return explicit
+    toml_value = _read_toml_flag_for(INTENTIONAL_CLUSTERING_FLAG, start)
     if toml_value is not None:
         return toml_value
     return False

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -1438,6 +1438,7 @@ def retrieve_with_tiers(
     heat_kernel_enabled: bool | None = None,
     eigenbasis_cache: GraphEigenbasisCache | None = None,
     use_type_aware_compression: bool | None = None,
+    use_intentional_clustering: bool | None = None,
 ) -> tuple[
     list[Belief], list[str], list[str], list[str], list[list[str]],
 ]:
@@ -1458,6 +1459,14 @@ def retrieve_with_tiers(
     `rendered_tokens` rather than `_belief_tokens(b)`. Locks always
     render verbatim per the strategy table, so locked accounting is
     unchanged. Default-OFF preserves byte-identical output.
+
+    When `use_intentional_clustering` resolves True (#436 v2.0), the L1
+    score-ranked greedy fill is replaced with `pack_with_clusters` over
+    the candidate-induced edge subgraph; locked + L2.5 are pre-included
+    unchanged, BFS expansion runs after as before. Mutually exclusive
+    with `use_type_aware_compression` at v2.0.0 — the cluster pack
+    accounts in raw tokens, composing it with compressed cost is a v2.x
+    follow-up; passing both raises ValueError.
     """
     global _LAST_TELEMETRY
     enabled = is_entity_index_enabled(entity_index_enabled)
@@ -1468,6 +1477,17 @@ def retrieve_with_tiers(
     compress_on = resolve_use_type_aware_compression(
         use_type_aware_compression,
     )
+    cluster_on = resolve_use_intentional_clustering(
+        use_intentional_clustering,
+    )
+    if cluster_on and compress_on:
+        raise ValueError(
+            "use_intentional_clustering and use_type_aware_compression "
+            "are mutually exclusive at v2.0.0 — the cluster pack uses "
+            "raw token cost; composing it with compressed cost is a "
+            "v2.x follow-up. See docs/feature-intentional-clustering.md "
+            "§ Reconciliation vs. type-aware compression (#434).",
+        )
     warn_placeholder_flags()
 
     def _cost(b: Belief) -> int:
@@ -1524,14 +1544,39 @@ def retrieve_with_tiers(
     out: list[Belief] = list(locked) + list(l25)
     l1_ids_list: list[str] = []
     l1_packed: list[Belief] = []
-    for b in l1:
-        cost: int = _cost(b)
-        if used + cost > effective_budget:
-            break
-        out.append(b)
-        l1_packed.append(b)
-        used += cost
-        l1_ids_list.append(b.id)
+    if cluster_on and l1:
+        # Diversity-aware fill over the candidate-induced edge subgraph
+        # (#436). Rank-position-as-score: l1 is already sorted descending
+        # by the rerank, so position is a monotone proxy for score and
+        # only the ordering matters to cluster_candidates / Stage 1.
+        cluster_scores: dict[str, float] = {
+            b.id: float(len(l1) - i) for i, b in enumerate(l1)
+        }
+        l1_edges = store.edges_for_beliefs([b.id for b in l1])
+        clusters = cluster_candidates(
+            l1, cluster_scores, edges=l1_edges,
+            edge_weight_floor=DEFAULT_CLUSTER_EDGE_FLOOR,
+        )
+        l1_by_id: dict[str, Belief] = {b.id: b for b in l1}
+        l1_remaining_budget = max(0, effective_budget - used)
+        l1_packed = pack_with_clusters(
+            clusters, l1_by_id,
+            token_budget=l1_remaining_budget,
+            cluster_diversity_target=DEFAULT_CLUSTER_DIVERSITY_TARGET,
+        )
+        for b in l1_packed:
+            out.append(b)
+            used += _cost(b)
+            l1_ids_list.append(b.id)
+    else:
+        for b in l1:
+            cost: int = _cost(b)
+            if used + cost > effective_budget:
+                break
+            out.append(b)
+            l1_packed.append(b)
+            used += cost
+            l1_ids_list.append(b.id)
 
     bfs_chains: list[list[str]] = []
     if bfs_on and query.strip():
@@ -1590,6 +1635,7 @@ def retrieve_v2(
     use_type_aware_compression: bool | None = None,
     use_vocab_bridge: bool | None = None,
     vocab_bridge_cache: VocabBridgeCache | None = None,
+    use_intentional_clustering: bool | None = None,
 ) -> RetrievalResult:
     """Lab-compatible retrieval wrapper for academic-suite adapters.
 
@@ -1677,6 +1723,7 @@ def retrieve_v2(
         use_bm25f_anchors=use_bm25f,
         bm25f_cache=bm25f_cache,
         use_type_aware_compression=use_type_aware_compression,
+        use_intentional_clustering=use_intentional_clustering,
     )
     if include_locked:
         beliefs = out

--- a/tests/test_clustering_integration.py
+++ b/tests/test_clustering_integration.py
@@ -1,0 +1,271 @@
+"""Integration tests for #436 intentional clustering wired into retrieve_v2.
+
+Covers flag-precedence resolution, byte-identical default-OFF behavior,
+the diversity-aware pack on graph-connected candidates, locked-belief
+pre-include, and the mutual-exclusion guard against type-aware
+compression at v2.0.0.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_SUPPORTS,
+    LOCK_NONE,
+    LOCK_USER,
+    RETENTION_FACT,
+    RETENTION_SNAPSHOT,
+    Belief,
+    Edge,
+)
+from aelfrice.retrieval import (
+    ENV_INTENTIONAL_CLUSTERING,
+    ENV_TYPE_AWARE_COMPRESSION,
+    INTENTIONAL_CLUSTERING_FLAG,
+    resolve_use_intentional_clustering,
+    retrieve_v2,
+)
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    bid: str,
+    content: str,
+    *,
+    retention_class: str = RETENTION_FACT,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-05-08T00:00:00Z",
+        last_retrieved_at=None,
+        retention_class=retention_class,
+    )
+
+
+@pytest.fixture
+def _no_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_INTENTIONAL_CLUSTERING, raising=False)
+    monkeypatch.delenv(ENV_TYPE_AWARE_COMPRESSION, raising=False)
+
+
+@pytest.fixture
+def _isolated_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# --- Flag resolution ---------------------------------------------------
+
+
+def test_default_is_off(_no_env_override: None, _isolated_cwd: Path) -> None:
+    assert resolve_use_intentional_clustering() is False
+
+
+def test_explicit_kwarg_overrides_default(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    assert resolve_use_intentional_clustering(True) is True
+    assert resolve_use_intentional_clustering(False) is False
+
+
+def test_env_overrides_explicit_kwarg(
+    monkeypatch: pytest.MonkeyPatch, _isolated_cwd: Path
+) -> None:
+    monkeypatch.setenv(ENV_INTENTIONAL_CLUSTERING, "1")
+    assert resolve_use_intentional_clustering(False) is True
+    monkeypatch.setenv(ENV_INTENTIONAL_CLUSTERING, "0")
+    assert resolve_use_intentional_clustering(True) is False
+
+
+def test_env_garbage_falls_through(
+    monkeypatch: pytest.MonkeyPatch, _isolated_cwd: Path
+) -> None:
+    monkeypatch.setenv(ENV_INTENTIONAL_CLUSTERING, "maybe")
+    assert resolve_use_intentional_clustering() is False
+    assert resolve_use_intentional_clustering(True) is True
+
+
+def test_toml_resolves_when_kwarg_and_env_unset(
+    _no_env_override: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / ".aelfrice.toml"
+    cfg.write_text(
+        f"[retrieval]\n{INTENTIONAL_CLUSTERING_FLAG} = true\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    assert resolve_use_intentional_clustering() is True
+
+
+# --- retrieve_v2 wiring ------------------------------------------------
+
+
+def _populate_clustered_store() -> MemoryStore:
+    """Two graph-connected clusters joined by SUPPORTS edges, plus an
+    isolated singleton. With clustering OFF, the score-ranked greedy
+    fill returns whatever ranks highest. With clustering ON, the
+    diversity-aware pack covers more clusters at the same budget."""
+    s = MemoryStore(":memory:")
+    # Cluster A: tightly-coupled deploy facts.
+    for bid in ("A1", "A2", "A3"):
+        s.insert_belief(_mk(
+            bid,
+            f"deploy {bid}: the system uses sqlite for persistence and ships nightly",
+            retention_class=RETENTION_FACT,
+        ))
+    s.insert_edge(Edge(src="A1", dst="A2", type=EDGE_SUPPORTS, weight=0.8))
+    s.insert_edge(Edge(src="A2", dst="A3", type=EDGE_SUPPORTS, weight=0.8))
+    # Cluster B: tightly-coupled prerequisite facts.
+    for bid in ("B1", "B2"):
+        s.insert_belief(_mk(
+            bid,
+            f"deploy {bid}: prerequisite is sqlite being installed on every host",
+            retention_class=RETENTION_FACT,
+        ))
+    s.insert_edge(Edge(src="B1", dst="B2", type=EDGE_SUPPORTS, weight=0.8))
+    # Singleton.
+    s.insert_belief(_mk(
+        "C1",
+        "deploy C1: rollback is via the previous nightly artifact for sqlite",
+        retention_class=RETENTION_FACT,
+    ))
+    return s
+
+
+def test_default_call_byte_identical_to_explicit_off(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    """Default and explicit-OFF must agree on the merged belief id list.
+
+    This is the OFF-byte-identity invariant that makes the wiring safe to
+    land default-OFF — pre-#436-Phase-2 callers see no behavior change."""
+    s = _populate_clustered_store()
+    explicit_off = retrieve_v2(
+        s, "deploy sqlite",
+        budget=2400,
+        use_entity_index=False,
+        use_intentional_clustering=False,
+    )
+    default_off = retrieve_v2(
+        s, "deploy sqlite",
+        budget=2400,
+        use_entity_index=False,
+    )
+    assert [b.id for b in explicit_off.beliefs] \
+        == [b.id for b in default_off.beliefs]
+
+
+def test_clustering_changes_selection_at_tight_budget(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    """At a budget tight enough that OFF can fit only Cluster A's top
+    members, ON pivots to cover Cluster B + the singleton via Stage 1
+    representatives. The selections differ as a set, demonstrating that
+    cluster_diversity_target=3 changed *which* beliefs survived the pack."""
+    s = _populate_clustered_store()
+    off = retrieve_v2(
+        s, "deploy sqlite",
+        budget=80,
+        use_entity_index=False,
+        use_intentional_clustering=False,
+    )
+    on = retrieve_v2(
+        s, "deploy sqlite",
+        budget=80,
+        use_entity_index=False,
+        use_intentional_clustering=True,
+    )
+    off_ids = {b.id for b in off.beliefs}
+    on_ids = {b.id for b in on.beliefs}
+    # ON must include at least one belief OFF didn't (cluster diversity)
+    # AND must drop at least one belief OFF kept (the second member of
+    # the highest-seed cluster, displaced by another cluster's rep).
+    assert on_ids != off_ids, (
+        f"clustering ON should differ from OFF at tight budget; "
+        f"got OFF={sorted(off_ids)} ON={sorted(on_ids)}"
+    )
+
+
+def test_locked_pre_included_when_clustering_on(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    """Spec § Open Q4: locked beliefs pre-include ahead of Stage 1.
+
+    Implementation satisfies this implicitly — `out = list(locked) +
+    list(l25)` runs before the cluster pack on the L1 candidates only."""
+    s = _populate_clustered_store()
+    s.insert_belief(_mk(
+        "L0",
+        "user-pinned: sqlite is the chosen substrate. immutable.",
+        retention_class=RETENTION_SNAPSHOT,
+        lock_level=LOCK_USER,
+        locked_at="2026-05-08T00:00:00Z",
+    ))
+    on = retrieve_v2(
+        s, "deploy sqlite",
+        budget=2400,
+        use_entity_index=False,
+        use_intentional_clustering=True,
+    )
+    assert on.beliefs[0].id == "L0", (
+        f"locked belief must be first regardless of clustering flag; "
+        f"got {[b.id for b in on.beliefs[:3]]}"
+    )
+
+
+def test_mutual_exclusion_with_compression_raises(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    """At v2.0.0, clustering + compression together raise ValueError —
+    the cluster pack accounts in raw token cost, composing it with the
+    compressed cost is a v2.x follow-up."""
+    s = _populate_clustered_store()
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        retrieve_v2(
+            s, "deploy sqlite",
+            budget=2400,
+            use_entity_index=False,
+            use_intentional_clustering=True,
+            use_type_aware_compression=True,
+        )
+
+
+def test_env_var_alone_enables_clustering(
+    monkeypatch: pytest.MonkeyPatch, _isolated_cwd: Path
+) -> None:
+    """No kwarg + env=1 + tight budget → ON behavior."""
+    monkeypatch.setenv(ENV_INTENTIONAL_CLUSTERING, "1")
+    s = _populate_clustered_store()
+    on_via_env = retrieve_v2(
+        s, "deploy sqlite",
+        budget=80,
+        use_entity_index=False,
+    )
+    monkeypatch.setenv(ENV_INTENTIONAL_CLUSTERING, "0")
+    off_via_env = retrieve_v2(
+        s, "deploy sqlite",
+        budget=80,
+        use_entity_index=False,
+    )
+    # The env-flip must change at least one of: belief count, ordering,
+    # or selection. If it changes none, the env wiring is broken.
+    on_ids = [b.id for b in on_via_env.beliefs]
+    off_ids = [b.id for b in off_via_env.beliefs]
+    assert on_ids != off_ids, (
+        f"env=1 must produce different selection than env=0 at tight "
+        f"budget; got both = {on_ids}"
+    )


### PR DESCRIPTION
Phase 2 of #436 — wire intentional clustering into `retrieve_v2`. Phase 1 (`clustering.py` module + `MemoryStore.edges_for_beliefs` + multi_fact corpus mount + bench-gate scaffold) shipped at #496 / `5465b3c`. This PR closes the wiring deferral listed in the Phase-1 PR body's "What's deferred" section: flag-resolution + retrieve_v2 integration + locked pre-include.

## Change

`retrieve_with_tiers()` accepts `use_intentional_clustering: bool | None`. When ON, the L1 score-ranked greedy fill is replaced with `pack_with_clusters` over the candidate-induced edge subgraph; locked + L2.5 are pre-included unchanged (spec § Open Q4 met implicitly — they are appended before the L1 pack runs in either path). BFS expansion runs after as before.

`retrieve_v2()` threads its existing flag through. Default-OFF preserves byte-identical L1 selection — the else-branch is the unmodified greedy loop.

## Mutual exclusion with type-aware compression

At v2.0.0, `use_intentional_clustering` and `use_type_aware_compression` together raise `ValueError`. The cluster pack accounts in raw token cost (`pack_with_clusters` uses its own `_belief_tokens`); composing with compressed cost requires a cost-callback in `pack_with_clusters` that's a v2.x follow-up. The error message points at the spec § Reconciliation row that documents this.

## Rank-position-as-score

`l1` is already sorted descending after the rerank, so position is a monotone proxy for the rank score. `cluster_candidates` only needs ordering — within a cluster `member_ids[0]` is the representative, across clusters `seed_score` is the max — so:

```python
cluster_scores = {b.id: float(len(l1) - i) for i, b in enumerate(l1)}
```

is sufficient. Switching to a real per-belief score would require widening `_l1_hits`'s return type, which is invasive and orthogonal to this PR's scope.

## Acceptance against spec

- A1 (multi_fact corpus): lab-side; this PR is public-side only
- A2 (recall@k uplift): wiring closes the precondition. Strict `cluster_coverage@k` bench still requires `AELFRICE_CORPUS_ROOT` lab cut
- A3 (single-fact non-regression): preserved by default-OFF; `test_default_call_byte_identical_to_explicit_off`
- A4 (latency): bound analytically per spec § "Latency budget"; microbench is still next gate
- A5 (composition tracker): waits on #154

## Test plan

- [x] 10 new integration tests in `tests/test_clustering_integration.py`:
  - flag resolution (default OFF, kwarg, env, TOML, env-garbage fall-through)
  - byte-identical default-vs-explicit-OFF
  - ON-vs-OFF selection differs at tight budget (diversity-aware Stage 1)
  - locked pre-include preserved when clustering ON
  - mutual-exclusion-with-compression raises
  - env=1 alone enables (no kwarg)
- [x] Full suite 2899 passed / 25 skipped — no regressions vs the 2889 baseline post-#497
- [ ] Bench-gate run against lab corpus — gated on `AELFRICE_CORPUS_ROOT` and the `tests.retrieve_uplift_runner.run_clustering_uplift` lab-side scorer (Phase-1 bench-gate scaffold from #496 picks it up automatically)

## Refs

- Spec: `docs/feature-intentional-clustering.md` § Where clustering sits / § Open Q4
- Phase 1: #496 / `5465b3c`
- Sibling Phase-2 wiring pattern: #497 (#434 Phase 2 — pack-loop budget compressed cost)

Closes the Phase-2 wiring for #436. Issue stays open as umbrella for the lab-side bench cut + the cost-callback follow-up that unlocks compression × clustering composition.

## Summary by Sourcery

Wire the intentional clustering feature into retrieve_v2 behind a new flag, keeping default behavior unchanged while enabling diversity-aware L1 packing when explicitly enabled.

New Features:
- Add a configurable use_intentional_clustering flag (env, TOML, or kwarg) to control diversity-aware clustering during retrieval.
- Integrate cluster-based packing into retrieve_with_tiers and expose it through retrieve_v2 to bias L1 results toward graph-diverse clusters.

Enhancements:
- Enforce mutual exclusion between intentional clustering and type-aware compression at v2.0.0, failing fast with a clear error message.
- Document the updated status of the intentional clustering feature in the spec to reflect retrieve_v2 wiring.

Documentation:
- Update the intentional clustering feature spec to note that it is now wired into retrieve_v2 behind a default-off flag.

Tests:
- Add integration tests covering flag precedence resolution, default-off byte-identical behavior, clustering’s impact under tight budgets, locked pre-include behavior, mutual exclusion with compression, and env-only enablement of clustering.