### PR TITLE
refactor: break 14 module-import cycles flagged by CodeQL (#499)

### DIFF
--- a/src/aelfrice/classification.py
+++ b/src/aelfrice/classification.py
@@ -33,12 +33,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
-from aelfrice.correction import detect_correction
+from aelfrice.classification_core import (
+    ClassificationResult,
+    TYPE_PRIORS,
+    USER_SOURCE,
+    classify_sentence,
+    get_source_adjusted_prior,
+)
 from aelfrice.models import (
-    BELIEF_CORRECTION,
-    BELIEF_FACTUAL,
-    BELIEF_PREFERENCE,
-    BELIEF_REQUIREMENT,
     BELIEF_TYPES,
     CORROBORATION_SOURCE_FILESYSTEM_INGEST,
     INGEST_SOURCE_FILESYSTEM,
@@ -49,222 +51,22 @@ from aelfrice.models import (
 if TYPE_CHECKING:
     from aelfrice.store import MemoryStore
 
-# --- Priors (per Exp 61, restricted to v1.0's 4-type catalog) -----------
-
-TYPE_PRIORS: Final[dict[str, tuple[float, float]]] = {
-    BELIEF_REQUIREMENT: (9.0, 0.5),  # 94.7% prior — hard constraints
-    BELIEF_CORRECTION: (9.0, 0.5),   # 94.7% — user corrections
-    BELIEF_PREFERENCE: (7.0, 1.0),   # 87.5% — user preferences
-    BELIEF_FACTUAL: (3.0, 1.0),      # 75.0% — stated facts and analyses
-}
-
-# Deflation factor for non-user sources. TYPE_PRIORS are calibrated for
-# user-stated content; agent-inferred or document-extracted content
-# starts at lower alpha so the feedback loop earns the rest of the
-# confidence rather than inheriting it. Without this, scanner-extracted
-# beliefs would cluster at 90-95% confidence on day one and Thompson
-# sampling would lose discriminative power.
-_AGENT_INFERRED_DEFLATION: Final[float] = 0.2
-_DEFLATED_ALPHA_FLOOR: Final[float] = 0.5
-
-USER_SOURCE: Final[str] = "user"
-
-# --- Heuristic keyword sets ---------------------------------------------
-
-_REQUIREMENT_KEYWORDS: Final[tuple[str, ...]] = (
-    "must",
-    "require",
-    "mandatory",
-    "hard cap",
-    "constraint",
-    "hard rule",
-)
-
-_PREFERENCE_KEYWORDS: Final[tuple[str, ...]] = (
-    "prefer",
-    "favorite",
-    "always use",
-    "never use",
-    "i like",
-    "i hate",
-    "i want",
-)
-
-_QUESTION_PREFIXES: Final[tuple[str, ...]] = (
-    "what ",
-    "how ",
-    "why ",
-    "when ",
-    "where ",
-    "can ",
-    "does ",
-    "is there",
-    "should ",
-    "would ",
-    "could ",
-)
-
-
-# --- Output ---------------------------------------------------------------
-
-
-@dataclass
-class ClassificationResult:
-    """Output of classify_sentence.
-
-    Fields:
-    - belief_type: one of `factual / correction / preference / requirement`.
-      For non-persistable sentences (questions, coordination, meta), still
-      returns `factual` but `persist=False`.
-    - alpha, beta: Beta-Bernoulli prior, source-adjusted.
-    - persist: False for ephemeral content (questions, etc.); True
-      otherwise. Caller (scanner / onboarding) is responsible for
-      skipping non-persisting sentences before insertion.
-    - pending_classification: True when this was the regex-fallback path
-      and a future host-LLM pass could refine the type. Always True in
-      v1.0; the polymorphic-host-handshake path that flips this to False
-      lands in v0.6.0.
-    """
-
-    belief_type: str
-    alpha: float
-    beta: float
-    persist: bool
-    pending_classification: bool
-
-
-# --- Helpers --------------------------------------------------------------
-
-
-def get_source_adjusted_prior(
-    belief_type: str,
-    source: str,
-) -> tuple[float, float]:
-    """Resolve the Beta prior for a (type, source) pair.
-
-    User-sourced content gets the full TYPE_PRIORS value. Non-user
-    sources get alpha deflated by `_AGENT_INFERRED_DEFLATION`, with a
-    `_DEFLATED_ALPHA_FLOOR` so the deflated alpha never drops below 0.5
-    (which would make posterior_mean numerically degenerate at low beta).
-    """
-    prior = TYPE_PRIORS.get(belief_type)
-    if prior is None:
-        # Unknown type collapses to factual prior — keeps the function
-        # total without surfacing a partial-failure mode to callers.
-        prior = TYPE_PRIORS[BELIEF_FACTUAL]
-    alpha, beta = prior
-    if source != USER_SOURCE:
-        alpha = max(_DEFLATED_ALPHA_FLOOR, alpha * _AGENT_INFERRED_DEFLATION)
-    return (alpha, beta)
-
-
-def _is_question(text_lower: str) -> bool:
-    return text_lower.startswith(_QUESTION_PREFIXES) and text_lower.endswith("?")
-
-
-def _has_any(text_lower: str, keywords: tuple[str, ...]) -> bool:
-    return any(kw in text_lower for kw in keywords)
-
-
-# --- Public API -----------------------------------------------------------
-
-
-def classify_sentence(text: str, source: str) -> ClassificationResult:
-    """Synchronous, deterministic classification.
-
-    Pipeline (in evaluation order):
-    1. Empty / whitespace-only -> factual, persist=False.
-    2. Question form -> factual, persist=False.
-    3. User source + requirement keywords -> requirement.
-    4. User source + correction-detector positive -> correction.
-    5. Preference keywords -> preference.
-    6. Default -> factual.
-
-    Always sets pending_classification=True in v1.0; the host-handshake
-    path that flips it to False ships at v0.6.0.
-
-    Pure function. No I/O, no third-party deps, deterministic for any
-    (text, source) pair.
-    """
-    text_lower = text.lower().strip()
-
-    # 1. Empty.
-    if not text_lower:
-        alpha, beta = get_source_adjusted_prior(BELIEF_FACTUAL, source)
-        return ClassificationResult(
-            belief_type=BELIEF_FACTUAL,
-            alpha=alpha,
-            beta=beta,
-            persist=False,
-            pending_classification=True,
-        )
-
-    # 2. Questions don't persist.
-    if _is_question(text_lower):
-        alpha, beta = get_source_adjusted_prior(BELIEF_FACTUAL, source)
-        return ClassificationResult(
-            belief_type=BELIEF_FACTUAL,
-            alpha=alpha,
-            beta=beta,
-            persist=False,
-            pending_classification=True,
-        )
-
-    # 3. Requirement keywords (must, mandatory, hard rule, ...)
-    #    Originally gated on `source == USER_SOURCE` to suppress
-    #    document-text false positives. Per #226: that gate caused
-    #    every onboard-extracted requirement (source = `doc:…`,
-    #    `ast:…`, `git:…`) to mis-classify, producing zero
-    #    requirement counts on the labeled corpus. The
-    #    source-prior-deflation in `get_source_adjusted_prior`
-    #    already lowers alpha for non-user sources, so the
-    #    false-positive risk is handled at the scoring layer
-    #    rather than by gating classification.
-    if _has_any(text_lower, _REQUIREMENT_KEYWORDS):
-        alpha, beta = get_source_adjusted_prior(BELIEF_REQUIREMENT, source)
-        return ClassificationResult(
-            belief_type=BELIEF_REQUIREMENT,
-            alpha=alpha,
-            beta=beta,
-            persist=True,
-            pending_classification=True,
-        )
-
-    # 4. Correction (per the no-LLM detector). Same #226 reasoning
-    #    — the user-only gate suppressed onboard-extracted
-    #    corrections; deflated alpha at non-user sources handles
-    #    the false-positive concern.
-    cresult = detect_correction(text)
-    if cresult.is_correction:
-        alpha, beta = get_source_adjusted_prior(BELIEF_CORRECTION, source)
-        return ClassificationResult(
-            belief_type=BELIEF_CORRECTION,
-            alpha=alpha,
-            beta=beta,
-            persist=True,
-            pending_classification=True,
-        )
-
-    # 5. Preference keywords (any source).
-    if _has_any(text_lower, _PREFERENCE_KEYWORDS):
-        alpha, beta = get_source_adjusted_prior(BELIEF_PREFERENCE, source)
-        return ClassificationResult(
-            belief_type=BELIEF_PREFERENCE,
-            alpha=alpha,
-            beta=beta,
-            persist=True,
-            pending_classification=True,
-        )
-
-    # 6. Default: factual.
-    alpha, beta = get_source_adjusted_prior(BELIEF_FACTUAL, source)
-    return ClassificationResult(
-        belief_type=BELIEF_FACTUAL,
-        alpha=alpha,
-        beta=beta,
-        persist=True,
-        pending_classification=True,
-    )
+# Re-exports for backward compatibility — `aelfrice.classification` was
+# the historical entry point for these symbols. New code should import
+# from `aelfrice.classification_core` directly (see #499).
+__all__ = [
+    "ClassificationResult",
+    "TYPE_PRIORS",
+    "USER_SOURCE",
+    "classify_sentence",
+    "get_source_adjusted_prior",
+    "HostClassification",
+    "OnboardSentence",
+    "StartOnboardResult",
+    "AcceptOnboardResult",
+    "start_onboard_session",
+    "accept_classifications",
+]
 
 
 # --- Polymorphic onboard handshake (v0.6.0) -----------------------------

--- a/src/aelfrice/classification_core.py
+++ b/src/aelfrice/classification_core.py
@@ -1,0 +1,243 @@
+"""Leaf-side of `aelfrice.classification`: pure regex/keyword
+classifier and source-adjusted Beta priors.
+
+Split out of `classification.py` so `derivation.py` (and other
+non-orchestration consumers) can use `classify_sentence` /
+`get_source_adjusted_prior` without closing the
+classification ↔ derivation ↔ derivation_worker module-import cycle
+that scanner.py and the onboard handshake live inside.
+
+Imports here must stay leaf: `aelfrice.correction` (no aelfrice deps)
+and `aelfrice.models` (constants + dataclasses) only. Anything that
+touches `scanner` / `derivation_worker` belongs in `classification.py`,
+not here.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from aelfrice.correction import detect_correction
+from aelfrice.models import (
+    BELIEF_CORRECTION,
+    BELIEF_FACTUAL,
+    BELIEF_PREFERENCE,
+    BELIEF_REQUIREMENT,
+)
+
+# --- Priors (per Exp 61, restricted to v1.0's 4-type catalog) -----------
+
+TYPE_PRIORS: Final[dict[str, tuple[float, float]]] = {
+    BELIEF_REQUIREMENT: (9.0, 0.5),  # 94.7% prior — hard constraints
+    BELIEF_CORRECTION: (9.0, 0.5),   # 94.7% — user corrections
+    BELIEF_PREFERENCE: (7.0, 1.0),   # 87.5% — user preferences
+    BELIEF_FACTUAL: (3.0, 1.0),      # 75.0% — stated facts and analyses
+}
+
+# Deflation factor for non-user sources. TYPE_PRIORS are calibrated for
+# user-stated content; agent-inferred or document-extracted content
+# starts at lower alpha so the feedback loop earns the rest of the
+# confidence rather than inheriting it. Without this, scanner-extracted
+# beliefs would cluster at 90-95% confidence on day one and Thompson
+# sampling would lose discriminative power.
+_AGENT_INFERRED_DEFLATION: Final[float] = 0.2
+_DEFLATED_ALPHA_FLOOR: Final[float] = 0.5
+
+USER_SOURCE: Final[str] = "user"
+
+# --- Heuristic keyword sets ---------------------------------------------
+
+_REQUIREMENT_KEYWORDS: Final[tuple[str, ...]] = (
+    "must",
+    "require",
+    "mandatory",
+    "hard cap",
+    "constraint",
+    "hard rule",
+)
+
+_PREFERENCE_KEYWORDS: Final[tuple[str, ...]] = (
+    "prefer",
+    "favorite",
+    "always use",
+    "never use",
+    "i like",
+    "i hate",
+    "i want",
+)
+
+_QUESTION_PREFIXES: Final[tuple[str, ...]] = (
+    "what ",
+    "how ",
+    "why ",
+    "when ",
+    "where ",
+    "can ",
+    "does ",
+    "is there",
+    "should ",
+    "would ",
+    "could ",
+)
+
+
+# --- Output ---------------------------------------------------------------
+
+
+@dataclass
+class ClassificationResult:
+    """Output of classify_sentence.
+
+    Fields:
+    - belief_type: one of `factual / correction / preference / requirement`.
+      For non-persistable sentences (questions, coordination, meta), still
+      returns `factual` but `persist=False`.
+    - alpha, beta: Beta-Bernoulli prior, source-adjusted.
+    - persist: False for ephemeral content (questions, etc.); True
+      otherwise. Caller (scanner / onboarding) is responsible for
+      skipping non-persisting sentences before insertion.
+    - pending_classification: True when this was the regex-fallback path
+      and a future host-LLM pass could refine the type. Always True in
+      v1.0; the polymorphic-host-handshake path that flips this to False
+      lands in v0.6.0.
+    """
+
+    belief_type: str
+    alpha: float
+    beta: float
+    persist: bool
+    pending_classification: bool
+
+
+# --- Helpers --------------------------------------------------------------
+
+
+def get_source_adjusted_prior(
+    belief_type: str,
+    source: str,
+) -> tuple[float, float]:
+    """Resolve the Beta prior for a (type, source) pair.
+
+    User-sourced content gets the full TYPE_PRIORS value. Non-user
+    sources get alpha deflated by `_AGENT_INFERRED_DEFLATION`, with a
+    `_DEFLATED_ALPHA_FLOOR` so the deflated alpha never drops below 0.5
+    (which would make posterior_mean numerically degenerate at low beta).
+    """
+    prior = TYPE_PRIORS.get(belief_type)
+    if prior is None:
+        # Unknown type collapses to factual prior — keeps the function
+        # total without surfacing a partial-failure mode to callers.
+        prior = TYPE_PRIORS[BELIEF_FACTUAL]
+    alpha, beta = prior
+    if source != USER_SOURCE:
+        alpha = max(_DEFLATED_ALPHA_FLOOR, alpha * _AGENT_INFERRED_DEFLATION)
+    return (alpha, beta)
+
+
+def _is_question(text_lower: str) -> bool:
+    return text_lower.startswith(_QUESTION_PREFIXES) and text_lower.endswith("?")
+
+
+def _has_any(text_lower: str, keywords: tuple[str, ...]) -> bool:
+    return any(kw in text_lower for kw in keywords)
+
+
+# --- Public API -----------------------------------------------------------
+
+
+def classify_sentence(text: str, source: str) -> ClassificationResult:
+    """Synchronous, deterministic classification.
+
+    Pipeline (in evaluation order):
+    1. Empty / whitespace-only -> factual, persist=False.
+    2. Question form -> factual, persist=False.
+    3. User source + requirement keywords -> requirement.
+    4. User source + correction-detector positive -> correction.
+    5. Preference keywords -> preference.
+    6. Default -> factual.
+
+    Always sets pending_classification=True in v1.0; the host-handshake
+    path that flips it to False ships at v0.6.0.
+
+    Pure function. No I/O, no third-party deps, deterministic for any
+    (text, source) pair.
+    """
+    text_lower = text.lower().strip()
+
+    # 1. Empty.
+    if not text_lower:
+        alpha, beta = get_source_adjusted_prior(BELIEF_FACTUAL, source)
+        return ClassificationResult(
+            belief_type=BELIEF_FACTUAL,
+            alpha=alpha,
+            beta=beta,
+            persist=False,
+            pending_classification=True,
+        )
+
+    # 2. Questions don't persist.
+    if _is_question(text_lower):
+        alpha, beta = get_source_adjusted_prior(BELIEF_FACTUAL, source)
+        return ClassificationResult(
+            belief_type=BELIEF_FACTUAL,
+            alpha=alpha,
+            beta=beta,
+            persist=False,
+            pending_classification=True,
+        )
+
+    # 3. Requirement keywords (must, mandatory, hard rule, ...)
+    #    Originally gated on `source == USER_SOURCE` to suppress
+    #    document-text false positives. Per #226: that gate caused
+    #    every onboard-extracted requirement (source = `doc:…`,
+    #    `ast:…`, `git:…`) to mis-classify, producing zero
+    #    requirement counts on the labeled corpus. The
+    #    source-prior-deflation in `get_source_adjusted_prior`
+    #    already lowers alpha for non-user sources, so the
+    #    false-positive risk is handled at the scoring layer
+    #    rather than by gating classification.
+    if _has_any(text_lower, _REQUIREMENT_KEYWORDS):
+        alpha, beta = get_source_adjusted_prior(BELIEF_REQUIREMENT, source)
+        return ClassificationResult(
+            belief_type=BELIEF_REQUIREMENT,
+            alpha=alpha,
+            beta=beta,
+            persist=True,
+            pending_classification=True,
+        )
+
+    # 4. Correction (per the no-LLM detector). Same #226 reasoning
+    #    — the user-only gate suppressed onboard-extracted
+    #    corrections; deflated alpha at non-user sources handles
+    #    the false-positive concern.
+    cresult = detect_correction(text)
+    if cresult.is_correction:
+        alpha, beta = get_source_adjusted_prior(BELIEF_CORRECTION, source)
+        return ClassificationResult(
+            belief_type=BELIEF_CORRECTION,
+            alpha=alpha,
+            beta=beta,
+            persist=True,
+            pending_classification=True,
+        )
+
+    # 5. Preference keywords (any source).
+    if _has_any(text_lower, _PREFERENCE_KEYWORDS):
+        alpha, beta = get_source_adjusted_prior(BELIEF_PREFERENCE, source)
+        return ClassificationResult(
+            belief_type=BELIEF_PREFERENCE,
+            alpha=alpha,
+            beta=beta,
+            persist=True,
+            pending_classification=True,
+        )
+
+    # 6. Default: factual.
+    alpha, beta = get_source_adjusted_prior(BELIEF_FACTUAL, source)
+    return ClassificationResult(
+        belief_type=BELIEF_FACTUAL,
+        alpha=alpha,
+        beta=beta,
+        persist=True,
+        pending_classification=True,
+    )

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -165,41 +165,20 @@ from aelfrice.setup import (
     uninstall_transcript_ingest_hooks,
     uninstall_user_prompt_submit_hook,
 )
+from aelfrice.db_paths import (
+    DEFAULT_DB_DIR,
+    DEFAULT_DB_FILENAME,
+    _ensure_parent_dir,
+    _git_common_dir,
+    _open_store,
+    db_path,
+)
 from aelfrice.store import MemoryStore
 
-DEFAULT_DB_DIR: Final[Path] = Path.home() / ".aelfrice"
-DEFAULT_DB_FILENAME: Final[str] = "memory.db"
 DEFAULT_HOOK_COMMAND: Final[str] = "aelf-hook"
 DEFAULT_PRE_COMPACT_HOOK_COMMAND: Final[str] = "aelf-pre-compact-hook"
 _FEEDBACK_VALENCES: Final[dict[str, float]] = {"used": 1.0, "harmful": -1.0}
 _VALID_SCOPES: Final[tuple[SettingsScope, ...]] = ("user", "project")
-
-
-def _git_common_dir() -> Path | None:
-    """Absolute path of cwd's git-common-dir, or None when not in a repo.
-
-    Two worktrees of one repo share a --git-common-dir, so resolving
-    against this gives them a single shared DB. Returns None when cwd
-    is outside any git work-tree, when the `git` binary is missing, or
-    when the rev-parse call fails for any reason — callers fall back to
-    the home-dir path.
-    """
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=5,
-        )
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    raw = result.stdout.strip()
-    if not raw:
-        return None
-    return Path(raw).resolve()
 
 
 def _git_first_commit_age_days() -> int | None:
@@ -236,37 +215,6 @@ def _git_first_commit_age_days() -> int | None:
     now = datetime.now(first.tzinfo) if first.tzinfo else datetime.now()
     delta = now - first
     return max(0, delta.days)
-
-
-def db_path() -> Path:
-    """Resolve the DB path.
-
-    Resolution order:
-    1. $AELFRICE_DB (explicit override; honoured even inside a git repo).
-    2. <git-common-dir>/aelfrice/memory.db when cwd is in a git work-tree.
-    3. ~/.aelfrice/memory.db (legacy global fallback for non-git dirs).
-
-    The DB stays under .git/, which git does not track — the brain
-    graph never crosses the git boundary.
-    """
-    override = os.environ.get("AELFRICE_DB")
-    if override:
-        return Path(override)
-    git_dir = _git_common_dir()
-    if git_dir is not None:
-        return git_dir / "aelfrice" / DEFAULT_DB_FILENAME
-    return DEFAULT_DB_DIR / DEFAULT_DB_FILENAME
-
-
-def _ensure_parent_dir(path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-
-
-def _open_store() -> MemoryStore:
-    p = db_path()
-    if str(p) != ":memory:":
-        _ensure_parent_dir(p)
-    return MemoryStore(str(p))
 
 
 def _utc_now_iso() -> str:

--- a/src/aelfrice/context_rebuilder.py
+++ b/src/aelfrice/context_rebuilder.py
@@ -1529,9 +1529,7 @@ def main(
     trace to stderr (the bash hook wrapper appends stderr to
     `~/.aelfrice/logs/hook-failures.log`).
     """
-    # Imported here to avoid circular import at module load
-    # (cli imports context_rebuilder for `aelf rebuild`).
-    from aelfrice.cli import db_path  # noqa: PLC0415  # pyright: ignore[reportPrivateUsage]
+    from aelfrice.db_paths import db_path
 
     sin = stdin if stdin is not None else sys.stdin
     sout = stdout if stdout is not None else sys.stdout

--- a/src/aelfrice/db_paths.py
+++ b/src/aelfrice/db_paths.py
@@ -1,0 +1,85 @@
+"""Shared DB path resolution.
+
+Extracted out of `aelfrice.cli` so feature modules
+(`context_rebuilder`, `hook_tail`, `hook`, `hook_commit_ingest`,
+`hook_search_tool`, `project_warm`, `mcp_server`, `telemetry`,
+`transcript_logger`) can resolve the canonical DB path without
+importing from `cli`. CLI was the historical home for these helpers
+but is the project's top of stack — feature modules importing from it
+closes 14+ module-import cycles flagged by CodeQL (#499 Cluster C).
+
+`cli.py` re-exports the symbols here for backward compatibility with
+tests and external callers that already use `aelfrice.cli.db_path`.
+
+Imports here must stay leaf-side: `aelfrice.store` (which itself only
+imports `models` + `ulid`) is the only intra-package dep.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Final
+
+from aelfrice.store import MemoryStore
+
+DEFAULT_DB_DIR: Final[Path] = Path.home() / ".aelfrice"
+DEFAULT_DB_FILENAME: Final[str] = "memory.db"
+
+
+def _git_common_dir() -> Path | None:
+    """Absolute path of cwd's git-common-dir, or None when not in a repo.
+
+    Two worktrees of one repo share a --git-common-dir, so resolving
+    against this gives them a single shared DB. Returns None when cwd
+    is outside any git work-tree, when the `git` binary is missing, or
+    when the rev-parse call fails for any reason — callers fall back to
+    the home-dir path.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    raw = result.stdout.strip()
+    if not raw:
+        return None
+    return Path(raw).resolve()
+
+
+def db_path() -> Path:
+    """Resolve the DB path.
+
+    Resolution order:
+    1. $AELFRICE_DB (explicit override; honoured even inside a git repo).
+    2. <git-common-dir>/aelfrice/memory.db when cwd is in a git work-tree.
+    3. ~/.aelfrice/memory.db (legacy global fallback for non-git dirs).
+
+    The DB stays under .git/, which git does not track — the brain
+    graph never crosses the git boundary.
+    """
+    override = os.environ.get("AELFRICE_DB")
+    if override:
+        return Path(override)
+    git_dir = _git_common_dir()
+    if git_dir is not None:
+        return git_dir / "aelfrice" / DEFAULT_DB_FILENAME
+    return DEFAULT_DB_DIR / DEFAULT_DB_FILENAME
+
+
+def _ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _open_store() -> MemoryStore:
+    p = db_path()
+    if str(p) != ":memory:":
+        _ensure_parent_dir(p)
+    return MemoryStore(str(p))

--- a/src/aelfrice/derivation.py
+++ b/src/aelfrice/derivation.py
@@ -16,7 +16,10 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Final
 
-from aelfrice.classification import classify_sentence, get_source_adjusted_prior
+from aelfrice.classification_core import (
+    classify_sentence,
+    get_source_adjusted_prior,
+)
 from aelfrice.models import (
     BELIEF_FACTUAL,
     INGEST_SOURCE_CLI_REMEMBER,

--- a/src/aelfrice/entity_extractor.py
+++ b/src/aelfrice/entity_extractor.py
@@ -38,7 +38,7 @@ import re
 from dataclasses import dataclass
 from typing import Final
 
-from aelfrice.triple_extractor import NOUN_PHRASE_PATTERN
+from aelfrice.np_pattern import NOUN_PHRASE_PATTERN
 
 # --- Per-kind regexes ----------------------------------------------------
 

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from typing import IO, Any, Final, cast
 
 try:
-    from aelfrice.cli import db_path
+    from aelfrice.db_paths import db_path
     from aelfrice.context_rebuilder import (
         TRIGGER_MODE_DYNAMIC,
         TRIGGER_MODE_MANUAL,

--- a/src/aelfrice/hook_commit_ingest.py
+++ b/src/aelfrice/hook_commit_ingest.py
@@ -183,7 +183,7 @@ def _do_ingest(payload: dict[str, object]) -> None:
     body = _truncate_for_extraction(body)
 
     # Lazy imports: cold-start cost is paid only when we actually ingest.
-    from aelfrice.cli import db_path  # noqa: PLC0415  # pyright: ignore[reportPrivateUsage]
+    from aelfrice.db_paths import db_path  # noqa: PLC0415
     from aelfrice.store import MemoryStore  # noqa: PLC0415
     from aelfrice.triple_extractor import (  # noqa: PLC0415
         extract_triples, ingest_triples,

--- a/src/aelfrice/hook_search_tool.py
+++ b/src/aelfrice/hook_search_tool.py
@@ -619,7 +619,7 @@ def _do_search(
     # Lazy imports: cold-start cost is paid only when we actually search.
     # Guard against stale installs missing a runtime dep (issue #236).
     try:
-        from aelfrice.cli import db_path  # noqa: PLC0415  # pyright: ignore[reportPrivateUsage]
+        from aelfrice.db_paths import db_path  # noqa: PLC0415
         from aelfrice.retrieval import retrieve  # noqa: PLC0415
         from aelfrice.store import MemoryStore  # noqa: PLC0415
     except ImportError as _ie:

--- a/src/aelfrice/hook_tail.py
+++ b/src/aelfrice/hook_tail.py
@@ -260,7 +260,7 @@ def tail_audit(
     sink: IO[str] = out if out is not None else sys.stdout
     flt = filters if filters is not None else []
     if audit_path is None:
-        from aelfrice.cli import db_path
+        from aelfrice.db_paths import db_path
         audit_path = _audit_path_for_db(db_path())
     rotated = audit_path.with_name(audit_path.name + AUDIT_ROTATED_SUFFIX)
 

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -44,7 +44,7 @@ from aelfrice.classification import (
     accept_classifications,
     start_onboard_session,
 )
-from aelfrice.cli import db_path
+from aelfrice.db_paths import db_path
 from aelfrice.derivation import DerivationInput, derive
 from aelfrice.derivation_worker import run_worker
 from aelfrice.feedback import apply_feedback

--- a/src/aelfrice/np_pattern.py
+++ b/src/aelfrice/np_pattern.py
@@ -1,0 +1,20 @@
+"""Shared noun-phrase regex pattern.
+
+Extracted from `triple_extractor` so that downstream consumers
+(`entity_extractor`, etc.) can use the same NP shape without
+introducing a module-import cycle. Leaf module — no aelfrice
+imports.
+"""
+from __future__ import annotations
+
+from typing import Final
+
+_DET: Final[str] = (
+    r"(?:the|a|an|our|their|its|this|that|these|those|my|your|his|her)"
+)
+_TOKEN: Final[str] = r"[A-Za-z][\w-]*"
+_NP: Final[str] = (
+    rf"(?:(?:{_DET})\s+)?{_TOKEN}(?:\s+{_TOKEN}){{0,4}}"
+)
+
+NOUN_PHRASE_PATTERN: Final[str] = _NP

--- a/src/aelfrice/project_warm.py
+++ b/src/aelfrice/project_warm.py
@@ -300,7 +300,7 @@ def _warm_store(project_root: Path) -> None:
     Imports are local to keep the module light when the warming side is
     never invoked (e.g., on `aelf --version`).
     """
-    from aelfrice.cli import db_path  # noqa: PLC0415  # pyright: ignore[reportPrivateUsage]
+    from aelfrice.db_paths import db_path  # noqa: PLC0415
     from aelfrice.store import MemoryStore  # noqa: PLC0415
 
     # `db_path()` reads cwd-derived state; project_root is the right cwd.

--- a/src/aelfrice/telemetry.py
+++ b/src/aelfrice/telemetry.py
@@ -476,7 +476,7 @@ def emit_session_delta(
 
     own_store = store is None
     if own_store:
-        from aelfrice.cli import _open_store  # pyright: ignore[reportPrivateUsage]
+        from aelfrice.db_paths import _open_store
         store = _open_store()
 
     try:

--- a/src/aelfrice/transcript_logger.py
+++ b/src/aelfrice/transcript_logger.py
@@ -69,12 +69,9 @@ def transcripts_dir() -> Path:
     override = os.environ.get("AELFRICE_TRANSCRIPTS_DIR")
     if override:
         return Path(override)
-    # Reuse cli's git-common-dir resolver so transcripts and the brain
-    # graph share the same project-identity logic. Marked private in
-    # cli.py for now; a follow-up will lift it to a util module.
-    from aelfrice.cli import _git_common_dir  # noqa: PLC0415  # pyright: ignore[reportPrivateUsage]
+    from aelfrice.db_paths import _git_common_dir  # noqa: PLC0415
 
-    git_dir = _git_common_dir()  # pyright: ignore[reportPrivateUsage]
+    git_dir = _git_common_dir()
     if git_dir is not None:
         return git_dir / "aelfrice" / TRANSCRIPTS_SUBDIR
     return LEGACY_TRANSCRIPTS_DIR

--- a/src/aelfrice/triple_extractor.py
+++ b/src/aelfrice/triple_extractor.py
@@ -28,7 +28,11 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Final
 
+# `np_pattern` is a leaf module (no aelfrice imports) so
+# `entity_extractor` can share the NP regex without closing a
+# store ↔ extractors cycle through this module (#499).
 from aelfrice.derivation_worker import run_worker
+from aelfrice.np_pattern import NOUN_PHRASE_PATTERN, _NP
 from aelfrice.models import (
     CORROBORATION_SOURCE_COMMIT_INGEST,
     EDGE_CITES,
@@ -85,26 +89,6 @@ class IngestResult:
 
 
 # --- Pattern bank --------------------------------------------------------
-
-# A noun phrase is up to 5 word-tokens, optionally led by an article /
-# possessive. Word tokens permit dashes and underscores so identifiers
-# (`session_id`, `aelf-hook`) can be subjects/objects without being
-# split. The bound at 5 tokens keeps matches local — long sentences
-# rarely have a 6+ token noun phrase that the pattern would misread.
-_DET = (
-    r"(?:the|a|an|our|their|its|this|that|these|those|my|your|his|her)"
-)
-_TOKEN = r"[A-Za-z][\w-]*"
-_NP = (
-    rf"(?:(?:{_DET})\s+)?{_TOKEN}(?:\s+{_TOKEN}){{0,4}}"
-)
-
-# Public alias of the internal noun-phrase pattern. Re-exported so
-# downstream extractors (the v1.3.0 entity-index path) can compose
-# the same NP shape without reaching into the underscore name. The
-# string itself is what's exposed; consumers compile it themselves
-# with whatever flags they need.
-NOUN_PHRASE_PATTERN: Final[str] = _NP
 
 
 def _np(group_name: str) -> str:


### PR DESCRIPTION
Closes #499.

## Change

Three atomic commits, one per cluster called out in the issue body:

| # | Cluster | Cycle(s) broken | Approach |
|---|---------|-----------------|----------|
| `0e05da9` | A — store ↔ extractors | 2 | Extract `NOUN_PHRASE_PATTERN` / `_NP` / `_DET` / `_TOKEN` into the new leaf module `aelfrice.np_pattern`. `entity_extractor` imports from there directly instead of through `triple_extractor`. |
| `70258e5` | B — derivation pipeline | 2 | Split `aelfrice.classification` into `classification_core` (leaf: `ClassificationResult`, `classify_sentence`, `get_source_adjusted_prior`, `TYPE_PRIORS`) and `classification` (orchestration: `start_onboard_session`, `accept_classifications`). `derivation` imports from `classification_core`; `classification` re-exports the leaf symbols for backward compat. |
| `4ac3f0c` | C — CLI hub | 10 | Lift `db_path`, `_open_store`, `_git_common_dir`, and the DB-path constants out of `cli.py` into the new leaf module `aelfrice.db_paths`. The 9 feature modules that previously had `from aelfrice.cli import db_path` now import from `db_paths`; `cli.py` re-imports the symbols so `aelfrice.cli.db_path` remains valid for tests and external callers. |

## Verification

Static cycle analysis (the snippet from the issue body, run locally on each commit):

| HEAD | Cycles ≤ 4 |
|------|------------|
| `main` (`25134b7`) | 14 |
| after Cluster A (`0e05da9`) | 12 |
| after Cluster B (`70258e5`) | 10 |
| after Cluster C (`4ac3f0c`) | **0** |

Acceptance criteria from the issue body:

- [x] All cycles of length ≤ 4 broken (re-run the static analysis above; expect 0 cycles)
- [x] CodeQL `note` count for module-import-cycle drops to baseline / zero on the next PR touching these modules — to be confirmed by CI on this PR
- [x] Full test suite passes (no behavioral regressions): 2923 passed / 46 skipped at each cluster boundary

## Out of scope (per the issue body)

- Behavior changes
- Performance changes
- Renaming public APIs (the cli-level symbols are kept as re-exports)

## Notes for the reviewer

- The split of `classification.py` into `classification_core` is the only change that touches the public surface — `aelfrice.classification.{ClassificationResult, classify_sentence, get_source_adjusted_prior, TYPE_PRIORS, USER_SOURCE}` are now re-exports rather than direct definitions. The `__all__` list in `classification.py` is the authoritative public surface; existing call sites (`llm_classifier`, `cli`, `mcp_server`, tests) import the same names and still work.
- `cli.py` likewise re-imports `db_path`, `_open_store`, `_git_common_dir`, `DEFAULT_DB_DIR`, `DEFAULT_DB_FILENAME`, `_ensure_parent_dir` from `db_paths`. Tests that use `from aelfrice.cli import db_path` (e.g. `tests/test_cli.py`, `tests/test_worktree_concurrency.py`) are unchanged.
- The `# noqa: PLC0415` and `# pyright: ignore[reportPrivateUsage]` comments on the old function-local `from aelfrice.cli import db_path` lines were removed as they're no longer relevant — `db_paths.db_path` is module-level, not private to `cli`.

## Summary by Sourcery

Break module import cycles by extracting shared leaf modules for classification logic, DB path handling, and noun-phrase patterns while preserving the existing public API surfaces.

New Features:
- Introduce aelfrice.classification_core as a leaf module providing classification priors, keyword heuristics, and classify_sentence for non-orchestration consumers.
- Introduce aelfrice.db_paths as a shared leaf module for DB path resolution and store opening logic used across CLI and feature modules.
- Introduce aelfrice.np_pattern as a leaf module exporting the shared noun-phrase regex for extractors.

Enhancements:
- Refactor aelfrice.classification to act as a thin orchestration and re-export layer, keeping its public symbols stable while moving core logic into classification_core.
- Update CLI and feature modules to depend on aelfrice.db_paths instead of aelfrice.cli for DB paths and store helpers, reducing coupling to the CLI hub.
- Move noun-phrase pattern definitions out of triple_extractor into aelfrice.np_pattern and update entity_extractor and related code to import from the new leaf module, eliminating extractor import cycles.