### PR TITLE
refactor: lift DocAnchor to leaf module to break residual doc_linker ↔ store cycle (#501)

### DIFF
--- a/src/aelfrice/doc_linker.py
+++ b/src/aelfrice/doc_linker.py
@@ -22,45 +22,29 @@ Out of scope at v2.0.0 (per spec):
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Final
 
-if TYPE_CHECKING:
-    from aelfrice.store import MemoryStore
-
-ANCHOR_INGEST: Final[str] = "ingest"
-ANCHOR_MANUAL: Final[str] = "manual"
-ANCHOR_DERIVED: Final[str] = "derived"
-
-ANCHOR_TYPES: Final[frozenset[str]] = frozenset(
-    {ANCHOR_INGEST, ANCHOR_MANUAL, ANCHOR_DERIVED},
+# Types + constants live in the leaf module so `aelfrice.store` can read
+# the `DocAnchor` shape without closing a `doc_linker ↔ store` cycle
+# (see #501). Re-exported here for backward compatibility.
+from aelfrice.doc_linker_types import (
+    ANCHOR_DERIVED,
+    ANCHOR_INGEST,
+    ANCHOR_MANUAL,
+    ANCHOR_TYPES,
+    DocAnchor,
 )
 
-
-@dataclass(frozen=True)
-class DocAnchor:
-    """One stored anchor row from ``belief_documents``.
-
-    ``doc_uri`` is opaque to the linker. Recommended encodings at v2.0.0:
-
-    - ``file:///abs/path/to/source.py#Lstart-Lend`` — local-source ingest.
-    - ``https://host/path#fragment`` — external doc / web ingest.
-
-    Other forms are accepted; the linker only rejects empty input.
-
-    ``position_hint`` is a free-form string (e.g. ``"L42-L60"``,
-    ``"#section"``); ``None`` when the URI itself encodes the position or
-    no hint is available.
-
-    ``created_at`` is a unix timestamp (seconds since epoch).
-    """
-
-    belief_id: str
-    doc_uri: str
-    anchor_type: str
-    position_hint: str | None
-    created_at: float
+__all__ = (
+    "ANCHOR_DERIVED",
+    "ANCHOR_INGEST",
+    "ANCHOR_MANUAL",
+    "ANCHOR_TYPES",
+    "DocAnchor",
+    "file_uri_from_path",
+    "get_doc_anchors",
+    "link_belief_to_document",
+)
 
 
 def file_uri_from_path(

--- a/src/aelfrice/doc_linker_types.py
+++ b/src/aelfrice/doc_linker_types.py
@@ -1,0 +1,47 @@
+"""Leaf module: types and constants for the document/semantic linker.
+
+Extracted from `aelfrice.doc_linker` so `aelfrice.store` can read the
+`DocAnchor` shape without closing a `doc_linker ↔ store` import cycle
+(`doc_linker.link_belief_to_document` calls `store.link_belief_to_document`,
+and `store` returns `DocAnchor` rows back). Mirrors the leaf-module
+pattern used in #500 for `np_pattern` / `classification_core` / `db_paths`.
+
+This module imports nothing from the rest of `aelfrice` — keep it that way.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+ANCHOR_INGEST: Final[str] = "ingest"
+ANCHOR_MANUAL: Final[str] = "manual"
+ANCHOR_DERIVED: Final[str] = "derived"
+
+ANCHOR_TYPES: Final[frozenset[str]] = frozenset(
+    {ANCHOR_INGEST, ANCHOR_MANUAL, ANCHOR_DERIVED},
+)
+
+
+@dataclass(frozen=True)
+class DocAnchor:
+    """One stored anchor row from ``belief_documents``.
+
+    ``doc_uri`` is opaque to the linker. Recommended encodings at v2.0.0:
+
+    - ``file:///abs/path/to/source.py#Lstart-Lend`` — local-source ingest.
+    - ``https://host/path#fragment`` — external doc / web ingest.
+
+    Other forms are accepted; the linker only rejects empty input.
+
+    ``position_hint`` is a free-form string (e.g. ``"L42-L60"``,
+    ``"#section"``); ``None`` when the URI itself encodes the position or
+    no hint is available.
+
+    ``created_at`` is a unix timestamp (seconds since epoch).
+    """
+
+    belief_id: str
+    doc_uri: str
+    anchor_type: str
+    position_hint: str | None
+    created_at: float

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -1958,9 +1958,7 @@ class MemoryStore:
         IGNORE turns repeats into no-op writes. Returns the canonical
         (first-write) row regardless of whether this call inserted.
         """
-        # Imported here to avoid a module-level cycle: doc_linker imports
-        # MemoryStore via TYPE_CHECKING-only.
-        from aelfrice.doc_linker import ANCHOR_TYPES, DocAnchor
+        from aelfrice.doc_linker_types import ANCHOR_TYPES, DocAnchor
 
         if not doc_uri:
             raise ValueError("doc_uri must be non-empty")
@@ -1998,7 +1996,7 @@ class MemoryStore:
 
     def get_doc_anchors(self, belief_id: str) -> list["DocAnchor"]:  # noqa: F821
         """Return every anchor for one belief, ordered by `created_at` ASC."""
-        from aelfrice.doc_linker import DocAnchor
+        from aelfrice.doc_linker_types import DocAnchor
 
         cur = self._conn.execute(
             """
@@ -2030,7 +2028,7 @@ class MemoryStore:
         costs one indexed read per call rather than one per surfaced
         belief. Result dict has an entry for every requested id.
         """
-        from aelfrice.doc_linker import DocAnchor
+        from aelfrice.doc_linker_types import DocAnchor
 
         out: dict[str, list[DocAnchor]] = {bid: [] for bid in belief_ids}
         if not belief_ids:


### PR DESCRIPTION
Phase 1 of #501 — close the residual `doc_linker ↔ store` cycle that #494's merge introduced and that PR #500's review flagged. Mirrors the leaf-module pattern PR #500 used for `np_pattern` / `classification_core` / `db_paths`.

## Change

`aelfrice.doc_linker_types` is a new leaf module containing `DocAnchor`, `ANCHOR_INGEST` / `ANCHOR_MANUAL` / `ANCHOR_DERIVED`, and `ANCHOR_TYPES`. It imports nothing from the rest of `aelfrice` — keep it that way.

`aelfrice.doc_linker` re-exports the lifted symbols so external callers (`from aelfrice.doc_linker import DocAnchor`) keep working. The `if TYPE_CHECKING: from aelfrice.store import MemoryStore` block is gone — `from __future__ import annotations` already makes the `"MemoryStore"` forward-ref strings runtime no-ops.

`aelfrice.store`'s three function-local imports in `link_belief_to_document`, `get_doc_anchors`, and `get_doc_anchors_batch` now read from `doc_linker_types` instead of `doc_linker`.

## Static analysis

Cycle-finder from #499's body, run on the PR head:

- **No-TYPE_CHECKING-filter (strictest, what my AST walk does):** 0 cycles ≤ length 4. Pre-PR (post-#500): 1 cycle (`doc_linker ↔ store`).
- **TYPE_CHECKING-filter (industry-standard, what CodeQL does):** 0 cycles ≤ length 4. Pre-PR: 0 (CodeQL never flagged this one — TYPE_CHECKING blocks aren't edges to it).

Both detectors agree at 0 now. Acceptance row for "cycle-finder reports 0 cycles ≤ length 4" met.

## Test plan

- [x] Doc-linker tests: 18/18 pass (`tests/test_doc_linker.py` + `tests/test_retrieve_doc_anchors.py`).
- [x] Full suite: 2948 passed / 48 skipped — no regressions vs the post-#500 baseline.
- [x] Discretion grep clean.
- [x] Both commits signed (G/G).
- [ ] CodeQL `note` count for module-import-cycle — verify on the next PR run picks up the cleanup.

## Refs

- Issue: #501 (filed during PR #500 review)
- Sibling pattern: PR #500 (`np_pattern` / `classification_core` / `db_paths`)
- Doc-linker module: #435 / PR #494

Closes #501.

## Summary by Sourcery

Extract document linker anchor types into a leaf module to break the remaining import cycle between the doc linker and store while preserving the external API.

Enhancements:
- Introduce a new doc_linker_types leaf module that holds DocAnchor and anchor-related constants without importing from the rest of the package.
- Update doc_linker to re-export DocAnchor and anchor constants from the new leaf module and to declare an explicit public API.
- Retarget store’s local imports for DocAnchor and anchor constants to the new doc_linker_types module to avoid a doc_linker ↔ store dependency cycle.