### PR TITLE
feat(test): run_clustering_uplift driver — bench-gate scorer for #436

### DIFF
--- a/tests/retrieve_uplift_runner.py
+++ b/tests/retrieve_uplift_runner.py
@@ -47,7 +47,11 @@ from aelfrice.models import (
     Belief,
     Edge,
 )
-from aelfrice.retrieval import retrieve
+from aelfrice.retrieval import (
+    DEFAULT_TOKEN_BUDGET,
+    retrieve,
+    retrieve_v2,
+)
 from aelfrice.store import MemoryStore
 
 _TS = "2026-05-05T00:00:00+00:00"
@@ -230,6 +234,137 @@ def run_per_flag_uplift(
                 mean_ndcg_on=on_total / n if n else 0.0,
             ))
     return out
+
+
+# ---------------------------------------------------------------------
+# Intentional clustering (#436) — multi_fact bench gate (spec § A2).
+#
+# Consumed by tests/bench_gate/test_intentional_clustering.py via
+# `pytest.importorskip("tests.retrieve_uplift_runner")` then
+# `runner_mod.run_clustering_uplift(rows)`. Activates on any
+# AELFRICE_CORPUS_ROOT pointing at a `multi_fact/*.jsonl` row set.
+#
+# Doc-linker (#435) symmetric runner intentionally NOT here — its A2
+# gate requires a downstream rerank that consumes the `with_doc_anchors`
+# projection to influence belief order, and that rerank has not shipped.
+# When it lands, the same shape applies (load rows → twin retrieve calls
+# → mean-NDCG uplift). Filed for a follow-up PR.
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ClusteringUplift:
+    """Spec § A2 result shape for #436.
+
+    Bench-gate test asserts ``cluster_coverage_uplift > 0`` and
+    formats the OFF/ON/uplift triple in its failure message; recall@k
+    fields are reported alongside as the don't-degrade backstop.
+    """
+
+    n_rows: int
+    mean_recall_off: float
+    mean_recall_on: float
+    cluster_coverage_off: float
+    cluster_coverage_on: float
+
+    @property
+    def cluster_coverage_uplift(self) -> float:
+        return self.cluster_coverage_on - self.cluster_coverage_off
+
+    @property
+    def recall_uplift(self) -> float:
+        return self.mean_recall_on - self.mean_recall_off
+
+
+def _cluster_coverage_at_k(
+    returned: list[str],
+    expected_clusters: list[list[str]],
+    n_clusters_required: int,
+) -> float:
+    """Spec § A2: number of expected clusters represented in the top-K
+    divided by ``n_clusters_required``. A cluster is represented if
+    at least one of its expected member ids appears in the returned
+    top-K. Returns 0.0 when ``n_clusters_required`` is non-positive
+    (degenerate row; treated as zero-uplift signal)."""
+    if n_clusters_required <= 0:
+        return 0.0
+    rs = set(returned)
+    covered = sum(
+        1 for cluster in expected_clusters
+        if any(bid in rs for bid in cluster)
+    )
+    return covered / n_clusters_required
+
+
+def _recall_at_k(returned: list[str], expected: list[str]) -> float:
+    if not expected:
+        return 0.0
+    return len(set(returned) & set(expected)) / len(expected)
+
+
+# Tight enough that ~2 multi_fact beliefs at ~30-50 tokens each fit;
+# spec § A2 calls for "fixed budget that forces the pack to choose
+# between cluster representatives." Override via the CLI / programmatic
+# kwarg if a corpus has a different per-belief size.
+DEFAULT_MULTI_FACT_BUDGET: int = 100
+
+
+def run_clustering_uplift(
+    rows: list[dict],  # type: ignore[type-arg]
+    *,
+    budget: int = DEFAULT_MULTI_FACT_BUDGET,
+    k: int | None = None,
+) -> ClusteringUplift:
+    """Spec § A2 multi-fact uplift driver.
+
+    Per row: build a transient ``MemoryStore`` from the row's
+    ``beliefs`` + ``edges``, run ``retrieve_v2`` once with
+    ``use_intentional_clustering=False`` and once with ``=True`` at the
+    same ``budget``. ``k`` defaults to ``row['n_clusters_required']``
+    so the metric asks "did the top-K cover the required clusters."
+    """
+    n = len(rows)
+    if n == 0:
+        return ClusteringUplift(0, 0.0, 0.0, 0.0, 0.0)
+
+    rec_off = rec_on = cov_off = cov_on = 0.0
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_root = Path(tmp)
+        for row in rows:
+            row_k = k if k is not None else int(row.get("n_clusters_required", 2))
+            expected = list(row["expected_belief_ids"])
+            clusters = list(row["expected_clusters"])
+            required = int(row["n_clusters_required"])
+
+            for clustering_on in (False, True):
+                _db_counter[0] += 1
+                db = tmp_root / f"clust_{row['id']}_{int(clustering_on)}_{_db_counter[0]}.db"
+                store = MemoryStore(str(db))
+                try:
+                    _seed_store(store, row)
+                    result = retrieve_v2(
+                        store, row["query"],
+                        budget=budget,
+                        use_entity_index=False,
+                        use_intentional_clustering=clustering_on,
+                    )
+                    returned = [b.id for b in result.beliefs[:row_k]]
+                finally:
+                    store.close()
+                if clustering_on:
+                    rec_on += _recall_at_k(returned, expected)
+                    cov_on += _cluster_coverage_at_k(returned, clusters, required)
+                else:
+                    rec_off += _recall_at_k(returned, expected)
+                    cov_off += _cluster_coverage_at_k(returned, clusters, required)
+
+    return ClusteringUplift(
+        n_rows=n,
+        mean_recall_off=rec_off / n,
+        mean_recall_on=rec_on / n,
+        cluster_coverage_off=cov_off / n,
+        cluster_coverage_on=cov_on / n,
+    )
 
 
 def _format_table(results: list[FlagUplift]) -> str:

--- a/tests/test_retrieve_uplift_runner.py
+++ b/tests/test_retrieve_uplift_runner.py
@@ -58,6 +58,94 @@ def test_flag_uplift_dataclass_uplift_property() -> None:
     assert abs(fu.uplift - 0.15) < 1e-9
 
 
+def test_clustering_uplift_empty_input() -> None:
+    """Empty corpus: zero rows, zero uplift, no exceptions."""
+    from tests.retrieve_uplift_runner import (
+        ClusteringUplift,
+        run_clustering_uplift,
+    )
+    r = run_clustering_uplift([])
+    assert isinstance(r, ClusteringUplift)
+    assert r.n_rows == 0
+    assert r.cluster_coverage_uplift == 0.0
+    assert r.recall_uplift == 0.0
+
+
+def test_clustering_uplift_shape_contract() -> None:
+    """Bench-gate test reads .cluster_coverage_uplift /
+    .cluster_coverage_on / .cluster_coverage_off — verify the names
+    haven't drifted."""
+    from tests.retrieve_uplift_runner import ClusteringUplift
+    r = ClusteringUplift(
+        n_rows=2,
+        mean_recall_off=0.5,
+        mean_recall_on=0.75,
+        cluster_coverage_off=0.5,
+        cluster_coverage_on=1.0,
+    )
+    assert r.cluster_coverage_uplift == 0.5
+    assert r.recall_uplift == 0.25
+
+
+def test_clustering_uplift_runs_on_synthetic_row() -> None:
+    """One row → driver returns valid bounded metrics. Doesn't assert
+    a specific uplift sign — that's bench evidence the test can't
+    reproduce deterministically across rerank tuning."""
+    from tests.retrieve_uplift_runner import run_clustering_uplift
+    row = {
+        "id": "mf-test-001",
+        "query": "deploy and prerequisites",
+        "beliefs": [
+            {"id": "d1", "content": "deploy: install via pip then run setup"},
+            {"id": "d2", "content": "deploy: provisions a sqlite store"},
+            {"id": "p1", "content": "prereqs: python 3.13 required"},
+            {"id": "p2", "content": "prereqs: writable git directory"},
+        ],
+        "edges": [
+            {"src": "d1", "dst": "d2", "type": "SUPPORTS", "weight": 0.8},
+            {"src": "p1", "dst": "p2", "type": "SUPPORTS", "weight": 0.8},
+        ],
+        "expected_belief_ids": ["d1", "p1"],
+        "expected_clusters": [["d1", "d2"], ["p1", "p2"]],
+        "n_clusters_required": 2,
+    }
+    r = run_clustering_uplift([row])
+    assert r.n_rows == 1
+    for v in (
+        r.mean_recall_off, r.mean_recall_on,
+        r.cluster_coverage_off, r.cluster_coverage_on,
+    ):
+        assert 0.0 <= v <= 1.0
+
+
+def test_clustering_uplift_k_falls_back_to_n_clusters_required() -> None:
+    """When k is omitted, the driver uses row['n_clusters_required'].
+    Verify by explicitly varying k=1 vs default-K=3 and confirming the
+    metric arithmetic reflects the smaller K's narrower window."""
+    from tests.retrieve_uplift_runner import run_clustering_uplift
+    row = {
+        "id": "mf-test-002",
+        "query": "alpha beta gamma",
+        "beliefs": [
+            {"id": "a", "content": "alpha alpha alpha"},
+            {"id": "b", "content": "beta beta beta"},
+            {"id": "c", "content": "gamma gamma gamma"},
+        ],
+        "edges": [],
+        "expected_belief_ids": ["a", "b", "c"],
+        "expected_clusters": [["a"], ["b"], ["c"]],
+        "n_clusters_required": 3,
+    }
+    r_default = run_clustering_uplift([row], budget=10_000)
+    r_explicit_k1 = run_clustering_uplift([row], budget=10_000, k=1)
+    # K=3 (default from n_clusters_required) admits all three singleton
+    # clusters; K=1 admits only the top-ranked one → coverage = 1/3.
+    assert r_default.cluster_coverage_off == 1.0
+    assert r_default.cluster_coverage_on == 1.0
+    assert abs(r_explicit_k1.cluster_coverage_off - (1.0 / 3.0)) < 1e-9
+    assert abs(r_explicit_k1.cluster_coverage_on - (1.0 / 3.0)) < 1e-9
+
+
 def test_run_per_flag_uplift_covers_all_flags() -> None:
     """Hypothesis: the harness reports one row per registered flag.
     Falsifiable if a flag is silently dropped."""


### PR DESCRIPTION
Closes the runner-deferral on the bench-gate scaffold for #436 / PR #496. Until this PR, `tests/bench_gate/test_intentional_clustering.py:49` did `pytest.importorskip("tests.retrieve_uplift_runner")` then called `runner_mod.run_clustering_uplift(rows)` — and that function didn't exist. The skip path was the only path. With this merge, any operator pointing `AELFRICE_CORPUS_ROOT` at a `multi_fact/*.jsonl` row set runs the spec § A2 cluster_coverage@k uplift and gets a real PASS/FAIL.

## Change

Two atomic commits:

- `7b47063` — `feat(test): run_clustering_uplift driver for #436 bench-gate`. Adds `ClusteringUplift` dataclass + `run_clustering_uplift(rows, *, budget=100, k=None)` to `tests/retrieve_uplift_runner.py`. Per row: build a transient `MemoryStore` from the row's `beliefs` + `edges`, run `retrieve_v2` once with `use_intentional_clustering=False` (baseline) and once with `=True` (treatment), at a fixed budget tight enough to force pack-time cluster choice. K defaults to `row['n_clusters_required']`.
- `8178230` — `test: ClusteringUplift shape + run_clustering_uplift unit tests (#436)`. Four new unit tests covering empty-input, dataclass field names (catch drift before the bench-gate test would), one-synthetic-row end-to-end, and the K-kwarg fallback to `n_clusters_required`. Runs without `AELFRICE_CORPUS_ROOT`.

## Why doc-linker / compression / vocab_bridge runners are NOT here

Atomic commits beat batched. Of the four bench-gate scaffolds in `tests/bench_gate/`:

- **#436 clustering** — `runner_mod.run_clustering_uplift(rows)` — **shipped here**.
- **#435 doc-linker** — `runner_mod.run_doc_linker_uplift(rows)` — **deferred**: spec § A2 NDCG uplift requires a downstream rerank that consumes `with_doc_anchors` to influence belief order, and that rerank has not shipped. When it lands, the same shape applies.
- **#434 compression** — bench-gate scaffold is self-contained (`test_compression_uplift.py` doesn't `importorskip` a runner; it asserts compression-monotone-decreases-token-cost in-line).
- **#433 vocab_bridge** — same — self-contained scaffold.

Filing the doc-linker runner as a follow-up issue would be redundant with the umbrella (#435 already tracks it).

## Spec acceptance against #436

- A1 (corpus): lab-side; this PR is public-side only.
- A2 (recall@k uplift): scorer landed; ship-gate now executable end-to-end against any operator-mounted corpus.
- A3 (single-fact non-regression): preserved by default-OFF (already covered by `test_clustering_integration.py`).
- A4 (latency): bound analytically; microbench is still next gate.
- A5 (composition tracker): waits on #154.

## Test plan

- [x] 4 new unit tests in `tests/test_retrieve_uplift_runner.py`
- [x] Full suite 2928 passed / 26 skipped — no regressions vs the 2899 baseline
- [x] Discretion clean
- [x] Both commits signed (G/G), FF on `main`

## Refs

- Spec: `docs/feature-intentional-clustering.md` § A2
- Phase 1 (substrate): #496 / `5465b3c`
- Phase 2 (wiring): #498 / `d59b921`

Once merged, the bench-gate at `tests/bench_gate/test_intentional_clustering.py` becomes the operator gate for flipping `use_intentional_clustering` to default-on at v2.x.

## Summary by Sourcery

Add an intentional clustering uplift driver and corresponding tests to enable the intentional clustering bench-gate to execute end-to-end.

New Features:
- Introduce a ClusteringUplift result dataclass and run_clustering_uplift driver for measuring intentional clustering uplift on multi-fact corpora.

Enhancements:
- Extend the retrieve uplift runner to compute recall and cluster coverage metrics for intentional clustering using retrieve_v2.

Tests:
- Add unit tests covering ClusteringUplift shape, empty-input behavior, synthetic single-row execution, and k-versus-n_clusters_required behavior in the uplift driver.