### PR TITLE
feat(eval): #365 R1 — P@K / AUC / ρ calibration harness on public synthetic corpus

### DIFF
--- a/scripts/audit_rebuild_log.py
+++ b/scripts/audit_rebuild_log.py
@@ -1,37 +1,56 @@
 #!/usr/bin/env python3
-"""Summarise a per-session rebuild_log JSONL.
+"""Summarise a per-session rebuild_log JSONL, or run the calibration
+harness against a public synthetic corpus.
 
-Phase-1c companion to the #288 phase-1a rebuild diagnostic log. Reads
-one or more `<session_id>.jsonl` files and prints:
+Two modes:
 
-    * total rebuild invocations
-    * pack rate (n_packed / n_candidates) distribution: mean, p50, p90
-    * drop-reason histogram (e.g. ``below_floor:0.40``,
-      ``content_hash_collision_with:<id>``, ``budget``)
-    * for packed rows, the rank distribution (1, 2, 3, ...) — surfaces
-      whether the rebuilder typically packs the top candidate or
-      something further down
-    * count of truncated session-files
+1. **Audit (default).** Phase-1c companion to the #288 phase-1a
+   rebuild diagnostic log. Reads one or more ``<session_id>.jsonl``
+   files and prints:
 
-Usage:
+       * total rebuild invocations
+       * pack rate (n_packed / n_candidates) distribution: mean, p50, p90
+       * drop-reason histogram (e.g. ``below_floor:0.40``,
+         ``content_hash_collision_with:<id>``, ``budget``)
+       * packed-rank distribution
+       * count of truncated session-files
 
-    python scripts/audit_rebuild_log.py <path-to-jsonl-or-dir> [...]
+   Usage:
+
+       python scripts/audit_rebuild_log.py <path-to-jsonl-or-dir> [...]
+
+2. **Calibrate (#365 R1, opt-in via ``--calibrate-corpus``).** Runs
+   the relevance-calibration harness against a public synthetic
+   corpus (default
+   ``benchmarks/posterior_ranking/fixtures/default.jsonl``) and emits
+   P@K / ROC-AUC / Spearman ρ. No live-data dependency. Establishes
+   the harness for the close-the-loop relevance-calibration loop
+   ratified at #317 (operator approval 2026-05-03).
+
+   Usage:
+
+       python scripts/audit_rebuild_log.py --calibrate-corpus \\
+           [path/to/corpus.jsonl] [--k 10] [--seed 0]
 
 Exit codes:
-    0   summary printed
-    1   no readable input
+    0   summary or report printed
+    1   no readable input / corpus
     2   usage error
 
-Reads only — never modifies the log files.
+Reads only — never modifies the input files.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import random
 import sys
 from collections import Counter
 from pathlib import Path
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
+
+if TYPE_CHECKING:
+    from aelfrice.calibration_metrics import CalibrationReport
 
 
 def _iter_records(path: Path) -> Iterable[dict]:
@@ -181,23 +200,276 @@ def _print_report(summary: dict, *, paths_read: int) -> None:
             print(f"  rank {rank:>2}: {summary['packed_ranks'][rank]}")
 
 
+DEFAULT_CALIBRATION_CORPUS = (
+    Path(__file__).resolve().parent.parent
+    / "benchmarks"
+    / "posterior_ranking"
+    / "fixtures"
+    / "default.jsonl"
+)
+DEFAULT_CALIBRATION_K = 10
+DEFAULT_CALIBRATION_SEED = 0
+
+
+def _load_calibration_fixtures(path: Path) -> list[dict]:
+    """Load a JSONL calibration corpus.
+
+    Each line must decode to a dict carrying ``id``, ``query``,
+    ``known_belief_content``, and ``noise_belief_contents`` (a list).
+    Fixtures missing any required key, or with malformed JSON, are
+    silently skipped — same fail-soft posture as the audit reader.
+    """
+    out: list[dict] = []
+    text = path.read_text(encoding="utf-8")
+    required = ("id", "query", "known_belief_content", "noise_belief_contents")
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        if not all(key in row for key in required):
+            continue
+        if not isinstance(row["noise_belief_contents"], list):
+            continue
+        out.append(row)
+    return out
+
+
+def _build_calibration_store(fixture: dict, seed: int):
+    """Build a fresh in-memory ``MemoryStore`` for one fixture.
+
+    Imports `aelfrice` lazily and inserts one belief per content row
+    (one relevant + N noise). The noise order is shuffled with the
+    supplied seed so AUC / ρ aggregates are deterministic across
+    reruns at fixed seed (per the #365 ship gate).
+    """
+    from aelfrice.models import (  # noqa: PLC0415
+        BELIEF_FACTUAL,
+        LOCK_NONE,
+        Belief,
+    )
+    from aelfrice.store import MemoryStore  # noqa: PLC0415
+
+    store = MemoryStore(":memory:")
+    fid = str(fixture["id"])
+    known_content = str(fixture["known_belief_content"])
+    noise_contents = list(fixture["noise_belief_contents"])
+
+    def make_belief(bid: str, content: str) -> Belief:
+        return Belief(
+            id=bid,
+            content=content,
+            content_hash=f"h_{bid}",
+            alpha=0.5,
+            beta=0.5,
+            type=BELIEF_FACTUAL,
+            lock_level=LOCK_NONE,
+            locked_at=None,
+            demotion_pressure=0,
+            created_at="2026-01-01T00:00:00Z",
+            last_retrieved_at=None,
+        )
+
+    rng = random.Random(seed)
+    rng.shuffle(noise_contents)
+
+    store.insert_belief(make_belief(f"{fid}_known", known_content))
+    for i, nc in enumerate(noise_contents):
+        store.insert_belief(make_belief(f"{fid}_noise_{i}", nc))
+
+    return store
+
+
+def _run_calibration(
+    corpus_path: Path, k: int, seed: int,
+) -> int:
+    """Run the #365 R1 calibration harness against a synthetic corpus.
+
+    For each fixture in the corpus, build an in-memory store with one
+    relevant belief and N noise beliefs, run ``aelfrice.retrieval.retrieve``
+    against the query, and observe the rank of the relevant belief.
+    Aggregate (rank-as-score, is_relevant) observations across queries
+    and report P@K / ROC-AUC / Spearman ρ.
+    """
+    # Imported lazily so the audit-mode CLI does not need the package
+    # installed, only the calibrate path does.
+    from aelfrice.calibration_metrics import (  # noqa: PLC0415
+        CalibrationReport,
+        precision_at_k,
+        roc_auc,
+        spearman_rho,
+    )
+    from aelfrice.retrieval import retrieve  # noqa: PLC0415
+
+    if not corpus_path.is_file():
+        print(
+            f"audit_rebuild_log: calibration corpus not found: "
+            f"{corpus_path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    fixtures = _load_calibration_fixtures(corpus_path)
+    if not fixtures:
+        print(
+            f"audit_rebuild_log: corpus is empty: {corpus_path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    p_at_k_values: list[float] = []
+    n_truncated = 0
+    pooled_scores: list[float] = []
+    pooled_labels: list[bool] = []
+
+    for fx in fixtures:
+        store = _build_calibration_store(fx, seed)
+        query = str(fx["query"])
+        known_content = str(fx["known_belief_content"])
+        n_candidates = 1 + len(fx["noise_belief_contents"])  # type: ignore[arg-type]
+
+        results = retrieve(
+            store,
+            query,
+            l1_limit=max(k, n_candidates),
+            entity_index_enabled=False,
+            bfs_enabled=False,
+            posterior_weight=None,
+        )
+
+        relevance_top_k = [b.content == known_content for b in results]
+        if len(relevance_top_k) < k:
+            n_truncated += 1
+        p_at_k_values.append(precision_at_k(relevance_top_k, k))
+
+        # Rank-as-score for AUC / ρ: top of the list maps to the
+        # highest score so AUC reads "score increases with relevance"
+        # naturally. Candidates the retriever did not surface get
+        # score 0 (lower than any returned), preserving the corpus's
+        # full positive/negative balance in the pooled observations.
+        for rank_idx, belief in enumerate(results):
+            pooled_scores.append(float(len(results) - rank_idx))
+            pooled_labels.append(belief.content == known_content)
+        retrieved_contents = {b.content for b in results}
+        for noise_content in fx["noise_belief_contents"]:  # type: ignore[union-attr]
+            if noise_content not in retrieved_contents:
+                pooled_scores.append(0.0)
+                pooled_labels.append(False)
+        if known_content not in retrieved_contents:
+            pooled_scores.append(0.0)
+            pooled_labels.append(True)
+
+        store.close()
+
+    avg_p_at_k = (
+        sum(p_at_k_values) / len(p_at_k_values) if p_at_k_values else 0.0
+    )
+    auc = roc_auc(pooled_scores, pooled_labels)
+    rho = spearman_rho(
+        pooled_scores, [1.0 if x else 0.0 for x in pooled_labels],
+    )
+
+    report = CalibrationReport(
+        p_at_k=avg_p_at_k,
+        k=k,
+        n_queries=len(fixtures),
+        n_truncated_queries=n_truncated,
+        roc_auc=auc,
+        spearman_rho=rho,
+        n_observations=len(pooled_scores),
+    )
+    _print_calibration_report(report, corpus_path=corpus_path, seed=seed)
+    return 0
+
+
+def _format_optional_float(value: float | None) -> str:
+    return f"{value:.4f}" if value is not None else "n/a (undefined)"
+
+
+def _print_calibration_report(
+    report: CalibrationReport, *, corpus_path: Path, seed: int,
+) -> None:
+    print(f"calibration harness — corpus {corpus_path.name}")
+    print(f"  n_queries:    {report.n_queries}")
+    print(f"  n_obs:        {report.n_observations}")
+    print(f"  seed:         {seed}")
+    if report.n_truncated_queries:
+        print(
+            f"  truncated:    {report.n_truncated_queries} "
+            f"(query returned <{report.k} candidates)"
+        )
+    print()
+    print(f"P@{report.k}:        {report.p_at_k:.4f}")
+    print(f"ROC-AUC:      {_format_optional_float(report.roc_auc)}")
+    print(f"Spearman ρ:   {_format_optional_float(report.spearman_rho)}")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Summarise rebuild_log JSONL files (phase-1c for #288). "
-            "Reads only; never modifies the input."
+            "Summarise rebuild_log JSONL files (phase-1c for #288), or "
+            "run the relevance-calibration harness on a synthetic "
+            "corpus (--calibrate-corpus, #365 R1)."
         ),
     )
     parser.add_argument(
         "paths",
-        nargs="+",
+        nargs="*",
         type=Path,
         help=(
             "One or more JSONL files, or directories containing "
-            "*.jsonl session-log files."
+            "*.jsonl session-log files. Required in audit mode; "
+            "ignored in calibration mode."
+        ),
+    )
+    parser.add_argument(
+        "--calibrate-corpus",
+        nargs="?",
+        const=DEFAULT_CALIBRATION_CORPUS,
+        default=None,
+        type=Path,
+        metavar="PATH",
+        help=(
+            "Run the #365 R1 calibration harness against the supplied "
+            "synthetic corpus (defaults to "
+            f"{DEFAULT_CALIBRATION_CORPUS.name} when no path is given)."
+        ),
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        default=DEFAULT_CALIBRATION_K,
+        help=(
+            "K for P@K in calibration mode "
+            f"(default {DEFAULT_CALIBRATION_K})."
+        ),
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_CALIBRATION_SEED,
+        help=(
+            "Deterministic seed for noise-belief shuffle in "
+            f"calibration mode (default {DEFAULT_CALIBRATION_SEED})."
         ),
     )
     args = parser.parse_args(argv)
+
+    if args.calibrate_corpus is not None:
+        if args.k <= 0:
+            print(
+                "audit_rebuild_log: --k must be positive",
+                file=sys.stderr,
+            )
+            return 2
+        return _run_calibration(args.calibrate_corpus, args.k, args.seed)
+
+    if not args.paths:
+        parser.error("paths required in audit mode")
 
     paths = _collect_paths(args.paths)
     if not paths:

--- a/src/aelfrice/calibration_metrics.py
+++ b/src/aelfrice/calibration_metrics.py
@@ -1,0 +1,132 @@
+"""Relevance-calibration metrics for the close-the-loop harness (#365 R1).
+
+Pure-stdlib leaf module. Three functions:
+
+- ``precision_at_k`` — precision at rank K (the gate metric per #365 Q3).
+- ``roc_auc`` — ROC-AUC via Mann-Whitney U with average-rank tie handling.
+- ``spearman_rho`` — Spearman rank correlation with average-rank ties.
+
+All three are deterministic: same input list → bytes-identical float
+return value across reruns. Used by:
+
+- ``scripts/audit_rebuild_log.py --calibrate-corpus`` (R1, this PR).
+- ``aelf eval`` subcommand (R4, future).
+- The CI synthetic-corpus aggregate workflow (R5, future).
+
+Imports nothing from the rest of ``aelfrice`` — keep it that way so the
+metrics can be lifted into other tooling without dragging the package.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import sqrt
+from typing import Sequence
+
+__all__ = (
+    "CalibrationReport",
+    "precision_at_k",
+    "roc_auc",
+    "spearman_rho",
+)
+
+
+@dataclass(frozen=True)
+class CalibrationReport:
+    """Aggregated calibration metrics for a single harness run.
+
+    ``p_at_k`` averages per-query precision@k across queries; queries
+    that returned fewer than ``k`` candidates contribute the count of
+    relevant items in the truncated list divided by ``k`` (missing
+    slots count as not-relevant — the standard P@K definition).
+
+    ``roc_auc`` and ``spearman_rho`` are computed over the pooled
+    (score, label) observations across all queries; both are ``None``
+    when the metric is undefined (single-class labels for AUC; zero
+    variance after ranking for ρ).
+    """
+
+    p_at_k: float
+    k: int
+    n_queries: int
+    n_truncated_queries: int
+    roc_auc: float | None
+    spearman_rho: float | None
+    n_observations: int
+
+
+def precision_at_k(relevance_top_k: Sequence[bool], k: int) -> float:
+    """Precision@K of a ranked list.
+
+    ``relevance_top_k`` is the relevance label of each item in the
+    top-K returned candidates, in rank order. Items beyond rank K are
+    ignored. Missing slots (input shorter than K) count as
+    not-relevant.
+    """
+    if k <= 0:
+        raise ValueError("k must be positive")
+    n_relevant = sum(1 for r in relevance_top_k[:k] if r)
+    return n_relevant / k
+
+
+def _average_ranks(values: Sequence[float]) -> list[float]:
+    """1-indexed average-rank conversion. Ties get the mean of the
+    spanning rank positions.
+    """
+    n = len(values)
+    indexed = sorted(enumerate(values), key=lambda iv: iv[1])
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and indexed[j + 1][1] == indexed[i][1]:
+            j += 1
+        avg = (i + j) / 2.0 + 1.0
+        for idx in range(i, j + 1):
+            ranks[indexed[idx][0]] = avg
+        i = j + 1
+    return ranks
+
+
+def roc_auc(
+    scores: Sequence[float], labels: Sequence[bool],
+) -> float | None:
+    """ROC-AUC via Mann-Whitney U with average-rank tie handling.
+
+    Higher score = more relevant. Returns ``None`` when the labels
+    are single-class (AUC undefined).
+    """
+    if len(scores) != len(labels):
+        raise ValueError("scores and labels must be the same length")
+    n_pos = sum(1 for label in labels if label)
+    n_neg = len(labels) - n_pos
+    if n_pos == 0 or n_neg == 0:
+        return None
+    ranks = _average_ranks(scores)
+    sum_ranks_pos = sum(r for r, label in zip(ranks, labels) if label)
+    return (sum_ranks_pos - n_pos * (n_pos + 1) / 2.0) / (n_pos * n_neg)
+
+
+def spearman_rho(
+    xs: Sequence[float], ys: Sequence[float],
+) -> float | None:
+    """Spearman rank correlation (Pearson on average-ranked vectors).
+
+    Returns ``None`` when either ranked vector has zero variance, or
+    when fewer than two observations are supplied.
+    """
+    if len(xs) != len(ys):
+        raise ValueError("xs and ys must be the same length")
+    n = len(xs)
+    if n < 2:
+        return None
+    rx = _average_ranks(xs)
+    ry = _average_ranks(ys)
+    sx = sum(rx)
+    sy = sum(ry)
+    sxx = sum(r * r for r in rx)
+    syy = sum(r * r for r in ry)
+    sxy = sum(a * b for a, b in zip(rx, ry))
+    denom = sqrt((n * sxx - sx * sx) * (n * syy - sy * sy))
+    if denom == 0:
+        return None
+    return (n * sxy - sx * sy) / denom

--- a/tests/test_audit_rebuild_log.py
+++ b/tests/test_audit_rebuild_log.py
@@ -228,3 +228,170 @@ def test_cli_percentile_nearest_rank() -> None:
     # 5 values, p50 -> middle, p90 -> last
     assert audit._percentile([0.1, 0.2, 0.3, 0.4, 0.5], 50) == 0.3
     assert audit._percentile([0.1, 0.2, 0.3, 0.4, 0.5], 90) == 0.5
+
+
+# ---- calibration mode (#365 R1) ---------------------------------------
+
+
+def _write_calibration_corpus(path: Path, fixtures: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for fx in fixtures:
+            f.write(json.dumps(fx, separators=(",", ":")) + "\n")
+
+
+def _toy_corpus() -> list[dict]:
+    """Three-query toy corpus where the BM25 lane will surface the
+    relevant belief (the only one whose tokens overlap the query) for
+    each fixture. Used to drive the calibration smoke tests below.
+    """
+    return [
+        {
+            "id": "q1",
+            "query": "python asyncio event loop scheduler coroutine",
+            "known_belief_content": (
+                "asyncio event loop schedules coroutines and "
+                "callbacks via a single-threaded scheduler"
+            ),
+            "noise_belief_contents": [
+                "the GIL prevents true thread parallelism in CPython",
+                "subprocess module launches child processes",
+                "multiprocessing spawns separate processes",
+                "threading provides OS-level threads",
+            ],
+        },
+        {
+            "id": "q2",
+            "query": "sqlite WAL journal mode concurrent reads",
+            "known_belief_content": (
+                "SQLite WAL journal mode allows concurrent readers "
+                "and one writer without blocking reads"
+            ),
+            "noise_belief_contents": [
+                "PostgreSQL MVCC uses row-level versioning",
+                "Redis persistence uses RDB snapshots and AOF logs",
+                "MySQL InnoDB uses a clustered primary index",
+                "database indexes trade write overhead for reads",
+            ],
+        },
+        {
+            "id": "q3",
+            "query": "rust borrow checker lifetimes references",
+            "known_belief_content": (
+                "Rust borrow checker enforces lifetime rules on "
+                "references at compile time"
+            ),
+            "noise_belief_contents": [
+                "Go has a garbage collector for memory management",
+                "C++ uses RAII for deterministic destruction",
+                "Java has a generational garbage collector",
+                "Swift uses ARC for reference counting",
+            ],
+        },
+    ]
+
+
+def test_calibrate_corpus_emits_metrics(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    corpus = tmp_path / "toy.jsonl"
+    _write_calibration_corpus(corpus, _toy_corpus())
+
+    rc = audit.main(["--calibrate-corpus", str(corpus)])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "calibration harness" in out
+    assert "n_queries:    3" in out
+    assert "P@10:" in out
+    assert "ROC-AUC:" in out
+    assert "Spearman" in out
+
+
+def test_calibrate_corpus_is_deterministic(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Ship gate per #365: same (corpus, seed) -> bytes-identical
+    metric lines across reruns."""
+    corpus = tmp_path / "toy.jsonl"
+    _write_calibration_corpus(corpus, _toy_corpus())
+
+    rc1 = audit.main(["--calibrate-corpus", str(corpus), "--seed", "42"])
+    out1 = capsys.readouterr().out
+    rc2 = audit.main(["--calibrate-corpus", str(corpus), "--seed", "42"])
+    out2 = capsys.readouterr().out
+
+    assert rc1 == 0 and rc2 == 0
+    metric_lines1 = [
+        line for line in out1.splitlines()
+        if line.startswith(("P@", "ROC-AUC:", "Spearman"))
+    ]
+    metric_lines2 = [
+        line for line in out2.splitlines()
+        if line.startswith(("P@", "ROC-AUC:", "Spearman"))
+    ]
+    assert metric_lines1 == metric_lines2
+    assert metric_lines1, "expected metric lines in output"
+
+
+def test_calibrate_corpus_missing_file_returns_1(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = audit.main([
+        "--calibrate-corpus", str(tmp_path / "no-such-corpus.jsonl"),
+    ])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "calibration corpus not found" in err
+
+
+def test_calibrate_corpus_empty_returns_1(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    corpus = tmp_path / "empty.jsonl"
+    corpus.write_text("", encoding="utf-8")
+    rc = audit.main(["--calibrate-corpus", str(corpus)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "corpus is empty" in err
+
+
+def test_calibrate_corpus_skips_malformed_rows(tmp_path: Path) -> None:
+    corpus = tmp_path / "mixed.jsonl"
+    corpus.write_text(
+        "this is not json\n"
+        + json.dumps({"id": "q1", "query": "q", "known_belief_content": "k"})
+        + "\n"
+        + json.dumps({
+            "id": "q2", "query": "q", "known_belief_content": "k",
+            "noise_belief_contents": "not-a-list",
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+    fixtures = audit._load_calibration_fixtures(corpus)
+    assert fixtures == []
+
+
+def test_calibrate_rejects_non_positive_k(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    corpus = tmp_path / "toy.jsonl"
+    _write_calibration_corpus(corpus, _toy_corpus())
+    rc = audit.main([
+        "--calibrate-corpus", str(corpus), "--k", "0",
+    ])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--k must be positive" in err
+
+
+def test_audit_mode_requires_paths(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No --calibrate-corpus and no positional paths -> usage error."""
+    with pytest.raises(SystemExit) as excinfo:
+        audit.main([])
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert "paths required" in err

--- a/tests/test_calibration_metrics.py
+++ b/tests/test_calibration_metrics.py
@@ -1,0 +1,167 @@
+"""Tests for `aelfrice.calibration_metrics` (#365 R1).
+
+Cover:
+- Precision@K basic / clamped / over-K input.
+- ROC-AUC: monotonic separation, perfect/inverted ranking, ties,
+  single-class undefined → None.
+- Spearman ρ: monotonic, ties, zero-variance undefined → None,
+  short inputs.
+- Determinism: bytes-identical return across reruns of the same input
+  (the ship gate per #365).
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from aelfrice.calibration_metrics import (
+    precision_at_k,
+    roc_auc,
+    spearman_rho,
+)
+
+
+# ---- precision_at_k ----------------------------------------------------
+
+
+def test_precision_at_k_basic() -> None:
+    assert precision_at_k([True, False, True, False, True], 5) == 0.6
+
+
+def test_precision_at_k_truncates_to_k() -> None:
+    # Only top-3 counted even if input has more.
+    assert precision_at_k([True, True, True, False, False], 3) == 1.0
+
+
+def test_precision_at_k_pads_short_input_with_not_relevant() -> None:
+    # Input shorter than k -> missing slots count as 0.
+    assert precision_at_k([True, True], 5) == 2 / 5
+
+
+def test_precision_at_k_rejects_non_positive_k() -> None:
+    with pytest.raises(ValueError):
+        precision_at_k([True], 0)
+    with pytest.raises(ValueError):
+        precision_at_k([True], -1)
+
+
+# ---- roc_auc -----------------------------------------------------------
+
+
+def test_roc_auc_perfect_ranking() -> None:
+    # Higher score -> higher label probability, no overlap.
+    scores = [3.0, 2.0, 1.0]
+    labels = [True, False, False]
+    assert roc_auc(scores, labels) == 1.0
+
+
+def test_roc_auc_inverted_ranking() -> None:
+    # All positives at the bottom of the score order.
+    scores = [3.0, 2.0, 1.0]
+    labels = [False, False, True]
+    assert roc_auc(scores, labels) == 0.0
+
+
+def test_roc_auc_chance() -> None:
+    # Symmetric around the median (positives at extremes) -> 0.5.
+    # pairs >: (4,2)+(4,3)=2; pairs <: (1,2)+(1,3)=2 -> AUC=0.5.
+    scores = [4.0, 3.0, 2.0, 1.0]
+    labels = [True, False, False, True]
+    assert roc_auc(scores, labels) == 0.5
+
+
+def test_roc_auc_three_quarter_separation() -> None:
+    # Two positives at score 4 and 2, two negatives at 3 and 1.
+    # Comparable pairs: (4,3),(4,1),(2,3),(2,1) -> 3 of 4 -> 0.75.
+    scores = [4.0, 3.0, 2.0, 1.0]
+    labels = [True, False, True, False]
+    assert roc_auc(scores, labels) == 0.75
+
+
+def test_roc_auc_handles_ties_via_average_rank() -> None:
+    # All scores tied -> Mann-Whitney with average ranks gives 0.5.
+    scores = [1.0, 1.0, 1.0, 1.0]
+    labels = [True, False, True, False]
+    assert roc_auc(scores, labels) == 0.5
+
+
+def test_roc_auc_single_class_returns_none() -> None:
+    assert roc_auc([1.0, 2.0, 3.0], [True, True, True]) is None
+    assert roc_auc([1.0, 2.0, 3.0], [False, False, False]) is None
+
+
+def test_roc_auc_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError):
+        roc_auc([1.0, 2.0], [True])
+
+
+# ---- spearman_rho ------------------------------------------------------
+
+
+def test_spearman_rho_monotonic_perfect() -> None:
+    xs = [1.0, 2.0, 3.0, 4.0]
+    ys = [10.0, 20.0, 30.0, 40.0]
+    assert spearman_rho(xs, ys) == pytest.approx(1.0)
+
+
+def test_spearman_rho_monotonic_inverted() -> None:
+    xs = [1.0, 2.0, 3.0, 4.0]
+    ys = [40.0, 30.0, 20.0, 10.0]
+    assert spearman_rho(xs, ys) == pytest.approx(-1.0)
+
+
+def test_spearman_rho_handles_ties() -> None:
+    # Tied ranks on the y side; ρ is well-defined and nonzero.
+    xs = [1.0, 2.0, 3.0, 4.0]
+    ys = [1.0, 1.0, 2.0, 2.0]
+    rho = spearman_rho(xs, ys)
+    assert rho is not None
+    # Pearson on rx=[1,2,3,4], ry=[1.5,1.5,3.5,3.5]:
+    # numerator = 4*29 - 10*10 = 16
+    # denom    = sqrt((4*30-100) * (4*29-100)) = sqrt(320) = 17.888...
+    # rho = 16 / sqrt(320) = 4/sqrt(20) = 2/sqrt(5).
+    expected = 2.0 / math.sqrt(5.0)
+    assert rho == pytest.approx(expected, rel=1e-12)
+
+
+def test_spearman_rho_zero_variance_returns_none() -> None:
+    # All-equal xs -> rank vector is constant -> denominator zero.
+    assert spearman_rho([5.0, 5.0, 5.0], [1.0, 2.0, 3.0]) is None
+
+
+def test_spearman_rho_short_input_returns_none() -> None:
+    assert spearman_rho([1.0], [2.0]) is None
+    assert spearman_rho([], []) is None
+
+
+def test_spearman_rho_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError):
+        spearman_rho([1.0, 2.0], [3.0])
+
+
+# ---- determinism (ship-gate per #365) ----------------------------------
+
+
+def test_metrics_are_deterministic_across_reruns() -> None:
+    """Same inputs -> bytes-identical floats. Required by the spec
+    ("Determinism: same `(store_snapshot, query_set)` -> bytes-identical
+    metrics across reruns")."""
+    scores = [0.9, 0.8, 0.4, 0.3, 0.1]
+    labels = [True, False, True, False, False]
+
+    p_a = precision_at_k(labels, 3)
+    p_b = precision_at_k(labels, 3)
+    assert p_a == p_b
+    # Bit-exact float comparison via bit pattern.
+    assert math.copysign(1.0, p_a) == math.copysign(1.0, p_b)
+
+    a_a = roc_auc(scores, labels)
+    a_b = roc_auc(scores, labels)
+    assert a_a is not None and a_b is not None
+    assert a_a == a_b
+
+    r_a = spearman_rho(scores, [1.0 if x else 0.0 for x in labels])
+    r_b = spearman_rho(scores, [1.0 if x else 0.0 for x in labels])
+    assert r_a is not None and r_b is not None
+    assert r_a == r_b


### PR DESCRIPTION
R1 of #365 — Phase A impl: extend `scripts/audit_rebuild_log.py` with P@10 / AUC / ρ on the public synthetic corpus. Establishes the harness for the close-the-loop relevance-calibration loop ratified at #317 (operator approval 2026-05-03).

## Change

**Commit 1** — `src/aelfrice/calibration_metrics.py` (new leaf module, pure stdlib):
- `precision_at_k(rankings, k)` — top-K precision; missing slots count as not-relevant.
- `roc_auc(scores, labels)` — Mann-Whitney U with average-rank tie handling; `None` on single-class labels.
- `spearman_rho(xs, ys)` — Pearson on average-ranked vectors; `None` on zero variance or n<2.
- `CalibrationReport` dataclass for structured output (consumed by R4 `aelf eval` and R5 CI later).
- Imports nothing from the rest of `aelfrice` (leaf-module pattern from #500 / #502).
- 18 unit tests in `tests/test_calibration_metrics.py` covering monotonic / inverted / chance / tied / single-class / length-mismatch / determinism cases. The determinism test is a direct check against the spec's ship gate.

**Commit 2** — extend `scripts/audit_rebuild_log.py` with `--calibrate-corpus`:

```
python scripts/audit_rebuild_log.py <jsonl-or-dir>            # audit (existing)
python scripts/audit_rebuild_log.py --calibrate-corpus         # new — default corpus
python scripts/audit_rebuild_log.py --calibrate-corpus PATH \
    [--k 10] [--seed 0]                                       # new — explicit
```

Default corpus is `benchmarks/posterior_ranking/fixtures/default.jsonl` (7 queries × 5 beliefs each — public synthetic only, per `docs/eval_fixture_policy.md`).

For each fixture: build an in-memory `MemoryStore` with the relevant + noise beliefs, run `aelfrice.retrieval.retrieve` against the query, observe the rank of the relevant belief, accumulate (rank-as-score, is_relevant) labels across queries, then emit P@K / AUC / ρ.

8 new tests cover end-to-end CLI exit codes, determinism, missing/empty corpus, malformed-row tolerance, `--k` validation, and the new audit-mode "paths required" usage error.

## Sample output

```
$ uv run python scripts/audit_rebuild_log.py --calibrate-corpus
calibration harness — corpus default.jsonl
  n_queries:    7
  n_obs:        35
  seed:         0
  truncated:    7 (query returned <10 candidates)

P@10:        0.1000
ROC-AUC:      0.8444
Spearman ρ:   0.5241
```

(P@10 = 0.10 because the public synthetic corpus has only 5 candidates per query — every query truncates against K=10. AUC = 0.844 / ρ = 0.524 reflect the existing retriever's calibration on this small corpus; setting the actual P@10 floor is R3's job, not R1's.)

## Test plan

- [x] New unit tests for the metrics module (18 tests in `tests/test_calibration_metrics.py`).
- [x] New CLI tests for the calibration mode (8 tests in `tests/test_audit_rebuild_log.py`).
- [x] Existing 9 audit-mode tests in `tests/test_audit_rebuild_log.py` — unchanged, all still pass.
- [x] Full suite: `uv run pytest -q` → **2986 passed / 48 skipped**, no regressions.
- [x] Determinism: same `(corpus, seed)` → bytes-identical metric lines across reruns (confirmed via `test_calibrate_corpus_is_deterministic` and via two manual back-to-back invocations).
- [x] Discretion grep clean.
- [x] Both commits signed (G/G).

## R-rounds context (recap of #365)

- **R1 (this PR)** — Phase A impl on the public synthetic corpus; no live-data dependency. Establishes the harness. ✓
- **R2** — Hybrid labeling pipeline: hand-label tooling + LLM-judge runner + implicit-signal extractor against the operator store. (Lab-side, future.)
- **R3** — Calibration: score-vs-relevance fit on hand-label set; pre-register the P@10 floor; verify monotonicity (Q2b) and top-K identity (Q2c). (Lab-side, future.)
- **R4** — Phase B `aelf eval` subcommand. (Reuses `aelfrice.calibration_metrics` from this PR.)
- **R5** — Phase C CI workflow (synthetic only). (Reuses both surfaces from this PR.)

## Out of scope for R1

- Setting a P@10 ship-gate floor — that is R3's job against a real calibration set.
- Operator-side `aelf eval` integration — R4.
- CI workflow on push to main — R5.
- Larger / additional synthetic corpora — orthogonal; the harness loads any JSONL with the `id` / `query` / `known_belief_content` / `noise_belief_contents` shape.

## Refs

- Issue: #365
- Umbrella: #317
- Spec ratification: https://github.com/robotrocketscience/aelfrice/issues/317#issuecomment-4365297285
- Hard-prereqs (all met): #288 / #289 / #290 closed; #291 R1+R3 PRs landed.

Closes — none directly (#365 stays open as the umbrella for R2…R5).

## Summary by Sourcery

Add a relevance-calibration harness to the audit_rebuild_log script and introduce reusable calibration metric utilities.

New Features:
- Introduce a pure-stdlib calibration_metrics module providing precision-at-k, ROC-AUC, Spearman rho functions and a CalibrationReport dataclass for reuse across tooling.
- Extend audit_rebuild_log.py with a --calibrate-corpus mode that evaluates retrieval calibration on a synthetic JSONL corpus and reports P@K, ROC-AUC, and Spearman rho metrics.

Tests:
- Add unit tests for the calibration_metrics module covering metric behaviour, edge cases, and determinism guarantees.
- Add CLI tests for the new calibration mode, including determinism, error handling, and audit-mode usage validation.