### PR TITLE
docs(readme): redraft for first-time discoverer (190 → 162 lines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,16 +129,6 @@ The same operations are also available as MCP tools and `/aelf:*` slash commands
 
 ---
 
-## Reproducibility
-
-`aelf bench all --canonical --out benchmarks/results/v2.0.0.json` reproduces every published headline number on a fresh clone within documented tolerance bands. The dispatcher subprocesses each academic-suite adapter (MAB, LoCoMo, LongMemEval, StructMemEval, AMA-Bench) at the canonical headline cut — full per the 2026-05-06 ratification on [#437](https://github.com/robotrocketscience/aelfrice/issues/437) — and merges the per-adapter results into one schema-v2 JSON.
-
-The `Bench Canonical` nightly cron runs the same harness daily on `main` and pushes the cron entry to a dedicated `bench-canonical-results` branch. Drift outside the per-metric tolerance band fails the workflow; drift inside the band emits a notice. The badge above flips to red on a band-busting regression and stays red until acknowledged.
-
-Detail: [docs/v2_reproducibility_harness.md](docs/v2_reproducibility_harness.md).
-
----
-
 ## Roadmap
 
 | Version | Status | Theme |

--- a/README.md
+++ b/README.md
@@ -129,24 +129,14 @@ The same operations are also available as MCP tools and `/aelf:*` slash commands
 
 ---
 
-## Roadmap
+## Status
 
-| Version | Status | Theme |
-|---|---|---|
-| v1.0.x | shipped | core memory, CLI, MCP, hook wiring, install routing |
-| v1.1.0 | shipped | per-project DBs (`.git/aelfrice/`), `aelf migrate`, `edges`→`threads` rename, `aelf health` rewrite |
-| v1.2.0 | shipped | auto-capture pipeline (transcript-ingest, commit-ingest, SessionStart), `agent_inferred → user_validated` promotion, triple extractor, `--batch` JSONL ingest, CLI consolidation, `INEDIBLE` per-file opt-out |
-| v1.2.x | planned | search-tool `PreToolUse` hook — memory-first context on Grep/Glob |
-| v1.3 | shipped | retrieval wave — entity index (L2.5), BFS multi-hop (L3), LLM-Haiku onboard classifier (opt-in), partial Bayesian-weighted ranking |
-| v1.4 | shipped | context rebuilder — PreCompact retrieval-curated continuation (augment mode); manual + threshold trigger; continuation-fidelity scorer (exact-match) |
-| v1.5 | shipped | retrieval plumbing — composition plumbing + per-lane telemetry (#232), BM25F anchor text (#148), search-tool Bash matcher (#155), v3 federation version-vector schema (#204), v1.4 dynamic-trigger re-park (#188) |
-| v1.5.x | shipped | default-on host-driven LLM onboard classifier (#238, in v1.5.1) |
-| v1.6 | shipped | hardening + observability — hook-hardening framing-tag contract + audit log (#280, #297, #314), `aelf tail` (#321, #322), belief retention class (#290), rebuild diagnostic log (#288), posterior-ranking eval harness + heat-kernel composition (#151, #306, #310; default-flip still gated), deferred-feedback sweeper (#191, #256), v2.0 corpus public scaffold + bench-gate (#307, #311, #319, #320), `replay_full_equality` probe (#262, #304), `session_id` propagation (#192), reachable-install detection (#345) |
-| v1.7 | shipped | graph signal wave + structural retrieval lane — signed Laplacian + eigenbasis (#149), heat kernel authority (#150), Plate FFT HRR primitives (#216), HRR bind/probe (#152), `uri_baki` post-rank adjuster retest (#153). BM25F anchor-text retrieval (#148) **default-on** at v1.7.0 per #154 bench evidence (+0.6650 NDCG@k uplift on the v0.1 retrieve_uplift fixture under Porter stemming). Heat-kernel authority (`use_heat_kernel`) and HRR structural (`use_hrr_structural`) are wired and ship behind opt-in `[retrieval]` flags in `.aelfrice.toml` — they stay default-OFF until the composition tracker (#154) bench gate flips them. Signed-Laplacian (`use_signed_laplacian`) and posterior-ranking (`use_posterior_ranking`) are still placeholder flags pending wiring. |
-| v2.0 | planned | feature parity with the original research line + benchmark reproducibility. v2.0's component issues land incrementally across v1.5–v1.7; final v2.0 tag is the reproducibility cut. |
-| v2.1 | planned | post-calibration retrieval-pipeline wave — view-flip (#265), bench-gated cluster (#197 dedup, #433 HRR vocab bridge, #434 type-aware compression, #435 doc/semantic linker, #436 intentional clustering), operator-gated query understanding (#291) + close-the-loop relevance (#365), and gate-commit follow-ups (smoke-fixture license (#311), badge cron-rewrite, dispatcher 3-state (#479), gate-list CLI (#475)). Tracker: [#474](https://github.com/robotrocketscience/aelfrice/issues/474). |
+Latest stable: **v1.7** — graph-signal retrieval lane (signed Laplacian, heat-kernel authority, Plate FFT HRR primitives), BM25F anchor-text retrieval default-on.
 
-Per-version detail: [docs/ROADMAP.md](docs/ROADMAP.md). Open issues: [docs/LIMITATIONS.md](docs/LIMITATIONS.md).
+Next: **v2.0** — research-line parity + benchmark reproducibility cut.
+
+Per-version detail: [docs/ROADMAP.md](docs/ROADMAP.md).
+Open issues / known limits: [docs/LIMITATIONS.md](docs/LIMITATIONS.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > Your AI stops forgetting your rules.
 > Set up once. Stays out of your way.
 >
-> _Local SQLite. No GPU, no network._
+> _Local SQLite. Auditable. No GPU, no network._
 
 [![PyPI](https://img.shields.io/pypi/v/aelfrice.svg)](https://pypi.org/project/aelfrice/)
 [![Python](https://img.shields.io/pypi/pyversions/aelfrice.svg)](https://pypi.org/project/aelfrice/)

--- a/README.md
+++ b/README.md
@@ -98,23 +98,15 @@ aelfrice replaces the chain with a mechanism. The hook injects matched beliefs *
 
 ---
 
-## Determinism
+## What you get for free
 
-Same store + same query gives the same beliefs. The retrieval path is stdlib + SQLite — no embeddings, no learned re-rankers, no LLM — so every result traces back to a specific belief and the user action that wrote it.
+Running in the background. No action required after `aelf setup`.
 
-Tradeoff: no fuzzy semantic recall. See [PHILOSOPHY.md](docs/PHILOSOPHY.md).
-
----
-
-## Your data stays yours
-
-- **100% local.** SQLite at `<repo>/.git/aelfrice/memory.db`. No network calls in the retrieval path.
-- **No telemetry.** No accounts, no signup, no phone-home.
-- **No GPU, no vector DB.** Stdlib + SQLite. The optional `[mcp]` extra adds `fastmcp`. That's it.
-- **Per-project isolation.** Beliefs from project A cannot leak into project B (they live in different `.git/` directories).
+- **Determinism.** Stdlib + SQLite. No embeddings, no learned re-rankers, no LLM in the retrieval path. Every result traces to the action that wrote it.
+- **Local-only.** SQLite at `<repo>/.git/aelfrice/memory.db`. No telemetry, no network calls, no accounts. Per-project isolation by construction. See [PRIVACY.md](docs/PRIVACY.md).
 - **Removable.** `aelf uninstall --archive backup.aenc` encrypts the DB to a file, then deletes it. Or `--purge` for a full wipe.
 
-[docs/PRIVACY.md](docs/PRIVACY.md) for verifiable specifics.
+Tradeoff: no fuzzy semantic recall. See [PHILOSOPHY.md](docs/PHILOSOPHY.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 # aelfrice
 
-> Persistent memory for AI agents.
+> Your AI stops forgetting your rules.
 > Set up once. Stays out of your way.
 >
-> _Local SQLite. Auditable. No GPU, no network._
+> _Local SQLite. No GPU, no network._
 
 [![PyPI](https://img.shields.io/pypi/v/aelfrice.svg)](https://pypi.org/project/aelfrice/)
 [![Python](https://img.shields.io/pypi/pyversions/aelfrice.svg)](https://pypi.org/project/aelfrice/)


### PR DESCRIPTION
## Summary

- Tagline: replaced generic "Persistent memory for AI agents" with pain-forward "Your AI stops forgetting your rules" (audited subline anchors preserved)
- Three short H2s (Determinism, Your data stays yours) merged into one "What you get for free" section that opens with the real benefit framing
- Reproducibility prose section dropped — the badge at the top already advertises it; landing-page real estate was being spent on docs content (issue numbers, schema versions, cron-branch names)
- Roadmap: 13-row inside-baseball table collapsed to a 7-line "Status" section. Per-version detail moved to docs/ROADMAP.md (already linked)

Net: 190 → 162 lines, +12/-40, single file. Optimized for first-time-discoverer audience per audience-pick during drafting.

H2 structure now: What it does → What it remembers → Why files don't solve this → What you get for free → Day-to-day surface → Status → Documentation → Citation.

Six atomic commits + one gate commit. No content changes outside README.md.

## Test plan

- [ ] Render check on github.com — confirm hero image, badges, install snippet, and `<aelfrice-memory>` example block still render correctly
- [ ] Click every internal doc link (PHILOSOPHY.md, PRIVACY.md, ROADMAP.md, LIMITATIONS.md, COMMANDS.md, MCP.md, SLASH_COMMANDS.md, RELEASING.md, CHANGELOG.md, CONTRIBUTING.md, SECURITY.md, LICENSE) — all should resolve
- [ ] Verify reproducibility badge at top of file still links to docs/v2_reproducibility_harness.md (should be unchanged)
- [ ] Sanity-read on a phone-width viewport — first screen should land on the install snippet

## Summary by Sourcery

Redraft the README to better orient first-time users and streamline status information without changing core functionality.

Documentation:
- Update the README tagline and benefits section to emphasize persistent, rule-focused memory and out-of-the-box guarantees.
- Consolidate determinism and privacy content into a single "What you get for free" section with clearer, user-facing bullets and updated links to supporting docs.
- Replace the detailed roadmap table and standalone reproducibility section with a concise status summary that points to dedicated roadmap and limitations documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README hero tagline to better reflect core value proposition.
  * Reorganized product benefits section consolidating key features and capabilities.
  * Added version status section highlighting current stable release and upcoming major version with links to relevant roadmaps and constraints documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->