### PR TITLE
feat(eval): aelf eval subcommand + lift calibration harness to module (#365 R4)

### DIFF
--- a/scripts/audit_rebuild_log.py
+++ b/scripts/audit_rebuild_log.py
@@ -43,14 +43,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import random
 import sys
 from collections import Counter
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable
-
-if TYPE_CHECKING:
-    from aelfrice.calibration_metrics import CalibrationReport
+from typing import Iterable
 
 
 def _iter_records(path: Path) -> Iterable[dict]:
@@ -200,111 +196,28 @@ def _print_report(summary: dict, *, paths_read: int) -> None:
             print(f"  rank {rank:>2}: {summary['packed_ranks'][rank]}")
 
 
-DEFAULT_CALIBRATION_CORPUS = (
-    Path(__file__).resolve().parent.parent
-    / "benchmarks"
-    / "posterior_ranking"
-    / "fixtures"
-    / "default.jsonl"
-)
-DEFAULT_CALIBRATION_K = 10
-DEFAULT_CALIBRATION_SEED = 0
+# Calibration mode delegates to ``aelfrice.eval_harness`` (#365 R4 lift).
+# The script's CLI keeps its existing flags, exit codes, and stderr
+# wording; only the implementation moved.
+def _load_aelfrice_eval_harness():
+    """Lazy import so audit mode keeps working without the wheel."""
+    from aelfrice import eval_harness  # noqa: PLC0415
+    return eval_harness
+
+
+def _calibration_defaults() -> tuple[Path, int, int]:
+    eh = _load_aelfrice_eval_harness()
+    return eh.DEFAULT_CALIBRATION_CORPUS, eh.DEFAULT_K, eh.DEFAULT_SEED
 
 
 def _load_calibration_fixtures(path: Path) -> list[dict]:
-    """Load a JSONL calibration corpus.
-
-    Each line must decode to a dict carrying ``id``, ``query``,
-    ``known_belief_content``, and ``noise_belief_contents`` (a list).
-    Fixtures missing any required key, or with malformed JSON, are
-    silently skipped — same fail-soft posture as the audit reader.
-    """
-    out: list[dict] = []
-    text = path.read_text(encoding="utf-8")
-    required = ("id", "query", "known_belief_content", "noise_belief_contents")
-    for line in text.splitlines():
-        if not line.strip():
-            continue
-        try:
-            row = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(row, dict):
-            continue
-        if not all(key in row for key in required):
-            continue
-        if not isinstance(row["noise_belief_contents"], list):
-            continue
-        out.append(row)
-    return out
+    """Back-compat alias for ``aelfrice.eval_harness.load_calibration_fixtures``."""
+    return _load_aelfrice_eval_harness().load_calibration_fixtures(path)
 
 
-def _build_calibration_store(fixture: dict, seed: int):
-    """Build a fresh in-memory ``MemoryStore`` for one fixture.
-
-    Imports `aelfrice` lazily and inserts one belief per content row
-    (one relevant + N noise). The noise order is shuffled with the
-    supplied seed so AUC / ρ aggregates are deterministic across
-    reruns at fixed seed (per the #365 ship gate).
-    """
-    from aelfrice.models import (  # noqa: PLC0415
-        BELIEF_FACTUAL,
-        LOCK_NONE,
-        Belief,
-    )
-    from aelfrice.store import MemoryStore  # noqa: PLC0415
-
-    store = MemoryStore(":memory:")
-    fid = str(fixture["id"])
-    known_content = str(fixture["known_belief_content"])
-    noise_contents = list(fixture["noise_belief_contents"])
-
-    def make_belief(bid: str, content: str) -> Belief:
-        return Belief(
-            id=bid,
-            content=content,
-            content_hash=f"h_{bid}",
-            alpha=0.5,
-            beta=0.5,
-            type=BELIEF_FACTUAL,
-            lock_level=LOCK_NONE,
-            locked_at=None,
-            demotion_pressure=0,
-            created_at="2026-01-01T00:00:00Z",
-            last_retrieved_at=None,
-        )
-
-    rng = random.Random(seed)
-    rng.shuffle(noise_contents)
-
-    store.insert_belief(make_belief(f"{fid}_known", known_content))
-    for i, nc in enumerate(noise_contents):
-        store.insert_belief(make_belief(f"{fid}_noise_{i}", nc))
-
-    return store
-
-
-def _run_calibration(
-    corpus_path: Path, k: int, seed: int,
-) -> int:
-    """Run the #365 R1 calibration harness against a synthetic corpus.
-
-    For each fixture in the corpus, build an in-memory store with one
-    relevant belief and N noise beliefs, run ``aelfrice.retrieval.retrieve``
-    against the query, and observe the rank of the relevant belief.
-    Aggregate (rank-as-score, is_relevant) observations across queries
-    and report P@K / ROC-AUC / Spearman ρ.
-    """
-    # Imported lazily so the audit-mode CLI does not need the package
-    # installed, only the calibrate path does.
-    from aelfrice.calibration_metrics import (  # noqa: PLC0415
-        CalibrationReport,
-        precision_at_k,
-        roc_auc,
-        spearman_rho,
-    )
-    from aelfrice.retrieval import retrieve  # noqa: PLC0415
-
+def _run_calibration(corpus_path: Path, k: int, seed: int) -> int:
+    """Run the #365 R1 calibration harness; print report or error."""
+    eh = _load_aelfrice_eval_harness()
     if not corpus_path.is_file():
         print(
             f"audit_rebuild_log: calibration corpus not found: "
@@ -313,7 +226,7 @@ def _run_calibration(
         )
         return 1
 
-    fixtures = _load_calibration_fixtures(corpus_path)
+    fixtures = eh.load_calibration_fixtures(corpus_path)
     if not fixtures:
         print(
             f"audit_rebuild_log: corpus is empty: {corpus_path}",
@@ -321,94 +234,17 @@ def _run_calibration(
         )
         return 1
 
-    p_at_k_values: list[float] = []
-    n_truncated = 0
-    pooled_scores: list[float] = []
-    pooled_labels: list[bool] = []
-
-    for fx in fixtures:
-        store = _build_calibration_store(fx, seed)
-        query = str(fx["query"])
-        known_content = str(fx["known_belief_content"])
-        n_candidates = 1 + len(fx["noise_belief_contents"])  # type: ignore[arg-type]
-
-        results = retrieve(
-            store,
-            query,
-            l1_limit=max(k, n_candidates),
-            entity_index_enabled=False,
-            bfs_enabled=False,
-            posterior_weight=None,
-        )
-
-        relevance_top_k = [b.content == known_content for b in results]
-        if len(relevance_top_k) < k:
-            n_truncated += 1
-        p_at_k_values.append(precision_at_k(relevance_top_k, k))
-
-        # Rank-as-score for AUC / ρ: top of the list maps to the
-        # highest score so AUC reads "score increases with relevance"
-        # naturally. Candidates the retriever did not surface get
-        # score 0 (lower than any returned), preserving the corpus's
-        # full positive/negative balance in the pooled observations.
-        for rank_idx, belief in enumerate(results):
-            pooled_scores.append(float(len(results) - rank_idx))
-            pooled_labels.append(belief.content == known_content)
-        retrieved_contents = {b.content for b in results}
-        for noise_content in fx["noise_belief_contents"]:  # type: ignore[union-attr]
-            if noise_content not in retrieved_contents:
-                pooled_scores.append(0.0)
-                pooled_labels.append(False)
-        if known_content not in retrieved_contents:
-            pooled_scores.append(0.0)
-            pooled_labels.append(True)
-
-        store.close()
-
-    avg_p_at_k = (
-        sum(p_at_k_values) / len(p_at_k_values) if p_at_k_values else 0.0
+    report = eh.run_calibration_on_fixtures(fixtures, k=k, seed=seed)
+    sys.stdout.write(
+        eh.format_calibration_report(
+            report, corpus_path=corpus_path, seed=seed,
+        ),
     )
-    auc = roc_auc(pooled_scores, pooled_labels)
-    rho = spearman_rho(
-        pooled_scores, [1.0 if x else 0.0 for x in pooled_labels],
-    )
-
-    report = CalibrationReport(
-        p_at_k=avg_p_at_k,
-        k=k,
-        n_queries=len(fixtures),
-        n_truncated_queries=n_truncated,
-        roc_auc=auc,
-        spearman_rho=rho,
-        n_observations=len(pooled_scores),
-    )
-    _print_calibration_report(report, corpus_path=corpus_path, seed=seed)
     return 0
 
 
-def _format_optional_float(value: float | None) -> str:
-    return f"{value:.4f}" if value is not None else "n/a (undefined)"
-
-
-def _print_calibration_report(
-    report: CalibrationReport, *, corpus_path: Path, seed: int,
-) -> None:
-    print(f"calibration harness — corpus {corpus_path.name}")
-    print(f"  n_queries:    {report.n_queries}")
-    print(f"  n_obs:        {report.n_observations}")
-    print(f"  seed:         {seed}")
-    if report.n_truncated_queries:
-        print(
-            f"  truncated:    {report.n_truncated_queries} "
-            f"(query returned <{report.k} candidates)"
-        )
-    print()
-    print(f"P@{report.k}:        {report.p_at_k:.4f}")
-    print(f"ROC-AUC:      {_format_optional_float(report.roc_auc)}")
-    print(f"Spearman ρ:   {_format_optional_float(report.spearman_rho)}")
-
-
 def main(argv: list[str] | None = None) -> int:
+    default_corpus, default_k, default_seed = _calibration_defaults()
     parser = argparse.ArgumentParser(
         description=(
             "Summarise rebuild_log JSONL files (phase-1c for #288), or "
@@ -429,32 +265,32 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--calibrate-corpus",
         nargs="?",
-        const=DEFAULT_CALIBRATION_CORPUS,
+        const=default_corpus,
         default=None,
         type=Path,
         metavar="PATH",
         help=(
             "Run the #365 R1 calibration harness against the supplied "
             "synthetic corpus (defaults to "
-            f"{DEFAULT_CALIBRATION_CORPUS.name} when no path is given)."
+            f"{default_corpus.name} when no path is given)."
         ),
     )
     parser.add_argument(
         "--k",
         type=int,
-        default=DEFAULT_CALIBRATION_K,
+        default=default_k,
         help=(
             "K for P@K in calibration mode "
-            f"(default {DEFAULT_CALIBRATION_K})."
+            f"(default {default_k})."
         ),
     )
     parser.add_argument(
         "--seed",
         type=int,
-        default=DEFAULT_CALIBRATION_SEED,
+        default=default_seed,
         help=(
             "Deterministic seed for noise-belief shuffle in "
-            f"calibration mode (default {DEFAULT_CALIBRATION_SEED})."
+            f"calibration mode (default {default_seed})."
         ),
     )
     args = parser.parse_args(argv)

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -1596,6 +1596,83 @@ def _cmd_bench(args: argparse.Namespace, out: object) -> int:
     return 2
 
 
+def _cmd_eval(args: argparse.Namespace, out: object) -> int:
+    """Run the relevance-calibration harness (#365 R4 Phase B).
+
+    Reuses ``aelfrice.eval_harness`` to score a synthetic corpus of
+    ``(query, known_belief, noise_beliefs)`` fixtures and report
+    P@K / ROC-AUC / Spearman ρ. Default corpus is the public synthetic
+    fixture bundled with the wheel; ``--corpus PATH`` points at any
+    JSONL with the same row schema.
+
+    Determinism contract (#365 ship gate): same ``(corpus, --k, --seed)``
+    -> bytes-identical output across reruns.
+
+    Output formats:
+      default   human-readable text block (same shape as
+                ``audit_rebuild_log.py --calibrate-corpus``)
+      --json    one JSON object per run with the report fields
+                (machine-readable; intended for the R5 CI surface).
+
+    Exit codes:
+      0  report printed
+      1  corpus missing or empty
+      2  usage error (--k <= 0)
+    """
+    import json as _json
+
+    from aelfrice import eval_harness  # noqa: PLC0415
+
+    if args.eval_k <= 0:
+        print("aelf eval: --k must be positive", file=out)  # type: ignore[arg-type]
+        return 2
+
+    corpus_path: Path = args.eval_corpus or eval_harness.DEFAULT_CALIBRATION_CORPUS
+    if not corpus_path.is_file():
+        print(
+            f"aelf eval: calibration corpus not found: {corpus_path}",
+            file=out,  # type: ignore[arg-type]
+        )
+        return 1
+
+    fixtures = eval_harness.load_calibration_fixtures(corpus_path)
+    if not fixtures:
+        print(
+            f"aelf eval: corpus is empty: {corpus_path}",
+            file=out,  # type: ignore[arg-type]
+        )
+        return 1
+
+    report = eval_harness.run_calibration_on_fixtures(
+        fixtures, k=args.eval_k, seed=args.eval_seed,
+    )
+
+    if args.eval_json:
+        payload = {
+            "corpus": str(corpus_path),
+            "seed": args.eval_seed,
+            "k": report.k,
+            "n_queries": report.n_queries,
+            "n_truncated_queries": report.n_truncated_queries,
+            "n_observations": report.n_observations,
+            "p_at_k": report.p_at_k,
+            "roc_auc": report.roc_auc,
+            "spearman_rho": report.spearman_rho,
+        }
+        print(
+            _json.dumps(payload, sort_keys=True, separators=(",", ":")),
+            file=out,  # type: ignore[arg-type]
+        )
+    else:
+        text = eval_harness.format_calibration_report(
+            report, corpus_path=corpus_path, seed=args.eval_seed,
+        )
+        # ``format_calibration_report`` already terminates with "\n";
+        # use ``end=""`` to avoid a double-newline trailing the block.
+        print(text, file=out, end="")  # type: ignore[arg-type]
+    return 0
+
+
 def _effective_scope(args: argparse.Namespace) -> SettingsScope:
     """Return the explicit `--scope` if given, else auto-detect."""
     scope = getattr(args, "scope", None)
@@ -4499,6 +4576,38 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help="(target=all) run SMOKE_INVOCATIONS instead of canonical.",
     )
     p_bench.set_defaults(func=_cmd_bench)
+
+    # `aelf eval` — relevance-calibration harness (#365 R4 Phase B).
+    # Operator-facing alias of `audit_rebuild_log.py --calibrate-corpus`.
+    p_eval = sub.add_parser(
+        "eval",
+        help=(
+            "run relevance-calibration harness (P@K / ROC-AUC / "
+            "Spearman ρ) on a synthetic corpus"
+        ),
+    )
+    p_eval.add_argument(
+        "--corpus", dest="eval_corpus", default=None, type=Path,
+        metavar="PATH",
+        help=(
+            "JSONL corpus with (query, known_belief_content, "
+            "noise_belief_contents) rows. Default: bundled public "
+            "synthetic corpus."
+        ),
+    )
+    p_eval.add_argument(
+        "--k", dest="eval_k", type=int, default=10,
+        help="K for P@K (default 10).",
+    )
+    p_eval.add_argument(
+        "--seed", dest="eval_seed", type=int, default=0,
+        help="deterministic seed for noise-belief shuffle (default 0).",
+    )
+    p_eval.add_argument(
+        "--json", dest="eval_json", action="store_true",
+        help="emit machine-readable JSON instead of text block.",
+    )
+    p_eval.set_defaults(func=_cmd_eval)
 
     # Hidden: invoked by the CwdChanged hook (HOME repo). Pre-loads the
     # active project's SQLite + OS page caches so the next aelf call

--- a/src/aelfrice/eval_harness.py
+++ b/src/aelfrice/eval_harness.py
@@ -1,0 +1,235 @@
+"""Relevance-calibration harness for the close-the-loop loop (#365 R4).
+
+Lifts the harness logic that previously lived inline in
+``scripts/audit_rebuild_log.py`` into a wheel-installable module, so
+both the script and the ``aelf eval`` CLI subcommand can call it
+without duplicating code.
+
+Public API:
+
+- ``DEFAULT_CALIBRATION_CORPUS`` — bundled synthetic corpus path.
+- ``DEFAULT_K`` / ``DEFAULT_SEED`` — defaults.
+- ``load_calibration_fixtures(path)`` — fail-soft JSONL loader.
+- ``build_calibration_store(fixture, seed)`` — fresh in-memory store.
+- ``run_calibration_on_fixtures(fixtures, k, seed)`` — returns a
+  ``CalibrationReport``. Raises ``ValueError`` for invalid ``k`` or
+  empty fixture list.
+- ``format_calibration_report(report, *, corpus_path, seed)`` —
+  deterministic human-readable text block.
+
+Determinism contract (#365 ship gate): given the same
+``(corpus, k, seed)``, the returned report's metric fields and the
+formatted text are bytes-identical across reruns.
+"""
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import TYPE_CHECKING, Sequence
+
+from aelfrice.calibration_metrics import (
+    CalibrationReport,
+    precision_at_k,
+    roc_auc,
+    spearman_rho,
+)
+
+if TYPE_CHECKING:
+    from aelfrice.store import MemoryStore
+
+__all__ = (
+    "DEFAULT_CALIBRATION_CORPUS",
+    "DEFAULT_K",
+    "DEFAULT_SEED",
+    "load_calibration_fixtures",
+    "build_calibration_store",
+    "run_calibration_on_fixtures",
+    "format_calibration_report",
+)
+
+DEFAULT_CALIBRATION_CORPUS = (
+    Path(__file__).resolve().parent.parent.parent
+    / "benchmarks"
+    / "posterior_ranking"
+    / "fixtures"
+    / "default.jsonl"
+)
+DEFAULT_K = 10
+DEFAULT_SEED = 0
+
+
+def load_calibration_fixtures(path: Path) -> list[dict]:
+    """Load a calibration JSONL corpus, fail-soft.
+
+    Each row must be a JSON object with ``id``, ``query``,
+    ``known_belief_content``, and a list-typed ``noise_belief_contents``.
+    Malformed rows or rows missing required keys are silently skipped —
+    same posture as the audit-mode reader.
+    """
+    out: list[dict] = []
+    text = path.read_text(encoding="utf-8")
+    required = ("id", "query", "known_belief_content", "noise_belief_contents")
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        if not all(key in row for key in required):
+            continue
+        if not isinstance(row["noise_belief_contents"], list):
+            continue
+        out.append(row)
+    return out
+
+
+def build_calibration_store(fixture: dict, seed: int) -> "MemoryStore":
+    """Build a fresh in-memory store seeded with one fixture's beliefs.
+
+    Inserts one belief per content row (one relevant + N noise). Noise
+    order is shuffled with ``seed`` so AUC / ρ aggregates are
+    deterministic across reruns at fixed seed.
+    """
+    from aelfrice.models import (  # noqa: PLC0415
+        BELIEF_FACTUAL,
+        LOCK_NONE,
+        Belief,
+    )
+    from aelfrice.store import MemoryStore  # noqa: PLC0415
+
+    store = MemoryStore(":memory:")
+    fid = str(fixture["id"])
+    known_content = str(fixture["known_belief_content"])
+    noise_contents = list(fixture["noise_belief_contents"])
+
+    def make_belief(bid: str, content: str) -> Belief:
+        return Belief(
+            id=bid,
+            content=content,
+            content_hash=f"h_{bid}",
+            alpha=0.5,
+            beta=0.5,
+            type=BELIEF_FACTUAL,
+            lock_level=LOCK_NONE,
+            locked_at=None,
+            demotion_pressure=0,
+            created_at="2026-01-01T00:00:00Z",
+            last_retrieved_at=None,
+        )
+
+    rng = random.Random(seed)
+    rng.shuffle(noise_contents)
+
+    store.insert_belief(make_belief(f"{fid}_known", known_content))
+    for i, nc in enumerate(noise_contents):
+        store.insert_belief(make_belief(f"{fid}_noise_{i}", nc))
+
+    return store
+
+
+def run_calibration_on_fixtures(
+    fixtures: Sequence[dict],
+    k: int = DEFAULT_K,
+    seed: int = DEFAULT_SEED,
+) -> CalibrationReport:
+    """Run the calibration harness over already-loaded fixtures.
+
+    Same shape as the harness used by ``audit_rebuild_log.py
+    --calibrate-corpus`` (#365 R1): rank-as-score, un-retrieved
+    candidates pooled at score 0, BM25-with-default-posterior-blend
+    posture (no L2.5/L3/heat-kernel/entity-index/BFS).
+
+    Raises ``ValueError`` for non-positive ``k`` or empty fixtures.
+    """
+    if k <= 0:
+        raise ValueError("k must be positive")
+    if not fixtures:
+        raise ValueError("fixtures must be non-empty")
+
+    from aelfrice.retrieval import retrieve  # noqa: PLC0415
+
+    p_at_k_values: list[float] = []
+    n_truncated = 0
+    pooled_scores: list[float] = []
+    pooled_labels: list[bool] = []
+
+    for fx in fixtures:
+        store = build_calibration_store(fx, seed)
+        try:
+            query = str(fx["query"])
+            known_content = str(fx["known_belief_content"])
+            noise_contents = list(fx["noise_belief_contents"])
+            n_candidates = 1 + len(noise_contents)
+
+            results = retrieve(
+                store,
+                query,
+                l1_limit=max(k, n_candidates),
+                entity_index_enabled=False,
+                bfs_enabled=False,
+                posterior_weight=None,
+            )
+
+            relevance_top_k = [b.content == known_content for b in results]
+            if len(relevance_top_k) < k:
+                n_truncated += 1
+            p_at_k_values.append(precision_at_k(relevance_top_k, k))
+
+            for rank_idx, belief in enumerate(results):
+                pooled_scores.append(float(len(results) - rank_idx))
+                pooled_labels.append(belief.content == known_content)
+            retrieved_contents = {b.content for b in results}
+            for noise_content in noise_contents:
+                if noise_content not in retrieved_contents:
+                    pooled_scores.append(0.0)
+                    pooled_labels.append(False)
+            if known_content not in retrieved_contents:
+                pooled_scores.append(0.0)
+                pooled_labels.append(True)
+        finally:
+            store.close()
+
+    avg_p_at_k = sum(p_at_k_values) / len(p_at_k_values)
+    auc = roc_auc(pooled_scores, pooled_labels)
+    rho = spearman_rho(
+        pooled_scores, [1.0 if x else 0.0 for x in pooled_labels],
+    )
+    return CalibrationReport(
+        p_at_k=avg_p_at_k,
+        k=k,
+        n_queries=len(fixtures),
+        n_truncated_queries=n_truncated,
+        roc_auc=auc,
+        spearman_rho=rho,
+        n_observations=len(pooled_scores),
+    )
+
+
+def _format_optional_float(value: float | None) -> str:
+    return f"{value:.4f}" if value is not None else "n/a (undefined)"
+
+
+def format_calibration_report(
+    report: CalibrationReport, *, corpus_path: Path, seed: int,
+) -> str:
+    """Format a report as a deterministic human-readable text block."""
+    lines = [
+        f"calibration harness — corpus {corpus_path.name}",
+        f"  n_queries:    {report.n_queries}",
+        f"  n_obs:        {report.n_observations}",
+        f"  seed:         {seed}",
+    ]
+    if report.n_truncated_queries:
+        lines.append(
+            f"  truncated:    {report.n_truncated_queries} "
+            f"(query returned <{report.k} candidates)",
+        )
+    lines.append("")
+    lines.append(f"P@{report.k}:        {report.p_at_k:.4f}")
+    lines.append(f"ROC-AUC:      {_format_optional_float(report.roc_auc)}")
+    lines.append(f"Spearman ρ:   {_format_optional_float(report.spearman_rho)}")
+    return "\n".join(lines) + "\n"

--- a/src/aelfrice/slash_commands/eval.md
+++ b/src/aelfrice/slash_commands/eval.md
@@ -1,0 +1,21 @@
+---
+name: aelf:eval
+description: Run the relevance-calibration harness (P@K / ROC-AUC / Spearman ρ) on a synthetic corpus.
+argument-hint: (optional) --corpus PATH --k N --seed N --json
+allowed-tools:
+  - Bash
+---
+<objective>
+Score retrieval relevance against a labeled corpus of
+`(query, known_belief, noise_beliefs)` rows and print the calibration
+metrics ratified at #365 (P@K, ROC-AUC, Spearman ρ).
+
+With no arguments, runs against the bundled public synthetic corpus —
+deterministic at fixed seed, so two consecutive runs produce
+bytes-identical output.
+</objective>
+
+<process>
+Run: `uv run aelf eval $ARGUMENTS`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/tests/test_cli_eval.py
+++ b/tests/test_cli_eval.py
@@ -1,0 +1,146 @@
+"""Tests for ``aelf eval`` (#365 R4 Phase B)."""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+from aelfrice import cli
+
+
+def _toy_corpus(path: Path) -> Path:
+    rows = [
+        {
+            "id": "q1",
+            "query": "python asyncio event loop",
+            "known_belief_content": (
+                "asyncio event loop runs coroutines on a single-threaded "
+                "scheduler"
+            ),
+            "noise_belief_contents": [
+                "threading module spawns OS-level threads",
+                "the GIL serializes CPython bytecode execution",
+                "subprocess launches child processes",
+            ],
+        },
+        {
+            "id": "q2",
+            "query": "SQLite WAL journal mode",
+            "known_belief_content": (
+                "SQLite WAL allows concurrent readers and one writer"
+            ),
+            "noise_belief_contents": [
+                "PostgreSQL MVCC uses row-level versioning",
+                "Redis persistence uses RDB snapshots and AOF logs",
+            ],
+        },
+    ]
+    path.write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8",
+    )
+    return path
+
+
+def _run(argv: list[str]) -> tuple[int, str]:
+    out = io.StringIO()
+    rc = cli.main(argv, out=out)
+    return rc, out.getvalue()
+
+
+def test_eval_default_corpus_emits_text_block(tmp_path: Path) -> None:
+    rc, output = _run(["eval"])
+    assert rc == 0
+    assert "calibration harness" in output
+    assert "P@10:" in output
+    assert "ROC-AUC:" in output
+    assert "Spearman" in output
+
+
+def test_eval_custom_corpus(tmp_path: Path) -> None:
+    corpus = _toy_corpus(tmp_path / "toy.jsonl")
+    rc, output = _run(["eval", "--corpus", str(corpus)])
+    assert rc == 0
+    assert "calibration harness — corpus toy.jsonl" in output
+    assert "n_queries:    2" in output
+
+
+def test_eval_json_mode_emits_one_line_object(tmp_path: Path) -> None:
+    corpus = _toy_corpus(tmp_path / "toy.jsonl")
+    rc, output = _run(["eval", "--corpus", str(corpus), "--json"])
+    assert rc == 0
+    payload = json.loads(output)
+    assert payload["k"] == 10
+    assert payload["n_queries"] == 2
+    assert payload["corpus"] == str(corpus)
+    assert payload["seed"] == 0
+    assert "p_at_k" in payload
+    assert "roc_auc" in payload
+    assert "spearman_rho" in payload
+
+
+def test_eval_is_deterministic_at_fixed_seed(tmp_path: Path) -> None:
+    """Ship gate per #365: same (corpus, seed) -> bytes-identical output."""
+    corpus = _toy_corpus(tmp_path / "toy.jsonl")
+    rc1, out1 = _run(["eval", "--corpus", str(corpus), "--seed", "42"])
+    rc2, out2 = _run(["eval", "--corpus", str(corpus), "--seed", "42"])
+    assert rc1 == 0 and rc2 == 0
+    assert out1 == out2
+
+
+def test_eval_json_is_deterministic_at_fixed_seed(tmp_path: Path) -> None:
+    corpus = _toy_corpus(tmp_path / "toy.jsonl")
+    rc1, out1 = _run([
+        "eval", "--corpus", str(corpus), "--seed", "7", "--json",
+    ])
+    rc2, out2 = _run([
+        "eval", "--corpus", str(corpus), "--seed", "7", "--json",
+    ])
+    assert rc1 == 0 and rc2 == 0
+    assert out1 == out2
+
+
+def test_eval_k_flag_changes_p_at_k_label(tmp_path: Path) -> None:
+    corpus = _toy_corpus(tmp_path / "toy.jsonl")
+    rc, output = _run([
+        "eval", "--corpus", str(corpus), "--k", "5",
+    ])
+    assert rc == 0
+    assert "P@5:" in output
+    assert "P@10:" not in output
+
+
+def test_eval_rejects_non_positive_k(tmp_path: Path) -> None:
+    corpus = _toy_corpus(tmp_path / "toy.jsonl")
+    rc, output = _run([
+        "eval", "--corpus", str(corpus), "--k", "0",
+    ])
+    assert rc == 2
+    assert "--k must be positive" in output
+
+
+def test_eval_missing_corpus_returns_1(tmp_path: Path) -> None:
+    missing = tmp_path / "no-such.jsonl"
+    rc, output = _run(["eval", "--corpus", str(missing)])
+    assert rc == 1
+    assert "calibration corpus not found" in output
+
+
+def test_eval_empty_corpus_returns_1(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+    rc, output = _run(["eval", "--corpus", str(empty)])
+    assert rc == 1
+    assert "corpus is empty" in output
+
+
+def test_eval_json_keys_sorted_for_diff_stability(tmp_path: Path) -> None:
+    """JSON output keys are sorted so the line is diff-stable across
+    Python versions / dict-ordering changes — important for the future
+    R5 CI status-check surface that diffs runs."""
+    corpus = _toy_corpus(tmp_path / "toy.jsonl")
+    rc, output = _run(["eval", "--corpus", str(corpus), "--json"])
+    assert rc == 0
+    payload_keys = [
+        m for m in json.loads(output).keys()
+    ]
+    assert payload_keys == sorted(payload_keys)

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,0 +1,221 @@
+"""Tests for ``aelfrice.eval_harness`` (#365 R4 lift)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice import eval_harness as eh
+from aelfrice.calibration_metrics import CalibrationReport
+
+
+def _toy_corpus() -> list[dict]:
+    return [
+        {
+            "id": "q1",
+            "query": "python asyncio event loop",
+            "known_belief_content": (
+                "asyncio event loop runs coroutines on a single-threaded "
+                "scheduler"
+            ),
+            "noise_belief_contents": [
+                "threading module spawns OS-level threads",
+                "multiprocessing forks separate processes",
+                "the GIL serializes CPython bytecode execution",
+                "subprocess launches child processes",
+            ],
+        },
+        {
+            "id": "q2",
+            "query": "SQLite WAL journal mode",
+            "known_belief_content": (
+                "SQLite WAL allows concurrent readers and one writer "
+                "without blocking reads"
+            ),
+            "noise_belief_contents": [
+                "PostgreSQL MVCC uses row-level versioning",
+                "Redis persistence uses RDB snapshots and AOF logs",
+                "MySQL InnoDB uses a clustered primary index",
+                "database indexes trade write overhead for reads",
+            ],
+        },
+    ]
+
+
+def _write_corpus(path: Path, rows: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8",
+    )
+
+
+def test_default_corpus_path_is_under_repo_root() -> None:
+    expected = "benchmarks/posterior_ranking/fixtures/default.jsonl"
+    assert str(eh.DEFAULT_CALIBRATION_CORPUS).endswith(expected)
+
+
+def test_load_calibration_fixtures_skips_malformed_rows(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "mixed.jsonl"
+    path.write_text(
+        "this is not json\n"
+        + json.dumps({"id": "q1"})  # missing required fields
+        + "\n"
+        + json.dumps({
+            "id": "q2", "query": "q", "known_belief_content": "k",
+            "noise_belief_contents": "not-a-list",
+        })
+        + "\n"
+        + json.dumps({
+            "id": "q3", "query": "q", "known_belief_content": "k",
+            "noise_belief_contents": ["n1"],
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+    fixtures = eh.load_calibration_fixtures(path)
+    assert [f["id"] for f in fixtures] == ["q3"]
+
+
+def test_load_calibration_fixtures_empty_file_returns_empty_list(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "empty.jsonl"
+    path.write_text("", encoding="utf-8")
+    assert eh.load_calibration_fixtures(path) == []
+
+
+def test_run_calibration_returns_report(tmp_path: Path) -> None:
+    fixtures = _toy_corpus()
+    report = eh.run_calibration_on_fixtures(fixtures, k=10, seed=0)
+    assert isinstance(report, CalibrationReport)
+    assert report.n_queries == len(fixtures)
+    assert report.k == 10
+    assert 0.0 <= report.p_at_k <= 1.0
+    assert report.n_observations >= report.n_queries
+    if report.roc_auc is not None:
+        assert 0.0 <= report.roc_auc <= 1.0
+    if report.spearman_rho is not None:
+        assert -1.0 <= report.spearman_rho <= 1.0
+
+
+def test_run_calibration_is_deterministic_at_fixed_seed() -> None:
+    fixtures = _toy_corpus()
+    r1 = eh.run_calibration_on_fixtures(fixtures, k=10, seed=42)
+    r2 = eh.run_calibration_on_fixtures(fixtures, k=10, seed=42)
+    assert r1 == r2
+
+
+def test_run_calibration_rejects_non_positive_k() -> None:
+    fixtures = _toy_corpus()
+    with pytest.raises(ValueError, match="k must be positive"):
+        eh.run_calibration_on_fixtures(fixtures, k=0, seed=0)
+    with pytest.raises(ValueError, match="k must be positive"):
+        eh.run_calibration_on_fixtures(fixtures, k=-1, seed=0)
+
+
+def test_run_calibration_rejects_empty_fixtures() -> None:
+    with pytest.raises(ValueError, match="fixtures must be non-empty"):
+        eh.run_calibration_on_fixtures([], k=10, seed=0)
+
+
+def test_format_calibration_report_is_deterministic(tmp_path: Path) -> None:
+    fixtures = _toy_corpus()
+    report = eh.run_calibration_on_fixtures(fixtures, k=10, seed=0)
+    text1 = eh.format_calibration_report(
+        report, corpus_path=tmp_path / "toy.jsonl", seed=0,
+    )
+    text2 = eh.format_calibration_report(
+        report, corpus_path=tmp_path / "toy.jsonl", seed=0,
+    )
+    assert text1 == text2
+    assert "calibration harness" in text1
+    assert "P@10:" in text1
+    assert "ROC-AUC:" in text1
+    assert "Spearman" in text1
+    assert text1.endswith("\n")
+
+
+def test_format_calibration_report_renders_undefined_metrics(
+    tmp_path: Path,
+) -> None:
+    """ROC-AUC / ρ render as 'n/a (undefined)' when the metric is None."""
+    report = CalibrationReport(
+        p_at_k=0.42,
+        k=10,
+        n_queries=3,
+        n_truncated_queries=1,
+        roc_auc=None,
+        spearman_rho=None,
+        n_observations=15,
+    )
+    text = eh.format_calibration_report(
+        report, corpus_path=tmp_path / "x.jsonl", seed=7,
+    )
+    assert "P@10:        0.4200" in text
+    assert "ROC-AUC:      n/a (undefined)" in text
+    assert "Spearman ρ:   n/a (undefined)" in text
+    assert "truncated:    1" in text
+
+
+def test_format_calibration_report_omits_truncated_when_zero(
+    tmp_path: Path,
+) -> None:
+    report = CalibrationReport(
+        p_at_k=0.5, k=10, n_queries=2, n_truncated_queries=0,
+        roc_auc=0.75, spearman_rho=0.5, n_observations=10,
+    )
+    text = eh.format_calibration_report(
+        report, corpus_path=tmp_path / "x.jsonl", seed=0,
+    )
+    assert "truncated:" not in text
+
+
+def _store_id_to_content(store) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for bid in store.list_belief_ids():
+        b = store.get_belief(bid)
+        if b is not None:
+            out[bid] = b.content
+    return out
+
+
+def test_build_calibration_store_inserts_one_known_plus_n_noise() -> None:
+    fixture = {
+        "id": "q1",
+        "query": "x",
+        "known_belief_content": "the known one",
+        "noise_belief_contents": ["n1", "n2", "n3"],
+    }
+    store = eh.build_calibration_store(fixture, seed=0)
+    try:
+        contents = sorted(_store_id_to_content(store).values())
+        assert contents == sorted(["the known one", "n1", "n2", "n3"])
+    finally:
+        store.close()
+
+
+def test_build_calibration_store_seed_controls_noise_order() -> None:
+    """Same seed reproduces noise content<->ID mapping; different seed
+    produces a different mapping."""
+    fixture = {
+        "id": "q1",
+        "query": "x",
+        "known_belief_content": "the known one",
+        "noise_belief_contents": [f"n{i}" for i in range(20)],
+    }
+    s1 = eh.build_calibration_store(fixture, seed=0)
+    s2 = eh.build_calibration_store(fixture, seed=0)
+    s3 = eh.build_calibration_store(fixture, seed=99)
+    try:
+        m1 = _store_id_to_content(s1)
+        m2 = _store_id_to_content(s2)
+        m3 = _store_id_to_content(s3)
+        assert m1 == m2  # determinism at fixed seed
+        assert m1 != m3  # 20-row shuffle differs across seeds
+        assert sorted(m1.keys()) == sorted(m3.keys())  # same belief IDs
+    finally:
+        s1.close()
+        s2.close()
+        s3.close()

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -51,6 +51,9 @@ EXPECTED_COMMANDS = (
     "delete",
     # v2.0 (#439) — load-bearing belief lens (locked ∪ corroborated ∪ high-posterior).
     "core",
+    # v2.0 (#365 R4) — operator-facing relevance-calibration harness
+    # (P@K / ROC-AUC / Spearman ρ).
+    "eval",
 )
 
 


### PR DESCRIPTION
Phase B of the close-the-loop relevance-calibration loop ratified at
#317 — exposes the R1 harness as an operator-facing `aelf eval`
subcommand.

## Shape

Three atomic commits + one slash-file follow-up:

1. `feat(eval): aelfrice.eval_harness module` — lift the calibration
   harness (`load_calibration_fixtures` / `build_calibration_store` /
   `run_calibration_on_fixtures` / `format_calibration_report`) out of
   `scripts/audit_rebuild_log.py` into a wheel-installable leaf module.
   12 unit tests.
2. `refactor(eval): audit_rebuild_log delegates calibration to
   aelfrice.eval_harness` — the script keeps its CLI surface (flags,
   exit codes, stderr wording) and now imports the harness instead of
   inlining it. Output is bytes-identical before and after; existing
   16 audit_rebuild_log tests stay green.
3. `feat(cli): aelf eval subcommand for relevance-calibration harness`
   — adds the `eval` subparser with `--corpus / --k / --seed / --json`
   flags. 10 new CLI tests.
4. `feat(slash): ship /aelf:eval slash file for the new subcommand` —
   ships `slash_commands/eval.md` and registers `eval` in the slash
   parity test, so the visible CLI surface matches `EXPECTED_COMMANDS`.

## Determinism contract

Same `(corpus, --k, --seed)` → bytes-identical output across reruns,
in both text and JSON modes. JSON keys are sorted so the line stays
diff-stable across Python releases — relevant for the future R5 CI
status-check surface.

## Verification

- Full suite: 3014 passed, 48 skipped.
- Discretion grep: clean.
- `uv run aelf eval` and `uv run python scripts/audit_rebuild_log.py
  --calibrate-corpus` produce identical metric lines on the bundled
  synthetic corpus (P@10=0.1000, ROC-AUC=0.8444, ρ=0.5241; n=7
  queries, n_obs=35; seed=0).

## Out of scope

R2 (hybrid labeling pipeline) and R3 (hand-label calibration) remain
lab-side per the issue spec. R5 (CI workflow on push to `main`) is
the next public-repo round and can now consume `aelf eval --json`
directly.

Refs #365.

## Summary by Sourcery

Introduce a reusable relevance-calibration harness module and expose it via both the existing audit script and a new `aelf eval` CLI subcommand.

New Features:
- Add the `aelfrice.eval_harness` module providing a reusable relevance-calibration harness API and defaults.
- Add an `aelf eval` CLI subcommand to run the calibration harness against a synthetic corpus with configurable corpus, k, seed, and JSON output.
- Ship an `/aelf:eval` slash command description for the new eval subcommand.

Enhancements:
- Refactor `scripts/audit_rebuild_log.py` to delegate calibration mode to the shared `aelfrice.eval_harness` module while preserving its CLI surface and output.

Tests:
- Add unit tests for the `aelfrice.eval_harness` module covering fixture loading, determinism, store construction, and report formatting.
- Add CLI tests for `aelf eval` covering default behavior, JSON output, determinism, flag handling, and error cases.
- Extend slash command parity tests to cover the new `eval` command.