### PR TITLE
feat(bench): wire deterministic correctness scorers for amabench + longmemeval (#507)

### DIFF
--- a/benchmarks/amabench_adapter.py
+++ b/benchmarks/amabench_adapter.py
@@ -27,6 +27,7 @@ from datasets import load_dataset  # type: ignore[import-untyped]
 from aelfrice.ingest import ingest_turn
 from aelfrice.retrieval import retrieve_v2 as retrieve  # v1.0.x lab-compat shim
 from aelfrice.store import MemoryStore
+from benchmarks.qa_scoring import score_multi_answer
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -244,6 +245,13 @@ class EpisodeResult:
     )
 
 
+_SCORE_KEYS: Final[tuple[str, ...]] = (
+    "exact_match",
+    "substring_exact_match",
+    "f1",
+)
+
+
 @dataclass
 class AggregateResult:
     """Aggregated benchmark results across episodes."""
@@ -261,6 +269,12 @@ class AggregateResult:
     )
     type_counts: dict[str, int] = field(
         default_factory=lambda: dict[str, int](),
+    )
+    # Per-metric score sums; mean = sum / total_qa. Per-type and
+    # per-domain breakdowns are computed at print/output time from
+    # per_question rows so we keep one source of truth.
+    score_sums: dict[str, float] = field(
+        default_factory=lambda: {k: 0.0 for k in _SCORE_KEYS},
     )
     per_question: list[dict[str, object]] = field(
         default_factory=lambda: list[dict[str, object]](),
@@ -290,8 +304,38 @@ def aggregate_results(results: list[EpisodeResult]) -> AggregateResult:
         for q in r.per_question:
             qt: str = str(q["qa_type"])
             agg.type_counts[qt] = agg.type_counts.get(qt, 0) + 1
+            for key in _SCORE_KEYS:
+                # Pre-#507 per_question rows have no score keys; treat
+                # them as missing rather than crashing the aggregator.
+                v = q.get(key)
+                if isinstance(v, (int, float)) and not isinstance(v, bool):
+                    agg.score_sums[key] += float(v)
 
     return agg
+
+
+def _accuracy_by_key(
+    rows: list[dict[str, object]], group_key: str,
+) -> dict[str, dict[str, float]]:
+    """Group rows by `group_key` and compute mean EM/SEM/F1 + count."""
+    by_group: dict[str, dict[str, float]] = {}
+    for q in rows:
+        g: str = str(q.get(group_key, "unknown"))
+        bucket = by_group.setdefault(
+            g, {**{k: 0.0 for k in _SCORE_KEYS}, "count": 0.0},
+        )
+        bucket["count"] += 1
+        for k in _SCORE_KEYS:
+            v = q.get(k)
+            if isinstance(v, (int, float)) and not isinstance(v, bool):
+                bucket[k] += float(v)
+    for g, bucket in by_group.items():
+        n: float = bucket["count"]
+        if n > 0:
+            for k in _SCORE_KEYS:
+                bucket[k] = round(bucket[k] / n, 4)
+        bucket["count"] = int(n)  # type: ignore[assignment]
+    return by_group
 
 
 # ---------------------------------------------------------------------------
@@ -325,6 +369,10 @@ def run_episode(
     t1: float = time.monotonic()
     for qa in episode.qa_pairs:
         context: str = query_aelfrice(store, qa.question, budget=budget)
+        # Deterministic correctness scorer per #507: substring-EM is
+        # the canonical metric (does retrieval surface the gold
+        # answer?), EM and F1 ride alongside as diagnostics.
+        scores: dict[str, float] = score_multi_answer(context, [qa.answer])
 
         result.total_qa += 1
         result.per_question.append({
@@ -336,6 +384,9 @@ def run_episode(
             "qa_type_name": QA_TYPE_NAMES.get(qa.qa_type, "unknown"),
             "question_uuid": qa.question_uuid,
             "context": context,
+            "exact_match": scores["exact_match"],
+            "substring_exact_match": scores["substring_exact_match"],
+            "f1": round(scores["f1"], 4),
         })
         result.ground_truth.append({
             "question_uuid": qa.question_uuid,
@@ -374,13 +425,33 @@ def print_results(agg: AggregateResult) -> None:
         qa_count: int = agg.domain_qa_counts.get(domain, 0)
         print(f"  {domain:25s}  episodes={ep_count:3d}  questions={qa_count:4d}")
 
+    # Overall correctness (deterministic, no LLM judge)
+    if agg.total_qa > 0:
+        em: float = agg.score_sums["exact_match"] / agg.total_qa
+        sem: float = agg.score_sums["substring_exact_match"] / agg.total_qa
+        f1: float = agg.score_sums["f1"] / agg.total_qa
+        print(f"\n{'- ' * 30}")
+        print("Overall correctness (deterministic):")
+        print(f"  Exact match:           {em:.4f} ({em * 100:.1f}%)")
+        print(f"  Substring exact match: {sem:.4f} ({sem * 100:.1f}%)")
+        print(f"  F1:                    {f1:.4f} ({f1 * 100:.1f}%)")
+
     # Per-QA-type breakdown
     print(f"\n{'- ' * 30}")
     print("Per-QA-type breakdown:")
+    type_acc: dict[str, dict[str, float]] = _accuracy_by_key(
+        agg.per_question, "qa_type",
+    )
     for qt in sorted(agg.type_counts.keys()):
         count: int = agg.type_counts[qt]
         name: str = QA_TYPE_NAMES.get(qt, "unknown")
-        print(f"  {qt}: {name:30s}  n={count}")
+        bucket = type_acc.get(qt, {})
+        sem_t: float = float(bucket.get("substring_exact_match", 0.0))
+        f1_t: float = float(bucket.get("f1", 0.0))
+        print(
+            f"  {qt}: {name:30s}  n={count:4d}  "
+            f"sub_em={sem_t:.4f}  f1={f1_t:.4f}"
+        )
 
     # Context length stats
     if agg.per_question:
@@ -503,11 +574,22 @@ def main() -> None:
 
     # Write detailed output
     if args.output:
+        # Overall correctness (means of per-question booleans / F1).
+        n_qa: int = agg.total_qa
+        overall: dict[str, float] = (
+            {k: round(agg.score_sums[k] / n_qa, 4) for k in _SCORE_KEYS}
+            if n_qa > 0 else {k: 0.0 for k in _SCORE_KEYS}
+        )
         output_data: dict[str, object] = {
             "total_episodes": agg.total_episodes,
             "total_qa": agg.total_qa,
             "domain_counts": agg.domain_counts,
             "type_counts": agg.type_counts,
+            "exact_match": overall["exact_match"],
+            "substring_exact_match": overall["substring_exact_match"],
+            "f1": overall["f1"],
+            "accuracy_by_type": _accuracy_by_key(agg.per_question, "qa_type"),
+            "accuracy_by_domain": _accuracy_by_key(agg.per_question, "domain"),
             "per_question": agg.per_question,
         }
         output_path: Path = Path(args.output)

--- a/benchmarks/longmemeval_adapter.py
+++ b/benchmarks/longmemeval_adapter.py
@@ -26,6 +26,7 @@ from typing import Final
 from aelfrice.ingest import ingest_turn
 from aelfrice.retrieval import retrieve_v2 as retrieve  # v1.0.x lab-compat shim
 from aelfrice.store import MemoryStore
+from benchmarks.qa_scoring import score_multi_answer
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -82,6 +83,13 @@ class LongMemEvalQuestion:
     answer_session_ids: list[str]
 
 
+_SCORE_KEYS: Final[tuple[str, ...]] = (
+    "exact_match",
+    "substring_exact_match",
+    "f1",
+)
+
+
 @dataclass
 class RetrievalResult:
     """Result of retrieval for one question."""
@@ -94,6 +102,9 @@ class RetrievalResult:
     retrieved_context: str
     num_beliefs: int
     retrieval_latency_ms: float
+    exact_match: float = 0.0
+    substring_exact_match: float = 0.0
+    f1: float = 0.0
 
 
 @dataclass
@@ -104,6 +115,9 @@ class CategoryStats:
     count: int = 0
     total_beliefs: int = 0
     total_latency_ms: float = 0.0
+    total_exact_match: float = 0.0
+    total_substring_exact_match: float = 0.0
+    total_f1: float = 0.0
 
     @property
     def avg_beliefs(self) -> float:
@@ -117,6 +131,24 @@ class CategoryStats:
             return 0.0
         return self.total_latency_ms / self.count
 
+    @property
+    def exact_match(self) -> float:
+        if self.count == 0:
+            return 0.0
+        return self.total_exact_match / self.count
+
+    @property
+    def substring_exact_match(self) -> float:
+        if self.count == 0:
+            return 0.0
+        return self.total_substring_exact_match / self.count
+
+    @property
+    def f1(self) -> float:
+        if self.count == 0:
+            return 0.0
+        return self.total_f1 / self.count
+
 
 @dataclass
 class BenchmarkResult:
@@ -127,6 +159,9 @@ class BenchmarkResult:
     total_latency_ms: float = 0.0
     total_ingest_turns: int = 0
     total_ingest_time_s: float = 0.0
+    total_exact_match: float = 0.0
+    total_substring_exact_match: float = 0.0
+    total_f1: float = 0.0
     category_stats: dict[str, CategoryStats] = field(
         default_factory=lambda: dict[str, CategoryStats](),
     )
@@ -145,6 +180,24 @@ class BenchmarkResult:
         if self.total_questions == 0:
             return 0.0
         return self.total_latency_ms / self.total_questions
+
+    @property
+    def exact_match(self) -> float:
+        if self.total_questions == 0:
+            return 0.0
+        return self.total_exact_match / self.total_questions
+
+    @property
+    def substring_exact_match(self) -> float:
+        if self.total_questions == 0:
+            return 0.0
+        return self.total_substring_exact_match / self.total_questions
+
+    @property
+    def f1(self) -> float:
+        if self.total_questions == 0:
+            return 0.0
+        return self.total_f1 / self.total_questions
 
 
 # ---------------------------------------------------------------------------
@@ -349,6 +402,16 @@ def run_question(
     )
     latency_ms: float = (time.monotonic() - t1) * 1000.0
 
+    # Score retrieved context against gold answer(s). LongMemEval lists
+    # multiple acceptable answer surfaces for some categories — fold
+    # via best-of multi-answer per #507.
+    gts: list[str] = (
+        [str(a) for a in question.answer]
+        if isinstance(question.answer, list)
+        else [str(question.answer)]
+    )
+    scores: dict[str, float] = score_multi_answer(context, gts)
+
     result: RetrievalResult = RetrievalResult(
         question_id=question.question_id,
         question_type=question.question_type,
@@ -358,6 +421,9 @@ def run_question(
         retrieved_context=context,
         num_beliefs=num_beliefs,
         retrieval_latency_ms=latency_ms,
+        exact_match=scores["exact_match"],
+        substring_exact_match=scores["substring_exact_match"],
+        f1=scores["f1"],
     )
     return result, ingest_turns, ingest_time
 
@@ -383,6 +449,9 @@ def run_benchmark(
             result.total_latency_ms += qr.retrieval_latency_ms
             result.total_ingest_turns += ingest_turns
             result.total_ingest_time_s += ingest_time
+            result.total_exact_match += qr.exact_match
+            result.total_substring_exact_match += qr.substring_exact_match
+            result.total_f1 += qr.f1
             result.per_question.append(qr)
 
             # Per-category stats
@@ -394,6 +463,9 @@ def run_benchmark(
             cat.count += 1
             cat.total_beliefs += qr.num_beliefs
             cat.total_latency_ms += qr.retrieval_latency_ms
+            cat.total_exact_match += qr.exact_match
+            cat.total_substring_exact_match += qr.substring_exact_match
+            cat.total_f1 += qr.f1
 
     return result
 
@@ -415,6 +487,13 @@ def print_results(result: BenchmarkResult) -> None:
     print(f"Avg query latency:    {result.avg_latency_ms:.1f}ms")
     print()
 
+    print(
+        f"Overall correctness (deterministic): "
+        f"EM={result.exact_match:.4f}  "
+        f"sub_EM={result.substring_exact_match:.4f}  "
+        f"F1={result.f1:.4f}"
+    )
+    print()
     print("Per-category retrieval stats:")
     for qtype in QUESTION_TYPES:
         cat: CategoryStats | None = result.category_stats.get(qtype)
@@ -423,7 +502,9 @@ def print_results(result: BenchmarkResult) -> None:
         print(
             f"  {qtype:30s}  n={cat.count:3d}  "
             f"avg_beliefs={cat.avg_beliefs:5.1f}  "
-            f"avg_latency={cat.avg_latency_ms:6.1f}ms"
+            f"avg_latency={cat.avg_latency_ms:6.1f}ms  "
+            f"sub_EM={cat.substring_exact_match:.4f}  "
+            f"F1={cat.f1:.4f}"
         )
     print()
 
@@ -572,11 +653,17 @@ def main() -> None:
             "avg_latency_ms": round(result.avg_latency_ms, 2),
             "total_ingest_turns": result.total_ingest_turns,
             "total_ingest_time_s": round(result.total_ingest_time_s, 2),
+            "exact_match": round(result.exact_match, 4),
+            "substring_exact_match": round(result.substring_exact_match, 4),
+            "f1": round(result.f1, 4),
             "category_stats": {
                 qtype: {
                     "count": cat.count,
                     "avg_beliefs": round(cat.avg_beliefs, 2),
                     "avg_latency_ms": round(cat.avg_latency_ms, 2),
+                    "exact_match": round(cat.exact_match, 4),
+                    "substring_exact_match": round(cat.substring_exact_match, 4),
+                    "f1": round(cat.f1, 4),
                 }
                 for qtype, cat in result.category_stats.items()
             },
@@ -588,6 +675,9 @@ def main() -> None:
                     "answer": qr.answer,
                     "num_beliefs": qr.num_beliefs,
                     "retrieval_latency_ms": round(qr.retrieval_latency_ms, 2),
+                    "exact_match": qr.exact_match,
+                    "substring_exact_match": qr.substring_exact_match,
+                    "f1": round(qr.f1, 4),
                 }
                 for qr in result.per_question
             ],

--- a/benchmarks/qa_scoring.py
+++ b/benchmarks/qa_scoring.py
@@ -1,0 +1,99 @@
+"""Deterministic QA correctness scorers for benchmark adapters.
+
+Pure stdlib leaf module. Mirrors the MemoryAgentBench paper's scoring
+functions (no Porter stemming) so adapters that currently emit only
+retrieval statistics can fold in answer-correctness without an LLM
+judge in the canonical dispatcher path.
+
+Spec: #507 acceptance criteria. The exposed surfaces are:
+
+- `normalize_answer(s)` — lowercase, drop punctuation, drop articles,
+  collapse whitespace.
+- `score_exact_match(prediction, ground_truth)` — normalized strings
+  must be identical. Returns 1.0 / 0.0.
+- `score_substring_exact_match(prediction, ground_truth)` — normalized
+  ground truth must appear inside normalized prediction. Returns
+  1.0 / 0.0.
+- `score_f1(prediction, ground_truth)` — token-level F1 on normalized
+  whitespace splits. Returns float in [0, 1].
+- `score_multi_answer(prediction, ground_truths)` — best-of across a
+  list of acceptable ground truths. Returns the three metrics keyed by
+  name.
+
+Determinism: every function is a pure transformation over its inputs.
+Two invocations on identical inputs produce identical outputs by
+construction (no RNG, no hashing, no time, no I/O).
+"""
+from __future__ import annotations
+
+import re
+import string
+from collections import Counter
+from typing import Final
+
+_ARTICLE_RE: Final[re.Pattern[str]] = re.compile(r"\b(a|an|the)\b")
+_PUNCT_TABLE: Final[dict[int, str | None]] = str.maketrans(
+    "", "", string.punctuation,
+)
+
+
+def normalize_answer(s: str) -> str:
+    """Normalize: lowercase, strip punctuation, drop articles, collapse spaces."""
+    s = s.lower()
+    s = s.translate(_PUNCT_TABLE)
+    s = _ARTICLE_RE.sub(" ", s)
+    return " ".join(s.split())
+
+
+def score_exact_match(prediction: str, ground_truth: str) -> float:
+    """Normalized strings must be identical."""
+    return 1.0 if normalize_answer(prediction) == normalize_answer(ground_truth) else 0.0
+
+
+def score_substring_exact_match(prediction: str, ground_truth: str) -> float:
+    """Normalized ground truth appears as a substring of normalized prediction."""
+    norm_gt: str = normalize_answer(ground_truth)
+    if not norm_gt:
+        return 0.0
+    return 1.0 if norm_gt in normalize_answer(prediction) else 0.0
+
+
+def score_f1(prediction: str, ground_truth: str) -> float:
+    """Token-level F1 on normalized whitespace splits."""
+    pred_tokens: list[str] = normalize_answer(prediction).split()
+    gt_tokens: list[str] = normalize_answer(ground_truth).split()
+    if not pred_tokens or not gt_tokens:
+        return 0.0
+    common: Counter[str] = Counter(pred_tokens) & Counter(gt_tokens)
+    num_common: int = sum(common.values())
+    if num_common == 0:
+        return 0.0
+    precision: float = num_common / len(pred_tokens)
+    recall: float = num_common / len(gt_tokens)
+    return (2 * precision * recall) / (precision + recall)
+
+
+def score_multi_answer(
+    prediction: str,
+    ground_truths: list[str],
+) -> dict[str, float]:
+    """Best-of EM / SEM / F1 across a list of acceptable ground truths.
+
+    Empty list → all three metrics are 0.0.
+    """
+    best_em: float = 0.0
+    best_sem: float = 0.0
+    best_f1: float = 0.0
+    for gt in ground_truths:
+        if score_exact_match(prediction, gt) > best_em:
+            best_em = 1.0
+        if score_substring_exact_match(prediction, gt) > best_sem:
+            best_sem = 1.0
+        f1: float = score_f1(prediction, gt)
+        if f1 > best_f1:
+            best_f1 = f1
+    return {
+        "exact_match": best_em,
+        "substring_exact_match": best_sem,
+        "f1": best_f1,
+    }

--- a/tests/test_amabench_scoring.py
+++ b/tests/test_amabench_scoring.py
@@ -1,0 +1,118 @@
+"""Tests for the #507 scoring wiring inside benchmarks.amabench_adapter.
+
+Real AMA-Bench runs need HuggingFace + retrieval, so these tests build
+synthetic EpisodeResult / per_question rows and exercise the
+aggregation + per-key breakdown helpers directly. The substring-EM
+math itself is covered by tests/test_bench_qa_scoring.py.
+
+Spec: #507 acceptance #1 (non-trivial correctness), #3 (determinism).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# Loading without HF: amabench_adapter top-level imports `datasets`,
+# which is heavy but installed as a hard dep. Import normally.
+import pytest
+
+pytest.importorskip("datasets")
+
+from benchmarks import amabench_adapter as ama
+
+
+def _row(qa_type: str, domain: str, em: float, sem: float, f1: float) -> dict:
+    return {
+        "episode_id": "ep0",
+        "domain": domain,
+        "task_type": "task",
+        "question": "q",
+        "qa_type": qa_type,
+        "qa_type_name": ama.QA_TYPE_NAMES.get(qa_type, "unknown"),
+        "question_uuid": f"uuid-{qa_type}-{domain}",
+        "context": "ctx",
+        "exact_match": em,
+        "substring_exact_match": sem,
+        "f1": f1,
+    }
+
+
+def _make_episode_result(rows: list[dict], domain: str) -> ama.EpisodeResult:
+    r = ama.EpisodeResult(episode_id="ep0", domain=domain)
+    r.total_qa = len(rows)
+    r.per_question = list(rows)
+    return r
+
+
+def test_aggregate_sums_scores_across_episodes():
+    rows = [
+        _row("A", "Game", 1.0, 1.0, 1.0),
+        _row("A", "Game", 0.0, 1.0, 0.5),
+        _row("B", "Game", 0.0, 0.0, 0.0),
+    ]
+    ep = _make_episode_result(rows, "Game")
+    agg = ama.aggregate_results([ep])
+    assert agg.total_qa == 3
+    assert agg.score_sums["exact_match"] == pytest.approx(1.0)
+    assert agg.score_sums["substring_exact_match"] == pytest.approx(2.0)
+    assert agg.score_sums["f1"] == pytest.approx(1.5)
+
+
+def test_aggregate_handles_legacy_rows_without_scores():
+    # Pre-#507 per_question rows had no score keys; aggregator must
+    # treat them as missing rather than crashing.
+    legacy = {
+        "episode_id": "old",
+        "domain": "Game",
+        "task_type": "task",
+        "question": "q",
+        "qa_type": "A",
+        "qa_type_name": ama.QA_TYPE_NAMES["A"],
+        "question_uuid": "old",
+        "context": "ctx",
+    }
+    ep = _make_episode_result([legacy], "Game")
+    agg = ama.aggregate_results([ep])
+    assert agg.total_qa == 1
+    for k in ama._SCORE_KEYS:
+        assert agg.score_sums[k] == 0.0
+
+
+def test_accuracy_by_qa_type_means():
+    rows = [
+        _row("A", "Game", 1.0, 1.0, 1.0),
+        _row("A", "Game", 1.0, 1.0, 0.0),
+        _row("B", "Web", 0.0, 1.0, 0.5),
+    ]
+    by_type = ama._accuracy_by_key(rows, "qa_type")
+    assert by_type["A"]["count"] == 2
+    assert by_type["A"]["exact_match"] == pytest.approx(1.0)
+    assert by_type["A"]["f1"] == pytest.approx(0.5)
+    assert by_type["B"]["count"] == 1
+    assert by_type["B"]["substring_exact_match"] == pytest.approx(1.0)
+
+
+def test_accuracy_by_domain_groups_independently_of_type():
+    rows = [
+        _row("A", "Game", 1.0, 1.0, 1.0),
+        _row("B", "Game", 0.0, 0.0, 0.0),
+        _row("A", "Web", 1.0, 1.0, 0.8),
+    ]
+    by_domain = ama._accuracy_by_key(rows, "domain")
+    assert by_domain["Game"]["count"] == 2
+    assert by_domain["Game"]["exact_match"] == pytest.approx(0.5)
+    assert by_domain["Web"]["count"] == 1
+    assert by_domain["Web"]["f1"] == pytest.approx(0.8)
+
+
+def test_accuracy_by_key_empty_input():
+    assert ama._accuracy_by_key([], "qa_type") == {}
+
+
+def test_score_keys_match_metric_band_names():
+    # Tolerance bands key off substring matches in the metric leaf
+    # name. The chosen names ride MAB's canonical band assignments.
+    assert "exact_match" in ama._SCORE_KEYS
+    assert "substring_exact_match" in ama._SCORE_KEYS
+    assert "f1" in ama._SCORE_KEYS

--- a/tests/test_bench_qa_scoring.py
+++ b/tests/test_bench_qa_scoring.py
@@ -1,0 +1,163 @@
+"""Tests for benchmarks.qa_scoring — deterministic QA correctness leaf.
+
+Spec: #507. The leaf is pure stdlib; tests cover normalization, the
+three score functions, and the multi-answer best-of wrapper.
+"""
+from __future__ import annotations
+
+from benchmarks import qa_scoring
+
+
+# ---------------------------------------------------------------------------
+# normalize_answer
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_lowercases():
+    assert qa_scoring.normalize_answer("Hello World") == "hello world"
+
+
+def test_normalize_strips_punctuation():
+    assert qa_scoring.normalize_answer("Hello, world!") == "hello world"
+
+
+def test_normalize_drops_articles():
+    assert qa_scoring.normalize_answer("the quick a fox") == "quick fox"
+
+
+def test_normalize_collapses_whitespace():
+    assert qa_scoring.normalize_answer("foo   bar\tbaz\n") == "foo bar baz"
+
+
+def test_normalize_empty_string():
+    assert qa_scoring.normalize_answer("") == ""
+
+
+def test_normalize_only_articles_and_punctuation():
+    # Articles → " ", punctuation removed; result is empty after collapse.
+    assert qa_scoring.normalize_answer("the, a! an?") == ""
+
+
+# ---------------------------------------------------------------------------
+# score_exact_match
+# ---------------------------------------------------------------------------
+
+
+def test_em_identical():
+    assert qa_scoring.score_exact_match("Paris", "paris") == 1.0
+
+
+def test_em_punctuation_insensitive():
+    assert qa_scoring.score_exact_match("Paris.", "paris") == 1.0
+
+
+def test_em_substring_does_not_match():
+    assert qa_scoring.score_exact_match("Paris is the capital", "paris") == 0.0
+
+
+def test_em_empty_inputs():
+    assert qa_scoring.score_exact_match("", "") == 1.0
+
+
+# ---------------------------------------------------------------------------
+# score_substring_exact_match
+# ---------------------------------------------------------------------------
+
+
+def test_sem_substring_match():
+    assert qa_scoring.score_substring_exact_match(
+        "The capital of France is Paris.", "paris",
+    ) == 1.0
+
+
+def test_sem_no_match():
+    assert qa_scoring.score_substring_exact_match(
+        "The capital of Germany is Berlin.", "paris",
+    ) == 0.0
+
+
+def test_sem_case_insensitive():
+    assert qa_scoring.score_substring_exact_match("PARIS", "paris") == 1.0
+
+
+def test_sem_empty_ground_truth_is_zero():
+    # Vacuous match would inflate scores; empty GT must not score.
+    assert qa_scoring.score_substring_exact_match("anything", "") == 0.0
+
+
+def test_sem_articles_dropped_in_both():
+    # "the moon" -> "moon"; pred "...moon..." matches.
+    assert qa_scoring.score_substring_exact_match(
+        "We saw the moon last night", "the moon",
+    ) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# score_f1
+# ---------------------------------------------------------------------------
+
+
+def test_f1_identical_tokens_is_one():
+    assert qa_scoring.score_f1("paris france", "paris france") == 1.0
+
+
+def test_f1_no_overlap_is_zero():
+    assert qa_scoring.score_f1("paris", "berlin") == 0.0
+
+
+def test_f1_partial_overlap():
+    # pred=["paris","france","capital"] gt=["paris","france"]
+    # common=2 ; p=2/3 r=2/2=1 ; f1=2*0.6667*1 / (0.6667+1) = 0.8
+    f1 = qa_scoring.score_f1("paris france capital", "paris france")
+    assert abs(f1 - 0.8) < 1e-9
+
+
+def test_f1_empty_prediction_is_zero():
+    assert qa_scoring.score_f1("", "paris") == 0.0
+
+
+def test_f1_empty_ground_truth_is_zero():
+    assert qa_scoring.score_f1("paris", "") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# score_multi_answer
+# ---------------------------------------------------------------------------
+
+
+def test_multi_picks_best_match():
+    result = qa_scoring.score_multi_answer(
+        "The capital is Paris.",
+        ["london", "paris", "berlin"],
+    )
+    assert result["substring_exact_match"] == 1.0
+    assert result["exact_match"] == 0.0  # full string isn't equal to "paris"
+    assert result["f1"] > 0.0
+
+
+def test_multi_empty_list_is_zero():
+    result = qa_scoring.score_multi_answer("anything", [])
+    assert result == {"exact_match": 0.0, "substring_exact_match": 0.0, "f1": 0.0}
+
+
+def test_multi_em_dominates_when_one_matches_exactly():
+    result = qa_scoring.score_multi_answer(
+        "paris",
+        ["london", "paris", "berlin"],
+    )
+    assert result["exact_match"] == 1.0
+    assert result["substring_exact_match"] == 1.0
+    assert result["f1"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# determinism: same inputs → bit-identical outputs (acceptance #3)
+# ---------------------------------------------------------------------------
+
+
+def test_determinism_repeated_calls():
+    pred = "The Eiffel Tower is in Paris, France."
+    gts = ["paris", "france"]
+    a = qa_scoring.score_multi_answer(pred, gts)
+    b = qa_scoring.score_multi_answer(pred, gts)
+    assert a == b

--- a/tests/test_longmemeval_scoring.py
+++ b/tests/test_longmemeval_scoring.py
@@ -1,0 +1,76 @@
+"""Tests for the #507 scoring wiring inside benchmarks.longmemeval_adapter.
+
+Real LongMemEval runs need HuggingFace + retrieval, so these tests
+construct synthetic RetrievalResult / CategoryStats / BenchmarkResult
+objects and exercise the aggregation derivations directly. The
+substring-EM math itself is covered by tests/test_bench_qa_scoring.py.
+
+Spec: #507 acceptance #1 (non-trivial correctness), #3 (determinism).
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("datasets")
+
+from benchmarks import longmemeval_adapter as lme
+
+
+def test_category_stats_means_zero_when_empty():
+    cat = lme.CategoryStats(question_type="x")
+    assert cat.exact_match == 0.0
+    assert cat.substring_exact_match == 0.0
+    assert cat.f1 == 0.0
+
+
+def test_category_stats_means_compute_correctly():
+    cat = lme.CategoryStats(question_type="x")
+    cat.count = 3
+    cat.total_exact_match = 1.0  # 1 hit out of 3
+    cat.total_substring_exact_match = 2.0
+    cat.total_f1 = 1.5
+    assert cat.exact_match == pytest.approx(1.0 / 3)
+    assert cat.substring_exact_match == pytest.approx(2.0 / 3)
+    assert cat.f1 == pytest.approx(0.5)
+
+
+def test_benchmark_result_means_zero_when_empty():
+    r = lme.BenchmarkResult()
+    assert r.exact_match == 0.0
+    assert r.substring_exact_match == 0.0
+    assert r.f1 == 0.0
+
+
+def test_benchmark_result_means_compute_correctly():
+    r = lme.BenchmarkResult()
+    r.total_questions = 4
+    r.total_exact_match = 2.0
+    r.total_substring_exact_match = 3.0
+    r.total_f1 = 2.0
+    assert r.exact_match == pytest.approx(0.5)
+    assert r.substring_exact_match == pytest.approx(0.75)
+    assert r.f1 == pytest.approx(0.5)
+
+
+def test_retrieval_result_default_scores_are_zero():
+    qr = lme.RetrievalResult(
+        question_id="q1",
+        question_type="single-session-user",
+        question="?",
+        question_date="2025-01-01",
+        answer="paris",
+        retrieved_context="",
+        num_beliefs=0,
+        retrieval_latency_ms=0.0,
+    )
+    assert qr.exact_match == 0.0
+    assert qr.substring_exact_match == 0.0
+    assert qr.f1 == 0.0
+
+
+def test_score_keys_match_metric_band_names():
+    # Same naming contract as amabench: tolerance bands key off
+    # substring matches in the metric leaf name.
+    assert "exact_match" in lme._SCORE_KEYS
+    assert "substring_exact_match" in lme._SCORE_KEYS
+    assert "f1" in lme._SCORE_KEYS


### PR DESCRIPTION
Closes #507.

## What landed

Three atomic commits wire deterministic answer-correctness scoring into the AMA-Bench and LongMemEval adapters so all 11 canonical-bench invocations produce a real correctness grade alongside the existing latency / corpus statistics.

1. **`feat(bench): qa_scoring leaf — normalize/EM/SEM/F1`** — new `benchmarks/qa_scoring.py`, pure-stdlib leaf module exposing `normalize_answer`, `score_exact_match`, `score_substring_exact_match`, `score_f1`, and the `score_multi_answer` best-of wrapper. 24 unit tests cover normalization edge cases, all four score functions, and the determinism contract.
2. **`feat(bench/amabench): wire deterministic correctness scorer`** — `amabench_adapter` now scores per-question retrieval against the gold answer, emitting overall `exact_match` / `substring_exact_match` / `f1` plus `accuracy_by_type` and `accuracy_by_domain` breakdowns. Aggregator handles legacy per_question rows missing score fields. 6 unit tests.
3. **`feat(bench/longmemeval): wire deterministic correctness scorer`** — `longmemeval_adapter` does the same; `category_stats` now carries the three correctness numbers per question type alongside latency / belief counts. The multi-answer best-of wrapper handles LongMemEval's `answer: str | list[str]` shape. 6 unit tests.

## How it satisfies the acceptance criteria

| Criterion | Status |
|---|---|
| 1. `aelf bench all` returns non-trivial correctness for `amabench/_` and `longmemeval/_` | ✅ Three correctness leaves added per adapter; will populate next canonical capture |
| 2. Tolerance bands cover observed variance | ✅ Metric names ride the existing `tolerance.py` substring-match assignments (`exact_match` → ±10%, `f1` → ±7%); no `metric_overrides` needed because substring-EM and F1 are pure transforms — bit-deterministic across runs |
| 3. Bit-determinism contract holds | ✅ Scorers are pure stdlib transforms over `(prediction, ground_truth)` — no RNG, no time, no I/O. Verified by `test_determinism_repeated_calls` |
| 4. README badge can flip from "partial (6/11 adapters)" to "full (11/11 adapters)" | ✅ Both adapters now produce a deterministic correctness metric. Operator action: re-capture `benchmarks/results/v2.0.0.json` to fold the new leaves in, then flip the README badge |

## Why substring-EM is the canonical metric (not LLM-judge)

Issue body suggested either an LLM judge or "exact-match, F1, or substring-EM" — substring-EM is the deterministic option. There is no LLM prediction here: the adapter currently retrieves a context and exits. Substring-EM treats the retrieved context as the "prediction" and asks "did retrieval surface the gold answer span?" — that's the deterministic stand-in for downstream LLM correctness. Determinism preserves the bit-equality contract from acceptance #3.

An LLM-judge metric can still stack on top behind an opt-in flag (LongMemEval already has the `longmemeval_score.py` plumbing for that path), but it would break determinism and shouldn't be on the canonical cut.

## Out of scope

- Re-capturing `benchmarks/results/v2.0.0.json` with the new metrics (operator-side, separate run).
- Flipping the README badge from "partial (6/11)" to "full (11/11)" (depends on the recapture).
- StructMemEval composition zeros (#197 territory).
- Refactoring `mab_adapter.py` to use the new `qa_scoring` leaf — out of scope; MAB's local copy stays. Future cleanup can DRY them.

## Test plan

- [x] `pytest tests/test_bench_qa_scoring.py` — 24 / 24 pass
- [x] `pytest tests/test_amabench_scoring.py` — 6 / 6 pass
- [x] `pytest tests/test_longmemeval_scoring.py` — 6 / 6 pass
- [x] `pytest tests/test_bench_dispatcher.py tests/test_bench_tolerance.py tests/test_bench_qa_scoring.py tests/test_amabench_scoring.py tests/test_longmemeval_scoring.py` — 69 / 69 pass
- [x] `import benchmarks.amabench_adapter` and `import benchmarks.longmemeval_adapter` clean
- [x] Discretion grep on the diff returns no hits
- [x] All 3 commits signed (`%G?` = G)
- [ ] Operator: recapture `v2.0.0.json` after merge to populate new metric leaves and confirm tolerance bands hold across a 3-run calibration pass.

## Summary by Sourcery

Add deterministic QA correctness scoring to AMA-Bench and LongMemEval adapters using a shared stdlib-only scoring leaf, and expose aggregated correctness metrics alongside existing retrieval statistics.

New Features:
- Introduce a reusable qa_scoring module providing normalized exact match, substring exact match, F1, and multi-answer scoring helpers.
- Augment AMA-Bench adapter outputs with per-question and aggregated correctness metrics plus per-type and per-domain accuracy breakdowns.
- Augment LongMemEval adapter outputs with per-question and aggregated correctness metrics and include correctness stats in printed and JSON benchmark results.

Tests:
- Add unit tests for qa_scoring normalization, scoring functions, multi-answer logic, and determinism guarantees.
- Add AMA-Bench adapter tests covering score aggregation, legacy row handling, and per-type/domain accuracy helpers.
- Add LongMemEval adapter tests covering correctness aggregation, default values, and metric naming consistency with tolerance bands.