### PR TITLE
ci(eval): synthetic-corpus calibration status check (#365 R5)

### DIFF
--- a/.github/workflows/eval-calibration.yml
+++ b/.github/workflows/eval-calibration.yml
@@ -1,0 +1,135 @@
+name: Eval Calibration
+
+# #365 R5 — Phase C: synthetic-corpus calibration as a status check.
+#
+# Runs `aelf eval --json` on the bundled public synthetic corpus
+# under default flags (--k 10 --seed 0), strips the path-dependent
+# `corpus` key, and asserts bytes-identical match against the pinned
+# baseline at benchmarks/posterior_ranking/baseline.json.
+#
+# Per #365 Q6: only the synthetic-corpus aggregate crosses the public
+# boundary. No live-data dependency, no operator stores. Live-corpus
+# calibration runs operator-side (R2/R3, lab repo).
+#
+# Surface:
+#   - PR-time: blocks merges that change metric output without a
+#     deliberate baseline update in the same PR.
+#   - Push-to-main: re-asserts post-merge so a green main is also a
+#     calibrated main. Step summary records the metric line for
+#     historical traceability.
+#
+# Determinism contract (#365 ship gate): same `(corpus, --k, --seed)`
+# → bytes-identical metrics across reruns.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/aelfrice/eval_harness.py'
+      - 'src/aelfrice/calibration_metrics.py'
+      - 'src/aelfrice/cli.py'
+      - 'benchmarks/posterior_ranking/**'
+      - '.github/workflows/eval-calibration.yml'
+      - 'pyproject.toml'
+      - 'uv.lock'
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: eval-calibration-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  calibration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          python-version: '3.13'
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install
+        # Base + default groups only — `aelf eval` and the
+        # eval_harness module use stdlib + intra-package imports;
+        # no dev/archive extras are needed.
+        run: uv sync --frozen
+
+      - name: Run aelf eval against bundled synthetic corpus
+        id: eval
+        run: |
+          set -euo pipefail
+          out=$(uv run aelf eval --json | tail -n 1)
+          echo "raw=${out}"
+          # Strip the path-dependent `corpus` key, re-canonicalize.
+          observed=$(printf '%s' "${out}" | python3 -c "
+          import json, sys
+          d = json.load(sys.stdin)
+          d.pop('corpus', None)
+          print(json.dumps(d, sort_keys=True, separators=(',', ':')))
+          ")
+          echo "observed=${observed}"
+          {
+            echo "observed<<EOF"
+            echo "${observed}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Assert match against pinned baseline
+        env:
+          OBSERVED: ${{ steps.eval.outputs.observed }}
+        run: |
+          set -euo pipefail
+          # Re-canonicalize the baseline file in case the checkout
+          # introduced whitespace drift; comparison is on canonical-form
+          # strings.
+          expected=$(python3 -c "
+          import json
+          d = json.load(open('benchmarks/posterior_ranking/baseline.json'))
+          print(json.dumps(d, sort_keys=True, separators=(',', ':')))
+          ")
+          if [ "${OBSERVED}" = "${expected}" ]; then
+            echo "::notice::synthetic-corpus calibration matches pinned baseline"
+            echo "metrics: ${OBSERVED}"
+          else
+            echo "::error::synthetic-corpus calibration drifted from pinned baseline"
+            echo "expected: ${expected}"
+            echo "observed: ${OBSERVED}"
+            echo "If the drift is intentional, regenerate baseline.json from"
+            echo "\`aelf eval --json\` (with the \`corpus\` key stripped) in"
+            echo "the same commit."
+            exit 1
+          fi
+
+      - name: Publish metrics to step summary
+        if: always()
+        env:
+          OBSERVED: ${{ steps.eval.outputs.observed }}
+          EVENT: ${{ github.event_name }}
+          REF: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## #365 R5 — synthetic-corpus calibration"
+            echo ""
+            echo "- run: \`${EVENT}\` on \`${REF}\` (\`${SHA}\`)"
+            echo "- corpus: bundled public synthetic (default.jsonl)"
+            echo "- flags: \`--k 10 --seed 0\`"
+            echo ""
+            echo "\`\`\`json"
+            echo "${OBSERVED}"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/benchmarks/posterior_ranking/baseline.json
+++ b/benchmarks/posterior_ranking/baseline.json
@@ -1,0 +1,1 @@
+{"k":10,"n_observations":35,"n_queries":7,"n_truncated_queries":7,"p_at_k":0.1,"roc_auc":0.8443877551020408,"seed":0,"spearman_rho":0.5241037078990654}

--- a/tests/test_eval_baseline.py
+++ b/tests/test_eval_baseline.py
@@ -1,0 +1,83 @@
+"""Drift guard for the synthetic-corpus calibration baseline (#365 R5).
+
+Pins ``benchmarks/posterior_ranking/baseline.json`` to the metric block
+that ``aelf eval --json`` produces against the bundled public corpus
+under default flags. Any change to the corpus, harness, or scorer that
+moves a metric must be a deliberate baseline update — this test is the
+PR-time tripwire that fires before the change reaches main, paired
+with the push-to-main status check workflow that re-asserts it.
+
+The ``corpus`` key is path-dependent (worktree absolute path) so it is
+stripped before comparison; what we pin is the metric subset.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aelfrice import eval_harness as eh
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BASELINE_PATH = REPO_ROOT / "benchmarks" / "posterior_ranking" / "baseline.json"
+
+
+def _metrics_only(payload: dict) -> dict:
+    return {k: v for k, v in payload.items() if k != "corpus"}
+
+
+def test_baseline_file_exists_and_parses():
+    assert BASELINE_PATH.is_file(), f"baseline missing at {BASELINE_PATH}"
+    data = json.loads(BASELINE_PATH.read_text())
+    assert "corpus" not in data, "baseline must not pin path-dependent corpus key"
+    assert set(data) == {
+        "k",
+        "n_observations",
+        "n_queries",
+        "n_truncated_queries",
+        "p_at_k",
+        "roc_auc",
+        "seed",
+        "spearman_rho",
+    }
+
+
+def test_baseline_matches_default_eval_output():
+    fixtures = eh.load_calibration_fixtures(eh.DEFAULT_CALIBRATION_CORPUS)
+    report = eh.run_calibration_on_fixtures(
+        fixtures, k=eh.DEFAULT_K, seed=eh.DEFAULT_SEED
+    )
+    observed = {
+        "k": eh.DEFAULT_K,
+        "n_observations": report.n_observations,
+        "n_queries": report.n_queries,
+        "n_truncated_queries": report.n_truncated_queries,
+        "p_at_k": report.p_at_k,
+        "roc_auc": report.roc_auc,
+        "seed": eh.DEFAULT_SEED,
+        "spearman_rho": report.spearman_rho,
+    }
+    expected = _metrics_only(json.loads(BASELINE_PATH.read_text()))
+    assert observed == expected, (
+        "synthetic-corpus calibration metrics drifted from pinned baseline. "
+        "If intentional, regenerate baseline.json from `aelf eval --json` "
+        "output (with `corpus` key stripped) in the same commit. "
+        f"observed={observed!r} expected={expected!r}"
+    )
+
+
+def test_baseline_is_canonical_form():
+    """Baseline must be sorted-keys, compact-separators, single line + \\n.
+
+    This makes diffs against future regenerations one-line, and matches
+    the canonical form `aelf eval --json` emits (sort_keys=True,
+    separators=(',', ':')).
+    """
+    raw = BASELINE_PATH.read_text()
+    assert raw.endswith("\n") and raw.count("\n") == 1, (
+        "baseline must be exactly one line followed by a single trailing newline"
+    )
+    parsed = json.loads(raw)
+    canonical = json.dumps(parsed, sort_keys=True, separators=(",", ":")) + "\n"
+    assert raw == canonical, (
+        "baseline.json is not in canonical form (sort_keys, compact separators)"
+    )


### PR DESCRIPTION
Closes out the #365 ratified rollout. The three-step sequence in
the spec (Q5) was:

1. extend `scripts/audit_rebuild_log.py` — landed in R1.
2. `aelf eval` subcommand — landed in R4 (#509).
3. CI workflow on push to `main` publishing the synthetic-corpus
   aggregate as a status check — **this PR**.

## What this adds

**`benchmarks/posterior_ranking/baseline.json`** — pinned canonical
metric line that `aelf eval --json` produces against the bundled
public corpus under default flags (`--k 10 --seed 0`):

```json
{"k":10,"n_observations":35,"n_queries":7,"n_truncated_queries":7,"p_at_k":0.1,"roc_auc":0.8443877551020408,"seed":0,"spearman_rho":0.5241037078990654}
```

The path-dependent `corpus` key is stripped before pinning since
absolute paths vary by checkout. Form is sort_keys + compact
separators + single trailing newline so a deliberate baseline
regeneration is a one-line diff.

**`tests/test_eval_baseline.py`** — three drift-guard tests:
baseline file presence/shape, observed-vs-baseline match, and
canonical-form invariant. Runs in the regular pytest suite, so
PRs that drift the metric without an accompanying baseline
update fail at PR-time.

**`.github/workflows/eval-calibration.yml`** — the status check.
Runs `aelf eval --json` on:

- `pull_request` to main (paths-filtered to harness, corpus, CLI,
  pyproject/uv.lock, and the workflow itself) — blocks merges
  that drift metrics without a deliberate baseline update.
- `push` to main — re-asserts post-merge so a green main is also
  a calibrated main, and writes the metric line to the step
  summary for traceability.

Strips the path-dependent `corpus` key, re-canonicalizes the
baseline JSON, asserts bytes-identical match. Per #365 Q6 only the
synthetic-corpus aggregate crosses the public boundary; live-corpus
calibration stays operator-side (R2/R3 — lab repo, not this PR).

## Determinism contract

#365 ship gate: same `(corpus, --k, --seed)` → bytes-identical
metrics across reruns.

Local dry-run of the workflow's compare logic:
```
OBSERVED={"k":10,"n_observations":35,...,"spearman_rho":0.5241037078990654}
EXPECTED={"k":10,"n_observations":35,...,"spearman_rho":0.5241037078990654}
MATCH
```

## Hardening

Workflow matches sibling-workflow conventions: pinned
`step-security/harden-runner`, pinned `actions/checkout` SHA,
`persist-credentials: false`, env-var indirection on every
`${{ ... }}` interpolation that flows into a `run` block (no
template-injection surface), `permissions: contents: read`,
`concurrency: cancel-in-progress: true`, 10-minute job timeout.

`uvx zizmor .github/workflows/eval-calibration.yml` → `No findings`.

## Verification

- Full pytest: 3034 passed, 48 skipped.
- Targeted eval tests: 138 passed (`test_eval_harness.py`,
  `test_cli_eval.py`, `test_slash_commands.py`, plus the new
  `test_eval_baseline.py`).
- Discretion grep on the diff: clean.
- 2 atomic signed commits.
- YAML parses; zizmor clean.

## Out of scope

- R2 (hybrid labeling pipeline) and R3 (calibration on
  hand-label set) remain operator-side per #365 Q6.
- The pre-registered P@10 floor from the ship gate is owned by
  R3 and not yet pinned here — the current baseline is the
  determinism floor, not the relevance floor. A follow-up can
  raise `assert observed == expected` to `assert p_at_k >= floor`
  once R3 produces the floor value.

Refs #365.

## Summary by Sourcery

Add a synthetic-corpus evaluation baseline and enforce it via tests and a CI status check to guard against unintended calibration metric drift.

New Features:
- Introduce a pinned synthetic-corpus evaluation baseline JSON for posterior ranking metrics.
- Add a GitHub Actions workflow that runs synthetic-corpus evaluation on PRs and pushes to main, comparing results against the pinned baseline and publishing metrics to the step summary.

CI:
- Create an eval calibration workflow that hardens the runner, runs `aelf eval --json` against the synthetic corpus, compares canonicalized metrics to the baseline, and exposes the result as a required status check on relevant changes.

Tests:
- Add drift-guard tests that validate the baseline file shape, ensure default evaluation metrics match the pinned baseline, and enforce a canonical JSON form for the baseline.