### PR TITLE
test: add run_doc_linker_uplift for #435 bench gate (#520)

### DIFF
--- a/tests/retrieve_uplift_runner.py
+++ b/tests/retrieve_uplift_runner.py
@@ -244,11 +244,14 @@ def run_per_flag_uplift(
 # `runner_mod.run_clustering_uplift(rows)`. Activates on any
 # AELFRICE_CORPUS_ROOT pointing at a `multi_fact/*.jsonl` row set.
 #
-# Doc-linker (#435) symmetric runner intentionally NOT here — its A2
-# gate requires a downstream rerank that consumes the `with_doc_anchors`
-# projection to influence belief order, and that rerank has not shipped.
-# When it lands, the same shape applies (load rows → twin retrieve calls
-# → mean-NDCG uplift). Filed for a follow-up PR.
+# Doc-linker (#435) symmetric runner lives further below
+# (`run_doc_linker_uplift`). It implements the spec § A2 contract:
+# anchors-OFF baseline (anchors NOT written) vs anchors-ON case
+# (anchors written via `link_belief_to_document`), both with
+# `with_doc_anchors=True`. Today the doc-anchor projection is read-only
+# (it does not influence ordering), so the gate reports flat uplift
+# until a downstream rerank lands; that is the correct gate-broken
+# signal — strictly-positive uplift is the ship trigger.
 # ---------------------------------------------------------------------
 
 
@@ -364,6 +367,132 @@ def run_clustering_uplift(
         mean_recall_on=rec_on / n,
         cluster_coverage_off=cov_off / n,
         cluster_coverage_on=cov_on / n,
+    )
+
+
+# ---------------------------------------------------------------------
+# Doc / semantic linker (#435) — doc_linker bench gate (spec § A2).
+#
+# Consumed by tests/bench_gate/test_doc_linker.py.
+# Row schema (`tests/corpus/v2_0/doc_linker/*.jsonl`):
+#
+#   {
+#     "id": "row-id",
+#     "query": "raw query string",
+#     "k": 10,
+#     "beliefs": [...],                     # seed beliefs (same shape as
+#                                            # other modules in this file)
+#     "edges": [...],                       # seed edges (optional)
+#     "expected_top_k": ["b1", "b2", ...],  # ground-truth ranking
+#     "anchors": [                          # written under anchors-ON
+#       {
+#         "belief_id": "b1",
+#         "doc_uri":   "file:docs/X.md",
+#         "anchor_type": "ingest",         # optional; defaults "ingest"
+#         "position_hint": null             # optional
+#       }
+#     ]
+#   }
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DocLinkerUpliftResults:
+    """Spec § A2 result shape for #435.
+
+    Field names mirror ``FlagUplift`` so the bench-gate failure-message
+    formatter can read ``mean_ndcg_off`` / ``mean_ndcg_on`` / ``uplift``
+    without per-runner branching.
+    """
+
+    n_rows: int
+    mean_ndcg_off: float
+    mean_ndcg_on: float
+
+    @property
+    def uplift(self) -> float:
+        return self.mean_ndcg_on - self.mean_ndcg_off
+
+
+def _seed_doc_anchors(store: MemoryStore, row: dict) -> None:  # type: ignore[type-arg]
+    """Write each anchor in ``row['anchors']`` via the doc-linker module.
+
+    Using the public ``link_belief_to_document`` (not the raw store call)
+    keeps the gate honest: any ingest-time validation a future revision
+    adds (URI shape, anchor-type checks) is exercised here too.
+    """
+    from aelfrice.doc_linker import link_belief_to_document
+
+    for a in row.get("anchors", []):
+        link_belief_to_document(
+            store,
+            belief_id=a["belief_id"],
+            doc_uri=a["doc_uri"],
+            anchor_type=a.get("anchor_type", "ingest"),
+            position_hint=a.get("position_hint"),
+        )
+
+
+def run_doc_linker_uplift(
+    rows: list[dict],  # type: ignore[type-arg]
+) -> DocLinkerUpliftResults:
+    """Spec § A2 doc-linker uplift driver.
+
+    Per row, runs ``retrieve_v2`` twice with ``with_doc_anchors=True`` on
+    fresh stores: once without anchors written (the OFF arm) and once
+    with each row's ``anchors`` populated via ``link_belief_to_document``
+    (the ON arm). Same query, same seed beliefs/edges, same ``k``. NDCG@k
+    is scored against ``expected_top_k`` and averaged across rows.
+
+    The doc-anchor projection is read-only at v2.0.0 — it surfaces
+    ``DocAnchor`` rows alongside beliefs but does not influence ranking.
+    On a corpus where ranking is invariant to anchor presence, ``uplift``
+    will be ~0 and the bench gate's strict ``> 0`` assertion will fail.
+    That is the correct gate-broken signal until a downstream rerank
+    consumes the projection.
+    """
+    n = len(rows)
+    if n == 0:
+        return DocLinkerUpliftResults(0, 0.0, 0.0)
+
+    off_total = 0.0
+    on_total = 0.0
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_root = Path(tmp)
+        for row in rows:
+            k = _default_k(row)
+            expected = list(row.get("expected_top_k", []))
+
+            for anchors_on in (False, True):
+                _db_counter[0] += 1
+                db = (
+                    tmp_root
+                    / f"doc_{row['id']}_{int(anchors_on)}_{_db_counter[0]}.db"
+                )
+                store = MemoryStore(str(db))
+                try:
+                    _seed_store(store, row)
+                    if anchors_on:
+                        _seed_doc_anchors(store, row)
+                    result = retrieve_v2(
+                        store, row["query"],
+                        budget=DEFAULT_TOKEN_BUDGET,
+                        use_entity_index=False,
+                        with_doc_anchors=True,
+                    )
+                    returned = [b.id for b in result.beliefs[:k]]
+                finally:
+                    store.close()
+                ndcg = ndcg_at_k(returned, expected, k)
+                if anchors_on:
+                    on_total += ndcg
+                else:
+                    off_total += ndcg
+
+    return DocLinkerUpliftResults(
+        n_rows=n,
+        mean_ndcg_off=off_total / n,
+        mean_ndcg_on=on_total / n,
     )
 
 

--- a/tests/test_retrieve_uplift_runner.py
+++ b/tests/test_retrieve_uplift_runner.py
@@ -146,6 +146,73 @@ def test_clustering_uplift_k_falls_back_to_n_clusters_required() -> None:
     assert abs(r_explicit_k1.cluster_coverage_on - (1.0 / 3.0)) < 1e-9
 
 
+def test_doc_linker_uplift_empty_input() -> None:
+    from tests.retrieve_uplift_runner import run_doc_linker_uplift
+
+    r = run_doc_linker_uplift([])
+    assert r.n_rows == 0
+    assert r.mean_ndcg_off == 0.0
+    assert r.mean_ndcg_on == 0.0
+    assert r.uplift == 0.0
+
+
+def test_doc_linker_uplift_runs_on_synthetic_row() -> None:
+    """OFF/ON arms run end-to-end without raising; metrics are bounded
+    and the ON arm did write the row's anchors (verified by re-reading
+    via ``get_doc_anchors_batch`` after the driver completes is out of
+    scope here — the contract under test is shape + non-negative
+    metric, not that the projection influences ranking, which today it
+    does not)."""
+    from tests.retrieve_uplift_runner import run_doc_linker_uplift
+
+    row = {
+        "id": "doc-test-001",
+        "query": "memory store",
+        "k": 3,
+        "beliefs": [
+            {"id": "b1", "content": "the memory store persists beliefs"},
+            {"id": "b2", "content": "the configuration file lives at /etc"},
+            {"id": "b3", "content": "the memory store uses sqlite"},
+        ],
+        "edges": [],
+        "expected_top_k": ["b1", "b3"],
+        "anchors": [
+            {"belief_id": "b1", "doc_uri": "file:docs/store.md#L1-L40"},
+            {"belief_id": "b3", "doc_uri": "file:docs/store.md#L41-L80"},
+        ],
+    }
+    r = run_doc_linker_uplift([row])
+    assert r.n_rows == 1
+    assert 0.0 <= r.mean_ndcg_off <= 1.0
+    assert 0.0 <= r.mean_ndcg_on <= 1.0
+
+
+def test_doc_linker_uplift_no_anchors_means_zero_uplift() -> None:
+    """A row with empty ``anchors`` is the degenerate case: the OFF and
+    ON arms see identical store state, so ``uplift`` must be exactly 0
+    regardless of what the retriever returns. Falsifiable if the driver
+    accidentally treats ``anchors-ON`` differently from ``anchors-OFF``
+    when there are no anchors to write."""
+    from tests.retrieve_uplift_runner import run_doc_linker_uplift
+
+    row = {
+        "id": "doc-test-002",
+        "query": "alpha",
+        "k": 2,
+        "beliefs": [
+            {"id": "a", "content": "alpha alpha alpha"},
+            {"id": "b", "content": "beta beta beta"},
+        ],
+        "edges": [],
+        "expected_top_k": ["a"],
+        "anchors": [],
+    }
+    r = run_doc_linker_uplift([row])
+    assert r.n_rows == 1
+    assert r.mean_ndcg_off == r.mean_ndcg_on
+    assert r.uplift == 0.0
+
+
 def test_run_per_flag_uplift_covers_all_flags() -> None:
     """Hypothesis: the harness reports one row per registered flag.
     Falsifiable if a flag is silently dropped."""


### PR DESCRIPTION
Closes #520. Parent gate: #435.

## What

Implements `run_doc_linker_uplift(rows)` + `DocLinkerUpliftResults` in `tests/retrieve_uplift_runner.py` so `tests/bench_gate/test_doc_linker.py` resolves `runner_mod.run_doc_linker_uplift` cleanly. Adds three unit tests in `tests/test_retrieve_uplift_runner.py` covering the empty-input path, a synthetic-row OFF/ON round-trip, and the no-anchors degenerate case (uplift must be exactly 0).

## Scoring contract (spec § A2)

For each row, two `retrieve_v2` calls on a fresh store, both with `with_doc_anchors=True`:

- **OFF arm:** seed beliefs/edges only, no anchors written.
- **ON arm:** seed beliefs/edges + each entry in `row['anchors']` written via `link_belief_to_document`.

NDCG@k scored against `expected_top_k`. Uplift = `mean_ndcg_on - mean_ndcg_off`. Strictly positive uplift is the ship trigger.

## Caveat — gate broken until rerank lands

The doc-anchor projection at v2.0.0 is read-only: `with_doc_anchors=True` surfaces `DocAnchor` rows alongside beliefs but does not influence ordering. On ranking-invariant corpora the gate will report `uplift ≈ 0` and fail the strict `> 0` assertion. That is the correct gate-broken signal — the gate ships when a downstream rerank consumes the projection.

## Verification

- `uv run pytest tests/test_retrieve_uplift_runner.py` — 14 passed (3 new + 11 existing).
- `uv run pytest tests/bench_gate/test_doc_linker.py` — skipped without `AELFRICE_CORPUS_ROOT` (autouse `bench_gated` marker), as expected.

## Out of scope

- Building the lab-side `tests/corpus/v2_0/doc_linker/` corpus.
- Downstream rerank that consumes `with_doc_anchors` for ordering.
- Bench-evidence sweep (closes #435 separately).

## Summary by Sourcery

Add a doc-linker uplift runner and results type used by the doc_linker bench gate and extend tests to cover its behavior, including empty input and edge cases.

New Features:
- Introduce DocLinkerUpliftResults dataclass to capture doc-linker uplift metrics in a standard shape.
- Add run_doc_linker_uplift driver that computes NDCG-based uplift for doc-linker benchmarks using anchors-off vs anchors-on retrieval runs.

Enhancements:
- Document the doc-linker bench gate contract and row schema within the uplift runner module.

Tests:
- Add unit tests validating doc-linker uplift behavior for empty input, a synthetic OFF/ON round-trip, and the no-anchors degenerate case where uplift must be zero.