### PR TITLE
fix(#522): upgrade-cmd --check emits run: line on update available

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2390,9 +2390,13 @@ def _cmd_upgrade(args: argparse.Namespace, out: object) -> int:
     mid-process is unreliable on Windows and can leave the user with a
     broken interpreter. We tell the user the exact line; they run it.
 
-    --check: only print "up to date" / "update available" status,
-    suppress the upgrade command line. Useful for scripts that want
-    a yes/no answer without copy-paste material.
+    --check: previously suppressed the install-context note and the
+    `run:` line. As of #522 both forms emit identical output when an
+    update is available — the `/aelf:upgrade` slash file (#513)
+    parses the `run:` line, so the two forms must agree. Both the
+    no-flags form and `--check` print the version banner, the verify
+    block, the install-context note, and `run: <command>`. The exit
+    code is unchanged: 0 either way.
     """
     advice = upgrade_advice()
     multi_warning = _format_multi_install_warning(
@@ -2425,17 +2429,20 @@ def _cmd_upgrade(args: argparse.Namespace, out: object) -> int:
                 f"        https://pypi.org/project/{_PKG}/{status.latest}/",
                 file=out,  # type: ignore[arg-type]
             )
-        if not args.check:
-            note = _UPGRADE_CONTEXT_NOTE.get(advice.context, "")
-            if note:
-                print(
-                    f"({note})",
-                    file=out,  # type: ignore[arg-type]
-                )
+        # #522: emit the install-context note + `run:` line under both
+        # forms so the /aelf:upgrade slash file (#513) can parse `run:`
+        # whichever form it called. The pre-#522 `--check` short-circuit
+        # broke the slash on pre-2.0.1 CLIs that had the new bundle.
+        note = _UPGRADE_CONTEXT_NOTE.get(advice.context, "")
+        if note:
             print(
-                f"run: {advice.command}",
+                f"({note})",
                 file=out,  # type: ignore[arg-type]
             )
+        print(
+            f"run: {advice.command}",
+            file=out,  # type: ignore[arg-type]
+        )
         return 0
     # No update or unknown -- be explicit.
     if status.latest and not status.update_available:

--- a/tests/test_upgrade_ux.py
+++ b/tests/test_upgrade_ux.py
@@ -545,8 +545,14 @@ def _run_upgrade_cmd_capturing(
 
     import aelfrice.cli as cli_mod
 
+    # Patch on `cli_mod`, not `lifecycle`: `cli.py` does
+    # `from aelfrice.lifecycle import upgrade_advice`, so the bound
+    # name in `cli_mod` is what `_cmd_upgrade` resolves. Patching
+    # `lifecycle` only worked locally on uv-tool installs where the
+    # real call happened to return the same value; CI runs in a venv
+    # and the venv branch fired instead.
     monkeypatch.setattr(
-        lifecycle,
+        cli_mod,
         "upgrade_advice",
         lambda: lifecycle.UpgradeAdvice(
             command="uv tool upgrade aelfrice", context="uv_tool"

--- a/tests/test_upgrade_ux.py
+++ b/tests/test_upgrade_ux.py
@@ -526,3 +526,89 @@ def test_reachable_installs_path_aelf_under_uv_root_not_double_counted(
     sites = lifecycle.detect_reachable_installs()
     assert len(sites) == 1
     assert sites[0].kind == "uv_tool"
+
+
+# ---------------------------------------------------------------------------
+# #522 — `aelf upgrade-cmd --check` must emit `run:` line on update available
+# ---------------------------------------------------------------------------
+
+
+def _run_upgrade_cmd_capturing(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    check: bool,
+    update_available: bool,
+) -> str:
+    """Drive _cmd_upgrade with a stubbed update status, return stdout."""
+    import argparse
+    import io
+
+    import aelfrice.cli as cli_mod
+
+    monkeypatch.setattr(
+        lifecycle,
+        "upgrade_advice",
+        lambda: lifecycle.UpgradeAdvice(
+            command="uv tool upgrade aelfrice", context="uv_tool"
+        ),
+    )
+    monkeypatch.setattr(
+        cli_mod, "detect_reachable_installs", lambda: ()
+    )
+    status = lifecycle.UpdateStatus(
+        update_available=update_available,
+        installed="2.0.0",
+        latest="2.0.1" if update_available else "2.0.0",
+        checked=0.0,
+        sha256="7f8a4311" if update_available else None,
+    )
+    monkeypatch.setattr(cli_mod, "check_for_update", lambda: status)
+    monkeypatch.setattr(cli_mod, "_read_update_cache", lambda: status)
+    monkeypatch.setattr(cli_mod, "_update_check_disabled", lambda: False)
+    monkeypatch.setattr(cli_mod, "_clear_update_cache", lambda: None)
+
+    buf = io.StringIO()
+    args = argparse.Namespace(check=check)
+    rc = cli_mod._cmd_upgrade(args, buf)
+    assert rc == 0
+    return buf.getvalue()
+
+
+def test_upgrade_cmd_check_emits_run_line_on_update_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#522: `aelf upgrade-cmd --check` must emit `run: <command>`
+    when an update is available, mirroring the no-flags form. The
+    /aelf:upgrade slash file (#513) parses the `run:` line and was
+    breaking on pre-2.0.1 CLIs that suppressed it under --check."""
+    out = _run_upgrade_cmd_capturing(
+        monkeypatch, check=True, update_available=True
+    )
+    assert "run: uv tool upgrade aelfrice" in out
+
+
+def test_upgrade_cmd_check_and_no_flags_match_on_update_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#522: the two forms agree byte-for-byte when an update is
+    available. Suppression-asymmetry was the original bug."""
+    check_out = _run_upgrade_cmd_capturing(
+        monkeypatch, check=True, update_available=True
+    )
+    no_flags_out = _run_upgrade_cmd_capturing(
+        monkeypatch, check=False, update_available=True
+    )
+    assert check_out == no_flags_out
+
+
+def test_upgrade_cmd_check_silent_run_line_on_no_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no update is available, neither form prints a `run:` line.
+    Only the 'aelfrice is up to date' status fires. Guards against the
+    slash file misfiring on a current install."""
+    out = _run_upgrade_cmd_capturing(
+        monkeypatch, check=True, update_available=False
+    )
+    assert "run:" not in out
+    assert "aelfrice is up to date" in out


### PR DESCRIPTION
Closes #522.

## Summary
The `/aelf:upgrade` slash file (#513) parses the `run: <command>` line printed by `aelf upgrade-cmd --check`. Pre-#522, `--check` short-circuited that line, so the slash silently produced nothing on pre-2.0.1 CLIs that had received the v2.0.1 slash bundle out-of-band.

Removes the `if not args.check:` guard around the install-context note + `run:` line in `_cmd_upgrade`. Both forms now emit identical output on update-available; the symmetric behavior is what the slash file's parser already assumed. The 'up to date' path is unchanged.

## Affected users
Per the issue body: dev-install paths and out-of-band slash bundle copies. Clean PyPI users not affected. Severity **minor**, not a release blocker.

## Test plan
- [x] 3 new regression tests in `tests/test_upgrade_ux.py`
- [x] Full local suite: 3067 passed, 51 skipped
- [ ] CI staging-gate

## Summary by Sourcery

Align `aelf upgrade-cmd --check` output with the no-flags form when an update is available so consumers can reliably parse the `run:` line.

Bug Fixes:
- Ensure `aelf upgrade-cmd --check` prints the install-context note and `run:` command when an update is available, matching the no-flags behavior.

Enhancements:
- Document the unified `--check` and no-flags upgrade output behavior directly in the `_cmd_upgrade` docstring.

Tests:
- Add regression tests covering `--check` vs no-flags output symmetry and `run:` line emission for both update-available and up-to-date scenarios.