### PR TITLE
feat(retrieval): query-strategy uplift runner + bench-gate scaffold for #291

### DIFF
--- a/tests/bench_gate/test_query_strategy.py
+++ b/tests/bench_gate/test_query_strategy.py
@@ -1,0 +1,53 @@
+"""Bench gate for #291 query-strategy uplift (sub-issue #527).
+
+#291 § Bench gates ratifies a real-corpus uplift contract:
+
+    NDCG@k(stack-r1-r3) > NDCG@k(legacy-bm25)
+
+The OFF arm runs `transform_query(raw, store, "legacy-bm25")` (raw
+passthrough) into `retrieve()`. The ON arm runs `transform_query(raw,
+store, "stack-r1-r3")` (R1 capitalised-token entity expand + R3 per-
+store IDF-quantile clip) into the same `retrieve()`. Strictly positive
+uplift is the ship trigger; zero or negative uplift fails the gate.
+
+The +0.05 absolute P@10 floor from #291 body is the *flip-default*
+trigger evaluated lab-side once the labelled corpus exists; the gate
+asserted here is the simpler `> 0` shape so PR-2.6 (corpus seeding) and
+PR-3 (default flip) can land independently.
+
+Public CI skips when ``AELFRICE_CORPUS_ROOT`` is unset, per the
+directory-of-origin rule (labelled corpus lives only in
+``~/projects/aelfrice-lab/tests/corpus/v2_0/query_strategy/``).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_corpus_module
+
+
+@pytest.mark.bench_gated
+def test_query_strategy_uplift(aelfrice_corpus_root: Path) -> None:
+    rows = load_corpus_module(aelfrice_corpus_root, "query_strategy")
+    assert rows, "query_strategy corpus produced zero rows"
+
+    runner_mod = pytest.importorskip(
+        "tests.retrieve_uplift_runner",
+        reason=(
+            "query-strategy uplift runner not yet wired (operator gate; "
+            "#291 § Bench gates — pending lab-side corpus)"
+        ),
+    )
+
+    results = runner_mod.run_query_strategy_uplift(rows)
+    detail = (
+        f"  NDCG_legacy_bm25={results.mean_ndcg_off:.4f} "
+        f"NDCG_stack_r1_r3={results.mean_ndcg_on:.4f} "
+        f"uplift={results.uplift:+.4f}"
+    )
+    assert results.uplift > 0, (
+        f"query-strategy uplift not strictly positive on "
+        f"{len(rows)} rows:\n{detail}"
+    )

--- a/tests/retrieve_uplift_runner.py
+++ b/tests/retrieve_uplift_runner.py
@@ -47,6 +47,11 @@ from aelfrice.models import (
     Belief,
     Edge,
 )
+from aelfrice.query_understanding import (
+    LEGACY_STRATEGY,
+    STACK_R1_R3_STRATEGY,
+    transform_query,
+)
 from aelfrice.retrieval import (
     DEFAULT_TOKEN_BUDGET,
     retrieve,
@@ -490,6 +495,114 @@ def run_doc_linker_uplift(
                     off_total += ndcg
 
     return DocLinkerUpliftResults(
+        n_rows=n,
+        mean_ndcg_off=off_total / n,
+        mean_ndcg_on=on_total / n,
+    )
+
+
+# ---------------------------------------------------------------------
+# Query-strategy (#291 / #527) — legacy-bm25 vs stack-r1-r3 bench gate.
+#
+# Consumed by tests/bench_gate/test_query_strategy.py.
+# Row schema (`tests/corpus/v2_0/query_strategy/*.jsonl`):
+#
+#   {
+#     "id": "row-id",
+#     "query": "raw query string",         # FTS5 MATCH input pre-rewrite
+#     "k": 10,
+#     "beliefs": [...],                     # seed beliefs (shared shape)
+#     "edges": [...],                       # seed edges (optional)
+#     "expected_top_k": ["b1", "b2", ...]   # ground-truth ranking
+#   }
+#
+# OFF arm: transform_query(raw, store, "legacy-bm25") -> raw query
+#          unchanged, retrieve(store, raw, ...).
+# ON arm:  transform_query(raw, store, "stack-r1-r3") -> R1 entity
+#          expand + R3 per-store IDF-quantile clip, retrieve(store,
+#          rewritten, ...).
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QueryStrategyUplift:
+    """#291 / #527 result shape.
+
+    Field names mirror ``FlagUplift`` / ``DocLinkerUpliftResults`` so the
+    bench-gate failure formatter reads ``mean_ndcg_off`` / ``mean_ndcg_on``
+    / ``uplift`` without per-runner branching.
+    """
+
+    n_rows: int
+    mean_ndcg_off: float
+    mean_ndcg_on: float
+
+    @property
+    def uplift(self) -> float:
+        return self.mean_ndcg_on - self.mean_ndcg_off
+
+
+def run_query_strategy_uplift(
+    rows: list[dict],  # type: ignore[type-arg]
+) -> QueryStrategyUplift:
+    """#291 § Mechanism / Bench gates query-strategy uplift driver.
+
+    Per row, runs ``retrieve()`` twice on a fresh seeded store:
+
+    * OFF arm — ``legacy-bm25`` (``transform_query`` passthrough; the raw
+      ``row['query']`` is the FTS5 MATCH input).
+    * ON arm  — ``stack-r1-r3`` (R1 capitalised-token entity expand →
+      R3 per-store IDF-quantile clip → joined whitespace term list).
+
+    Same seed beliefs/edges, same ``k``, same ``BASELINE_KWARGS`` to
+    ``retrieve()`` (so any future flag-default change in this module
+    affects both arms identically). NDCG@k is scored against
+    ``expected_top_k`` and averaged across rows.
+
+    Degenerate case: a row whose query has no capitalised tokens AND
+    whose tokens fall inside the per-store IDF quantile band produces
+    an identical transformed query for both strategies, so the OFF and
+    ON arms see identical retrieval state and ``uplift == 0`` by
+    construction. Falsifiable in the unit test at
+    ``tests/test_retrieve_uplift_runner.py``.
+    """
+    n = len(rows)
+    if n == 0:
+        return QueryStrategyUplift(0, 0.0, 0.0)
+
+    off_total = 0.0
+    on_total = 0.0
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_root = Path(tmp)
+        for row in rows:
+            k = _default_k(row)
+            expected = list(row.get("expected_top_k", []))
+
+            for strategy_on in (False, True):
+                _db_counter[0] += 1
+                strategy = (
+                    STACK_R1_R3_STRATEGY if strategy_on else LEGACY_STRATEGY
+                )
+                db = (
+                    tmp_root
+                    / f"qs_{row['id']}_{int(strategy_on)}_{_db_counter[0]}.db"
+                )
+                store = MemoryStore(str(db))
+                try:
+                    _seed_store(store, row)
+                    rewritten = transform_query(
+                        row["query"], store, strategy,
+                    )
+                    result_ids = _retrieve_ids(store, rewritten, k)
+                finally:
+                    store.close()
+                ndcg = ndcg_at_k(result_ids, expected, k)
+                if strategy_on:
+                    on_total += ndcg
+                else:
+                    off_total += ndcg
+
+    return QueryStrategyUplift(
         n_rows=n,
         mean_ndcg_off=off_total / n,
         mean_ndcg_on=on_total / n,

--- a/tests/test_retrieve_uplift_runner.py
+++ b/tests/test_retrieve_uplift_runner.py
@@ -213,6 +213,75 @@ def test_doc_linker_uplift_no_anchors_means_zero_uplift() -> None:
     assert r.uplift == 0.0
 
 
+def test_query_strategy_uplift_empty_input() -> None:
+    from tests.retrieve_uplift_runner import run_query_strategy_uplift
+
+    r = run_query_strategy_uplift([])
+    assert r.n_rows == 0
+    assert r.mean_ndcg_off == 0.0
+    assert r.mean_ndcg_on == 0.0
+    assert r.uplift == 0.0
+
+
+def test_query_strategy_uplift_runs_on_synthetic_row() -> None:
+    """OFF/ON arms run end-to-end without raising; metrics are bounded.
+
+    The contract under test is shape + non-negative metric, not that
+    the rewrite influences ranking on this hand-crafted row — the
+    real-corpus uplift is the lab-side gate."""
+    from tests.retrieve_uplift_runner import run_query_strategy_uplift
+
+    row = {
+        "id": "qs-test-001",
+        "query": "MemoryStore persistence",
+        "k": 3,
+        "beliefs": [
+            {"id": "b1", "content": "the memory store persists beliefs"},
+            {"id": "b2", "content": "the configuration file lives at /etc"},
+            {"id": "b3", "content": "the memory store uses sqlite"},
+        ],
+        "edges": [],
+        "expected_top_k": ["b1", "b3"],
+    }
+    r = run_query_strategy_uplift([row])
+    assert r.n_rows == 1
+    assert 0.0 <= r.mean_ndcg_off <= 1.0
+    assert 0.0 <= r.mean_ndcg_on <= 1.0
+
+
+def test_query_strategy_uplift_lowercase_no_extremes_means_zero_uplift() -> None:
+    """Degenerate row: query has no capitalised tokens (R1 entity expand
+    is a no-op) and the per-store IDF distribution is uniform enough
+    that R3 quantile clipping doesn't drop or duplicate any term. In
+    that case ``transform_query`` returns the same string for both
+    strategies, so the OFF and ON arms see identical retrieval state
+    and ``uplift == 0`` by construction.
+
+    Falsifiable if the driver accidentally seeds the store differently
+    between arms or threads through a non-deterministic dependency.
+
+    A two-belief synthetic store with identical token counts puts every
+    query token at the IDF median, so the default 5%/95% quantile band
+    keeps every term at its baseline qf."""
+    from tests.retrieve_uplift_runner import run_query_strategy_uplift
+
+    row = {
+        "id": "qs-test-002",
+        "query": "alpha",
+        "k": 2,
+        "beliefs": [
+            {"id": "a", "content": "alpha"},
+            {"id": "b", "content": "beta"},
+        ],
+        "edges": [],
+        "expected_top_k": ["a"],
+    }
+    r = run_query_strategy_uplift([row])
+    assert r.n_rows == 1
+    assert r.mean_ndcg_off == r.mean_ndcg_on
+    assert r.uplift == 0.0
+
+
 def test_run_per_flag_uplift_covers_all_flags() -> None:
     """Hypothesis: the harness reports one row per registered flag.
     Falsifiable if a flag is silently dropped."""


### PR DESCRIPTION
## Summary

PR-2.5 of #291 — implements the public-side bench-gate scaffold so PR-3 (default flip to `stack-r1-r3`) can be unblocked once the lab corpus produces clean numbers. Mirrors how #520 served #435.

Three atomic commits:

1. `feat(retrieval): run_query_strategy_uplift driver` — adds `QueryStrategyUplift` dataclass + `run_query_strategy_uplift(rows)` to `tests/retrieve_uplift_runner.py`, modelled on `run_doc_linker_uplift`. OFF arm = `transform_query(raw, store, "legacy-bm25")` (raw passthrough); ON arm = `transform_query(raw, store, "stack-r1-r3")` (R1 entity expand + R3 per-store IDF-quantile clip). NDCG@k vs `expected_top_k`.

2. `feat(bench-gate): query-strategy uplift gate scaffold` — adds `tests/bench_gate/test_query_strategy.py`. Asserts `uplift > 0`. Skips on public CI when `AELFRICE_CORPUS_ROOT` unset, per the directory-of-origin rule.

3. `test(retrieval): unit tests for run_query_strategy_uplift` — three corpus-free assertions: empty-input, synthetic-row shape contract, and degenerate row (no caps, no IDF extremes) → `uplift == 0` falsifiability anchor.

No call-site change to `retrieve()`, the rebuilder, or the strategy dispatcher. PR-1 + PR-2 of #291 already shipped the surface this gate consumes.

The +0.05 absolute P@10 flip-default trigger from #291 § Bench gates is the heavier gate evaluated lab-side once the labelled corpus exists; the `> 0` shape asserted here is the smaller correctness gate so this PR and PR-2.6 (corpus seeding) can land independently.

Closes #527.

## Test plan

- [x] `uv run pytest tests/test_retrieve_uplift_runner.py` — 17 pass (existing 14 + 3 new).
- [x] `uv run pytest tests/bench_gate/test_query_strategy.py` — 1 skipped (no `AELFRICE_CORPUS_ROOT`), as designed.
- [ ] Lab-side: with `AELFRICE_CORPUS_ROOT=~/projects/aelfrice-lab` and a populated `tests/corpus/v2_0/query_strategy/`, the gate produces the OFF/ON/uplift triple and asserts `> 0`. Lab corpus seeding is PR-2.6 work; this PR is scaffold-only.

## Summary by Sourcery

Add a query-strategy uplift runner and bench gate to compare legacy BM25 against the stack-r1-r3 query strategy using NDCG-based uplift.

New Features:
- Introduce QueryStrategyUplift result type and run_query_strategy_uplift driver to measure NDCG uplift between legacy-bm25 and stack-r1-r3 query strategies.
- Add a bench-gate test that runs the query-strategy uplift on a labelled corpus and asserts strictly positive uplift, skipping when the external corpus is unavailable.

Tests:
- Add unit tests covering query-strategy uplift behavior on empty input, a synthetic row, and a degenerate case that should yield zero uplift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added benchmarking tests to measure query strategy performance improvements across the corpus.
  * Implemented uplift measurement infrastructure that validates query transformation effectiveness using NDCG metrics.
  * Added unit test coverage for empty input handling and synthetic query scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/528)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->