### PR TITLE
fix(issue-template): allow rich text + images in bug report 'What happened' (#531)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,8 +15,8 @@ body:
     id: what-happened
     attributes:
       label: What happened
-      description: Exact CLI invocation or MCP call, exact output. Paste the command and the response.
-      render: shell
+      description: |
+        Describe the unexpected behavior. Screenshots, images, and rich-text formatting are supported here — drag-and-drop or paste images directly. Put exact CLI commands and their output under "Minimal reproduction" below.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## Summary

Fixes #531. The first textarea in the bug report template ("What happened") had `render: shell`, which wraps the field in a code block. That prevents inline image embedding — pasted screenshots render as raw `<img>` markdown text instead of as images. dmayman hit this when filing #530, where the screenshot only rendered in "What you expected" (which has no `render: shell`).

## Change

- Drop `render: shell` from the `what-happened` field
- Reword the description to direct exact CLI invocations/output to "Minimal reproduction" (which keeps `render: shell`)

## Verification

- YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`)
- `Minimal reproduction` still has `render: shell` for code-block paste of exact commands
- All other fields unchanged

## Test plan

- [ ] Open a fresh test issue using the bug template after merge; confirm screenshots/images render inline in the "What happened" field

## Summary by Sourcery

Update the bug report issue template to allow rich-text and image-friendly input in the 'What happened' field while directing exact CLI commands and output to the 'Minimal reproduction' section instead.

Enhancements:
- Remove code-block rendering from the 'What happened' field so that screenshots and rich text render correctly in bug reports.
- Clarify bug report guidance by steering exact CLI commands and outputs to the dedicated 'Minimal reproduction' field.