### PR TITLE
feat(setup): default-on auto-capture pipeline (#529)

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -136,20 +136,39 @@ Auto-detects the JSONL format on a per-line basis (handles both aelfrice's trans
 
 ---
 
-## Optional hooks (v1.2+)
+## Hooks installed by `aelf setup`
 
-`aelf setup` wires only the `UserPromptSubmit` hook by default. The rest are opt-in:
+Bare `aelf setup` wires the v1.2.0 auto-capture pipeline alongside the read-side `UserPromptSubmit` retrieval hook:
+
+| Hook | Event(s) | Default | What it does |
+|---|---|---|---|
+| UserPromptSubmit retrieval | `UserPromptSubmit` | always | injects matched beliefs as `<aelfrice-memory>` block |
+| transcript-ingest | `UserPromptSubmit` + `Stop` + `PreCompact` + `PostCompact` | **on** | logs every turn to a per-project JSONL; PreCompact rotates the file and ingests it into beliefs/edges |
+| commit-ingest | `PostToolUse:Bash` | **on** | each successful `git commit` runs the triple extractor on the message |
+| session-start | `SessionStart` | **on** | new sessions open with L0 locked beliefs already injected |
+| rebuilder | `PreCompact` | off | retrieval-curated context rebuilder (augment-mode, v1.4 alpha) |
+| search-tool | `PreToolUse:Grep` / `Glob` | off | belief-store check before the agent's own search tool fires |
+
+Opt out per-hook:
 
 ```bash
-aelf setup --transcript-ingest      # turn-by-turn capture; PreCompact rotates and re-ingests
-aelf setup --commit-ingest          # PostToolUse:Bash hook ingests commit messages
-aelf setup --session-start          # SessionStart hook injects locked beliefs at session boot
-aelf setup --rebuilder              # PreCompact context rebuilder (alpha)
+aelf setup --no-transcript-ingest      # skip the four transcript-logger hooks
+aelf setup --no-commit-ingest          # skip the commit-message ingest hook
+aelf setup --no-session-start          # skip the SessionStart locked-belief injection
 ```
 
-Each is independently uninstallable: `aelf unsetup --transcript-ingest`, etc.
+Opt in to the off-by-default hooks:
+
+```bash
+aelf setup --rebuilder                 # PreCompact context rebuilder (alpha)
+aelf setup --search-tool               # PreToolUse:Grep|Glob memory-first search
+```
+
+`aelf unsetup` mirrors: bare invocation removes every default-on hook. `--no-*` flags suppress per-hook removal.
 
 All hooks are non-blocking. Every failure path returns exit 0 — a hook problem must never break a prompt or a commit.
+
+> **Privacy note.** Default-on transcript-ingest means every turn you type lands in the per-project SQLite DB on `PreCompact` rotation. The DB is local-only (no network, no telemetry — see § "Your data stays yours" in the README) but the JSONL has no PII scrubber. If you paste secrets, customer data, or anything you don't want indexed in chat, opt out with `--no-transcript-ingest` and use `aelf lock` / `aelf onboard` for explicit ingestion only.
 
 ---
 

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -4385,8 +4385,8 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         "--session-start", dest="session_start",
         action=argparse.BooleanOptionalAction, default=True,
         help=(
-            "wire the SessionStart hook so each new Claude Code "
-            "session opens with L0 locked beliefs already injected. "
+            "wire the SessionStart hook so each new host session "
+            "opens with L0 locked beliefs already injected. "
             "Coexists with the UserPromptSubmit and transcript-ingest hooks. "
             "Default: ON. Pass --no-session-start to skip."
         ),

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -1741,7 +1741,7 @@ def _cmd_setup(args: argparse.Namespace, out: object) -> int:
             f"(command={command!r})",
             file=out,  # type: ignore[arg-type]
         )
-    if getattr(args, "transcript_ingest", False):
+    if getattr(args, "transcript_ingest", True):
         ti_command = resolve_transcript_logger_command(scope)
         ti_result = install_transcript_ingest_hooks(
             path, command=ti_command, timeout=args.timeout,
@@ -1759,7 +1759,7 @@ def _cmd_setup(args: argparse.Namespace, out: object) -> int:
                 f"({', '.join(ti_result.already)}) in {ti_result.path}",
                 file=out,  # type: ignore[arg-type]
             )
-    if getattr(args, "session_start", False):
+    if getattr(args, "session_start", True):
         ss_command = resolve_session_start_hook_command(scope)
         ss_result = install_session_start_hook(
             path, command=ss_command, timeout=args.timeout,
@@ -1821,7 +1821,7 @@ def _cmd_setup(args: argparse.Namespace, out: object) -> int:
                 f"(command={pc_command!r})",
                 file=out,  # type: ignore[arg-type]
             )
-    if getattr(args, "commit_ingest", False):
+    if getattr(args, "commit_ingest", True):
         ci_command = resolve_commit_ingest_command(scope)
         ci_result = install_commit_ingest_hook(
             path, command=ci_command, timeout=args.timeout,
@@ -2000,7 +2000,7 @@ def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
             f"({match_label})",
             file=out,  # type: ignore[arg-type]
         )
-    if getattr(args, "session_start", False):
+    if getattr(args, "session_start", True):
         ss_result = uninstall_session_start_hook(
             path, command_basename=SESSION_START_HOOK_SCRIPT_NAME,
         )
@@ -2015,7 +2015,7 @@ def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
                 f"{'y' if ss_result.removed == 1 else 'ies'} from {ss_result.path}",
                 file=out,  # type: ignore[arg-type]
             )
-    if getattr(args, "transcript_ingest", False):
+    if getattr(args, "transcript_ingest", True):
         ti_result = uninstall_transcript_ingest_hooks(
             path, command_basename=TRANSCRIPT_LOGGER_SCRIPT_NAME,
         )
@@ -2057,7 +2057,7 @@ def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
             f"restored prior statusline command in {sl.path}",
             file=out,  # type: ignore[arg-type]
         )
-    if getattr(args, "commit_ingest", False):
+    if getattr(args, "commit_ingest", True):
         ci_result = uninstall_commit_ingest_hook(
             path, command_basename=COMMIT_INGEST_SCRIPT_NAME,
         )
@@ -4351,12 +4351,14 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help="skip the auto-install of the update-notifier statusline snippet",
     )
     p_setup.add_argument(
-        "--transcript-ingest", dest="transcript_ingest", action="store_true",
+        "--transcript-ingest", dest="transcript_ingest",
+        action=argparse.BooleanOptionalAction, default=True,
         help=(
-            "additionally wire the four transcript-logger hooks "
+            "wire the four transcript-logger hooks "
             "(UserPromptSubmit, Stop, PreCompact, PostCompact) so live "
             "conversation turns are captured to the per-project transcripts "
-            "log and ingested at compaction boundaries."
+            "log and ingested at compaction boundaries. Default: ON. "
+            "Pass --no-transcript-ingest to skip."
         ),
     )
     p_setup.add_argument(
@@ -4369,20 +4371,24 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         ),
     )
     p_setup.add_argument(
-        "--commit-ingest", dest="commit_ingest", action="store_true",
+        "--commit-ingest", dest="commit_ingest",
+        action=argparse.BooleanOptionalAction, default=True,
         help=(
-            "additionally wire the PostToolUse:Bash hook so each "
+            "wire the PostToolUse:Bash hook so each "
             "successful `git commit` runs the triple extractor on its "
             "commit message and persists the resulting beliefs and "
-            "edges under a session derived from git context."
+            "edges under a session derived from git context. Default: ON. "
+            "Pass --no-commit-ingest to skip."
         ),
     )
     p_setup.add_argument(
-        "--session-start", dest="session_start", action="store_true",
+        "--session-start", dest="session_start",
+        action=argparse.BooleanOptionalAction, default=True,
         help=(
-            "additionally wire the SessionStart hook so each new Claude Code "
+            "wire the SessionStart hook so each new Claude Code "
             "session opens with L0 locked beliefs already injected. "
-            "Coexists with the UserPromptSubmit and transcript-ingest hooks."
+            "Coexists with the UserPromptSubmit and transcript-ingest hooks. "
+            "Default: ON. Pass --no-session-start to skip."
         ),
     )
     p_setup.add_argument(
@@ -4518,10 +4524,12 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         ),
     )
     p_unsetup.add_argument(
-        "--transcript-ingest", dest="transcript_ingest", action="store_true",
+        "--transcript-ingest", dest="transcript_ingest",
+        action=argparse.BooleanOptionalAction, default=True,
         help=(
-            "also remove the four transcript-logger entries "
-            "(UserPromptSubmit, Stop, PreCompact, PostCompact)."
+            "remove the four transcript-logger entries "
+            "(UserPromptSubmit, Stop, PreCompact, PostCompact). "
+            "Default: ON. Pass --no-transcript-ingest to leave them in place."
         ),
     )
     p_unsetup.add_argument(
@@ -4529,12 +4537,20 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help="also remove the rebuilder PreCompact hook entry.",
     )
     p_unsetup.add_argument(
-        "--commit-ingest", dest="commit_ingest", action="store_true",
-        help="also remove the PostToolUse:Bash commit-ingest entry.",
+        "--commit-ingest", dest="commit_ingest",
+        action=argparse.BooleanOptionalAction, default=True,
+        help=(
+            "remove the PostToolUse:Bash commit-ingest entry. "
+            "Default: ON. Pass --no-commit-ingest to leave it in place."
+        ),
     )
     p_unsetup.add_argument(
-        "--session-start", dest="session_start", action="store_true",
-        help="also remove the SessionStart hook entry.",
+        "--session-start", dest="session_start",
+        action=argparse.BooleanOptionalAction, default=True,
+        help=(
+            "remove the SessionStart hook entry. Default: ON. "
+            "Pass --no-session-start to leave it in place."
+        ),
     )
     p_unsetup.add_argument(
         "--search-tool", dest="search_tool", action="store_true",

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -50,6 +50,13 @@ def _project_settings(tmp_path: Path) -> Path:
     return tmp_path / ".claude" / "settings.json"
 
 
+_OPT_OUT_AUTO_CAPTURE = (
+    "--no-transcript-ingest",
+    "--no-commit-ingest",
+    "--no-session-start",
+)
+
+
 def _hook_commands(settings_path: Path) -> list[str]:
     data = _read_settings(settings_path)
     hooks = data["hooks"]
@@ -69,8 +76,11 @@ def _hook_commands(settings_path: Path) -> list[str]:
 
 
 def test_setup_default_command_writes_project_settings(tmp_path: Path) -> None:
+    # Auto-capture hooks default-on as of #529; this test scopes itself to
+    # the UserPromptSubmit (read-side) wiring path by opting them out.
     code, output = _run(
-        "setup", "--scope", "project", "--project-root", str(tmp_path)
+        "setup", "--scope", "project", "--project-root", str(tmp_path),
+        *_OPT_OUT_AUTO_CAPTURE,
     )
     assert code == 0
     settings = _project_settings(tmp_path)
@@ -83,9 +93,13 @@ def test_setup_default_command_writes_project_settings(tmp_path: Path) -> None:
 
 
 def test_setup_idempotent_reports_already_present(tmp_path: Path) -> None:
-    _run("setup", "--scope", "project", "--project-root", str(tmp_path))
+    _run(
+        "setup", "--scope", "project", "--project-root", str(tmp_path),
+        *_OPT_OUT_AUTO_CAPTURE,
+    )
     code, output = _run(
-        "setup", "--scope", "project", "--project-root", str(tmp_path)
+        "setup", "--scope", "project", "--project-root", str(tmp_path),
+        *_OPT_OUT_AUTO_CAPTURE,
     )
     assert code == 0
     assert "already installed" in output
@@ -124,7 +138,9 @@ def test_setup_custom_command_timeout_and_status_message(
 
 def test_setup_explicit_settings_path_overrides_scope(tmp_path: Path) -> None:
     explicit = tmp_path / "weird-place" / "claude.json"
-    code, _ = _run("setup", "--settings-path", str(explicit))
+    code, _ = _run(
+        "setup", "--settings-path", str(explicit), *_OPT_OUT_AUTO_CAPTURE,
+    )
     assert code == 0
     assert explicit.exists()
     # Without an explicit --scope, auto-detect from cwd. Whichever scope
@@ -176,11 +192,56 @@ def test_user_scope_writes_into_monkeypatched_user_path(
     import aelfrice.setup as setup_mod
 
     monkeypatch.setattr(setup_mod, "USER_SETTINGS_PATH", fake_user_settings)
-    code, _ = _run("setup", "--scope", "user")
+    code, _ = _run("setup", "--scope", "user", *_OPT_OUT_AUTO_CAPTURE)
     assert code == 0
     assert fake_user_settings.exists()
     expected = resolve_hook_command("user")
     assert _hook_commands(fake_user_settings) == [expected]
+
+
+def test_setup_default_on_auto_capture_writes_all_hooks(
+    tmp_path: Path,
+) -> None:
+    """Bare `aelf setup` wires the v1.2.0 auto-capture pipeline (#529).
+
+    Asserts UserPromptSubmit + Stop + PreCompact + PostCompact (transcript-
+    ingest), PostToolUse:Bash (commit-ingest), and SessionStart land
+    without any opt-in flag.
+    """
+    code, output = _run(
+        "setup", "--scope", "project", "--project-root", str(tmp_path)
+    )
+    assert code == 0
+    data = _read_settings(_project_settings(tmp_path))
+    hooks = data["hooks"]
+    assert isinstance(hooks, dict)
+    hooks_typed = cast(dict[str, object], hooks)
+    # All four transcript-ingest events present.
+    for event in ("UserPromptSubmit", "Stop", "PreCompact", "PostCompact"):
+        assert event in hooks_typed, f"missing {event} in default setup"
+    # SessionStart and PostToolUse (commit-ingest) present.
+    assert "SessionStart" in hooks_typed, "SessionStart not default-on"
+    assert "PostToolUse" in hooks_typed, "commit-ingest PostToolUse not default-on"
+
+
+def test_setup_no_flags_skip_auto_capture(tmp_path: Path) -> None:
+    """Opt-out flags suppress each auto-capture hook independently (#529)."""
+    code, _ = _run(
+        "setup", "--scope", "project", "--project-root", str(tmp_path),
+        *_OPT_OUT_AUTO_CAPTURE,
+    )
+    assert code == 0
+    data = _read_settings(_project_settings(tmp_path))
+    hooks = data["hooks"]
+    assert isinstance(hooks, dict)
+    hooks_typed = cast(dict[str, object], hooks)
+    # UserPromptSubmit (read-side) is unaffected by these flags.
+    assert "UserPromptSubmit" in hooks_typed
+    # Auto-capture event types should be absent.
+    for event in ("Stop", "PreCompact", "PostCompact", "SessionStart", "PostToolUse"):
+        assert event not in hooks_typed, (
+            f"{event} present despite --no-* opt-out"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #529 — bare `aelf setup` now wires the v1.2.0 auto-capture pipeline the README marketed as shipped.

The user-reported gap: the README roadmap claims `auto-capture pipeline (transcript-ingest, commit-ingest, SessionStart)` shipped at v1.2.0, the README quickstart prescribes `aelf setup` (no flags), but bare `aelf setup` was wiring only the read-side `UserPromptSubmit` hook. New users followed the quickstart verbatim and saw nothing recorded from session activity. That's a code-vs-claim gap, not a documentation triage item.

### What changed

- `--transcript-ingest`, `--commit-ingest`, `--session-start` flip from `action="store_true"` to `argparse.BooleanOptionalAction` with `default=True`.
- New opt-out flags: `--no-transcript-ingest`, `--no-commit-ingest`, `--no-session-start`.
- Same flip on `aelf unsetup` so bare invocation cleans up the full set symmetrically.
- `--rebuilder` and `--search-tool` remain opt-in (separate scope).
- Two new tests: bare-setup wiring asserts UserPromptSubmit + Stop + PreCompact + PostCompact + SessionStart + PostToolUse all land; opt-outs suppress them while leaving UserPromptSubmit alone.
- `docs/INSTALL.md` § "Optional hooks" rewritten as "Hooks installed by `aelf setup`" with a 6-row table (3 default-on, 3 default-off) and an explicit privacy callout for default-on transcript-ingest.

### Commits

- `c63a80b` feat(setup): default-on transcript-ingest, commit-ingest, session-start (#529)
- `2e0a72e` test(cli): cover default-on auto-capture + opt-out flags (#529)
- `0af0ada` docs(install): rewrite "Optional hooks" → default-on table (#529)

### What this fix does NOT close

Transcript-ingest writes per-turn JSONL but only ingests at `PreCompact`. Mid-session `aelf search` against findings made earlier in the same session won't surface them until compaction rotates the JSONL. A separate timing question; flagged on the issue.

## Test plan

- [x] `uv run pytest` — 3086 passed, 52 skipped on the branch tip
- [x] `uv run aelf setup --help` shows `--transcript-ingest, --no-transcript-ingest` (BooleanOptionalAction grouped form)
- [x] Smoke test: bare `setup` ns has all three flags True; explicit `--no-*` flips them False
- [ ] Reviewer: pull the branch, run `aelf setup` against a tmp `--scope project --project-root <dir>`, confirm settings.json contains entries for UserPromptSubmit, Stop, PreCompact, PostCompact, SessionStart, PostToolUse
- [ ] Reviewer: confirm `aelf unsetup` (no flags) removes all six hook entries

## Summary by Sourcery

Enable the auto-capture pipeline to be installed and removed by default when running `aelf setup` and `aelf unsetup`, with opt-out controls and updated documentation.

New Features:
- Default-on transcript, commit, and session-start auto-capture hooks are installed by bare `aelf setup`, with corresponding `--no-*` flags to disable them per hook.

Enhancements:
- `aelf unsetup` now removes the default-on auto-capture hooks by default, mirroring `aelf setup` behavior while allowing per-hook opt-out.
- CLI help text clarifies default-on behavior for auto-capture and unsetup flags.
- Installation docs now describe all hooks in a table, indicating which are default-on vs opt-in and how to opt out.

Tests:
- New CLI tests cover default-on auto-capture behavior, opt-out flags, and keep existing setup tests focused on the read-side hook via explicit opt-outs.