### PR TITLE
perf(hrr): default dim 2048 -> 512 per lab R4 verdict (#538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+### Performance
+
+- **`hrr.DEFAULT_DIM` flips 2048 → 512** ([#538](https://github.com/robotrocketscience/aelfrice/issues/538)). Aligns the HRR default dimensionality with the lab campaign R4 verdict ("adopt dim=512 default; dim=2048 escape hatch") that produced the spec at `docs/hrr_structural_query_lane.md`. ~4× memory footprint reduction for the structural-query lane: ~200 MB at N=50k vs the prior ~800 MB. Capacity per Plate's bound stays well above realistic per-belief role multiplicity (~57 retrievable bound pairs at dim=512 vs ~5 typical outgoing edges per belief). Set `dim=2048` explicitly via the `HRRStructIndex(dim=...)` kwarg for high-multiplicity corpora.
+
 ### Changed
 
 - **`use_heat_kernel` and `use_hrr_structural` flip to default-on** ([#154](https://github.com/robotrocketscience/aelfrice/issues/154)). Both retrieval-lane flags shipped opt-in earlier (heat-kernel #150 in v1.6, HRR structural-query lane #152 in v1.7) pending the calibrated reproducibility-harness gate. That gate cleared at 11/11 via [PR #489](https://github.com/robotrocketscience/aelfrice/pull/489) closing #437, so the #154 composition tracker flips the defaults per its status banner. Precedence (env > kwarg > TOML > default) is unchanged; only the default values flip `False` → `True`. Reversible via `[retrieval] use_heat_kernel = false` / `use_hrr_structural = false` in `.aelfrice.toml` (or `AELFRICE_HEAT_KERNEL=0` / `AELFRICE_HRR_STRUCTURAL=0`) for parity with the v2.0.x ranking.

--- a/src/aelfrice/hrr.py
+++ b/src/aelfrice/hrr.py
@@ -28,10 +28,13 @@ import numpy.typing as npt
 Vector = npt.NDArray[np.float64]
 
 # Default dimensionality. Capacity per Plate's analysis is roughly
-# dim/9 retrievable bound pairs at signal-to-noise threshold; 2048
-# accommodates ~227 distinct bindings, well above aelfrice's typical
-# ~5 outgoing edges per belief.
-DEFAULT_DIM: Final[int] = 2048
+# dim/9 retrievable bound pairs at signal-to-noise threshold; 512
+# accommodates ~57 distinct bindings, well above aelfrice's typical
+# ~5 outgoing edges per belief. dim=2048 is the escape hatch for
+# high-multiplicity corpora where K approaches the lower bound.
+# See #538 / lab campaign R4 verdict (full-corpus latency budget at
+# N=100k holds at dim=512; dim=2048 does not).
+DEFAULT_DIM: Final[int] = 512
 
 
 # ---------------------------------------------------------------------------

--- a/src/aelfrice/hrr_index.py
+++ b/src/aelfrice/hrr_index.py
@@ -11,8 +11,8 @@ A structural query of the form ``"<KIND>:<belief-id>"`` (e.g.
 ``bind(role[KIND], id_vec[target])`` and ranks beliefs by the
 inner product against ``struct[b]``. Beliefs whose structure
 contains exactly that bound term score high; orthogonal noise from
-other bindings is ``~1/sqrt(dim)`` per term, so at ``dim=2048`` the
-top-K is dominated by true structural matches.
+other bindings is ``~1/sqrt(dim)`` per term, so at the default
+``dim=512`` the top-K is dominated by true structural matches.
 
 Parallel to the textual lane (BM25F + heat kernel), not a competitor.
 A query parser (:func:`parse_structural_marker`) routes structural
@@ -106,7 +106,9 @@ class HRRStructIndex:
     Build is offline (walks every edge once); query is one matvec
     against the ``(N, dim)`` struct matrix plus one bind. Storage
     cost is dominated by the struct matrix at ``8 * N * dim`` bytes;
-    at ``N=50k, dim=2048`` that is ~800 MB, fitting the AC8 budget.
+    at ``N=50k`` and the default ``dim=512`` that is ~200 MB
+    (~800 MB at the ``dim=2048`` escape-hatch value), both within
+    the AC8 budget.
 
     Determinism: ``random_vector`` draws are reproducible from
     ``np.random.default_rng(seed)``. Two builds against the same


### PR DESCRIPTION
## Summary

Closes #538.

Flips `aelfrice.hrr.DEFAULT_DIM` from 2048 → 512 to match the lab campaign R4 verdict (closing commit `74cd9d9`):

> Adopt: HRR full-corpus pass at dim=512 (R1, R4, R5)
> Adopt: dim=512 default; dim=2048 escape hatch

Two atomic commits:

1. `perf(hrr):` flip the constant, update the docstring rationale, fix the `~1/sqrt(dim)` and AC8-budget references in `hrr_index.py` to cite the new default with the dim=2048 escape-hatch number alongside.
2. `docs(changelog):` Unreleased entry.

## Why

- **Memory**: ~4× reduction. AC8 budget at N=50k goes from ~800 MB to ~200 MB. dim=2048 escape-hatch path remains via the `HRRStructIndex(dim=...)` kwarg.
- **Latency**: R4 validated full-corpus pass latency at N=100k holding at p50=20.5ms specifically at dim=512. The public default was shipping at a config the lab didn't latency-budget for at N≥50k.
- **Capacity**: Plate's bound at dim=512 admits ~57 retrievable bound pairs (dim/9), comfortably above aelfrice's typical ~5 outgoing edges per belief. R3 (capacity stress) holds through K=256 at this dim.

`vocab_bridge.py` is also a `DEFAULT_DIM` consumer but is being removed in the #536 cleanup PR — its docstring is left untouched here.

## Test plan

- [x] `uv run pytest -q` → 3090 passed, 53 skipped on the branch tip.
- [x] HRR-specific suites pass at dim=512 (`tests/test_hrr.py`, `tests/test_hrr_struct_index.py`, `tests/test_retrieve_v2_hrr_structural.py`).
- [x] Discretion grep on diff: clean.
- [ ] CI matrix (3.12 + 3.13 + analyze + scans + commit-msg-prefix + pr-title/body checks) on PR open.

## Summary by Sourcery

Set HRR’s default vector dimensionality to 512 to reduce memory usage and align with lab performance findings.

Enhancements:
- Change the HRR DEFAULT_DIM from 2048 to 512, keeping 2048 as an explicit escape-hatch option for high-multiplicity corpora.
- Update in-code documentation around HRR structural indexing to reflect the new default dimensionality, memory, and noise characteristics.

Documentation:
- Add an unreleased changelog entry documenting the HRR default dimensionality change and its performance and capacity implications.