### PR TITLE
docs(vocab_bridge): cite default dim=512 alongside dim=2048 escape-hatch (#541)

### DIFF
--- a/src/aelfrice/vocab_bridge.py
+++ b/src/aelfrice/vocab_bridge.py
@@ -110,7 +110,9 @@ class VocabBridge:
     anchor-text edges); rewrite is one ``unbind`` and one
     cleanup-memory query per query token. Storage cost is dominated
     by the surface-form ``(N_surfaces, dim)`` matrix at ``8 *
-    N_surfaces * dim`` bytes; at ``N=10k, dim=2048`` that is ~160 MB.
+    N_surfaces * dim`` bytes; at ``N=10k`` and the default
+    ``dim=512`` that is ~40 MB (~160 MB at the ``dim=2048``
+    escape-hatch value).
 
     Determinism: ``random_vector`` draws are reproducible from
     ``np.random.default_rng(seed)``. Two builds against the same store


### PR DESCRIPTION
Closes #541.

Updates the `VocabBridge` storage-cost docstring (`src/aelfrice/vocab_bridge.py:113`) to cite `dim=512` (the post-#539 default via `from aelfrice.hrr import DEFAULT_DIM`) as the primary number, with `dim=2048` shown as the escape-hatch path. Mirrors the format already used in `hrr_index.py:107-110` from PR #539.

```
- N_surfaces * dim`` bytes; at ``N=10k, dim=2048`` that is ~160 MB.
+ N_surfaces * dim`` bytes; at ``N=10k`` and the default
+ ``dim=512`` that is ~40 MB (~160 MB at the ``dim=2048``
+ escape-hatch value).
```

`8 * 10000 * 512 ≈ 40 MB`; `8 * 10000 * 2048 ≈ 160 MB` (unchanged).

## Acceptance

- [x] vocab_bridge.py:113 docstring cites the new default with the escape-hatch number alongside, mirroring `hrr_index.py:107-110` style.
- [x] Spot-check of file for other `dim=2048` references that read as default-cited: only one (the cited line); other `dim` references either don't carry a numeric value or pull from `DEFAULT_DIM` directly.

## Out of scope

- The actual VocabBridge re-spec / removal disposition (#536 closed NOT_PLANNED; this PR doesn't touch behavior).
- CHANGELOG: docstring-only follow-up; the user-facing dim flip is already documented under [Unreleased]/Performance from PR #539.

## References

- #538 / PR #539 — DEFAULT_DIM flip 2048 → 512
- #536 — closed NOT_PLANNED VocabBridge re-spec
- #433 — original VocabBridge ship

## Summary by Sourcery

Documentation:
- Adjust VocabBridge docstring to cite dim=512 as the default dimension with dim=2048 documented as an escape-hatch option, including updated storage cost figures.