### PR TITLE
feat(doctor): document + flag missing v2.1 auto-capture hooks (#557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ installable release; see the roadmap in [README.md](README.md).
 
 ### Added
 
+- **`aelf doctor` flags pre-v2.1 installs missing default-on auto-capture hooks** ([#557](https://github.com/robotrocketscience/aelfrice/issues/557)). When any of `aelf-transcript-logger`, `aelf-commit-ingest`, or `aelf-session-start-hook` is absent from every scanned `settings.json`, the doctor report appends a one-line nag pointing to `aelf setup` to wire them. Catches the upgrade-from-v2.0 case where `aelf upgrade-cmd` updates the package but does not re-run `setup` to install the v2.1 default-on hooks. Quiet when no settings.json was scanned (the existing no-scopes-scanned message already covers that case) and when every default-on hook is present.
+
 - **Research-agent dispatch wonder surface** ([#551](https://github.com/robotrocketscience/aelfrice/issues/551), umbrella [#542](https://github.com/robotrocketscience/aelfrice/issues/542) track E). New `aelfrice.wonder.dispatch` module exposes `analyze_gaps()` and `generate_research_axes()`. `analyze_gaps(store, query, ...)` returns a `GapAnalysis` dataclass with known beliefs, high-uncertainty beliefs (normalized 0..1 variance proxy > 0.7), unresolved CONTRADICTS pairs (CONTRADICTS minus matching SUPERSEDES), query-term coverage, and named gaps. `generate_research_axes(gap, agent_count)` produces 2–6 orthogonal `ResearchAxis` records: always-on `domain_research` + `internal_gap_analysis`, conditional `contradiction_resolution` / `uncertainty_deep_dive` / `coverage_extension`. Surfaced via the new `aelf_wonder` MCP tool (13th tool) and `aelf wonder --axes QUERY` CLI flag — both return the same JSON shape for downstream skill-layer consumption (E4, separate sub-issue).
+
+### Documentation
+
+- **README documents default-on auto-capture** ([#557](https://github.com/robotrocketscience/aelfrice/issues/557)). Adds a passive-capture row to the `What it remembers` table and a `Passive capture` bullet to `What you get for free` so the headline narrative reflects the v2.1 default flip (#529). Pre-v2.1 the table listed only manual inputs, so a model reading the README inferred aelfrice was for user-locked rules only — the symptom in #557.
 
 ## [2.1.0] - 2026-05-09
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Default budget is 2,400 tokens per prompt. Locked beliefs are the always-injecte
 | `aelf onboard .` | Walks the project — git log, README headings, code structure — and ingests structural facts. |
 | `aelf feedback <id> used` | Bayesian feedback. Strengthens the belief's posterior. |
 | `aelf feedback <id> harmful` | Weakens it. After enough independent harmfuls, locks auto-demote. |
+| _(passive — no command)_ | Default-on auto-capture: every prompt/response turn is logged to per-project JSONL and ingested into the belief graph at compaction; successful `git commit` events are ingested too. See [INSTALL § hooks](docs/INSTALL.md). Opt out with `aelf setup --no-transcript-ingest --no-commit-ingest`. |
 
 Each belief carries a `(α, β)` Beta-Bernoulli posterior. `α / (α+β)` is the confidence. Locks short-circuit decay; everything else fades over time so stale beliefs eventually drop out of retrieval.
 
@@ -117,6 +118,7 @@ aelfrice replaces the chain with a mechanism. The hook injects matched beliefs *
 
 Running in the background. No action required after `aelf setup`.
 
+- **Passive capture.** Default-on transcript-ingest, commit-ingest, and session-start hooks (since v2.1). Session activity flows into the belief graph without you typing `aelf` at all; opt out per-hook via `aelf setup --no-transcript-ingest`, `--no-commit-ingest`, `--no-session-start`. See [INSTALL § default-on hooks](docs/INSTALL.md).
 - **Determinism.** Stdlib + SQLite. No embeddings, no learned re-rankers, no LLM in the retrieval path. Every result traces to the action that wrote it.
 - **Local-only.** SQLite at `<repo>/.git/aelfrice/memory.db`. No telemetry, no network calls, no accounts. Per-project isolation by construction. See [PRIVACY.md](docs/PRIVACY.md).
 - **Removable.** `aelf uninstall --archive backup.aenc` encrypts the DB to a file, then deletes it. Or `--purge` for a full wipe.

--- a/src/aelfrice/doctor.py
+++ b/src/aelfrice/doctor.py
@@ -285,6 +285,13 @@ class DoctorReport:
     missing_runtime_deps: list[str] = field(
         default_factory=lambda: cast(list[str], [])
     )
+    # Default-on auto-capture hook basenames (since v2.1, #529) that
+    # are absent from every scanned settings.json. Pre-v2.1 installs
+    # that ran `aelf setup` before the default flip end up here
+    # (#557): they have retrieval-only wiring and need a re-run.
+    missing_auto_capture_hooks: list[str] = field(
+        default_factory=lambda: cast(list[str], [])
+    )
 
     @property
     def broken(self) -> list[CommandFinding]:
@@ -350,6 +357,7 @@ def diagnose(
     report.hook_failures_log = log_path
     report.hook_failures_tail = _tail_log(log_path, _HOOK_FAILURES_TAIL)
     report.missing_runtime_deps = _check_runtime_deps()
+    report.missing_auto_capture_hooks = _check_auto_capture_hooks(report.findings)
     if known_cli_subcommands is not None:
         slash_dir = (
             slash_commands_dir if slash_commands_dir is not None
@@ -739,7 +747,64 @@ def format_report(report: DoctorReport) -> str:
     _format_telemetry_section(report, lines)
     _format_user_prompt_submit_telemetry_section(report, lines)
     _format_missing_runtime_deps_section(report, lines)
+    _format_missing_auto_capture_section(report, lines)
     return "\n".join(lines)
+
+
+# Default-on auto-capture hook basenames the v2.1 `aelf setup` wires
+# (#529 commit 3c27f45). Mirrors `setup.TRANSCRIPT_LOGGER_SCRIPT_NAME`,
+# `setup.COMMIT_INGEST_SCRIPT_NAME`, `setup.SESSION_START_HOOK_SCRIPT_NAME`.
+# Duplicated here to keep the doctor module dependency-free of setup's
+# install primitives; if the names drift, the test in
+# tests/test_doctor.py::test_auto_capture_basenames_match_setup catches it.
+_AUTO_CAPTURE_HOOK_BASENAMES: Final[tuple[str, ...]] = (
+    "aelf-transcript-logger",
+    "aelf-commit-ingest",
+    "aelf-session-start-hook",
+)
+
+
+def _check_auto_capture_hooks(
+    findings: list[CommandFinding],
+) -> list[str]:
+    """Return basenames of v2.1 default-on hooks absent from all scanned scopes.
+
+    A hook is "present" if any finding's command string contains the
+    basename. Substring match is intentional: the command may be a bare
+    basename (PATH-resolved pipx install) or an absolute path
+    (project venv); both should count as installed (#557).
+    """
+    missing: list[str] = []
+    for basename in _AUTO_CAPTURE_HOOK_BASENAMES:
+        if not any(basename in f.command for f in findings):
+            missing.append(basename)
+    return missing
+
+
+def _format_missing_auto_capture_section(
+    report: DoctorReport, lines: list[str],
+) -> None:
+    """Append the v2.1 auto-capture nag block (#557) to `lines`.
+
+    Quiet when no settings.json was scanned (the install-broken case
+    is already covered by the no-scopes-scanned message at line 1 of
+    format_report) or when every default-on hook is present.
+    """
+    if not report.scopes_scanned:
+        return
+    if not report.missing_auto_capture_hooks:
+        return
+    lines.append("")
+    lines.append(
+        "auto-capture hooks not installed (v2.1+, #529). missing: "
+        + ", ".join(report.missing_auto_capture_hooks)
+    )
+    lines.append(
+        "fix: re-run 'aelf setup' to wire transcript-ingest, "
+        "commit-ingest, and session-start (default-on since v2.1). "
+        "to opt out per-hook: `aelf setup --no-transcript-ingest "
+        "--no-commit-ingest --no-session-start`."
+    )
 
 
 def _format_missing_runtime_deps_section(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -329,3 +329,130 @@ def test_doctor_cli_exit_0_when_clean(
     )
     assert code == 0
     assert "1 ok" in buf.getvalue()
+
+
+# --- v2.1 default-on auto-capture nag (#557) -----------------------------
+
+
+def test_diagnose_flags_missing_auto_capture_hooks_when_pre_v21(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pre-v2.1 install: settings has only the retrieval hook, none of
+    the three default-on auto-capture hooks. Report should list all
+    three as missing and the rendered output should print the re-run
+    nag."""
+    bin_dir = tmp_path / "bin"
+    retrieval_hook = _exec(bin_dir / "aelf-hook")
+    user_path = tmp_path / "settings.json"
+    _write_settings(user_path, {
+        "hooks": {
+            "UserPromptSubmit": [{
+                "hooks": [{"type": "command", "command": str(retrieval_hook)}],
+            }],
+        },
+    })
+    monkeypatch.setenv("PATH", str(bin_dir))
+    report = diagnose(
+        user_settings=user_path, project_root=tmp_path / "noproj"
+    )
+    assert report.missing_auto_capture_hooks == [
+        "aelf-transcript-logger",
+        "aelf-commit-ingest",
+        "aelf-session-start-hook",
+    ]
+    rendered = format_report(report)
+    assert "auto-capture hooks not installed" in rendered
+    assert "re-run 'aelf setup'" in rendered
+
+
+def test_diagnose_quiet_when_all_auto_capture_hooks_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fresh v2.1 install: all three default-on hooks present. No nag
+    line in the rendered report."""
+    bin_dir = tmp_path / "bin"
+    retrieval = _exec(bin_dir / "aelf-hook")
+    transcript = _exec(bin_dir / "aelf-transcript-logger")
+    commit_ingest = _exec(bin_dir / "aelf-commit-ingest")
+    session_start = _exec(bin_dir / "aelf-session-start-hook")
+    user_path = tmp_path / "settings.json"
+    _write_settings(user_path, {
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{"type": "command", "command": str(retrieval)}]},
+                {"hooks": [{"type": "command", "command": str(transcript)}]},
+            ],
+            "Stop": [
+                {"hooks": [{"type": "command", "command": str(transcript)}]},
+            ],
+            "PreCompact": [
+                {"hooks": [{"type": "command", "command": str(transcript)}]},
+            ],
+            "PostCompact": [
+                {"hooks": [{"type": "command", "command": str(transcript)}]},
+            ],
+            "PostToolUse": [{
+                "matcher": "Bash",
+                "hooks": [{"type": "command", "command": str(commit_ingest)}],
+            }],
+            "SessionStart": [
+                {"hooks": [{"type": "command", "command": str(session_start)}]},
+            ],
+        },
+    })
+    monkeypatch.setenv("PATH", str(bin_dir))
+    report = diagnose(
+        user_settings=user_path, project_root=tmp_path / "noproj"
+    )
+    assert report.missing_auto_capture_hooks == []
+    rendered = format_report(report)
+    assert "auto-capture hooks not installed" not in rendered
+
+
+def test_diagnose_partial_auto_capture_lists_only_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mixed install: transcript-logger present, the other two absent.
+    Only the absent two should appear in the missing list."""
+    bin_dir = tmp_path / "bin"
+    transcript = _exec(bin_dir / "aelf-transcript-logger")
+    user_path = tmp_path / "settings.json"
+    _write_settings(user_path, {
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{"type": "command", "command": str(transcript)}]},
+            ],
+        },
+    })
+    monkeypatch.setenv("PATH", str(bin_dir))
+    report = diagnose(
+        user_settings=user_path, project_root=tmp_path / "noproj"
+    )
+    assert report.missing_auto_capture_hooks == [
+        "aelf-commit-ingest",
+        "aelf-session-start-hook",
+    ]
+
+
+def test_diagnose_quiet_when_no_settings_scanned(tmp_path: Path) -> None:
+    """No settings.json at either scope → suppress the auto-capture
+    nag (the no-scopes-scanned message already covers that case)."""
+    report = diagnose(
+        user_settings=tmp_path / "missing-user.json",
+        project_root=tmp_path / "missing-project",
+    )
+    rendered = format_report(report)
+    assert "auto-capture hooks not installed" not in rendered
+
+
+def test_auto_capture_basenames_match_setup() -> None:
+    """Guardrail: doctor's hardcoded auto-capture basename list must
+    stay in sync with `aelfrice.setup`. If setup renames a script,
+    this test fires before the doctor check silently misses it."""
+    from aelfrice import setup
+    from aelfrice.doctor import _AUTO_CAPTURE_HOOK_BASENAMES
+    assert set(_AUTO_CAPTURE_HOOK_BASENAMES) == {
+        setup.TRANSCRIPT_LOGGER_SCRIPT_NAME,
+        setup.COMMIT_INGEST_SCRIPT_NAME,
+        setup.SESSION_START_HOOK_SCRIPT_NAME,
+    }


### PR DESCRIPTION
Closes #557.

## What

Two surface fixes for the v2.1 default-on auto-capture pipeline (#529, shipped today in v2.1.0).

**A — README messaging** (`c782497`). The `What it remembers` table at README:66-75 listed only manual inputs (`aelf lock`, `aelf onboard`, `aelf feedback`); a model reading the README inferred aelfrice was for user-locked rules only. Adds a passive-capture row to the table and a `Passive capture` bullet to `What you get for free`, both pointing at `docs/INSTALL.md` for the full hook table and per-hook opt-out flags.

**B — `aelf doctor` nag** (`b9ee58e`). Pre-v2.1 installs that already ran `aelf setup` have retrieval-only wiring; `aelf upgrade-cmd` does not re-run `setup`. Doctor now scans the findings list and reports any of `aelf-transcript-logger`, `aelf-commit-ingest`, `aelf-session-start-hook` that are absent from every scanned `settings.json`, with a one-line nag pointing to `aelf setup`. Substring match on the basename so PATH-resolved (pipx) and absolute-path (venv) installs both count as present. Quiet when no settings.json was scanned (existing no-scopes message already covers that) and when every default-on hook is present.

## Out of scope

A third proposed fix (`LIMITATIONS.md § Out of scope` entry rejecting checkpoint-event memory as a primitive) was dropped per maintainer direction — that's a design call for a later release, not part of #557's surface.

## Verification

- `uv run pytest tests/test_doctor.py` — 20 passed (15 prior + 5 new). The new tests cover: pre-v2.1 install (all three hooks missing → nag fires), fresh v2.1 install (all present → quiet), partial install (only the missing two listed), no-settings.json (quiet), and a guardrail asserting doctor's hardcoded basename list matches the `aelfrice.setup` constants.
- README diff renders cleanly on GitHub (table + bullet); manual scan.

## Diagnostic

Posted at https://github.com/robotrocketscience/aelfrice/issues/557#issuecomment-4414485763 before implementation; confirms three-way root cause (README mismatch, no upgrade nag, decision-event memory out of scope) and the A+B+C disposition options. Maintainer picked A+B.

## Summary by Sourcery

Document v2.1’s default-on auto-capture behavior and add an `aelf doctor` check that warns when the new auto-capture hooks are missing after upgrades from pre-v2.1 installs.

New Features:
- Extend `aelf doctor` to detect missing default-on auto-capture hooks and emit a guided message to re-run setup when they are absent.

Documentation:
- Update README and changelog to describe v2.1’s default-on passive capture hooks, opt-out flags, and installation behavior.

Tests:
- Add unit tests covering auto-capture hook detection in `aelf doctor`, including pre-v2.1 installs, fully wired installs, partial installs, no-settings cases, and a guardrail that keeps the doctor’s hook list in sync with setup.