### PR TITLE
docs: scrub 2026-05-09 — refresh user-facing docs against v2.1.0 ship state

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ The same operations are also available as MCP tools and `/aelf:*` slash commands
 
 ## Status
 
-Latest stable: **v1.7** — graph-signal retrieval lane (signed Laplacian, heat-kernel authority, Plate FFT HRR primitives), BM25F anchor-text retrieval default-on.
+Latest stable: **v2.1.0** — heat-kernel + HRR-structural defaults flipped on (#154) after the #437 reproducibility-harness gate cleared 11/11; HRR `dim` default 512 (#538); default-on transcript / commit / session-start hooks (#529).
 
-Next: **v2.0** — research-line parity + benchmark reproducibility cut.
+Next: **v2.2** — descend the V2_REENTRY_QUEUE backlog (dedup wire-up, sentiment-feedback integration, multimodel).
 
 Per-version detail: [docs/ROADMAP.md](docs/ROADMAP.md).
 Open issues / known limits: [docs/LIMITATIONS.md](docs/LIMITATIONS.md).

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -7,7 +7,7 @@ aelfrice ships two benchmark surfaces with different purposes and cadences.
 | Synthetic regression | `src/aelfrice/benchmark.py` | Catch retrieval/scoring regressions | <1s | $0 | Every PR (CI) |
 | Academic suite | `benchmarks/` | Reproduce published numbers vs. external benchmarks | minutes–hours | LLM API spend | Nightly + on-tag |
 
-The synthetic harness is a measurement instrument. It is **not** a proof of the central feedback claim — at v1.0–v1.2 the posterior doesn't drive ranking yet. See [LIMITATIONS](LIMITATIONS.md).
+The synthetic harness is a measurement instrument. It is **not** a proof of the central feedback claim — through v1.2 the posterior didn't drive ranking; v1.3 added partial Bayesian re-rank, v1.6 the eval harness + heat-kernel composition wiring, v1.7 BM25F default-on, and v2.1 the use_heat_kernel + use_hrr_structural default-flips. See [LIMITATIONS](LIMITATIONS.md).
 
 The academic suite is the reproducibility deliverable. Most adapters scaffold against MAB, LoCoMo, LongMemEval, StructMemEval, and AMA-Bench but are inert at v1.0; they activate as their feature dependencies port forward. Per-adapter status: [`benchmarks/README.md`](../benchmarks/README.md).
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -167,11 +167,11 @@ The trade-off vs. `exclude_words`: phrase match is a literal substring, no word 
 
 ### `[onboard.llm]` (v1.3.0+)
 
-Opt-in LLM-Haiku classifier for onboard ingest. Replaces the default regex `classify_sentence` path with one Haiku call per onboard run. Default: off. Boundary policy: [`docs/llm_classifier.md`](llm_classifier.md). Privacy: [`docs/PRIVACY.md § Optional outbound calls`](PRIVACY.md#optional-outbound-calls).
+Host-driven LLM classifier for onboard ingest. Replaces the default regex `classify_sentence` path with the host model's Task tool (no API key required) — direct-API fallback gated by the `[onboard-llm]` extra. Default at v1.5.1+ (#238): on (`enabled = true`); soft-fallback to the regex classifier when no host Task tool is reachable. Boundary policy: [`docs/llm_classifier.md`](llm_classifier.md). Privacy: [`docs/PRIVACY.md § Optional outbound calls`](PRIVACY.md#optional-outbound-calls).
 
 | Key | Type | Default | Effect |
 |---|---|---|---|
-| `enabled` | bool | `false` | Turns on the LLM path when no `--llm-classify` flag is passed. The CLI flag wins on conflict; pass `--llm-classify=false` to force regex even when this is `true`. |
+| `enabled` | bool | `true` (since v1.5.1, #238; was `false` v1.3.0–v1.5.0) | Turns on the LLM path when no `--llm-classify` flag is passed. The CLI flag wins on conflict; pass `--llm-classify=false` to force regex even when this is `true`. |
 | `max_tokens` | int | `200_000` | Hard cap on total input+output tokens per onboard run. The classifier aborts mid-stream when exceeded; already-classified candidates persist and the deterministic belief id ensures a re-run resumes idempotently. `0` disables the cap (power-user). |
 | `model` | str | `"claude-haiku-4-5-20251001"` | Anthropic model id. Pinned by default. Override only if you have a reason — classification recall and the few-shot block are calibrated against the pinned model. |
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -256,7 +256,7 @@ Precedence (first decisive wins): env var `AELFRICE_POSTERIOR_WEIGHT=<float>` > 
 
 Negative values clamp to `0.0`. Non-numeric env values trace to stderr and fall through. The cache key is extended with the resolved weight (rounded to four decimals), so two callers passing different weights against the same store do not collide on a shared `RetrievalCache`.
 
-BM25F-only L1 shipped default-on at v1.7.0 (see `use_bm25f_anchors`); the heat-kernel and HRR-structural lanes are implemented but stay opt-in pending the composition-tracker bench gate (#154). The full joint-composition eval — 10-round MRR uplift, ECE calibration, BM25F × heat-kernel × HRR-structural — is the unfinished v2.0.0+ work. See [`docs/bayesian_ranking.md`](bayesian_ranking.md) for the v1.3 contract and the rejected-alternatives analysis.
+BM25F-only L1 shipped default-on at v1.7.0 (see `use_bm25f_anchors`); the heat-kernel and HRR-structural lanes shipped default-on at v2.1.0 once the #154 composition-tracker bench gate cleared 11/11 against the #437 reproducibility-harness corpus (see `use_heat_kernel` and `use_hrr_structural` below). See [`docs/bayesian_ranking.md`](bayesian_ranking.md) for the v1.3 contract and the rejected-alternatives analysis.
 
 ### `bfs_enabled`
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -8,7 +8,7 @@ Through v1.2.x: `apply_feedback` updates `(α, β)` and writes an audit row. The
 
 The benchmark harness shipped at v1.0 as the measurement instrument; it was not yet a proof of the feedback claim. The v1.3 partial Bayesian re-rank, v1.6 deferred-feedback sweeper, and v1.7 BM25F default-on flip (see below) progressively closed that gap.
 
-**At v1.3.0:** ranking begins to consume the posterior. L1 score becomes `log(bm25) + 0.5 * log(posterior_mean)`; locked beliefs (L0) bypass scoring as before; the cache invalidates correctly through the existing store-mutation hook. **At v1.6.0:** the MRR-uplift + ECE-calibration eval harness ships at `benchmarks/posterior_ranking.py` and the heat-kernel composition wiring lands as a log-additive term in the ranking score (#151, #306, #310). Both ship default-OFF; the default-flip is gated on the harness clearing the MRR-uplift / ECE thresholds against the v2.0 corpus and lands at v1.7.0 (#154). See [`docs/bayesian_ranking.md`](bayesian_ranking.md) for the v1.3 contract.
+**At v1.3.0:** ranking begins to consume the posterior. L1 score becomes `log(bm25) + 0.5 * log(posterior_mean)`; locked beliefs (L0) bypass scoring as before; the cache invalidates correctly through the existing store-mutation hook. **At v1.6.0:** the MRR-uplift + ECE-calibration eval harness ships at `benchmarks/posterior_ranking.py` and the heat-kernel composition wiring lands as a log-additive term in the ranking score (#151, #306, #310). Both ship default-OFF. **At v2.1.0:** the #154 default-flip lands once the #437 reproducibility-harness gate clears 11/11 — `use_heat_kernel` and `use_hrr_structural` flip default-on. See [`docs/bayesian_ranking.md`](bayesian_ranking.md) for the v1.3 contract.
 
 ## No semantic similarity
 
@@ -31,7 +31,7 @@ Classification on the CLI path defaults to regex-based priors. Higher-quality cl
 
 The v1.3.0 BFS multi-hop expansion (see [bfs_multihop.md](bfs_multihop.md)) resolves each hop to the globally latest serial of its target belief independently. For audit-shaped queries ("what did the agent believe at the time it made this decision?") this can surface a chain whose intermediate hops postdate the seed's session — a fidelity loss against a corpus where supersessions accumulated after the seed was written.
 
-The default retrieval mode (recall, not audit) is correctly served by latest-serial-per-hop. The temporal-coherence fix is targeted at v2.0.0 alongside the published-numbers reproducibility harness; the spec § Open question: temporal coherence documents why deferring is the right call for v1.3.
+The default retrieval mode (recall, not audit) is correctly served by latest-serial-per-hop. The temporal-coherence fix was originally targeted at v2.0.0 alongside the reproducibility harness; the harness shipped (#437) but the temporal fix slipped past v2.0/v2.1 and is now deferred to v2.x. The spec § Open question: temporal coherence documents why deferring is the right call for v1.3.
 
 ## Sharp edges
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -58,7 +58,7 @@ Tools register under the `aelf:` namespace.
 | Tool | Required | Optional | Returns |
 |---|---|---|---|
 | `aelf:onboard` | — | `path`, `session_id`, `classifications` | polymorphic — see below |
-| `aelf:search` | `query` | `budget` (default 2,000) | `{kind, n_hits, hits[]}` |
+| `aelf:search` | `query` | `budget` (default 2,400) | `{kind, n_hits, hits[]}` |
 | `aelf:lock` | `statement` | — | `{kind, id, action}` |
 | `aelf:locked` | — | `pressured` | `{kind, n, locked[]}` |
 | `aelf:demote` | `belief_id` | — | `{kind, id, demoted}` |

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -102,9 +102,9 @@ it.
 
 ## Local, always
 
-Your corrections live in one SQLite file on your machine. No cloud sync, no telemetry, no API calls in the retrieval path. The cloud LLM at the other end of your prompt sees whatever aelfrice injects — that's inherent — but aelfrice limits the slice (default 2,000 tokens, scoped to the current query) rather than dumping the whole memory.
+Your corrections live in one SQLite file on your machine. No cloud sync, no telemetry, no API calls in the retrieval path. The cloud LLM at the other end of your prompt sees whatever aelfrice injects — that's inherent — but aelfrice limits the slice (default 2,400 tokens, scoped to the current query) rather than dumping the whole memory.
 
-The 2,000-token default is a calibrated choice, not an arbitrary one. The hypothesis from the research line is that focused context beats exhaustive context: a 2K-token retrieval that selects the right beliefs should match or exceed a 10K-token full-memory dump on response quality, while burning 5× fewer tokens on memory plumbing. The reproducibility cut at v2.0 is where that curve gets re-measured against the public retrieval pipeline; until then the 2,000-token budget is the inherited research-line default, configurable per-call.
+The 2,400-token default is a calibrated choice, not an arbitrary one. The hypothesis from the research line is that focused context beats exhaustive context: a ~2.4K-token retrieval that selects the right beliefs should match or exceed a 10K-token full-memory dump on response quality, while burning ~4× fewer tokens on memory plumbing. The reproducibility cut at v2.0 was where that curve got re-measured against the public retrieval pipeline; the 2,400-token budget is the post-v1.3 default, configurable per-call.
 
 [PRIVACY.md](PRIVACY.md) for verifiable specifics.
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -101,7 +101,7 @@ To turn it off after enabling, remove the config line (or set `[feedback] sentim
 
 The cloud LLM at the other end of your prompt sees whatever aelfrice injects. That's inherent to using a cloud LLM. Mitigations:
 
-- **Per-query token budget** (default 2,000). The full memory is never injected.
+- **Per-query token budget** (default 2,400). The full memory is never injected.
 - **L0/L1 ordering** surfaces locks plus query-relevant matches, not a memory dump.
 - **Per-project isolation** means cross-project context cannot bleed in.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,8 +25,10 @@ This is a rebuild, not a port. Structural issues that survived the research line
 | **v1.5.0** | shipped | retrieval plumbing — composition plumbing + telemetry, BM25F anchor text, search-tool Bash matcher, v3 federation version-vector schema, dynamic-trigger re-park |
 | **v1.5.1** | shipped | corroboration tracking sibling table (#190); default-on host-driven LLM onboard classifier (#238) |
 | **v1.6.0** | shipped | hardening + observability — hook-hardening framing-tag contract + per-turn audit log, `aelf tail`, belief retention class, rebuild diagnostic log, posterior-ranking eval harness + heat-kernel composition (default-flip gated), deferred-feedback sweeper, v2.0 corpus public scaffold + bench-gate, `replay_full_equality` probe, `session_id` propagation, reachable-install detection |
-| **v1.7.0** | planned | graph signal wave + structural retrieval lane — signed Laplacian + eigenbasis (#149), heat kernel authority (#150), Plate FFT HRR primitives (#216), HRR bind/probe (#152), `uri_baki` post-rank adjuster retest (#153), benchmark-gate default-on flip (#154) |
-| **v2.0.0** | planned | feature parity with the research line + benchmark reproducibility |
+| **v1.7.0** | shipped | graph signal wave + structural retrieval lane — signed Laplacian + eigenbasis (#149), heat kernel authority (#150), Plate FFT HRR primitives (#216), HRR bind/probe (#152), `uri_baki` post-rank adjuster retest (#153). Heat-kernel + HRR-structural shipped opt-in; benchmark-gate default-on flip (#154) deferred to v2.1.0. |
+| **v2.0.0** | shipped | feature parity with the research line + reproducibility-harness scaffolding (#437); wonder lifecycle + dispatch surface; sentiment-feedback module (hook integration pending); dedup read-path (audit-only) |
+| **v2.1.0** | shipped | reproducibility-harness gate cleared 11/11 (#437); `use_heat_kernel` + `use_hrr_structural` defaults flipped on (#154); HRR `dim` default 2048→512 (#538); default-on transcript / commit / session-start hooks (#529); query-strategy uplift bench gate (#291); vocab-bridge bench gate (#433) |
+| **v2.2** | planned | descend the V2_REENTRY_QUEUE backlog — dedup write-path wire-up (#197), sentiment-feedback hook integration (#193), multimodel (#194) |
 
 ## What shipped
 

--- a/docs/SLASH_COMMANDS.md
+++ b/docs/SLASH_COMMANDS.md
@@ -1,6 +1,6 @@
 # Slash Commands
 
-Eighteen markdown files in `src/aelfrice/slash_commands/`, tracking the v1.2.0 CLI consolidation plus the v1.4.0 `rebuild` promotion and the v2.0 reasoning surfaces. After `aelf setup`, they appear as `/aelf:*` in the host. Each is a thin wrapper over the CLI — `/aelf:foo` invokes `aelf foo` against the active project's DB.
+Nineteen markdown files in `src/aelfrice/slash_commands/`, tracking the v1.2.0 CLI consolidation, the v1.4.0 `rebuild` promotion, the v2.0 reasoning surfaces, and the v2.x `eval` calibration surface. After `aelf setup`, they appear as `/aelf:*` in the host. Each is a thin wrapper over the CLI — `/aelf:foo` invokes `aelf foo` against the active project's DB.
 
 Slash files are not shipped for hidden CLI subcommands (`bench`, `feedback`, `health`, `migrate`, `project-warm`, `regime`, `session-delta`, `stats`, `statusline`, `unsetup`). Those subcommands stay callable from the CLI for scripting, hook entry-points, and back-compat aliases — they're just not surfaced as slashes.
 
@@ -28,6 +28,7 @@ Slash files are not shipped for hidden CLI subcommands (`bench`, `feedback`, `he
 | `/aelf:rebuild` | optional `--n N`, `--budget T`, `--transcript PATH` — manually fire the context rebuilder; v1.4.0+ |
 | `/aelf:reason` | keyword query — walks the belief graph from BM25-seeded starting points; v2.0+ (#389) |
 | `/aelf:wonder` | optional flags (`--top N`, `--seed ID`, `--emit-phantoms`) — surfaces consolidation candidates / phantom-belief suggestions; v2.0+ (#389), phantom-store integration deferred to v2.x |
+| `/aelf:eval` | optional `--corpus PATH`, `--k N`, `--seed N`, `--json` — runs the relevance-calibration harness (P@K / ROC-AUC / Spearman ρ) ratified at #365 |
 
 Behaviour matches the CLI exactly — see [COMMANDS](COMMANDS.md). The v1.1.0 `edges` → `threads` user-facing rename does not surface here; the program name remains `aelf`.
 

--- a/docs/bayesian_ranking.md
+++ b/docs/bayesian_ranking.md
@@ -2,7 +2,7 @@
 
 Spec for issue [#146](https://github.com/robotrocketscience/aelfrice/issues/146). Closely related: issue [#151](https://github.com/robotrocketscience/aelfrice/issues/151) (full log-additive Beta-Bernoulli ranking).
 
-Status: spec, no implementation. Implementation lands in a follow-up PR against this spec's acceptance list.
+Status: shipped. v1.3.0 wired the partial Bayesian re-rank (`DEFAULT_POSTERIOR_WEIGHT = 0.5` in `src/aelfrice/scoring.py`). v1.7.0 added heat-kernel and HRR-structural primitives behind opt-in flags. v2.1.0 (#154) flipped both default-on after the #437 reproducibility-harness gate cleared 11/11.
 
 ## Motivation
 

--- a/docs/bfs_multihop.md
+++ b/docs/bfs_multihop.md
@@ -1,7 +1,7 @@
 # BFS multi-hop graph traversal
 
-**Status:** spec.
-**Target milestone:** v1.3.0.
+**Status:** shipped opt-in. Implementation wired in `src/aelfrice/retrieval.py` (`bfs_enabled` flag, default `False`). Default-on flip is gated on benchmark uplift; per-edge ship-gate notes for #383–#388 (RELATES_TO, IMPLEMENTS, TESTS, TEMPORAL_NEXT, DERIVED_FROM weights) live in this doc's body.
+**Shipped at milestone:** v1.3.0.
 **Tracking issue:** [#144](https://github.com/robotrocketscience/aelfrice/issues/144).
 **Dependencies:** stdlib only. Reads the v1.2 edge schema (`anchor_text`,
 `session_id`, `DERIVED_FROM`). Soft dependency on the v1.3.0

--- a/docs/entity_index.md
+++ b/docs/entity_index.md
@@ -1,8 +1,11 @@
 # Entity-index retrieval (L2.5)
 
-**Status:** spec.
-**Target milestone:** v1.3.0 (named on the public roadmap as "entity-index
-retrieval"; ports forward from the earlier research line).
+**Status:** shipped. Module: `src/aelfrice/entity_extractor.py`; storage:
+`belief_entities` table referenced from `src/aelfrice/store.py`,
+`src/aelfrice/retrieval.py`, and `src/aelfrice/eval_harness.py`. Flag:
+`entity_index_enabled` default-on since v1.3.0.
+**Shipped at milestone:** v1.3.0 (named on the public roadmap as
+"entity-index retrieval"; ported forward from the earlier research line).
 **Dependencies:** v1.2.0 triple-extraction port (already shipped). Stdlib
 only — no new third-party deps. Consumes the v1.2.0 [`Belief.session_id`](../src/aelfrice/models.py),
 the v1.2.0 [`Edge.anchor_text`](../src/aelfrice/models.py), and the

--- a/docs/search_tool_hook.md
+++ b/docs/search_tool_hook.md
@@ -171,7 +171,7 @@ Tactics:
 3. **Cap token count and per-token length.** First 5 tokens, ≥ 3
    chars each. Bounds FTS5 query complexity.
 4. **Reduced retrieval budget.** `token_budget=600`, `l1_limit=10` —
-   well below the user-facing default 2000 / 50.
+   well below the user-facing default 2400 / 50.
 5. **Read-only access.** No write paths — the hook only reads the
    FTS5 index and the locked-beliefs table.
 

--- a/docs/v2_close_the_loop.md
+++ b/docs/v2_close_the_loop.md
@@ -3,7 +3,8 @@
 **Issue:** [#317](https://github.com/robotrocketscience/aelfrice/issues/317)
 **Status:** spec, no implementation. Implementation lands as a follow-up
 PR against this spec's acceptance list.
-**Target:** v2.0.0
+**Target:** v2.x — deferred per V2_REENTRY_QUEUE; original v2.0.0 anchor
+slipped past the v2.0/v2.1 cuts without a `close_the_loop` module landing.
 
 ---
 

--- a/docs/v2_dedup.md
+++ b/docs/v2_dedup.md
@@ -2,7 +2,7 @@
 
 Spec for issue [#197](https://github.com/robotrocketscience/aelfrice/issues/197). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B).
 
-Status: spec, no implementation. Recommendation included; decision is the user's.
+Status: read-path shipped. `src/aelfrice/dedup.py` is wired and exposed via `aelf doctor dedup` (audit-only mode); it's also imported by `relationship_detector.py`. The write-path `SUPERSEDES` hook (collapse-on-ingest) is bench-gated behind the corpus benchmark and remains deferred per V2_REENTRY_QUEUE.
 
 ## What's being decided
 

--- a/docs/v2_directive_detection.md
+++ b/docs/v2_directive_detection.md
@@ -2,7 +2,7 @@
 
 Iteration spec for issue [#374](https://github.com/robotrocketscience/aelfrice/issues/374). Successor memo to [`v2_enforcement.md` § H1](v2_enforcement.md#h1-directive-detection--defer-to-v2x-with-benchmark-gate); does not re-decide the deferral or the gate, only the path to clearing it.
 
-Status: deferred. Harness shipped (PR [#377](https://github.com/robotrocketscience/aelfrice/pull/377)). Candidate detector measured at P=0.664 / R=0.937 against the lab corpus v0.1 (285 rows, ≥200 floor met). Below the P≥0.80 floor, so H1 stays deferred per spec; iteration target is precision, not recall.
+Status: deferred. Harness shipped (PR [#377](https://github.com/robotrocketscience/aelfrice/pull/377)). Path A intent-prefix filter shipped at PR [#374](https://github.com/robotrocketscience/aelfrice/pull/374) — `src/aelfrice/directive_detector.py` is in-tree. Candidate detector measured at P=0.664 / R=0.937 against the lab corpus v0.1 (285 rows, ≥200 floor met). Below the P≥0.80 floor, so H1 stays deferred per spec; iteration target is precision, not recall.
 
 ## What's being decided
 

--- a/docs/v2_sentiment_feedback.md
+++ b/docs/v2_sentiment_feedback.md
@@ -2,7 +2,7 @@
 
 Spec for issue [#193](https://github.com/robotrocketscience/aelfrice/issues/193). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B).
 
-Status: spec, no implementation. **Recommendation: ship at v2.0, opt-in via `.aelfrice.toml`, off by default.**
+Status: module shipped, hook integration pending. `src/aelfrice/sentiment_feedback.py` ports the research-line module (detect_sentiment, distribute, is_enabled). `aelf health` surfaces enabled/disabled state via `_sentiment_from_prose_state`. The transcript-ingest hook does not yet call `detect_sentiment` per turn — that wire-up is the open work. Recommended posture is unchanged: opt-in via `.aelfrice.toml`, off by default.
 
 ## What's being decided
 

--- a/docs/v2_wonder_consolidation.md
+++ b/docs/v2_wonder_consolidation.md
@@ -2,7 +2,7 @@
 
 Spec for issue [#228](https://github.com/robotrocketscience/aelfrice/issues/228). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B). Companion to [`v2_phantom_promotion_trigger.md`](v2_phantom_promotion_trigger.md) (#229) — that issue specifies the rule applied to the phantoms this issue's strategy generates.
 
-Status: research-plan spec, no implementation. The lab pre-registration is the campaign blueprint; this memo is the public-side commitment that lets the campaign close decisions land downstream.
+Status: lifecycle and dispatch shipped at v2.1+. `src/aelfrice/wonder_consolidation.py` is wired; the `aelf:wonder` MCP tool and the `aelf wonder --axes` CLI verb both ship. The generation-strategy bake-off (RW / TC / STS / ensemble) below is still the open question — gated on lab pre-registration close.
 
 ## What's being decided
 


### PR DESCRIPTION
## Summary

19 atomic doc-only commits + 1 gate commit. Refreshes user-facing claims that drifted past v2.1.0 ship state.

**HIGH (correctness / user-misleading):**
- 4 docs (`PHILOSOPHY`, `PRIVACY`, `MCP`, `search_tool_hook`) still cited token-budget default \`2,000\`; \`DEFAULT_TOKEN_BUDGET = 2400\` since v1.3.
- \`README.md:134\` still labeled v1.7 as "latest stable" (v2.1.0 shipped 2026-05-09).
- \`bayesian_ranking.md\`, \`bfs_multihop.md\`, \`entity_index.md\` all said \`Status: spec\` — code shipped them long ago. Updated to cite the live module + flag + version.

**MED:**
- \`SLASH_COMMANDS.md\` said "Eighteen markdown files" (filesystem has 19); added missing \`/aelf:eval\` row.
- 4 \`v2_*\` design docs (\`wonder_consolidation\`, \`dedup\`, \`sentiment_feedback\`, \`directive_detection\`) said "no implementation"; modules ship — refined status per actual wire state (lifecycle shipped vs read-path-shipped vs module-shipped-hook-pending).
- \`v2_close_the_loop.md\` retired stale v2.0.0 anchor → v2.x.
- \`ROADMAP.md\` flipped v1.7 / v2.0 from \`planned\` → \`shipped\`; added v2.1.0 row + v2.2 planned row.
- \`CONFIG.md\`: heat-kernel/HRR-structural shipped default-on at v2.1 (was "stay opt-in pending #154"); reconciled \`[onboard.llm].enabled\` default with code (\`True\` since v1.5.1, not \`False\`).

**LOW:**
- \`LIMITATIONS.md\`: refreshed v1.7 default-flip → v2.1; retired v2.0.0 BFS temporal anchor.
- \`BENCHMARKS.md\`: reframed v1.0–v1.2 posterior claim as past-tense (adapter activation map untouched — needs calibration owner input).

## Test plan
- [x] \`grep -rn 'default 2,000\\|default 2000' docs/ README.md\` → 0 hits
- [x] \`grep -n 'Latest stable' README.md\` → v2.1.0
- [x] \`grep -n 'Status:' docs/{bayesian_ranking,bfs_multihop,entity_index}.md\` → all "shipped"
- [x] \`ls src/aelfrice/slash_commands/*.md | wc -l\` → 19, matches doc count
- [x] Rebased clean onto github/main HEAD
- [x] Discretion grep on commits + diff → 0 hits
- [x] Local pytest passes (uv-synced venv)
- [ ] CI staging-gate green

## Summary by Sourcery

Refresh user-facing documentation to align with the v2.1.0 shipped state, current defaults, and actual module status across retrieval, ranking, onboarding, and evaluation surfaces.

Bug Fixes:
- Correct outdated token-budget defaults in multiple docs to reflect the 2,400-token retrieval budget.
- Update README and roadmap version status to mark v2.0.0 and v2.1.0 as shipped and adjust the "latest" / "next" release pointers.
- Fix stale status labels for bayesian ranking, BFS multi-hop, entity index, and configuration defaults so they match the behavior of the running code.
- Clarify temporal-coherence and benchmark limitations language to match what has and has not shipped by v2.1.0.

Enhancements:
- Document that heat-kernel and HRR-structural retrieval lanes are now default-on as of v2.1.0 and summarize their evolution across versions.
- Clarify the lifecycle and integration state of v2.* features like wonder consolidation, dedup, directive detection, and sentiment-feedback so specs accurately track shipped modules vs deferred hooks.
- Expand slash-command docs to cover the full set of shipped commands including the eval calibration surface and adjust counts accordingly.
- Refine benchmark and roadmap narratives to describe the reproducibility harness, evaluation gates, and planned v2.2 reentry work.

Documentation:
- Update PHILOSOPHY, PRIVACY, MCP, and search-tool-hook docs to describe the current token budget and retrieval behavior.
- Revise CONFIG docs for the onboard LLM classifier and retrieval settings to reflect current defaults, capabilities, and privacy boundaries.