### PR TITLE
docs(readme): add 'What makes aelfrice different' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ That's it. Your next prompt that mentions "push" already has the rule attached. 
 
 ---
 
+## What makes aelfrice different
+
+<p align="center"><img src="docs/assets/02-eterne-hrr.png" width="100%" alt="A layered retrieval pipeline: keyword matches at the surface, structural-marker queries below, locked beliefs threading through both"></p>
+
+- **The agent can't skip the rule.** The `UserPromptSubmit` hook injects matched beliefs into your prompt *before* the model sees it. Not "the agent will check a file" — the file is already in the prompt.
+- **Bit-level determinism.** No embeddings, no learned re-rankers, no LLM in the retrieval path. Same write log, same code → bit-for-bit identical results across runs and machines. ([PHILOSOPHY.md](docs/PHILOSOPHY.md))
+- **Every belief has a confidence and a confidence-in-its-confidence.** A `(α, β)` Beta-Bernoulli posterior gives both: `α / (α+β)` says which way the belief leans, `α + β` says how sure we are of that lean. New beliefs sit at low evidence (high variance, retrievable but discounted); locked beliefs short-circuit decay and pin as ground truth.
+- **Layered retrieval — every lane default-on.** Locked beliefs (always returned), FTS5 keyword (BM25-ranked), BM25F anchor-text (#154, default-on at v1.7.0), HRR structural lane for `KIND:target_id` graph queries (#154, default-on at v1.7.0). Build cost is paid once; every prompt gets every lane.
+- **Local-only.** SQLite at `<git-common-dir>/aelfrice/memory.db` (or `~/.aelfrice/memory.db` outside git). No network calls, no telemetry, no accounts. One brain per project, your machine. ([PRIVACY.md](docs/PRIVACY.md))
+- **Auditable to the row.** Every belief has an `origin` column (`user_stated`, `user_corrected`, `commit_ingest`, …) tying it to the action that wrote it. Open the DB in any SQLite browser; nothing hidden.
+- **Reversible.** `aelf uninstall --archive backup.aenc` encrypts the DB and deletes the live copy. `--purge` wipes it. `--keep-db` leaves data untouched. No vendor lock-in by construction.
+- **No GPU, no network, no inference cost.** Runtime deps are `numpy`, `scipy`, `snowballstemmer` — all CPU, all offline. Retrieval is a sparse-matrix query, not a model call.
+
+---
+
 ## What it does
 
 When you submit a prompt in Claude Code, aelfrice's `UserPromptSubmit` hook fires before the model sees your message. It runs a two-layer search:


### PR DESCRIPTION
## Summary

Adds a differentiator section to the README between the install snippet and "What it does." Eight bullets, each grounded in a fact-checkable anchor on `github/main`. Embeds the existing `docs/assets/02-eterne-hrr.png` (orphan since Apr 28 / `7a6759a`).

## Why now

A reader of the current README has to scroll through "What it does" + "What it remembers" + "Why files don't solve this" before they find out *why aelfrice is different from a CLAUDE.md and a couple of slash commands*. This block answers that on first scroll, with the layered-retrieval graphic above it.

## Fact-check trail

| bullet | anchor |
|---|---|
| `UserPromptSubmit` injection | `src/aelfrice/setup.py:5,76` |
| Bit-level determinism | `docs/PHILOSOPHY.md:28,32` |
| Beta-Bernoulli `(α, β)` axes | `docs/PHILOSOPHY.md:52-62`, `src/aelfrice/store.py:148-149` |
| Lane default-on flips | commits `c31f55a`, `d31c8b7`, `95e563b` (#154) |
| DB path | `src/aelfrice/cli.py:26-27` |
| `origin` audit column | `src/aelfrice/store.py:442-480` |
| `--archive` / `--purge` / `--keep-db` | `src/aelfrice/cli.py:4499,4506,4519` |
| Runtime dep set | `pyproject.toml` `dependencies` |

The "Stdlib-only" claim from earlier marketing was deliberately dropped — `numpy` + `scipy` + `snowballstemmer` are runtime deps since v1.5.0 and v1.7.0. The "no GPU, no network" promise is preserved (and verifiable from the dep list itself).

## Discretion

- Diff additions: clean against banned-vocab grep.
- The image filename `02-eterne-hrr.png` was already committed to `main` on Apr 28 in `7a6759a`. This PR does not introduce a new written leak; alt-text uses public idiom only.

## Follow-up to consider (not in this PR)

The existing "What you get for free" section (`README.md:101-109`) now overlaps with the new section on three of its three bullets (determinism / local-only / removable). Two clean follow-ups:
1. Delete "What you get for free" entirely — its content is now upstream in the new section.
2. Trim it to a one-liner pointing at the section.

I'd lean on (1) but left it untouched to keep this PR a single atomic addition.

## Test plan

- [x] `git diff` shows +15 lines, README.md only
- [x] Discretion grep on additions clean
- [x] All 8 bullets fact-checked against `github/main` HEAD
- [ ] CI passes
- [ ] Visual render check on GitHub once pushed

## Summary by Sourcery

Documentation:
- Add a "What makes aelfrice different" section to the README with a diagram and bullet list explaining its retrieval model, determinism, privacy, auditability, and runtime characteristics.