### PR TITLE
fix(extraction): preserve underscored identifiers in markdown strip

### DIFF
--- a/src/aelfrice/extraction.py
+++ b/src/aelfrice/extraction.py
@@ -40,10 +40,19 @@ def extract_sentences(text: str) -> list[str]:
     cleaned = re.sub(r"^#{1,6}\s+", "", cleaned, flags=re.MULTILINE)
     # Bold: **text** or __text__
     cleaned = re.sub(r"\*{2}([^*]*)\*{2}", r"\1", cleaned)
-    cleaned = re.sub(r"_{2}([^_]*)_{2}", r"\1", cleaned)
+    # Underscore-bold/italic must be at a true word boundary so
+    # snake_case identifiers and file paths like ``auth_service.py``
+    # are not mangled. Negative lookbehind/lookahead require non-
+    # alphanumeric context outside the underscore (``\b`` does not
+    # work because ``_`` is in ``\w``).
+    cleaned = re.sub(
+        r"(?<![A-Za-z0-9])_{2}([^_]*)_{2}(?![A-Za-z0-9])", r"\1", cleaned,
+    )
     # Italic: *text* or _text_ (single, not double)
     cleaned = re.sub(r"\*([^*]+)\*", r"\1", cleaned)
-    cleaned = re.sub(r"_([^_]+)_", r"\1", cleaned)
+    cleaned = re.sub(
+        r"(?<![A-Za-z0-9])_([^_]+)_(?![A-Za-z0-9])", r"\1", cleaned,
+    )
     # Markdown table rows: lines containing | characters
     cleaned = re.sub(r"^\s*\|.*\|\s*$", " ", cleaned, flags=re.MULTILINE)
     # List markers: leading -, *, +, or numbered list items

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -57,3 +57,54 @@ def test_strips_table_rows_and_list_markers() -> None:
     out = extract_sentences(text)
     assert all("|" not in s for s in out)
     assert any("Intro paragraph" in s for s in out)
+
+
+def test_underscore_identifiers_preserved() -> None:
+    """Regression: italic-stripping regex must not mangle snake_case
+    identifiers, file paths, or error codes that contain underscores."""
+    text = "The auth_service.py module imports from user_session.py."
+    out = extract_sentences(text)
+    joined = " ".join(out)
+    assert "auth_service.py" in joined, f"snake_case file_path mangled: {joined!r}"
+    assert "user_session.py" in joined, f"snake_case file_path mangled: {joined!r}"
+
+
+def test_multiple_underscored_tokens_preserved() -> None:
+    """Regression: multiple underscored tokens in one sentence must
+    not be glued together by an unanchored italic regex."""
+    text = "The error E_AUTH_001 is raised by auth_service.py at runtime."
+    out = extract_sentences(text)
+    joined = " ".join(out)
+    assert "E_AUTH_001" in joined, f"error_code mangled: {joined!r}"
+    assert "auth_service.py" in joined, f"file_path mangled: {joined!r}"
+
+
+def test_underscore_italic_still_stripped() -> None:
+    """The fix must keep stripping real Markdown italic at word
+    boundaries (whitespace/punctuation outside the underscores)."""
+    text = "This is _emphasized_ text in a sentence."
+    out = extract_sentences(text)
+    joined = " ".join(out)
+    assert "_emphasized_" not in joined
+    assert "emphasized" in joined
+
+
+def test_underscore_bold_still_stripped() -> None:
+    """The fix must keep stripping real Markdown __bold__ at word
+    boundaries."""
+    text = "This is __very important__ to remember in a sentence."
+    out = extract_sentences(text)
+    joined = " ".join(out)
+    assert "__very important__" not in joined
+    assert "very important" in joined
+
+
+def test_mixed_italic_and_identifier() -> None:
+    """A sentence containing both real italic and identifiers must
+    strip the italic and preserve the identifier."""
+    text = "Use _emphasis_ when documenting auth_service.py behavior in a sentence."
+    out = extract_sentences(text)
+    joined = " ".join(out)
+    assert "_emphasis_" not in joined
+    assert "emphasis" in joined
+    assert "auth_service.py" in joined


### PR DESCRIPTION
Closes #572.

## Summary

`aelfrice.extraction.extract_sentences` strips Markdown `_italic_` and `__bold__` formatting with unanchored regexes. When a sentence contains 2+ underscored tokens (snake_case modules, file paths, error codes), the first underscore of one token pairs with an underscore in the next, eating the outer underscores and concatenating the spans. See #572 for full mechanism + impact analysis.

## Fix

Anchor with negative lookbehind/lookahead requiring non-alphanumeric context outside the underscores. `\b` does not work because `_` is in `\w`; the boundary must specifically exclude alphanumeric on both sides.

```python
cleaned = re.sub(
    r"(?<![A-Za-z0-9])_{2}([^_]*)_{2}(?![A-Za-z0-9])", r"\1", cleaned,
)
cleaned = re.sub(
    r"(?<![A-Za-z0-9])_([^_]+)_(?![A-Za-z0-9])", r"\1", cleaned,
)
```

The asterisk variants (`*italic*`, `**bold**`) are unaffected by the same surface issue (asterisks rarely appear inside identifiers); left untouched.

## Test plan

- [x] 5 new regression cases in `tests/test_extraction.py`:
  - `test_underscore_identifiers_preserved`
  - `test_multiple_underscored_tokens_preserved`
  - `test_underscore_italic_still_stripped`
  - `test_underscore_bold_still_stripped`
  - `test_mixed_italic_and_identifier`
- [x] Existing `test_strips_markdown_headers_and_emphasis` (uses `**` for bold) still passes.
- [x] Full suite: **3140 passed, 53 skipped, 0 failed** (68s).