### PR TITLE
feat(benchmark): add multi-hop section to validate L2.5 entity-index lift (#597)

### DIFF
--- a/src/aelfrice/benchmark.py
+++ b/src/aelfrice/benchmark.py
@@ -320,6 +320,54 @@ class BenchmarkReport:
         return asdict(self)
 
 
+@dataclass(frozen=True)
+class _ArmMetrics:
+    """Hit@1, hit@3, and MRR for one retrieval arm."""
+
+    hit_at_1: float
+    hit_at_3: float
+    mrr: float
+
+    def to_dict(self) -> dict[str, float]:
+        return asdict(self)  # type: ignore[return-value]
+
+
+@dataclass(frozen=True)
+class MultiHopBenchmarkReport:
+    """Three-arm multi-hop benchmark results.
+
+    Each arm corresponds to a different layer combination passed to
+    ``retrieve()``:
+
+    - ``multihop_l1_only`` — Arm A: entity_index_enabled=False, bfs_enabled=False
+    - ``multihop_l1_l25``  — Arm B: entity_index_enabled=True,  bfs_enabled=False
+    - ``multihop_full``    — Arm C: entity_index_enabled=True,  bfs_enabled=True
+
+    The sanity contract: ``multihop_l1_only.hit_at_1 < 0.50`` — confirming
+    that the queries are genuinely multi-hop and not surface-keyword-solvable
+    by BM25 alone.
+    """
+
+    aelfrice_version: str
+    corpus_size: int
+    query_count: int
+    top_k: int
+    multihop_l1_only: _ArmMetrics
+    multihop_l1_l25: _ArmMetrics
+    multihop_full: _ArmMetrics
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "aelfrice_version": self.aelfrice_version,
+            "corpus_size": self.corpus_size,
+            "query_count": self.query_count,
+            "top_k": self.top_k,
+            "multihop_l1_only": self.multihop_l1_only.to_dict(),
+            "multihop_l1_l25": self.multihop_l1_l25.to_dict(),
+            "multihop_full": self.multihop_full.to_dict(),
+        }
+
+
 # --- Harness ----------------------------------------------------------
 
 
@@ -391,6 +439,71 @@ def seed_multihop_corpus(
             )
         )
     return inserted
+
+
+def run_multihop_benchmark(
+    store: MemoryStore,
+    *,
+    aelfrice_version: str,
+    top_k: int = DEFAULT_TOP_K,
+) -> MultiHopBenchmarkReport:
+    """Run the multi-hop queries against ``store`` with three retrieval arms.
+
+    The caller must have seeded the multi-hop corpus (via
+    ``seed_multihop_corpus``) before calling. The three arms exercise:
+
+    - Arm A (L1-only): ``entity_index_enabled=False, bfs_enabled=False``
+    - Arm B (L0+L2.5+L1): ``entity_index_enabled=True, bfs_enabled=False``
+    - Arm C (full four-layer): ``entity_index_enabled=True, bfs_enabled=True``
+
+    Raises ``ValueError`` if ``top_k`` is not positive.
+    """
+    if top_k <= 0:
+        raise ValueError(f"top_k must be positive, got {top_k}")
+
+    def _score_arm(
+        entity_index_enabled: bool,
+        bfs_enabled: bool,
+    ) -> _ArmMetrics:
+        hits_1 = 0
+        hits_3 = 0
+        rr_sum = 0.0
+        for q in _MULTIHOP_QUERIES:
+            results = retrieve(
+                store,
+                q.query,
+                token_budget=DEFAULT_TOKEN_BUDGET,
+                l1_limit=top_k,
+                entity_index_enabled=entity_index_enabled,
+                bfs_enabled=bfs_enabled,
+            )
+            rank = _rank_of(q.correct_id, results)
+            if rank is not None:
+                rr_sum += 1.0 / rank
+                if rank == 1:
+                    hits_1 += 1
+                if rank <= 3:
+                    hits_3 += 1
+        n = len(_MULTIHOP_QUERIES)
+        return _ArmMetrics(
+            hit_at_1=hits_1 / n,
+            hit_at_3=hits_3 / n,
+            mrr=rr_sum / n,
+        )
+
+    arm_a = _score_arm(entity_index_enabled=False, bfs_enabled=False)
+    arm_b = _score_arm(entity_index_enabled=True, bfs_enabled=False)
+    arm_c = _score_arm(entity_index_enabled=True, bfs_enabled=True)
+
+    return MultiHopBenchmarkReport(
+        aelfrice_version=aelfrice_version,
+        corpus_size=len(_MULTIHOP_CORPUS),
+        query_count=len(_MULTIHOP_QUERIES),
+        top_k=top_k,
+        multihop_l1_only=arm_a,
+        multihop_l1_l25=arm_b,
+        multihop_full=arm_c,
+    )
 
 
 def run_benchmark(

--- a/src/aelfrice/benchmark.py
+++ b/src/aelfrice/benchmark.py
@@ -271,9 +271,10 @@ _MULTIHOP_EDGES: Final[tuple[_MultiHopEdgeSpec, ...]] = (
 )
 
 
-# 8 multi-hop queries. Surface terms in each query do NOT appear in the
-# target belief. The path from query to target requires traversing at least
-# one CITES/SUPPORTS edge whose anchor_text contains the bridge identifier.
+# 8 multi-hop queries. The query terms are drawn ONLY from source beliefs
+# or edge anchor_text — they do not appear (surface-form) in the target
+# belief. BM25 cannot match the target directly; retrieval must traverse
+# the CITES/SUPPORTS edge whose anchor_text carries the bridge identifier.
 @dataclass(frozen=True)
 class _MultiHopQuery:
     query: str
@@ -281,19 +282,25 @@ class _MultiHopQuery:
 
 
 _MULTIHOP_QUERIES: Final[tuple[_MultiHopQuery, ...]] = (
-    # Chain 1 — query names auth_service.py, target is mh_auth_04 (E_AUTH_001 behavior)
-    _MultiHopQuery("auth_service.py expired token forced re-login", "mh_auth_04"),
-    _MultiHopQuery("auth_service.py E_AUTH_001 credential cache redirect", "mh_auth_04"),
-    # Chain 1 — query names AuthController, target is mh_auth_04
-    _MultiHopQuery("AuthController session creation E_AUTH_001 behavior", "mh_auth_04"),
-    # Chain 2 — query names ingest_pipeline.py, target is mh_pipe_04 (dead-letter)
-    _MultiHopQuery("ingest_pipeline.py batch processing dead-letter", "mh_pipe_04"),
-    _MultiHopQuery("ingest_pipeline.py E_PIPE_002 alert on-call", "mh_pipe_04"),
-    # Chain 3 — query names config_loader.py, target is mh_cfg_04 (exit behavior)
-    _MultiHopQuery("config_loader.py startup failure exit status", "mh_cfg_04"),
-    _MultiHopQuery("config_loader.py E_CFG_003 missing key operator", "mh_cfg_04"),
-    # Chain 3 — query names SettingsManager, target is mh_cfg_04
-    _MultiHopQuery("SettingsManager E_CFG_003 application exit non-zero", "mh_cfg_04"),
+    # Chain 1: source=mh_auth_01 (auth_service.py), target=mh_auth_04 (sign-in page).
+    # auth_service.py appears in mh_auth_01 and in the A->B edge anchor only; it
+    # does NOT appear in the target mh_auth_04 ("sign-in page" belief).
+    _MultiHopQuery("auth_service.py JWT signature expiry", "mh_auth_04"),
+    _MultiHopQuery("auth_service.py inbound API validation", "mh_auth_04"),
+    # Chain 1: source=mh_auth_02 (AuthController), target=mh_auth_04.
+    # AuthController appears in mh_auth_02/mh_auth_03 but NOT in mh_auth_04.
+    _MultiHopQuery("AuthController cookie token factory", "mh_auth_04"),
+    # Chain 2: source=mh_pipe_01 (ingest_pipeline.py), target=mh_pipe_04 (dead-letter).
+    # ingest_pipeline.py appears in mh_pipe_01 and A->B anchor; NOT in mh_pipe_04.
+    _MultiHopQuery("ingest_pipeline.py message queue transformer", "mh_pipe_04"),
+    _MultiHopQuery("ingest_pipeline.py raw events configurable stages", "mh_pipe_04"),
+    # Chain 3: source=mh_cfg_01 (config_loader.py), target=mh_cfg_04 (startup exit).
+    # config_loader.py appears in mh_cfg_01 and A->B anchor; NOT in mh_cfg_04.
+    _MultiHopQuery("config_loader.py YAML environment overrides", "mh_cfg_04"),
+    _MultiHopQuery("config_loader.py startup directory merges", "mh_cfg_04"),
+    # Chain 3: source=mh_cfg_02 (SettingsManager), target=mh_cfg_04.
+    # SettingsManager appears in mh_cfg_02/mh_cfg_03 but NOT in mh_cfg_04.
+    _MultiHopQuery("SettingsManager typed accessor subsystem cache", "mh_cfg_04"),
 )
 
 

--- a/src/aelfrice/benchmark.py
+++ b/src/aelfrice/benchmark.py
@@ -39,7 +39,15 @@ import time
 from dataclasses import asdict, dataclass
 from typing import Final
 
-from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, ORIGIN_UNKNOWN, Belief
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CITES,
+    EDGE_SUPPORTS,
+    LOCK_NONE,
+    ORIGIN_UNKNOWN,
+    Belief,
+    Edge,
+)
 from aelfrice.retrieval import retrieve
 from aelfrice.store import MemoryStore
 
@@ -128,6 +136,167 @@ _QUERIES: Final[tuple[_QueryEntry, ...]] = (
 )
 
 
+# --- Multi-hop corpus -------------------------------------------------
+#
+# 3 chains of 4 hops each (12 beliefs total). Each chain anchors on a
+# developer-style identifier that appears in the source belief AND in
+# the edge's anchor_text, but NOT in the terminal belief. That gap is
+# exactly the L2.5 entity-index / edge-traversal gap: L1 BM25 cannot
+# bridge it; L2.5 can.
+#
+# Chain layout (A -> B -> C -> D):
+#   A mentions identifier_X in body.
+#   Edge A->B has anchor_text = "identifier_X".
+#   B does NOT contain identifier_X.
+#   Queries reference identifier_X and ask about D.
+#
+# Bridge identifiers per chain:
+#   Chain 1 (auth):   auth_service.py / AuthController / E_AUTH_001
+#   Chain 2 (ingest): ingest_pipeline.py / DataNormalizer / E_PIPE_002
+#   Chain 3 (config): config_loader.py / SettingsManager / E_CFG_003
+
+
+@dataclass(frozen=True)
+class _MultiHopEntry:
+    id: str
+    content: str
+
+
+_MULTIHOP_CORPUS: Final[tuple[_MultiHopEntry, ...]] = (
+    # --- Chain 1: auth ---
+    # A: auth_service.py is the bridge identifier into B
+    _MultiHopEntry(
+        "mh_auth_01",
+        "auth_service.py validates JWT tokens by checking signature and expiry "
+        "on every inbound API request",
+    ),
+    # B: bridge is referenced only in edge anchor_text, not here
+    _MultiHopEntry(
+        "mh_auth_02",
+        "AuthController delegates session creation to the token factory and "
+        "stores the resulting session identifier in a short-lived cookie",
+    ),
+    # C: AuthController is the bridge identifier into D
+    _MultiHopEntry(
+        "mh_auth_03",
+        "AuthController raises E_AUTH_001 when the token factory reports an "
+        "expired refresh token that cannot be silently renewed",
+    ),
+    # D: target — does NOT contain auth_service.py
+    _MultiHopEntry(
+        "mh_auth_04",
+        "E_AUTH_001 triggers a forced re-login flow in the client that clears "
+        "the local credential cache and redirects to the sign-in page",
+    ),
+    # --- Chain 2: ingest ---
+    # A: ingest_pipeline.py is the bridge identifier into B
+    _MultiHopEntry(
+        "mh_pipe_01",
+        "ingest_pipeline.py reads raw events from the message queue and passes "
+        "each batch to a configurable chain of transformer stages",
+    ),
+    # B: bridge is referenced only in edge anchor_text
+    _MultiHopEntry(
+        "mh_pipe_02",
+        "DataNormalizer converts ISO-8601 timestamps to Unix epoch integers "
+        "and strips null fields before the batch reaches the sink stage",
+    ),
+    # C: DataNormalizer is the bridge identifier into D
+    _MultiHopEntry(
+        "mh_pipe_03",
+        "DataNormalizer raises E_PIPE_002 when a batch contains a record whose "
+        "timestamp field is missing entirely rather than null",
+    ),
+    # D: target — does NOT contain ingest_pipeline.py
+    _MultiHopEntry(
+        "mh_pipe_04",
+        "E_PIPE_002 causes the entire batch to be moved to a dead-letter queue "
+        "and an alert is sent to the on-call rotation",
+    ),
+    # --- Chain 3: config ---
+    # A: config_loader.py is the bridge identifier into B
+    _MultiHopEntry(
+        "mh_cfg_01",
+        "config_loader.py reads YAML files from the config directory and merges "
+        "them with environment variable overrides at startup",
+    ),
+    # B: bridge is referenced only in edge anchor_text
+    _MultiHopEntry(
+        "mh_cfg_02",
+        "SettingsManager caches the merged configuration in memory and exposes "
+        "a typed accessor interface to all subsystems that need runtime config",
+    ),
+    # C: SettingsManager is the bridge identifier into D
+    _MultiHopEntry(
+        "mh_cfg_03",
+        "SettingsManager raises E_CFG_003 when a required key is absent from "
+        "both the YAML file and the environment variable overrides",
+    ),
+    # D: target — does NOT contain config_loader.py
+    _MultiHopEntry(
+        "mh_cfg_04",
+        "E_CFG_003 causes the application to exit with a non-zero status code "
+        "and logs the missing key name to help operators diagnose startup failures",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class _MultiHopEdgeSpec:
+    """Lightweight spec for a CITES/SUPPORTS edge in the multi-hop corpus."""
+
+    src: str
+    dst: str
+    edge_type: str
+    anchor: str
+
+
+# Each edge carries the bridge identifier as anchor_text.
+# Chain 1: auth_service.py bridges A->B; AuthController bridges B->C; E_AUTH_001 bridges C->D.
+# Chain 2: ingest_pipeline.py bridges A->B; DataNormalizer bridges B->C; E_PIPE_002 bridges C->D.
+# Chain 3: config_loader.py bridges A->B; SettingsManager bridges B->C; E_CFG_003 bridges C->D.
+_MULTIHOP_EDGES: Final[tuple[_MultiHopEdgeSpec, ...]] = (
+    # Chain 1 auth
+    _MultiHopEdgeSpec("mh_auth_01", "mh_auth_02", EDGE_CITES, "auth_service.py"),
+    _MultiHopEdgeSpec("mh_auth_02", "mh_auth_03", EDGE_SUPPORTS, "AuthController"),
+    _MultiHopEdgeSpec("mh_auth_03", "mh_auth_04", EDGE_CITES, "E_AUTH_001"),
+    # Chain 2 ingest
+    _MultiHopEdgeSpec("mh_pipe_01", "mh_pipe_02", EDGE_CITES, "ingest_pipeline.py"),
+    _MultiHopEdgeSpec("mh_pipe_02", "mh_pipe_03", EDGE_SUPPORTS, "DataNormalizer"),
+    _MultiHopEdgeSpec("mh_pipe_03", "mh_pipe_04", EDGE_CITES, "E_PIPE_002"),
+    # Chain 3 config
+    _MultiHopEdgeSpec("mh_cfg_01", "mh_cfg_02", EDGE_CITES, "config_loader.py"),
+    _MultiHopEdgeSpec("mh_cfg_02", "mh_cfg_03", EDGE_SUPPORTS, "SettingsManager"),
+    _MultiHopEdgeSpec("mh_cfg_03", "mh_cfg_04", EDGE_CITES, "E_CFG_003"),
+)
+
+
+# 8 multi-hop queries. Surface terms in each query do NOT appear in the
+# target belief. The path from query to target requires traversing at least
+# one CITES/SUPPORTS edge whose anchor_text contains the bridge identifier.
+@dataclass(frozen=True)
+class _MultiHopQuery:
+    query: str
+    correct_id: str
+
+
+_MULTIHOP_QUERIES: Final[tuple[_MultiHopQuery, ...]] = (
+    # Chain 1 — query names auth_service.py, target is mh_auth_04 (E_AUTH_001 behavior)
+    _MultiHopQuery("auth_service.py expired token forced re-login", "mh_auth_04"),
+    _MultiHopQuery("auth_service.py E_AUTH_001 credential cache redirect", "mh_auth_04"),
+    # Chain 1 — query names AuthController, target is mh_auth_04
+    _MultiHopQuery("AuthController session creation E_AUTH_001 behavior", "mh_auth_04"),
+    # Chain 2 — query names ingest_pipeline.py, target is mh_pipe_04 (dead-letter)
+    _MultiHopQuery("ingest_pipeline.py batch processing dead-letter", "mh_pipe_04"),
+    _MultiHopQuery("ingest_pipeline.py E_PIPE_002 alert on-call", "mh_pipe_04"),
+    # Chain 3 — query names config_loader.py, target is mh_cfg_04 (exit behavior)
+    _MultiHopQuery("config_loader.py startup failure exit status", "mh_cfg_04"),
+    _MultiHopQuery("config_loader.py E_CFG_003 missing key operator", "mh_cfg_04"),
+    # Chain 3 — query names SettingsManager, target is mh_cfg_04
+    _MultiHopQuery("SettingsManager E_CFG_003 application exit non-zero", "mh_cfg_04"),
+)
+
+
 # --- Scored output ----------------------------------------------------
 
 
@@ -179,6 +348,48 @@ def seed_corpus(store: MemoryStore, *, created_at: str = "2026-04-26T00:00:00Z")
             )
         )
         inserted += 1
+    return inserted
+
+
+def seed_multihop_corpus(
+    store: MemoryStore, *, created_at: str = "2026-04-26T00:00:00Z"
+) -> int:
+    """Insert the multi-hop benchmark corpus and edges into ``store``.
+
+    Inserts the 12 beliefs from ``_MULTIHOP_CORPUS`` followed by all 9 edges
+    from ``_MULTIHOP_EDGES``. Returns the number of beliefs inserted (12).
+    The caller is responsible for creating the store; this function does not
+    seed the original 16-belief corpus.
+    """
+    inserted = 0
+    for entry in _MULTIHOP_CORPUS:
+        store.insert_belief(
+            Belief(
+                id=entry.id,
+                content=entry.content,
+                content_hash=f"bench_{entry.id}",
+                alpha=1.0,
+                beta=1.0,
+                type=BELIEF_FACTUAL,
+                lock_level=LOCK_NONE,
+                locked_at=None,
+                demotion_pressure=0,
+                created_at=created_at,
+                last_retrieved_at=None,
+                origin=ORIGIN_UNKNOWN,
+            )
+        )
+        inserted += 1
+    for spec in _MULTIHOP_EDGES:
+        store.insert_edge(
+            Edge(
+                src=spec.src,
+                dst=spec.dst,
+                type=spec.edge_type,
+                weight=1.0,
+                anchor_text=spec.anchor,
+            )
+        )
     return inserted
 
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -10,8 +10,11 @@ from aelfrice.benchmark import (
     BENCHMARK_NAME,
     BenchmarkReport,
     DEFAULT_TOP_K,
+    MultiHopBenchmarkReport,
     run_benchmark,
+    run_multihop_benchmark,
     seed_corpus,
+    seed_multihop_corpus,
 )
 from aelfrice.benchmark import _percentile, _rank_of  # type: ignore[reportPrivateUsage]
 from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
@@ -213,3 +216,139 @@ def test_percentile_rejects_out_of_range_q() -> None:
         _percentile([1.0, 2.0], -0.1)
     with pytest.raises(ValueError):
         _percentile([1.0, 2.0], 1.1)
+
+
+# --- Multi-hop corpus + three-arm reporter tests ---------------------
+
+
+def _fresh_multihop_store(tmp_path: Path) -> MemoryStore:
+    return MemoryStore(str(tmp_path / "bench_mh.db"))
+
+
+def test_seed_multihop_corpus_inserts_12_beliefs(tmp_path: Path) -> None:
+    s = _fresh_multihop_store(tmp_path)
+    try:
+        n = seed_multihop_corpus(s)
+    finally:
+        s.close()
+    assert n == 12
+    s = _fresh_multihop_store(tmp_path)
+    try:
+        assert s.count_beliefs() == 12
+    finally:
+        s.close()
+
+
+def test_seed_multihop_corpus_inserts_9_edges(tmp_path: Path) -> None:
+    s = _fresh_multihop_store(tmp_path)
+    try:
+        seed_multihop_corpus(s)
+        counts = s.count_edges_by_type()
+    finally:
+        s.close()
+    total = sum(counts.values())
+    assert total == 9, f"expected 9 edges, got {total} ({counts})"
+
+
+def test_run_multihop_benchmark_returns_well_formed_report(tmp_path: Path) -> None:
+    s = _fresh_multihop_store(tmp_path)
+    try:
+        seed_multihop_corpus(s)
+        report = run_multihop_benchmark(s, aelfrice_version="test")
+    finally:
+        s.close()
+    assert isinstance(report, MultiHopBenchmarkReport)
+    assert report.aelfrice_version == "test"
+    assert report.corpus_size == 12
+    assert report.query_count == 8
+    assert report.top_k == DEFAULT_TOP_K
+    # All arm fields present and in [0, 1]
+    for arm_name in ("multihop_l1_only", "multihop_l1_l25", "multihop_full"):
+        arm = getattr(report, arm_name)
+        assert 0.0 <= arm.hit_at_1 <= 1.0, f"{arm_name}.hit_at_1 out of range"
+        assert 0.0 <= arm.hit_at_3 <= 1.0, f"{arm_name}.hit_at_3 out of range"
+        assert 0.0 <= arm.mrr <= 1.0, f"{arm_name}.mrr out of range"
+
+
+def test_multihop_l1_only_hit_at_1_below_sanity_threshold(tmp_path: Path) -> None:
+    """L1-only arm must hit@1 < 0.50 — queries are multi-hop, not
+    surface-keyword-solvable by BM25 alone. Failure means the corpus
+    design is broken (bridge identifier leaked into the target belief)."""
+    s = _fresh_multihop_store(tmp_path)
+    try:
+        seed_multihop_corpus(s)
+        report = run_multihop_benchmark(s, aelfrice_version="test")
+    finally:
+        s.close()
+    assert report.multihop_l1_only.hit_at_1 < 0.50, (
+        f"L1-only hit@1={report.multihop_l1_only.hit_at_1:.3f} >= 0.50 — "
+        "queries appear to be surface-keyword-solvable; corpus design needs review"
+    )
+
+
+def test_run_multihop_benchmark_rejects_nonpositive_top_k(tmp_path: Path) -> None:
+    s = _fresh_multihop_store(tmp_path)
+    try:
+        seed_multihop_corpus(s)
+        with pytest.raises(ValueError):
+            run_multihop_benchmark(s, aelfrice_version="test", top_k=0)
+        with pytest.raises(ValueError):
+            run_multihop_benchmark(s, aelfrice_version="test", top_k=-1)
+    finally:
+        s.close()
+
+
+def test_multihop_report_to_dict_structure(tmp_path: Path) -> None:
+    """to_dict() must include all top-level keys and each arm as a dict."""
+    s = _fresh_multihop_store(tmp_path)
+    try:
+        seed_multihop_corpus(s)
+        report = run_multihop_benchmark(s, aelfrice_version="test")
+    finally:
+        s.close()
+    d = report.to_dict()
+    assert "aelfrice_version" in d
+    assert "corpus_size" in d
+    assert "query_count" in d
+    assert "top_k" in d
+    for arm_key in ("multihop_l1_only", "multihop_l1_l25", "multihop_full"):
+        assert arm_key in d, f"missing key {arm_key}"
+        arm_d = d[arm_key]
+        assert isinstance(arm_d, dict), f"{arm_key} should be a dict"
+        assert set(arm_d.keys()) == {"hit_at_1", "hit_at_3", "mrr"}
+    import json
+    assert json.dumps(d)  # fully JSON-serialisable
+
+
+def test_run_multihop_benchmark_is_deterministic(tmp_path: Path) -> None:
+    """Two runs against fresh stores yield identical accuracy scores."""
+    s1 = MemoryStore(str(tmp_path / "mh_a.db"))
+    s2 = MemoryStore(str(tmp_path / "mh_b.db"))
+    try:
+        seed_multihop_corpus(s1)
+        seed_multihop_corpus(s2)
+        r1 = run_multihop_benchmark(s1, aelfrice_version="test")
+        r2 = run_multihop_benchmark(s2, aelfrice_version="test")
+    finally:
+        s1.close()
+        s2.close()
+    assert r1.multihop_l1_only.hit_at_1 == r2.multihop_l1_only.hit_at_1
+    assert r1.multihop_l1_l25.hit_at_1 == r2.multihop_l1_l25.hit_at_1
+    assert r1.multihop_full.hit_at_1 == r2.multihop_full.hit_at_1
+
+
+def test_existing_run_benchmark_unaffected_by_multihop_additions(
+    tmp_path: Path,
+) -> None:
+    """seed_corpus + run_benchmark still produce the same results after
+    the multi-hop tables were added. Guards against accidental coupling."""
+    s = MemoryStore(str(tmp_path / "compat.db"))
+    try:
+        seed_corpus(s)
+        report = run_benchmark(s, aelfrice_version="compat-test")
+    finally:
+        s.close()
+    assert report.benchmark_name == BENCHMARK_NAME
+    assert report.corpus_size == 16
+    assert report.query_count == 16
+    assert report.hit_at_5 >= 0.75


### PR DESCRIPTION
Closes #597.

## What lands

Adds a multi-hop benchmark section to `src/aelfrice/benchmark.py` that
actually exercises the L2.5 entity-index lift, post-#571's `extract_sentences`
identifier-preservation fix.

The shipped 16-belief / 16-query corpus has surface-form keywords in every
query that hit the target belief — L1 BM25 alone resolves it, so it can't
distinguish L2.5 from L1. This adds a bounded multi-hop section where
queries reference bridge identifiers that appear in source beliefs and
edge `anchor_text` but **not** in the target belief, forcing retrieval to
traverse a CITES/SUPPORTS edge.

## Shape

- **12 multi-hop beliefs** in 3 chains of 4 hops each, using developer-style
  identifiers (`auth_service.py`, `AuthController`, `E_AUTH_001`, etc.).
- **9 CITES/SUPPORTS edges** linking each chain, with bridge identifiers as
  `anchor_text`.
- **8 multi-hop queries** whose surface terms appear only in source beliefs
  / edge anchors, never in the target.
- **`MultiHopBenchmarkReport`** sibling struct (additive — `BenchmarkReport`
  unchanged) carrying `multihop_l1_only`, `multihop_l1_l25`, `multihop_full`,
  each with `hit_at_1` / `hit_at_3` / `mrr`.
- **Three-arm reporter**: each arm runs the same 8 queries with different
  `retrieve()` flag combinations:
    - Arm A: `entity_index_enabled=False, bfs_enabled=False`
    - Arm B: `entity_index_enabled=True,  bfs_enabled=False`
    - Arm C: `entity_index_enabled=True,  bfs_enabled=True`

## Atomic commits

3 SSH-signed commits, dispatched via Sonnet rook subagent then reviewed:

1. `feat(benchmark): seed_multihop_corpus + multi-hop corpus and edges tables (#597)`
2. `feat(benchmark): MultiHopBenchmarkReport + run_multihop_benchmark three-arm reporter (#597)`
3. `test(benchmark): multi-hop arm coverage + L1-only hit@1 < 0.5 sanity (#597)`

## Acceptance

- [x] New keys: `multihop_l1_only`, `multihop_l1_l25`, `multihop_full`, each `{hit_at_1, hit_at_3, mrr}`.
- [x] L1-only multi-hop hit@1 < 0.50 (sanity that queries are genuinely multi-hop and not surface-keyword-solvable). Asserted in test.
- [x] `BenchmarkReport` and `run_benchmark` semantics unchanged (additive surface).

## Verification

- `uv run pytest tests/test_benchmark.py -x -q` → **23 passed** (15 baseline + 8 new).
- All 3 commits SSH-signed.
- Discretion grep clean.
- Diff bounded to `src/aelfrice/benchmark.py` and `tests/test_benchmark.py`.

## Out of scope (explicit)

- Temporal-coherence multi-hop work tracked separately (see ARCHITECTURE.md "BFS temporal-coherence caveat").
- External MAB / LongMemEval re-runs.
- Latency / token budget tuning.

## Summary by Sourcery

Add a dedicated multi-hop retrieval benchmark and reporting to evaluate L2.5 entity-index lift without affecting existing benchmarks.

New Features:
- Introduce a multi-hop benchmark corpus with chained beliefs, edges, and queries that require traversing CITES/SUPPORTS links rather than surface-form matching.
- Add a MultiHopBenchmarkReport structure capturing three retrieval arms (L1-only, L1+L2.5, and full) with hit@1, hit@3, and MRR metrics.
- Provide a run_multihop_benchmark harness that executes the multi-hop queries under different retrieval configurations and returns structured metrics.

Tests:
- Add tests for seeding the multi-hop corpus and edges, validating report shape and JSON-serialisability, sanity-checking low L1-only accuracy, enforcing positive top_k, and ensuring determinism.
- Add a regression test confirming the original benchmark corpus and run_benchmark behaviour remain unchanged after introducing the multi-hop additions.