### PR TITLE
ci(merge-thrash): pr-size-soft-cap advisory workflow (#602)

### DIFF
--- a/.github/workflows/pr-size-soft-cap.yml
+++ b/.github/workflows/pr-size-soft-cap.yml
@@ -1,0 +1,105 @@
+name: pr-size-soft-cap
+
+# #602 — advisory soft cap on PR size to reduce merge-thrash. Comments
+# (and updates a sticky marker comment) when a PR exceeds 200 LOC or
+# 3 changed files. Authors split or apply `size:override` to opt out;
+# no hard block. Quiet when the PR is under both thresholds, including
+# when a previously-flagged PR is shrunk back below the line — the
+# sticky comment is removed in that case so the PR view stays clean.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# One pass per PR. New pushes cancel an in-flight check so we don't
+# race on the comment edit.
+concurrency:
+  group: pr-size-soft-cap-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  size-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    # Skip drafts — they're work-in-progress and the author already knows.
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Check size and post / update / remove sticky comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_ADDITIONS: ${{ github.event.pull_request.additions }}
+          PR_DELETIONS: ${{ github.event.pull_request.deletions }}
+          PR_CHANGED_FILES: ${{ github.event.pull_request.changed_files }}
+          # Comma-separated label names. `size:override` opts out.
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          LOC_LIMIT: '200'
+          FILES_LIMIT: '3'
+          MARKER: '<!-- pr-size-soft-cap-v1 -->'
+        run: |
+          set -euo pipefail
+
+          # Opt-out via label.
+          if printf '%s' ",${PR_LABELS}," | grep -q ',size:override,'; then
+            echo "size:override label present; nothing to do."
+            exit 0
+          fi
+
+          loc=$((PR_ADDITIONS + PR_DELETIONS))
+          files="${PR_CHANGED_FILES}"
+          over=0
+          if [ "$loc" -gt "$LOC_LIMIT" ]; then over=1; fi
+          if [ "$files" -gt "$FILES_LIMIT" ]; then over=1; fi
+
+          # Find any prior sticky comment authored by github-actions[bot].
+          existing_id="$(gh api \
+              "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+              --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"${MARKER}\")))] | .[0].id // empty")"
+
+          if [ "$over" -eq 0 ]; then
+            # Under threshold. Remove a prior sticky if present so a
+            # shrunk PR doesn't carry a stale warning.
+            if [ -n "$existing_id" ]; then
+              echo "PR back under threshold; deleting sticky comment ${existing_id}."
+              gh api -X DELETE "repos/${REPO}/issues/comments/${existing_id}" >/dev/null
+            else
+              echo "Under threshold (loc=${loc}, files=${files}); nothing to do."
+            fi
+            exit 0
+          fi
+
+          # Over threshold — compose the sticky.
+          cat > /tmp/comment.md <<EOF
+          ${MARKER}
+          ### PR-size soft cap
+
+          This PR is over the advisory size threshold:
+
+          - **${loc}** changed lines (limit: ${LOC_LIMIT})
+          - **${files}** changed files (limit: ${FILES_LIMIT})
+
+          Bigger PRs collide with more open work, which under the parallel-session workflow tends to produce repeated \`attn:merge-conflict\` cycles (see #602). When practical, split into smaller PRs that each touch a focused surface.
+
+          This is **advisory only** — nothing is blocked. If the size is intentional (large refactor, module removal, generated code), apply the \`size:override\` label and this comment will be removed on the next push.
+          EOF
+
+          jq -Rs '{body: .}' < /tmp/comment.md > /tmp/payload.json
+
+          if [ -n "$existing_id" ]; then
+            echo "Updating sticky comment ${existing_id}."
+            gh api -X PATCH "repos/${REPO}/issues/comments/${existing_id}" \
+                --input /tmp/payload.json >/dev/null
+          else
+            echo "Posting sticky comment."
+            gh api -X POST "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+                --input /tmp/payload.json >/dev/null
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+### Added
+
+- **PR-size soft-cap advisory workflow** ([#602](https://github.com/robotrocketscience/aelfrice/issues/602)). New `.github/workflows/pr-size-soft-cap.yml` posts (and updates) a sticky `<!-- pr-size-soft-cap-v1 -->` comment on PRs whose `additions + deletions > 200` or `changed_files > 3`, suggesting a split. Quiet on PRs under both thresholds; the comment is removed automatically if a previously-flagged PR is shrunk back below the line. Authors apply `size:override` to opt out (large refactors / module removals / generated code). Concurrency-1 per PR number; cancels in-progress runs on new pushes so comment edits don't race. First half of the merge-thrash mitigation in #602 — addresses the conflict-probability axis (smaller PRs collide with fewer open branches). The serialization axis (label-driven merge-train) ships in a follow-up PR.
+
 ### Performance
 
 - **Update-check cache TTL: 6h → 15min** (`src/aelfrice/lifecycle.py:CACHE_TTL_SECONDS`). The PyPI version-check cache used to expire after six hours, so a freshly-published release could lag the user-visible "update available" banner by up to that long on a busy machine (longer on a quiet one — the check is gated behind the next CLI call or `UserPromptSubmit` hook fire). PyPI's JSON endpoint is CDN-cached and unauthenticated, so a 15-minute cadence is well within the polling-etiquette band and shrinks the worst-case banner-lag window from 6h to ~15min. Detached-subprocess + on-disk-cache architecture is unchanged.


### PR DESCRIPTION
Closes part of #602 (the conflict-probability axis).

## What lands

A new advisory GitHub Actions workflow that comments on oversize PRs without blocking them.

- `.github/workflows/pr-size-soft-cap.yml` — runs on PR `opened` / `synchronize` / `reopened` / `labeled` / `unlabeled`. Skips drafts.
- Computes `loc = additions + deletions` and `files = changed_files` from the PR event payload (no extra API calls for the metrics themselves).
- Over threshold → posts (or updates) a sticky `<!-- pr-size-soft-cap-v1 -->` comment.
- Under threshold → removes any prior sticky comment so a shrunk-back PR doesn't carry a stale warning.
- `size:override` label suppresses the comment entirely (legitimate large refactors, module removals, generated code).
- `concurrency.cancel-in-progress: true` on a per-PR group so rapid pushes don't race the comment edit.

Thresholds: 200 LOC, 3 files. Both editable in the workflow `env:` block; living constants, not vendored.

## Why advisory not enforcing

The atomic-commits norm already pushes toward small units at the commit level. The merge-thrash data in #602 shows the *PR-level* aggregate is what determines blast radius — but a hard size block would prevent things like PR #540 (1,747-line module removal) from existing at all. Soft advisory + opt-out label keeps the door open for those while creating useful pressure on the 200–500-line "would-be-fine-as-two-PRs" cohort.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-size-soft-cap.yml'))"` → loads cleanly.
- Pinned action SHAs match other workflows in the repo (`harden-runner@8d3c67de…` v2.19.0).
- `egress-policy: audit` matches the house style.
- Permissions scoped to `pull-requests: write` + `contents: read`.
- Sticky comment idempotency: the `MARKER` constant in the workflow doubles as the comment-search key. `gh api .../comments` filtered to `github-actions[bot]` author + `body | startswith(MARKER)` finds the existing comment for in-place PATCH or DELETE.

## Out of scope (follow-ups)

- **Label-driven merge-train bot.** The other half of #602 — serializes merges to one-at-a-time so rebases can converge. Separate PR.
- Hard PR-size enforcement (intentionally not included; see "Why advisory not enforcing" above).
- Per-file LOC weighting or generated-file exclusions. Could be added if the bot's signal-to-noise turns out to be poor in practice.

## Discretion

Workflow YAML reviewed for any private terminology — clean. The CHANGELOG entry references #602 by number; nothing about session names or any private context. PR body, ditto.

## Summary by Sourcery

Add an advisory GitHub Actions workflow that comments on oversized pull requests to encourage splitting them without blocking merges.

New Features:
- Introduce a pr-size-soft-cap workflow that posts and updates a sticky advisory comment on PRs exceeding configurable LOC or changed-file thresholds, and removes it when PRs fall back under the limits.

CI:
- Add a pull_request-triggered workflow that computes PR size from event payload, respects a size:override opt-out label, and uses per-PR concurrency to avoid racing comment updates.

Documentation:
- Document the new PR-size soft-cap advisory workflow and its behavior in the Unreleased section of the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added automated pull request size monitoring that posts advisory comments when changes exceed defined thresholds. Comments are automatically managed and can be bypassed using a label override.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/603)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->