### PR TITLE
fix(merge-train): grant issues:write to allow auto-close (closes #637)

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -25,6 +25,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write  # #637: `gh issue close --comment` (#634 auto-close) needs issues:write
 
 # Concurrency-1: this is the whole point. Two labeled events queue
 # rather than race.


### PR DESCRIPTION
Closes #637.

## What lands

One-line addition to `.github/workflows/merge-train.yml` `permissions:` block:

```yaml
permissions:
  contents: write
  pull-requests: write
  issues: write  # #637: `gh issue close --comment` (#634 auto-close) needs issues:write
```

## Why

PR #635 (closes #634) shipped the auto-close step. It runs successfully, parses `Closes #N` correctly, and reaches `gh issue close <N> --reason completed --comment "..."` — but the `--comment` flag performs an `addComment` GraphQL mutation, which requires `issues: write`. With only `contents: write` + `pull-requests: write` declared, the mutation is rejected.

## Evidence

Workflow run `25678261684`, step `Attempt merge-train FF`, log line at `2026-05-11T15:04:11Z`:

```
[6/6] auto-closing linked issues...
GraphQL: Resource not accessible by integration (addComment)
  #600: close failed (non-fatal; merge already landed).
```

Net effect: #600 (PR #601 merged 15:04Z) and #634 (PR #635 merged 14:52Z) both stuck `OPEN` after their PRs landed. Any future linked-issue would hit the same fate until this permission is granted.

## Verification

- [x] `yamllint` / structural — single key added at the existing indent depth, parses cleanly.
- [x] All four commits on this branch signed (`%G?` = `G`).
- [x] Branch FF on `github/main`.
- [ ] Post-merge: the next merge-train run that processes a PR with `Closes #N` should print `  #N: closed.` rather than `close failed`. This PR is itself a candidate — once merged, the auto-close should fire on #637.

## Out of scope

- Retroactively closing #600 and #634. Operator can sweep manually with `gh issue close`, or the next merge-train run that picks up either issue number via a new `Closes #` reference would do it. Keeping this change surgical.

## Reference

- [GitHub docs — `GITHUB_TOKEN` permissions / `issues` scope](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

## Summary by Sourcery

CI:
- Extend merge-train workflow permissions to include issues: write so the auto-close step can add comments and close issues via gh.