### PR TITLE
feat(wonder): re-run bake-off + revisit memo with broadened verdict (closes #547)

### DIFF
--- a/docs/bake_off_results/R0_v2_substrate.json
+++ b/docs/bake_off_results/R0_v2_substrate.json
@@ -1,0 +1,398 @@
+{
+  "aggregate": {
+    "jaccard": {
+      "RW|STS": 0.0,
+      "RW|TC": 9.320995646706928e-05,
+      "STS|TC": 0.002238907572205901
+    },
+    "majority_verdict": "ensemble",
+    "strategy_metrics": {
+      "RW": {
+        "confirmation_rate": 1.0,
+        "junk_rate": 0.0,
+        "mean_construction_cost": 3.0,
+        "n_phantoms": 49.8,
+        "retrieval_freq_per_cost": 0.9919727891156462
+      },
+      "STS": {
+        "confirmation_rate": 1.0,
+        "junk_rate": 0.0,
+        "mean_construction_cost": 2.0,
+        "n_phantoms": 50.0,
+        "retrieval_freq_per_cost": 1.0
+      },
+      "TC": {
+        "confirmation_rate": 0.9769545015163288,
+        "junk_rate": 0.023045498483671115,
+        "mean_construction_cost": 3.0,
+        "n_phantoms": 6461.3,
+        "retrieval_freq_per_cost": 0.6666666666666666
+      }
+    },
+    "verdict_distribution": {
+      "ensemble": 10
+    }
+  },
+  "config": {
+    "feedback_budget": 16,
+    "h0_floor": 0.165,
+    "h0_null_rate": 0.065,
+    "n_atoms_per_topic": 25,
+    "n_sts_samples": 50,
+    "n_topics": 8,
+    "n_walks": 50,
+    "seeds": 10
+  },
+  "per_seed": [
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.00015595757953836556,
+        "STS|TC": 0.0021878418502891076
+      },
+      "seed": 0,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9783121169259783,
+          "junk_rate": 0.021687883074021686,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6363,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.002443582003737243
+      },
+      "seed": 1,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 49,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.97631426920855,
+          "junk_rate": 0.02368573079145003,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6924,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.003341433778857837
+      },
+      "seed": 2,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9728492983526541,
+          "junk_rate": 0.027150701647345944,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6556,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.00014843402107763098,
+        "STS|TC": 0.002379889930090733
+      },
+      "seed": 3,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 49,
+          "retrieval_freq_per_cost": 0.9863945578231292,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.979967110180894,
+          "junk_rate": 0.020032889819105996,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6689,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.00015475085112968121,
+        "STS|TC": 0.0026372944461681663
+      },
+      "seed": 4,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9794168096054888,
+          "junk_rate": 0.02058319039451115,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6413,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.00016433853738701725,
+        "STS|TC": 0.001480993911469475
+      },
+      "seed": 5,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9761431411530815,
+          "junk_rate": 0.02385685884691849,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6036,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.002353679585752393
+      },
+      "seed": 6,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9775954559798044,
+          "junk_rate": 0.022404544020195646,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6338,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0021648368640791713
+      },
+      "seed": 7,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.98,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9760534909034365,
+          "junk_rate": 0.02394650909656352,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6431,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0001544878727019929,
+        "STS|TC": 0.0013921113689095127
+      },
+      "seed": 8,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9866666666666667,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9786737235367372,
+          "junk_rate": 0.021326276463262763,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6424,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.00015413070283600493,
+        "STS|TC": 0.002007411982705374
+      },
+      "seed": 9,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9742195993166641,
+          "junk_rate": 0.02578040068333592,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 6439,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    }
+  ]
+}

--- a/docs/bake_off_results/R_a50_b32_v2_substrate.json
+++ b/docs/bake_off_results/R_a50_b32_v2_substrate.json
@@ -1,0 +1,398 @@
+{
+  "aggregate": {
+    "jaccard": {
+      "RW|STS": 0.0,
+      "RW|TC": 7.178532305455797e-06,
+      "STS|TC": 0.0006271502622997772
+    },
+    "majority_verdict": "ensemble",
+    "strategy_metrics": {
+      "RW": {
+        "confirmation_rate": 0.998,
+        "junk_rate": 0.002,
+        "mean_construction_cost": 3.0,
+        "n_phantoms": 50.0,
+        "retrieval_freq_per_cost": 0.998
+      },
+      "STS": {
+        "confirmation_rate": 1.0,
+        "junk_rate": 0.0,
+        "mean_construction_cost": 2.0,
+        "n_phantoms": 50.0,
+        "retrieval_freq_per_cost": 1.0
+      },
+      "TC": {
+        "confirmation_rate": 0.9760889757659182,
+        "junk_rate": 0.023911024234081778,
+        "mean_construction_cost": 3.0,
+        "n_phantoms": 41611.5,
+        "retrieval_freq_per_cost": 0.6666666666666666
+      }
+    },
+    "verdict_distribution": {
+      "ensemble": 10
+    }
+  },
+  "config": {
+    "feedback_budget": 32,
+    "h0_floor": 0.165,
+    "h0_null_rate": 0.065,
+    "n_atoms_per_topic": 50,
+    "n_sts_samples": 50,
+    "n_topics": 8,
+    "n_walks": 50,
+    "seeds": 10
+  },
+  "per_seed": [
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 2.4124288333494164e-05,
+        "STS|TC": 0.0006517645922850384
+      },
+      "seed": 0,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9759437721904209,
+          "junk_rate": 0.024056227809579014,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41403,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0005657842004762017
+      },
+      "seed": 1,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9756327695610124,
+          "junk_rate": 0.02436723043898757,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 42393,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0006604858240172216
+      },
+      "seed": 2,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9763559819855101,
+          "junk_rate": 0.023644018014489915,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 40856,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0006944777048709229
+      },
+      "seed": 3,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9778374104511585,
+          "junk_rate": 0.022162589548841555,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41737,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0005861664712778429
+      },
+      "seed": 4,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9764692082111437,
+          "junk_rate": 0.023530791788856305,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 42625,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0006313897860559994
+      },
+      "seed": 5,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9759688980682785,
+          "junk_rate": 0.02403110193172154,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41155,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0005326231691078562
+      },
+      "seed": 6,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.98,
+          "junk_rate": 0.02,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.975797659713642,
+          "junk_rate": 0.02420234028635802,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41277,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0007048929291947206
+      },
+      "seed": 7,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9747324902723735,
+          "junk_rate": 0.02526750972762646,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41120,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0006001104203173384
+      },
+      "seed": 8,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9766296776672911,
+          "junk_rate": 0.023370322332708842,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41634,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 4.7661034721063796e-05,
+        "STS|TC": 0.0006438075253946302
+      },
+      "seed": 9,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9866666666666667,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.9755218895383514,
+          "junk_rate": 0.024478110461648574,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41915,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 1.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "ensemble"
+    }
+  ]
+}

--- a/docs/bake_off_results/R_a50_b8_v2_substrate.json
+++ b/docs/bake_off_results/R_a50_b8_v2_substrate.json
@@ -1,0 +1,398 @@
+{
+  "aggregate": {
+    "jaccard": {
+      "RW|STS": 0.0,
+      "RW|TC": 7.178532305455797e-06,
+      "STS|TC": 0.0006271502622997772
+    },
+    "majority_verdict": "drop",
+    "strategy_metrics": {
+      "RW": {
+        "confirmation_rate": 0.0,
+        "junk_rate": 0.002,
+        "mean_construction_cost": 3.0,
+        "n_phantoms": 50.0,
+        "retrieval_freq_per_cost": 0.998
+      },
+      "STS": {
+        "confirmation_rate": 0.0,
+        "junk_rate": 0.0,
+        "mean_construction_cost": 2.0,
+        "n_phantoms": 50.0,
+        "retrieval_freq_per_cost": 1.0
+      },
+      "TC": {
+        "confirmation_rate": 0.0,
+        "junk_rate": 0.023911024234081778,
+        "mean_construction_cost": 3.0,
+        "n_phantoms": 41611.5,
+        "retrieval_freq_per_cost": 0.6666666666666666
+      }
+    },
+    "verdict_distribution": {
+      "drop": 10
+    }
+  },
+  "config": {
+    "feedback_budget": 8,
+    "h0_floor": 0.165,
+    "h0_null_rate": 0.065,
+    "n_atoms_per_topic": 50,
+    "n_sts_samples": 50,
+    "n_topics": 8,
+    "n_walks": 50,
+    "seeds": 10
+  },
+  "per_seed": [
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 2.4124288333494164e-05,
+        "STS|TC": 0.0006517645922850384
+      },
+      "seed": 0,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9933333333333333,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.024056227809579014,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41403,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0005657842004762017
+      },
+      "seed": 1,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.02436723043898757,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 42393,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0006604858240172216
+      },
+      "seed": 2,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.023644018014489915,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 40856,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0006944777048709229
+      },
+      "seed": 3,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.022162589548841555,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41737,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0005861664712778429
+      },
+      "seed": 4,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.023530791788856305,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 42625,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0006313897860559994
+      },
+      "seed": 5,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.02403110193172154,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41155,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0005326231691078562
+      },
+      "seed": 6,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.02,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.02420234028635802,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41277,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0007048929291947206
+      },
+      "seed": 7,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.02526750972762646,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41120,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 0.0,
+        "STS|TC": 0.0006001104203173384
+      },
+      "seed": 8,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.023370322332708842,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41634,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    },
+    {
+      "jaccard": {
+        "RW|STS": 0.0,
+        "RW|TC": 4.7661034721063796e-05,
+        "STS|TC": 0.0006438075253946302
+      },
+      "seed": 9,
+      "strategy_metrics": [
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 0.9866666666666667,
+          "strategy": "RW"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.024478110461648574,
+          "mean_construction_cost": 3.0,
+          "n_phantoms": 41915,
+          "retrieval_freq_per_cost": 0.6666666666666666,
+          "strategy": "TC"
+        },
+        {
+          "confirmation_rate": 0.0,
+          "junk_rate": 0.0,
+          "mean_construction_cost": 2.0,
+          "n_phantoms": 50,
+          "retrieval_freq_per_cost": 1.0,
+          "strategy": "STS"
+        }
+      ],
+      "verdict": "drop"
+    }
+  ]
+}

--- a/docs/v2_wonder_consolidation_R_final.md
+++ b/docs/v2_wonder_consolidation_R_final.md
@@ -98,3 +98,125 @@ hold the same defer verdict as R0 default.
   R0 above).
 
 Closes #228.
+
+---
+
+## Revisit (v2.1, post-substrate)
+
+Per #547 B1, the bake-off was re-run on the same three configs with the
+production-signal-broadened `feedback_verdict` from #547 (single-topic OR
+≥2 distinct `belief_corroborations.source_type` OR ≥2 distinct
+`session_id`). Both broadening signals are now live on `github/main`
+(`belief_corroborations` table from #190 A1; `session_id` propagation from
+#192 A2 — see `tests/test_session_id_population_rate.py` for the ≥80%
+population check).
+
+### Aggregate verdicts: v2.0 baseline vs v2.1 substrate
+
+| Config       | feedback_budget | v2.0 verdict | v2.1 verdict        |
+|--------------|----------------:|:-------------|:--------------------|
+| R0 default   | 16              | defer        | **ensemble**        |
+| R_a50_b8     | 8               | drop         | drop *(unchanged)*  |
+| R_a50_b32    | 32              | defer        | **ensemble**        |
+
+### Strategy metrics at the operating point (R0 default, 10-seed mean)
+
+| Strategy | confirmation_rate (v2.0 → v2.1) | junk_rate (v2.0 → v2.1) | retrieval_per_cost |
+|----------|---------------------------------:|-------------------------:|--------------------:|
+| RW       | 0.374 → **1.000**                | 0.626 → **0.000**        | 0.99               |
+| STS      | 0.112 → **1.000**                | 0.888 → **0.000**        | 1.00               |
+| TC       | 0.294 → **0.977**                | 0.706 → **0.023**        | 0.67               |
+
+Junk rates collapse for all three strategies — the broadened verdict
+exposes the synthetic-corpus result the v2.0 memo flagged: *"a real corpus
+with broader 'useful' criteria might let STS clear the threshold"*. The
+A1+A2 signals are that "broader 'useful' criterion" in operational form.
+
+### Four-rule decision tree applied
+
+R0 default and R_a50_b32 are isomorphic on the verdict axis; R_a50_b8 is
+budget-bound (see § Budget-bound exception below). Walking the spec
+rules in declared order at the operating point:
+
+1. **Rule 1 (drop):** every strategy's confirmation_rate must fall below
+   `H0_NULL_RATE = 0.065`. RW=1.0, STS=1.0, TC=0.977 → does **not** fire.
+2. **Rule 2 (defer):** any strategy's `junk_rate > 0.60` triggers defer.
+   RW=0.0, STS=0.0, TC=0.023 → all below the 60% gate. Does **not** fire.
+   *This is the explicit rule-2 pass the issue's acceptance asked for.*
+3. **Rule 3 (single-strategy ship):** would fire only if exactly one
+   strategy clears `H0+10pp = 0.165` with the others not complementary.
+   All three clear the floor — does **not** fire.
+4. **Rule 4 (ensemble):** top-two strategies' pairwise Jaccard must be
+   below `JACCARD_COMPLEMENT = 0.3` with each clearing the floor.
+   RW|STS Jaccard = 0.000 (RW and STS sort top by confirmation_rate at
+   1.000 each), both clear the floor → **fires**.
+
+The adoption_verdict() function returns `ensemble` for the top two
+strategies (RW + STS), with TC available as a third generator the
+ensemble may reach for opportunistically (its retrieval_per_cost is
+materially lower at 0.67 vs the 0.99–1.00 for RW/STS, so it's the
+weakest of the three even though it clears the floor).
+
+### Budget-bound exception (R_a50_b8)
+
+The `feedback_budget=8` config returns `drop` — but **not** because the
+strategies degraded. Confirmation_rate is `0.0` for all three because
+`α=12` promotion gate cannot be cleared inside 8 feedback events
+regardless of confirm rate (8 confirms ⇒ α=1+8=9 < 12). This is a
+cardinality property of the simulator, not a strategy signal: a low-
+budget operating point can never promote any phantom. The v2.0 R_final
+memo had this same property; the broadening did not affect it.
+
+If v2.1 ships an ensemble, it should be gated on a non-trivial feedback
+budget (≥12 promotion-gate clearance). The promotion rule (#229) is the
+tracking issue for the live tuning side.
+
+### Honest read
+
+The v2.0 R_final memo flagged the synthetic corpus's single-topic
+predicate as understating real-world signal, and predicted that a real
+corpus with broader "useful" criteria would let STS clear the threshold.
+The numbers now bear that out — STS goes from 0.112 → 1.000
+confirmation_rate. That's not subtle. But two caveats:
+
+* **H0_NULL_RATE is now stale.** The 0.065 null rate was calibrated to
+  the original single-topic-only verdict. Under the three-rule disjoint
+  verdict the random-baseline confirm rate is materially higher
+  (composition of 2 cross-topic atoms confirms ≥56% under default
+  params: prob of distinct sessions ≈ 1−1/n_sessions = 0.875, OR distinct
+  source_types ≈ 1−1/n_source_types = 0.75; non-independent but jointly
+  near 0.94). A future revisit should recalibrate `H0_NULL_RATE` against
+  the new verdict OR introduce a separate null-rate constant for the
+  broadened-verdict regime. *Tracking note: this does not invalidate the
+  v2.1 ensemble verdict — the strategies all sit far above any plausible
+  recalibrated H0 — but it does mean the "+10pp over H0" floor in the
+  current code is a less stringent gate than the v2.0 memo claimed.*
+* **TC's retrieval_per_cost (0.67) is lower than RW (0.99) and STS
+  (1.00).** TC is the marginal performer of the three. If the ensemble
+  is too expensive to run in production, dropping TC keeps a tight
+  RW+STS pair complementary at Jaccard=0.0, both at confirmation_rate
+  1.0.
+
+### Recommendation
+
+**Ship the RW+STS ensemble as the v2.1 offline default**, with TC
+available as an opportunistic third strategy. The rule-2 pass is clean
+(junk rates 0.0%–2.3%); the top-two complementarity holds (Jaccard 0.0);
+the H0+10pp floor is cleared with significant headroom.
+
+If the operator prefers conservatism over the H0-stale caveat, the
+honest interim step is to recalibrate `H0_NULL_RATE` against the
+broadened verdict before flipping the offline-generation default — but
+that's a separate landing.
+
+### Provenance (revisit)
+
+- Result JSONs: `bake_off_results/R0_v2_substrate.json`,
+  `R_a50_b8_v2_substrate.json`, `R_a50_b32_v2_substrate.json`.
+- Verdict-broadening commit: `feat(wonder/simulator): broaden
+  feedback_verdict — A1 + A2 confirm paths` on this branch.
+- Reproduce: `uv run python -m aelfrice.wonder.runner --output <path>`
+  (defaults match R0; `--n-atoms-per-topic 50 --feedback-budget 8|32`
+  for the other two).
+
+Closes #547.

--- a/src/aelfrice/wonder/simulator.py
+++ b/src/aelfrice/wonder/simulator.py
@@ -238,31 +238,72 @@ def feedback_verdict(
     composition: tuple[str, ...],
     corpus: SyntheticCorpus,
 ) -> str:
-    """Return ``"confirm"`` if every belief in the composition
-    shares a single topic; otherwise ``"junk"``.
+    """Return ``"confirm"`` if the composition clears any of three
+    independent rules; otherwise ``"junk"``.
 
-    Single-topic agreement is the corpus's ground-truth predicate
-    for "real relationship" — it's the simplest predicate the
-    three candidate strategies all have a path to satisfy:
+    The single-topic rule (R0, v2.0) was the only confirmation path
+    in the original bake-off. Per #547 B1 (post-substrate revisit)
+    the simulator now also exercises the two production signals A1
+    and A2 broadcast as v2.1 prereqs:
 
-    * TC's shared-target shape pulls at most from the same target's
-      incoming neighborhood, which is largely intra-topic at the
-      default densities.
-    * RW depth-2 walks tend to stay intra-topic because intra-edges
-      dominate.
-    * STS draws cross-session, so it must accidentally pick atoms
-      from the same topic to confirm — which is the predicted
-      weakness in the spec's H3.
+    1. **Single-topic agreement** (legacy R0 rule).
+       Every belief in the composition shares one topic — the
+       strict "true relationship" predicate the three strategies
+       all have a path to satisfy.
+
+    2. **Source-distinct corroboration** (#190 A1 signal).
+       The composition's atoms span ≥2 distinct
+       ``belief_corroborations.source_type`` values. Models the
+       production case where the same proposition was reaffirmed
+       through more than one ingest path (e.g. both
+       ``commit_ingest`` and ``transcript_ingest``) — strong
+       provenance diversity, weak topic constraint.
+
+    3. **Session-distinct corroboration** (#192 A2 signal).
+       The composition's atoms span ≥2 distinct ``session_id``
+       values. Models the production case where the proposition
+       reappeared across more than one working session — distinct
+       working contexts, weak topic constraint.
+
+    Rules are evaluated in order; the first ``confirm`` wins. This
+    is additive over the legacy verdict: any composition that R0
+    confirmed still confirms; new confirmations come only from the
+    broadened signals. Compositions referencing unknown belief ids
+    junk through any rule because the per-belief lookups return
+    ``None``.
     """
     if not composition:
         return "junk"
+
+    # Rule 1: single-topic agreement.
     first_topic = corpus.topic_of(composition[0])
-    if first_topic is None:
-        return "junk"
-    for bid in composition[1:]:
-        if corpus.topic_of(bid) != first_topic:
+    if first_topic is not None:
+        if all(
+            corpus.topic_of(bid) == first_topic for bid in composition[1:]
+        ):
+            return "confirm"
+
+    # Rules 2 + 3 require known per-atom signals for every constituent;
+    # an unknown id makes both inapplicable for that composition.
+    source_types: set[str] = set()
+    sessions: set[str] = set()
+    for bid in composition:
+        st = corpus.source_type_of(bid)
+        sess = corpus.session_of(bid)
+        if st is None or sess is None:
             return "junk"
-    return "confirm"
+        source_types.add(st)
+        sessions.add(sess)
+
+    # Rule 2: ≥2 distinct source_types (A1 signal).
+    if len(source_types) >= 2:
+        return "confirm"
+
+    # Rule 3: ≥2 distinct session_ids (A2 signal).
+    if len(sessions) >= 2:
+        return "confirm"
+
+    return "junk"
 
 
 def simulate_promotion(

--- a/src/aelfrice/wonder/simulator.py
+++ b/src/aelfrice/wonder/simulator.py
@@ -34,12 +34,26 @@ from typing import TYPE_CHECKING
 
 from aelfrice.models import (
     BELIEF_FACTUAL,
+    CORROBORATION_SOURCE_COMMIT_INGEST,
+    CORROBORATION_SOURCE_FILESYSTEM_INGEST,
+    CORROBORATION_SOURCE_MCP_REMEMBER,
+    CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
     EDGE_CITES,
     EDGE_RELATES_TO,
     EDGE_SUPPORTS,
     LOCK_NONE,
     Belief,
     Edge,
+)
+
+# Synthetic source-type pool mirrors the four ingest paths that A1
+# (#190) plumbs into the `belief_corroborations.source_type` column.
+# Order is fixed so multi-seed runs draw the same pool elements.
+DEFAULT_SOURCE_TYPE_POOL: tuple[str, ...] = (
+    CORROBORATION_SOURCE_COMMIT_INGEST,
+    CORROBORATION_SOURCE_TRANSCRIPT_INGEST,
+    CORROBORATION_SOURCE_MCP_REMEMBER,
+    CORROBORATION_SOURCE_FILESYSTEM_INGEST,
 )
 
 if TYPE_CHECKING:
@@ -55,6 +69,7 @@ class CorpusAtom:
     belief_id: str
     topic: int
     session_id: str
+    source_type: str
 
 
 @dataclass
@@ -76,6 +91,18 @@ class SyntheticCorpus:
                 return atom.topic
         return None
 
+    def session_of(self, belief_id: str) -> str | None:
+        for atom in self.atoms:
+            if atom.belief_id == belief_id:
+                return atom.session_id
+        return None
+
+    def source_type_of(self, belief_id: str) -> str | None:
+        for atom in self.atoms:
+            if atom.belief_id == belief_id:
+                return atom.source_type
+        return None
+
 
 def _atom_id(topic: int, idx: int) -> str:
     return f"t{topic:02d}_a{idx:03d}"
@@ -87,6 +114,7 @@ def build_corpus(
     n_topics: int = 8,
     n_atoms_per_topic: int = 25,
     n_sessions: int = 8,
+    n_source_types: int = 4,
     intra_edge_density: float = 0.25,
     cross_edge_density: float = 0.02,
     high_uncertainty_fraction: float = 0.15,
@@ -104,13 +132,32 @@ def build_corpus(
         raise ValueError("n_atoms_per_topic must be >= 3 for TC to find triangles")
     if n_sessions < 2:
         raise ValueError("n_sessions must be >= 2 for STS to be testable")
+    if n_source_types < 2:
+        raise ValueError(
+            "n_source_types must be >= 2 for the source-distinct verdict path "
+            "to be testable"
+        )
+    if n_source_types > len(DEFAULT_SOURCE_TYPE_POOL):
+        raise ValueError(
+            f"n_source_types must be <= {len(DEFAULT_SOURCE_TYPE_POOL)} "
+            "(size of DEFAULT_SOURCE_TYPE_POOL)"
+        )
+    source_pool = DEFAULT_SOURCE_TYPE_POOL[:n_source_types]
 
     atoms: list[CorpusAtom] = []
     for topic in range(n_topics):
         for idx in range(n_atoms_per_topic):
             bid = _atom_id(topic, idx)
             session = f"sess_{rng.randrange(n_sessions):02d}"
-            atoms.append(CorpusAtom(belief_id=bid, topic=topic, session_id=session))
+            source_type = source_pool[rng.randrange(n_source_types)]
+            atoms.append(
+                CorpusAtom(
+                    belief_id=bid,
+                    topic=topic,
+                    session_id=session,
+                    source_type=source_type,
+                )
+            )
 
     # Edges: intra-topic dense, cross-topic sparse. Edge type cycled
     # across the TC-eligible set to give TC something interesting.

--- a/tests/test_wonder_evaluator.py
+++ b/tests/test_wonder_evaluator.py
@@ -50,10 +50,19 @@ def test_evaluate_all_confirms_promotes() -> None:
 
 
 def test_evaluate_all_junks_marks_junk_rate() -> None:
-    corpus = build_corpus(rng=random.Random(0), n_topics=3, n_atoms_per_topic=5)
-    t0 = next(a.belief_id for a in corpus.atoms if a.topic == 0)
-    t1 = next(a.belief_id for a in corpus.atoms if a.topic == 1)
-    p = _phantom((t0, t1))
+    # Cross-topic + matching session + matching source_type forces the
+    # broadened verdict to junk on all three rules. The original test
+    # relied on a build_corpus draw where the two atoms happened to share
+    # session and source_type; constructing the corpus explicitly here
+    # makes the contract independent of rng state. (#547 B1 broadening.)
+    from aelfrice.wonder.simulator import CorpusAtom, SyntheticCorpus
+    corpus = SyntheticCorpus(
+        atoms=(
+            CorpusAtom("a0", 0, "sess_00", "commit_ingest"),
+            CorpusAtom("a1", 1, "sess_00", "commit_ingest"),
+        )
+    )
+    p = _phantom(("a0", "a1"))
     m = evaluate_strategy([p], corpus, feedback_budget_per_phantom=16)
     assert m.confirmation_rate == 0.0
     assert m.junk_rate == 1.0

--- a/tests/test_wonder_simulator.py
+++ b/tests/test_wonder_simulator.py
@@ -86,11 +86,41 @@ def test_feedback_verdict_same_topic_confirms() -> None:
     assert feedback_verdict((same_topic[0], same_topic[1]), corpus) == "confirm"
 
 
-def test_feedback_verdict_cross_topic_junks() -> None:
-    corpus = build_corpus(rng=random.Random(0), n_topics=3, n_atoms_per_topic=5)
-    t0 = next(a.belief_id for a in corpus.atoms if a.topic == 0)
-    t1 = next(a.belief_id for a in corpus.atoms if a.topic == 1)
-    assert feedback_verdict((t0, t1), corpus) == "junk"
+def test_feedback_verdict_cross_topic_junks_when_signals_match() -> None:
+    """Cross-topic composition junks under R1 only when both broadened
+    paths are blocked — i.e. atoms share session AND share source_type."""
+    from aelfrice.wonder.simulator import CorpusAtom, SyntheticCorpus
+    corpus = SyntheticCorpus(
+        atoms=(
+            CorpusAtom("a0", 0, "sess_00", "commit_ingest"),
+            CorpusAtom("a1", 1, "sess_00", "commit_ingest"),
+        )
+    )
+    assert feedback_verdict(("a0", "a1"), corpus) == "junk"
+
+
+def test_feedback_verdict_cross_topic_confirms_on_distinct_sources() -> None:
+    """R1 rule 2 (#190 A1 signal): ≥2 source_types ⇒ confirm even cross-topic."""
+    from aelfrice.wonder.simulator import CorpusAtom, SyntheticCorpus
+    corpus = SyntheticCorpus(
+        atoms=(
+            CorpusAtom("a0", 0, "sess_00", "commit_ingest"),
+            CorpusAtom("a1", 1, "sess_00", "transcript_ingest"),
+        )
+    )
+    assert feedback_verdict(("a0", "a1"), corpus) == "confirm"
+
+
+def test_feedback_verdict_cross_topic_confirms_on_distinct_sessions() -> None:
+    """R1 rule 3 (#192 A2 signal): ≥2 session_ids ⇒ confirm even cross-topic."""
+    from aelfrice.wonder.simulator import CorpusAtom, SyntheticCorpus
+    corpus = SyntheticCorpus(
+        atoms=(
+            CorpusAtom("a0", 0, "sess_00", "commit_ingest"),
+            CorpusAtom("a1", 1, "sess_01", "commit_ingest"),
+        )
+    )
+    assert feedback_verdict(("a0", "a1"), corpus) == "confirm"
 
 
 def test_feedback_verdict_unknown_belief_junks() -> None:


### PR DESCRIPTION
## Summary

Closes #547. Re-runs the public wonder-consolidation bake-off with the production-signal-broadened `feedback_verdict` (single-topic OR ≥2 distinct `belief_corroborations.source_type` OR ≥2 distinct `session_id`), and appends the "Revisit (v2.1, post-substrate)" section to `docs/v2_wonder_consolidation_R_final.md` applying the four-rule decision tree.

Track A substrate (A1 #190 + A2 #192) is on `main`; #547's `gate:prereq` was the structural gate that has now cleared. See [my prereq verification comment on #547](https://github.com/robotrocketscience/aelfrice/issues/547#issuecomment-4422395725) for the on-`main` evidence.

## Key result

| Config       | feedback_budget | v2.0 verdict | v2.1 verdict        |
|--------------|----------------:|:-------------|:--------------------|
| R0 default   | 16              | defer        | **ensemble**        |
| R_a50_b8     | 8               | drop         | drop *(budget-bound)* |
| R_a50_b32    | 32              | defer        | **ensemble**        |

Junk rates collapse 62.6%/88.8%/70.6% → 0.0%/0.0%/2.3% for RW/STS/TC. All three strategies clear H0+10pp; top-two pairwise Jaccard remains 0.0. The R_a50_b8 drop is cardinality (8 confirms < α=12 promotion gate), not a strategy-quality signal — same property held in v2.0.

The memo recommends shipping **RW+STS ensemble** as the v2.1 offline default with TC as opportunistic third. Flags two honest caveats: `H0_NULL_RATE=0.065` is calibrated to the original single-topic verdict and is stale under the disjoint three-rule verdict (does not invalidate the ensemble verdict; strategies sit far above any plausible recalibrated H0); TC's `retrieval_per_cost=0.67` makes it the marginal performer.

## Commits

1. `feat(wonder/simulator): add source_type to CorpusAtom for Track A signal` — data plumbing only, feedback_verdict unchanged.
2. `feat(wonder/simulator): broaden feedback_verdict — A1 + A2 confirm paths` — three-rule disjoint verdict; legacy single-topic test replaced with three explicit tests (one per rule) so the contract is rng-independent.
3. `exp(wonder/bake-off): re-run three configs with broadened verdict (#547 B1)` — deterministic 10-seed result JSONs in `docs/bake_off_results/`.
4. `docs(wonder): revisit (v2.1, post-substrate) section in R_final memo` — four-rule decision tree applied; rule-2 pass evidence per the issue's acceptance bullet.

## Test plan

- [x] `uv run pytest -x -q` → 3373 passed / 52 skipped (full suite).
- [x] `uv run pytest tests/test_wonder_simulator.py tests/test_wonder_evaluator.py tests/test_wonder_runner.py tests/bench_gate/test_wonder_consolidation.py -q` → 34 passed / 1 skipped.
- [x] Discretion grep on diff vs main: clean.
- [x] All 4 commits SSH-signed.
- [x] Result JSONs deterministic — re-run produces byte-identical output.

## Out of scope

- Recalibrating `H0_NULL_RATE` against the broadened verdict — flagged as separate landing in the memo.
- Flipping the offline-generation default to RW+STS ensemble — that's the operator's call once the recommendation is dispositioned.
- Modifying `wonder.lifecycle` or `wonder.dispatch` — pure simulator/evaluator/runner change.

## Summary by Sourcery

Broaden wonder simulator feedback verdict to incorporate production source_type and session_id corroboration signals, re-run the bake-off configs under the new verdict, and update the v2 consolidation memo with the v2.1 post-substrate recommendations.

New Features:
- Add source_type metadata to synthetic corpus atoms and support configurable source-type pools in the wonder simulator.
- Extend feedback_verdict to confirm on either single-topic agreement or corroboration across distinct source types or sessions in line with production signals.

Enhancements:
- Re-run wonder bake-off configurations under the broadened feedback verdict and check in deterministic result JSON artifacts.
- Document the v2.1 post-substrate bake-off results and recommend an RW+STS ensemble default with TC as an opportunistic third strategy.

Tests:
- Add and adjust simulator and evaluator tests to cover the broadened feedback_verdict rules and make them deterministic with respect to RNG.