### PR TITLE
fix(merge-train): re-fire on rebased PRs (closes #646)

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -20,7 +20,11 @@ name: merge-train
 
 on:
   pull_request:
-    types: [labeled]
+    # `labeled` catches the operator's initial ready-to-merge add.
+    # `synchronize` catches subsequent pushes (rebases) while the label
+    # is already attached — without it, a rebased PR's new head SHA is
+    # never re-evaluated until the label is manually cycled. See #646.
+    types: [labeled, synchronize]
 
 permissions:
   contents: write
@@ -35,7 +39,13 @@ concurrency:
 
 jobs:
   merge:
-    if: github.event.label.name == 'ready-to-merge'
+    # On `labeled`: only fire when *this* event added ready-to-merge.
+    # On `synchronize`: only fire when ready-to-merge is *currently* on
+    # the PR (i.e. the operator already consented and the rebase is
+    # bringing it onto a fresh head SHA). See #646.
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'ready-to-merge') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ready-to-merge'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Closes #646.

## What lands

Two small changes to `.github/workflows/merge-train.yml`:

1. `on.pull_request.types`: `[labeled]` → `[labeled, synchronize]`
2. `jobs.merge.if`: gates each event type on `ready-to-merge` being currently present.

```yaml
on:
  pull_request:
    types: [labeled, synchronize]

jobs:
  merge:
    if: |
      (github.event.action == 'labeled' && github.event.label.name == 'ready-to-merge') ||
      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ready-to-merge'))
```

## Why

Without `synchronize`, a push to a PR that's already labeled `ready-to-merge` does not re-fire the merge-train. The label sits there and the new head SHA never gets evaluated.

Observed on PR #639 today: rebased-and-force-pushed the branch (resolving a not-FF state), but the existing `ready-to-merge` label didn't trigger a fresh merge-train run. Had to remove + re-add the label to wake it up. That cycle is friction every parallel-session rebase pays.

## Why the job-level `if:` matters

`synchronize` fires on every PR push. Without the guard, every routine commit to a feature branch would invoke merge-train. The `if:` short-circuits the `merge` job when `ready-to-merge` isn't set, so the workflow is invoked-but-skipped on routine pushes — cost-flat, just one event slot per push.

## Verification

- [x] YAML syntax valid (`yq` parses; GH Actions handles the multi-line `if:` block correctly).
- [x] Discretion grep on `github/main...HEAD` clean.
- [x] Commit signed (`%G?` = `G`).
- [ ] Post-merge self-test: open a small PR, label `ready-to-merge`, force-push to it (no need to actually rebase — any push will do); merge-train should re-fire without needing the label cycled.

## Out of scope

- Re-triggering merge-train when ready-to-merge is *removed* (no use case).
- Cancel-in-progress changes — `concurrency: { group: merge-train, cancel-in-progress: false }` already serializes correctly for the new event volume.

## Files

- `.github/workflows/merge-train.yml` — 12 insertions / 2 deletions.

## Reference

PR #639 incident timeline (rebased at 16:15Z, label cycled at 16:14Z, merge at 16:16Z) is the live evidence. See also #634 (auto-close, shipped earlier today) and #637 (the `issues: write` permission fix) — three small workflow papercuts surfaced in one window.

## Summary by Sourcery

Ensure the merge-train workflow re-evaluates rebased pull requests while limiting runs to ready-to-merge PRs.

CI:
- Trigger the merge-train workflow on both label additions and PR synchronizations.
- Gate the merge job so it only runs when the ready-to-merge label is present for the corresponding event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced merge automation workflow to trigger when pull requests with the `ready-to-merge` label are updated or newly labeled, improving merge train responsiveness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/647)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->