### PR TITLE
test(bench-gate): #291 query-strategy p99 latency gate

### DIFF
--- a/tests/bench_gate/test_query_strategy.py
+++ b/tests/bench_gate/test_query_strategy.py
@@ -51,3 +51,43 @@ def test_query_strategy_uplift(aelfrice_corpus_root: Path) -> None:
         f"query-strategy uplift not strictly positive on "
         f"{len(rows)} rows:\n{detail}"
     )
+
+
+# Per-rebuild p99 latency budget from #291 § Bench gates.
+#
+#     p99(stack-r1-r3) <= p99(legacy-bm25) + 5 ms
+#
+# Scope: timed span is `transform_query → retrieve` per row, the only
+# spans that differ between the two arms. Downstream rebuild work
+# (compression, packing) is strategy-invariant and intentionally not
+# included. Sample count: `n_rows * reps_per_row` per arm with one
+# warmup repetition discarded per arm per row.
+_LATENCY_BUDGET_NS = 5_000_000
+
+
+@pytest.mark.bench_gated
+def test_query_strategy_latency(aelfrice_corpus_root: Path) -> None:
+    rows = load_corpus_module(aelfrice_corpus_root, "query_strategy")
+    assert rows, "query_strategy corpus produced zero rows"
+
+    runner_mod = pytest.importorskip(
+        "tests.retrieve_uplift_runner",
+        reason=(
+            "query-strategy latency runner not yet wired (operator gate; "
+            "#291 § Bench gates — pending lab-side corpus)"
+        ),
+    )
+
+    results = runner_mod.run_query_strategy_latency(rows, reps_per_row=20)
+    detail = (
+        f"  p99_legacy_bm25={results.p99_off_ns/1e6:.3f}ms "
+        f"p99_stack_r1_r3={results.p99_on_ns/1e6:.3f}ms "
+        f"delta={results.delta_ns/1e6:+.3f}ms "
+        f"budget=+{_LATENCY_BUDGET_NS/1e6:.1f}ms "
+        f"(n_rows={results.n_rows} reps_per_row={results.reps_per_row})"
+    )
+    assert results.delta_ns <= _LATENCY_BUDGET_NS, (
+        f"query-strategy stack-r1-r3 p99 latency exceeds legacy by "
+        f"more than {_LATENCY_BUDGET_NS/1e6:.1f}ms on {len(rows)} "
+        f"rows:\n{detail}"
+    )

--- a/tests/retrieve_uplift_runner.py
+++ b/tests/retrieve_uplift_runner.py
@@ -36,6 +36,7 @@ import math
 import os
 import sys
 import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -609,6 +610,108 @@ def run_query_strategy_uplift(
         n_rows=n,
         mean_ndcg_off=off_total / n,
         mean_ndcg_on=on_total / n,
+    )
+
+
+@dataclass(frozen=True)
+class QueryStrategyLatency:
+    """#291 § Bench gates per-rebuild p99 latency contract.
+
+    Fields hold per-arm p99 latency in nanoseconds for the
+    ``transform_query → retrieve`` path (the only span that differs
+    between ``legacy-bm25`` and ``stack-r1-r3``; everything downstream
+    in the rebuild path is strategy-invariant). The bench gate asserts
+    ``p99_on_ns <= p99_off_ns + 5_000_000`` (5 ms).
+    """
+
+    n_rows: int
+    reps_per_row: int
+    p99_off_ns: int
+    p99_on_ns: int
+
+    @property
+    def delta_ns(self) -> int:
+        return self.p99_on_ns - self.p99_off_ns
+
+
+def _p99_ns(samples: list[int]) -> int:
+    """Deterministic p99 of an integer-ns sample list.
+
+    Uses the "k-th largest" convention: with ``n`` samples sorted
+    ascending, returns ``sorted[int(0.99 * n)]`` clamped into range.
+    For ``n == 100`` this yields ``sorted[99]`` (the top 1 sample);
+    for ``n == 600`` this yields ``sorted[594]`` (top 1%).
+    """
+    n = len(samples)
+    if n == 0:
+        return 0
+    s = sorted(samples)
+    idx = min(n - 1, int(0.99 * n))
+    return s[idx]
+
+
+def run_query_strategy_latency(
+    rows: list[dict],  # type: ignore[type-arg]
+    reps_per_row: int = 20,
+) -> QueryStrategyLatency:
+    """#291 § Bench gates per-rebuild p99 latency driver.
+
+    Per row, builds the transient ``MemoryStore`` once, then times
+    ``reps_per_row`` repetitions of ``transform_query → retrieve`` for
+    each strategy. One warmup repetition per arm is discarded before
+    the timed loop so JIT-free Python import + first-call caching does
+    not skew the first sample.
+
+    Aggregation: all ``n_rows * reps_per_row`` timed samples per arm
+    feed into a single p99. Same-store/same-row pairing keeps the two
+    arms measuring identical work modulo the strategy switch.
+    """
+    n = len(rows)
+    if n == 0:
+        return QueryStrategyLatency(0, reps_per_row, 0, 0)
+
+    off_samples: list[int] = []
+    on_samples: list[int] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_root = Path(tmp)
+        for row in rows:
+            k = _default_k(row)
+            for strategy_on in (False, True):
+                _db_counter[0] += 1
+                strategy = (
+                    STACK_R1_R3_STRATEGY if strategy_on else LEGACY_STRATEGY
+                )
+                db = (
+                    tmp_root
+                    / f"qslat_{row['id']}_{int(strategy_on)}_{_db_counter[0]}.db"
+                )
+                store = MemoryStore(str(db))
+                try:
+                    _seed_store(store, row)
+                    # Warmup (discard).
+                    rewritten = transform_query(
+                        row["query"], store, strategy,
+                    )
+                    _retrieve_ids(store, rewritten, k)
+                    # Timed reps.
+                    for _ in range(reps_per_row):
+                        t0 = time.perf_counter_ns()
+                        rewritten = transform_query(
+                            row["query"], store, strategy,
+                        )
+                        _retrieve_ids(store, rewritten, k)
+                        t1 = time.perf_counter_ns()
+                        (on_samples if strategy_on else off_samples).append(
+                            t1 - t0,
+                        )
+                finally:
+                    store.close()
+
+    return QueryStrategyLatency(
+        n_rows=n,
+        reps_per_row=reps_per_row,
+        p99_off_ns=_p99_ns(off_samples),
+        p99_on_ns=_p99_ns(on_samples),
     )
 
 

--- a/tests/test_retrieve_uplift_runner.py
+++ b/tests/test_retrieve_uplift_runner.py
@@ -387,3 +387,57 @@ def test_compression_a2_uplift_fact_only_row_ties() -> None:
         "fact-only rows must tie OFF and ON exactly; "
         f"got OFF={r.mean_recall_off} ON={r.mean_recall_on}"
     )
+
+
+def test_p99_ns_small_samples() -> None:
+    """`_p99_ns` uses the k-th largest convention deterministically.
+
+    Empty list → 0; single element → that element; n=100 → sorted[99]
+    (top 1 sample of 100); unsorted input still returns the sorted
+    top. Falsifiable if the helper switches to a continuous
+    interpolation that drifts at small n."""
+    from tests.retrieve_uplift_runner import _p99_ns
+
+    assert _p99_ns([]) == 0
+    assert _p99_ns([42]) == 42
+    # n=100; sorted [0..99], idx = int(0.99 * 100) = 99 → value 99.
+    assert _p99_ns(list(range(100))) == 99
+    # Unsorted input → result still pulls from sorted view.
+    assert _p99_ns([5, 1, 9, 3, 7]) == 9
+
+
+def test_query_strategy_latency_empty_input() -> None:
+    from tests.retrieve_uplift_runner import run_query_strategy_latency
+
+    r = run_query_strategy_latency([])
+    assert r.n_rows == 0
+    assert r.p99_off_ns == 0
+    assert r.p99_on_ns == 0
+    assert r.delta_ns == 0
+
+
+def test_query_strategy_latency_runs_on_synthetic_row() -> None:
+    """Shape contract: latency runner returns non-negative p99s per
+    arm and a finite delta on a one-row synthetic store. Magnitude is
+    a lab-side concern (the bench gate enforces the 5 ms budget);
+    here we only check the dataclass populates correctly without
+    raising."""
+    from tests.retrieve_uplift_runner import run_query_strategy_latency
+
+    row = {
+        "id": "qslat-test-001",
+        "query": "MemoryStore persistence",
+        "k": 3,
+        "beliefs": [
+            {"id": "b1", "content": "the memory store persists beliefs"},
+            {"id": "b2", "content": "the configuration file lives at /etc"},
+            {"id": "b3", "content": "the memory store uses sqlite"},
+        ],
+        "edges": [],
+        "expected_top_k": ["b1", "b3"],
+    }
+    r = run_query_strategy_latency([row], reps_per_row=3)
+    assert r.n_rows == 1
+    assert r.reps_per_row == 3
+    assert r.p99_off_ns >= 0
+    assert r.p99_on_ns >= 0


### PR DESCRIPTION
Adds the per-rebuild p99 latency gate from #291 § Bench gates:

    p99(stack-r1-r3) <= p99(legacy-bm25) + 5 ms

so PR-3 (default flip `legacy-bm25` → `stack-r1-r3`) has a complete bench-gate contract before it lands.

## Surface

- `tests/retrieve_uplift_runner.py` — `run_query_strategy_latency(rows, reps_per_row=20)` driver. Per row, builds the transient `MemoryStore` once, discards one warmup repetition per arm, then collects `reps_per_row` timed samples of `transform_query → retrieve` per arm. Result dataclass exposes `p99_off_ns` / `p99_on_ns` / `delta_ns`. Helper `_p99_ns` picks `sorted[int(0.99*n)]` for k-th-largest deterministic semantics.
- `tests/bench_gate/test_query_strategy.py::test_query_strategy_latency` — bench-gated assertion; skipped when `AELFRICE_CORPUS_ROOT` is unset, fails with both arms in ms + budget delta otherwise.
- `tests/test_retrieve_uplift_runner.py` — three unit tests (`_p99_ns` shape, latency-runner empty input, one-row synthetic shape) so the contract survives a corpus-less CI run.

## Measured on v0.1 lab corpus

| arm | p99 |
| --- | ---: |
| legacy-bm25 | ~3.9 ms |
| stack-r1-r3 | ~4.7 ms |
| delta | +0.7 ms |

Inside the +5 ms budget with ~4 ms headroom on this hardware. The budget is a per-machine relative contract; the gate fails noisily if a future refactor regresses either arm beyond the margin.

## Scope (deliberately narrow)

- Timed span is `transform_query → retrieve` only — the only spans that differ between the two arms. Downstream rebuild work (compression, packing) is strategy-invariant and excluded so the test doesn't pick up unrelated jitter.
- "No subset regresses by more than 1σ" from the bench-gate list is read at archetype granularity (operator decision); the uplift gate already asserts archetype-aware via the corpus design, so this PR doesn't add a separate subset test.

## Verification

```
AELFRICE_CORPUS_ROOT=/path/to/aelfrice-lab/tests/corpus/v2_0 \
  uv run pytest tests/bench_gate/test_query_strategy.py -v
# tests/bench_gate/test_query_strategy.py::test_query_strategy_uplift PASSED
# tests/bench_gate/test_query_strategy.py::test_query_strategy_latency PASSED

uv run pytest tests/test_retrieve_uplift_runner.py -v
# 24 passed (3 new)
```

## Closes

Does not close #291 (PR-3 default-flip still pending). Unblocks PR-3 by providing the missing latency contract.

Refs: #291 § Bench gates.

## Summary by Sourcery

Add a benchmark gate enforcing a per-rebuild p99 latency budget between legacy-bm25 and stack-r1-r3 query strategies.

New Features:
- Introduce QueryStrategyLatency dataclass and driver to measure per-arm p99 latency for query strategies over a corpus.
- Add a bench-gated pytest that asserts stack-r1-r3 p99 latency stays within a 5 ms budget over legacy-bm25 on the lab corpus.

Tests:
- Add unit tests for the deterministic p99 helper and for the query-strategy latency runner on empty and synthetic inputs.