### PR TITLE
feat(reason): VERDICT + IMPASSES classifiers on aelf reason (#645 R1)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -74,6 +74,7 @@ from aelfrice.models import (
     Phantom,
 )
 from aelfrice.bfs_multihop import expand_bfs
+from aelfrice.reason import Impasse, Verdict, classify as _reason_classify
 from aelfrice import wonder_consolidation
 from aelfrice import __version__ as _AELFRICE_VERSION
 from aelfrice import auto_install as _auto_install
@@ -746,6 +747,7 @@ def _cmd_reason(args: argparse.Namespace, out: object) -> int:
             nodes_per_hop=args.fanout,
             total_budget=args.budget,
         )
+        verdict, impasses = _reason_classify(seeds, hops, store)
     finally:
         store.close()
 
@@ -766,6 +768,15 @@ def _cmd_reason(args: argparse.Namespace, out: object) -> int:
                 }
                 for h in hops
             ],
+            "verdict": verdict.value,
+            "impasses": [
+                {
+                    "kind": imp.kind.value,
+                    "belief_ids": list(imp.belief_ids),
+                    "note": imp.note,
+                }
+                for imp in impasses
+            ],
         }
         print(json.dumps(payload, indent=2), file=out)  # type: ignore[arg-type]
         return 0
@@ -776,6 +787,7 @@ def _cmd_reason(args: argparse.Namespace, out: object) -> int:
         print(f"  {b.id}: {b.content}", file=out)  # type: ignore[arg-type]
     if not hops:
         print("(no expansions — seeds have no outbound edges within budget)", file=out)  # type: ignore[arg-type]
+        _emit_reason_footer(verdict, impasses, out)
         return 0
     print("chain:", file=out)  # type: ignore[arg-type]
     for h in hops:
@@ -787,7 +799,31 @@ def _cmd_reason(args: argparse.Namespace, out: object) -> int:
         )
         if path_str:
             print(f"{indent}  via {path_str}", file=out)  # type: ignore[arg-type]
+    _emit_reason_footer(verdict, impasses, out)
     return 0
+
+
+def _emit_reason_footer(
+    verdict: Verdict, impasses: list[Impasse], out: object
+) -> None:
+    """Print the verdict + impasses block at the tail of `aelf reason`.
+
+    Two-line minimum: a `verdict:` line and an `impasses:` line. When
+    impasses are present, each one renders on its own indented row
+    after the header. Format is grep-friendly so downstream tooling
+    (e.g. R3 dispatch policy) can pick the verdict out of stdout.
+    """
+    print(f"verdict: {verdict.value}", file=out)  # type: ignore[arg-type]
+    if not impasses:
+        print("impasses: (none)", file=out)  # type: ignore[arg-type]
+        return
+    print("impasses:", file=out)  # type: ignore[arg-type]
+    for imp in impasses:
+        ids_str = ",".join(imp.belief_ids)
+        print(
+            f"  {imp.kind.value} [{ids_str}]: {imp.note}",
+            file=out,  # type: ignore[arg-type]
+        )
 
 
 # Edge-type → suggested-action heuristic for `aelf wonder`. The path

--- a/src/aelfrice/reason.py
+++ b/src/aelfrice/reason.py
@@ -1,0 +1,201 @@
+"""Reason verdict + impasse classifiers (#645 R1).
+
+Pure-derivation module: takes the BFS walk evidence (seeds + ScoredHops)
+plus the underlying MemoryStore and returns a typed verdict together
+with the list of impasses observed. No graph traversal of its own and
+no mutation — the walk has already happened in :func:`aelfrice.bfs_multihop.expand_bfs`.
+
+Ports the four agentmemory diagnostic outputs into aelfrice while
+preserving the deterministic, stdlib-only retrieval contract (PHILOSOPHY
+#605):
+
+- ``Verdict`` enum: ``SUFFICIENT`` / ``INSUFFICIENT`` / ``CONTRADICTORY``
+  / ``UNCERTAIN`` / ``PARTIAL``.
+- ``ImpasseKind`` enum: ``TIE`` / ``GAP`` / ``CONSTRAINT_FAILURE`` /
+  ``NO_CHANGE``.
+
+The derivation is a pure function of (seeds, hops, store-leaf-lookup)
+with two named thresholds (:data:`CONFIDENT_TRIALS_MIN`,
+:data:`CLOSE_MEAN_DELTA`). Two runs with the same inputs return the
+same verdict + impasse list byte-for-byte.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final
+
+from aelfrice.bfs_multihop import ScoredHop
+from aelfrice.models import (
+    EDGE_CONTRADICTS,
+    LOCK_USER,
+    Belief,
+)
+from aelfrice.store import MemoryStore
+
+
+class Verdict(str, Enum):
+    """Top-level classification of the walk's evidence sufficiency."""
+
+    SUFFICIENT = "SUFFICIENT"
+    INSUFFICIENT = "INSUFFICIENT"
+    CONTRADICTORY = "CONTRADICTORY"
+    UNCERTAIN = "UNCERTAIN"
+    PARTIAL = "PARTIAL"
+
+
+class ImpasseKind(str, Enum):
+    """Categorical label for one observed reasoning impasse."""
+
+    TIE = "TIE"
+    GAP = "GAP"
+    CONSTRAINT_FAILURE = "CONSTRAINT_FAILURE"
+    NO_CHANGE = "NO_CHANGE"
+
+
+@dataclass(frozen=True)
+class Impasse:
+    """One reasoning impasse observed over the walk.
+
+    ``belief_ids`` are the loci of the impasse: the leaf for ``GAP``,
+    the locked endpoint for ``CONSTRAINT_FAILURE``, both sides for
+    ``TIE``, and every visited belief for ``NO_CHANGE``. Tuples (not
+    lists) so the impasse is hashable and stable across JSON round-
+    trips.
+    """
+
+    kind: ImpasseKind
+    belief_ids: tuple[str, ...]
+    note: str
+
+
+CONFIDENT_TRIALS_MIN: Final[int] = 4
+"""Posterior trials (``alpha + beta``) floor above which a belief
+has enough evidence to be treated as confident for verdict / impasse
+purposes. A fresh ``Beta(1, 1)`` belief has ``alpha + beta == 2`` (the
+uninformative prior); two additional observations (total = 4) is the
+smallest sample that meaningfully narrows the credible interval over
+the prior."""
+
+CLOSE_MEAN_DELTA: Final[float] = 0.15
+"""Two posterior means whose absolute difference is below this delta
+count as "similar" for ``TIE`` detection. Empirical: a 0.15 gap in
+posterior mean is roughly the noise floor of a ``Beta(2, 4)`` vs
+``Beta(3, 3)`` comparison (both ~6 trials)."""
+
+
+def _trials(b: Belief) -> float:
+    return b.alpha + b.beta
+
+
+def _mean(b: Belief) -> float:
+    t = _trials(b)
+    if t <= 0:
+        return 0.5
+    return b.alpha / t
+
+
+def _is_low_evidence(b: Belief) -> bool:
+    return _trials(b) < CONFIDENT_TRIALS_MIN
+
+
+def classify(
+    seeds: list[Belief],
+    hops: list[ScoredHop],
+    store: MemoryStore,
+) -> tuple[Verdict, list[Impasse]]:
+    """Derive ``(verdict, impasses)`` from walk evidence.
+
+    Pure derivation — does not traverse the graph. The store is only
+    consulted for :meth:`MemoryStore.edges_from` (leaf detection on
+    ``GAP``); all other inputs are already materialised on ``seeds``
+    and ``hops``.
+
+    Determinism: impasse list order is fixed by construction order in
+    this function (``NO_CHANGE`` first, then ``CONSTRAINT_FAILURE``,
+    then ``TIE``, then ``GAP``); within each kind impasses are emitted
+    in hop-list order (which itself is deterministic per
+    :func:`aelfrice.bfs_multihop.expand_bfs`'s ordering contract).
+    """
+    impasses: list[Impasse] = []
+
+    if not hops:
+        return Verdict.INSUFFICIENT, [
+            Impasse(
+                kind=ImpasseKind.NO_CHANGE,
+                belief_ids=tuple(sorted(s.id for s in seeds)),
+                note="no expansions from seeds",
+            )
+        ]
+
+    all_low = all(_is_low_evidence(h.belief) for h in hops) and all(
+        _is_low_evidence(s) for s in seeds
+    )
+    if all_low:
+        impasses.append(
+            Impasse(
+                kind=ImpasseKind.NO_CHANGE,
+                belief_ids=tuple(sorted(h.belief.id for h in hops)),
+                note=(
+                    f"every visited belief has alpha+beta < {CONFIDENT_TRIALS_MIN}"
+                ),
+            )
+        )
+
+    contradiction_hops = [
+        h for h in hops if h.path and h.path[-1] == EDGE_CONTRADICTS
+    ]
+
+    for h in contradiction_hops:
+        if h.belief.lock_level == LOCK_USER:
+            impasses.append(
+                Impasse(
+                    kind=ImpasseKind.CONSTRAINT_FAILURE,
+                    belief_ids=(h.belief.id,),
+                    note="path blocked by a locked belief via CONTRADICTS",
+                )
+            )
+
+    for i in range(len(contradiction_hops)):
+        for j in range(i + 1, len(contradiction_hops)):
+            a = contradiction_hops[i].belief
+            b = contradiction_hops[j].belief
+            if abs(_mean(a) - _mean(b)) < CLOSE_MEAN_DELTA:
+                impasses.append(
+                    Impasse(
+                        kind=ImpasseKind.TIE,
+                        belief_ids=tuple(sorted([a.id, b.id])),
+                        note="contradicting beliefs at similar posterior means",
+                    )
+                )
+
+    for h in hops:
+        if _is_low_evidence(h.belief) and not store.edges_from(h.belief.id):
+            impasses.append(
+                Impasse(
+                    kind=ImpasseKind.GAP,
+                    belief_ids=(h.belief.id,),
+                    note="path ends at high-uncertainty leaf",
+                )
+            )
+
+    has_tie = any(i.kind == ImpasseKind.TIE for i in impasses)
+    has_cf = any(i.kind == ImpasseKind.CONSTRAINT_FAILURE for i in impasses)
+    has_gap = any(i.kind == ImpasseKind.GAP for i in impasses)
+    has_no_change = any(i.kind == ImpasseKind.NO_CHANGE for i in impasses)
+    has_confident_hop = any(not _is_low_evidence(h.belief) for h in hops)
+
+    if has_tie:
+        verdict = Verdict.CONTRADICTORY
+    elif has_no_change:
+        verdict = Verdict.INSUFFICIENT
+    elif has_cf:
+        verdict = Verdict.PARTIAL
+    elif has_gap and not has_confident_hop:
+        verdict = Verdict.UNCERTAIN
+    elif impasses and has_confident_hop:
+        verdict = Verdict.PARTIAL
+    else:
+        verdict = Verdict.SUFFICIENT
+
+    return verdict, impasses

--- a/tests/test_cli_reason_wonder.py
+++ b/tests/test_cli_reason_wonder.py
@@ -102,6 +102,30 @@ def test_reason_json_payload_shape(_isolated_db: Path) -> None:
     assert isinstance(payload["hops"], list)
     assert len(payload["hops"]) >= 1
     assert {"id", "content", "score", "depth", "path"} <= set(payload["hops"][0].keys())
+    # #645 R1: verdict + impasses surface in --json payload.
+    assert "verdict" in payload
+    assert payload["verdict"] in (
+        "SUFFICIENT",
+        "INSUFFICIENT",
+        "CONTRADICTORY",
+        "UNCERTAIN",
+        "PARTIAL",
+    )
+    assert isinstance(payload["impasses"], list)
+    for imp in payload["impasses"]:
+        assert {"kind", "belief_ids", "note"} <= set(imp.keys())
+        assert imp["kind"] in ("TIE", "GAP", "CONSTRAINT_FAILURE", "NO_CHANGE")
+        assert isinstance(imp["belief_ids"], list)
+
+
+def test_reason_text_output_includes_verdict_footer(_isolated_db: Path) -> None:
+    """#645 R1: text mode trails the chain with a `verdict:` line and
+    an `impasses:` line (grep-friendly for downstream R3 dispatch)."""
+    a, _, _ = _seed_chain(_isolated_db)
+    code, out = _run("reason", "indentation", "--seed-id", a)
+    assert code == 0, out
+    assert "verdict:" in out
+    assert "impasses:" in out
 
 
 def test_reason_unknown_seed_id_exits_nonzero(_isolated_db: Path) -> None:

--- a/tests/test_reason_classify.py
+++ b/tests/test_reason_classify.py
@@ -1,0 +1,219 @@
+"""Pure-derivation tests for :func:`aelfrice.reason.classify` (#645 R1).
+
+Synthetic fixtures cover each verdict + impasse kind on a tiny store.
+The classifier is a pure function of ``(seeds, hops, store)`` and
+must produce deterministic output, so each test pins the expected
+verdict and the expected impasse kinds in order.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aelfrice.bfs_multihop import ScoredHop
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CONTRADICTS,
+    EDGE_RELATES_TO,
+    EDGE_SUPERSEDES,
+    LOCK_NONE,
+    LOCK_USER,
+    ORIGIN_AGENT_INFERRED,
+    Belief,
+    Edge,
+)
+from aelfrice.reason import (
+    CLOSE_MEAN_DELTA,
+    CONFIDENT_TRIALS_MIN,
+    Impasse,
+    ImpasseKind,
+    Verdict,
+    classify,
+)
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    bid: str,
+    *,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+    lock: str = LOCK_NONE,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=bid,
+        content_hash=f"h-{bid}",
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=lock,
+        locked_at="2026-05-11T00:00:00Z" if lock == LOCK_USER else None,
+        demotion_pressure=0,
+        created_at="2026-05-11T00:00:00Z",
+        last_retrieved_at=None,
+        origin=ORIGIN_AGENT_INFERRED,
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> MemoryStore:
+    s = MemoryStore(str(tmp_path / "r.db"))
+    yield s
+    s.close()
+
+
+def _hop(b: Belief, path: list[str], depth: int = 1, score: float = 0.8) -> ScoredHop:
+    return ScoredHop(belief=b, score=score, depth=depth, path=path)
+
+
+def test_empty_hops_returns_insufficient_with_no_change(store: MemoryStore) -> None:
+    seeds = [_mk("s1"), _mk("s2")]
+    verdict, impasses = classify(seeds, [], store)
+    assert verdict == Verdict.INSUFFICIENT
+    assert len(impasses) == 1
+    assert impasses[0].kind == ImpasseKind.NO_CHANGE
+    assert impasses[0].belief_ids == ("s1", "s2")
+
+
+def test_all_low_evidence_yields_no_change_insufficient(store: MemoryStore) -> None:
+    # Seeds + hops all at Beta(1, 1) — alpha+beta = 2 < CONFIDENT_TRIALS_MIN.
+    seed = _mk("seed")
+    h1 = _hop(_mk("h1"), [EDGE_RELATES_TO])
+    h2 = _hop(_mk("h2"), [EDGE_RELATES_TO, EDGE_RELATES_TO], depth=2)
+    # Mark h1 and h2 as non-leaf so GAP doesn't compete with NO_CHANGE.
+    store.insert_belief(h1.belief)
+    store.insert_belief(h2.belief)
+    store.insert_edge(Edge(src="h1", dst="h2", type=EDGE_RELATES_TO, weight=1.0))
+    store.insert_edge(Edge(src="h2", dst="h1", type=EDGE_RELATES_TO, weight=1.0))
+    verdict, impasses = classify([seed], [h1, h2], store)
+    kinds = [i.kind for i in impasses]
+    assert ImpasseKind.NO_CHANGE in kinds
+    assert verdict == Verdict.INSUFFICIENT
+
+
+def test_constraint_failure_on_locked_contradicting_endpoint(
+    store: MemoryStore,
+) -> None:
+    # Seed: low-evidence start. Hop: locked belief reached via CONTRADICTS.
+    # The seed is also low-evidence so NO_CHANGE could fire — bump the
+    # locked endpoint's trial count so it's NOT low-evidence and the
+    # walk has at least one confident node.
+    seed = _mk("s", alpha=5.0, beta=2.0)
+    locked = _mk("locked", alpha=10.0, beta=1.0, lock=LOCK_USER)
+    h = _hop(locked, [EDGE_CONTRADICTS])
+    verdict, impasses = classify([seed], [h], store)
+    kinds = [i.kind for i in impasses]
+    assert ImpasseKind.CONSTRAINT_FAILURE in kinds
+    assert verdict == Verdict.PARTIAL
+
+
+def test_tie_on_two_contradictions_with_similar_means(store: MemoryStore) -> None:
+    seed = _mk("seed", alpha=5.0, beta=3.0)
+    # Two contradicting endpoints with similar posterior means (~0.5).
+    c1 = _mk("c1", alpha=4.0, beta=4.0)  # mean = 0.500
+    c2 = _mk("c2", alpha=5.0, beta=4.0)  # mean ≈ 0.556 → delta ≈ 0.056 < 0.15
+    assert abs(c1.alpha / (c1.alpha + c1.beta) - c2.alpha / (c2.alpha + c2.beta)) < CLOSE_MEAN_DELTA
+    h1 = _hop(c1, [EDGE_CONTRADICTS])
+    h2 = _hop(c2, [EDGE_RELATES_TO, EDGE_CONTRADICTS], depth=2)
+    verdict, impasses = classify([seed], [h1, h2], store)
+    tie = [i for i in impasses if i.kind == ImpasseKind.TIE]
+    assert len(tie) == 1
+    assert tie[0].belief_ids == ("c1", "c2")
+    assert verdict == Verdict.CONTRADICTORY
+
+
+def test_far_apart_contradictions_do_not_tie(store: MemoryStore) -> None:
+    seed = _mk("seed", alpha=5.0, beta=3.0)
+    c1 = _mk("c1", alpha=9.0, beta=1.0)  # mean = 0.9
+    c2 = _mk("c2", alpha=1.0, beta=9.0)  # mean = 0.1 → delta = 0.8
+    h1 = _hop(c1, [EDGE_CONTRADICTS])
+    h2 = _hop(c2, [EDGE_CONTRADICTS])
+    verdict, impasses = classify([seed], [h1, h2], store)
+    assert not any(i.kind == ImpasseKind.TIE for i in impasses)
+    # Two confident hops + no impasse → SUFFICIENT (CONTRADICTS edges
+    # alone don't make a verdict; only TIE / CONSTRAINT_FAILURE do).
+    assert verdict == Verdict.SUFFICIENT
+
+
+def test_gap_on_low_evidence_leaf(store: MemoryStore) -> None:
+    seed = _mk("seed", alpha=5.0, beta=2.0)
+    confident = _mk("conf", alpha=5.0, beta=2.0)
+    leaf = _mk("leaf")  # alpha+beta = 2 (low evidence)
+    # `conf` has an outbound edge; `leaf` is a true leaf.
+    store.insert_belief(confident)
+    store.insert_belief(leaf)
+    store.insert_edge(
+        Edge(src="conf", dst="other", type=EDGE_RELATES_TO, weight=1.0)
+    )
+    h_conf = _hop(confident, [EDGE_SUPERSEDES])
+    h_leaf = _hop(leaf, [EDGE_SUPERSEDES, EDGE_RELATES_TO], depth=2)
+    verdict, impasses = classify([seed], [h_conf, h_leaf], store)
+    gaps = [i for i in impasses if i.kind == ImpasseKind.GAP]
+    assert len(gaps) == 1
+    assert gaps[0].belief_ids == ("leaf",)
+    # confident hop + gap impasse → PARTIAL.
+    assert verdict == Verdict.PARTIAL
+
+
+def test_gap_only_low_evidence_yields_uncertain(store: MemoryStore) -> None:
+    seed = _mk("seed", alpha=5.0, beta=2.0)
+    leaf = _mk("leaf")  # low evidence, leaf
+    h = _hop(leaf, [EDGE_RELATES_TO])
+    verdict, impasses = classify([seed], [h], store)
+    # Note: this triggers NO_CHANGE first (seed=high, hop=low; not "all
+    # low") — actually only NO_CHANGE fires when *both* seed and hop
+    # are low. So here NO_CHANGE does not fire; GAP does (leaf + low).
+    kinds = [i.kind for i in impasses]
+    assert ImpasseKind.GAP in kinds
+    assert ImpasseKind.NO_CHANGE not in kinds
+    assert verdict == Verdict.UNCERTAIN
+
+
+def test_sufficient_when_confident_hop_and_no_impasse(store: MemoryStore) -> None:
+    seed = _mk("seed", alpha=5.0, beta=2.0)
+    confident = _mk("conf", alpha=8.0, beta=2.0)
+    # Non-leaf so no GAP fires.
+    store.insert_edge(
+        Edge(src="conf", dst="x", type=EDGE_RELATES_TO, weight=1.0)
+    )
+    h = _hop(confident, [EDGE_SUPERSEDES])
+    verdict, impasses = classify([seed], [h], store)
+    assert verdict == Verdict.SUFFICIENT
+    assert impasses == []
+
+
+def test_classify_is_deterministic(store: MemoryStore) -> None:
+    """Two runs with the same inputs must return identical results."""
+    seed = _mk("seed", alpha=5.0, beta=2.0)
+    c1 = _mk("c1", alpha=4.0, beta=4.0)
+    c2 = _mk("c2", alpha=5.0, beta=4.0)
+    h1 = _hop(c1, [EDGE_CONTRADICTS])
+    h2 = _hop(c2, [EDGE_RELATES_TO, EDGE_CONTRADICTS], depth=2)
+    v1, i1 = classify([seed], [h1, h2], store)
+    v2, i2 = classify([seed], [h1, h2], store)
+    assert v1 == v2
+    assert i1 == i2
+
+
+def test_constants_documented_and_load_bearing() -> None:
+    """The module constants must be importable and have the values the
+    derivation rules assume."""
+    assert CONFIDENT_TRIALS_MIN == 4
+    assert CLOSE_MEAN_DELTA == 0.15
+
+
+def test_impasse_is_frozen_and_hashable() -> None:
+    a = Impasse(ImpasseKind.GAP, ("x",), "note")
+    b = Impasse(ImpasseKind.GAP, ("x",), "note")
+    assert a == b
+    assert hash(a) == hash(b)
+    with pytest.raises(Exception):
+        a.kind = ImpasseKind.TIE  # type: ignore[misc]
+
+
+def test_verdict_and_impasse_kind_are_string_valued() -> None:
+    # Required for JSON serialisation downstream.
+    assert Verdict.SUFFICIENT.value == "SUFFICIENT"
+    assert ImpasseKind.NO_CHANGE.value == "NO_CHANGE"


### PR DESCRIPTION
Per the 16:47Z ratification on #645 (parallel-session triage / decision thread): this is the **R1** slice of the reason-side parity work — `Verdict` classifier + `IMPASSES` typology on `aelf reason` output. R2 (compound-confidence decay + fork-on-CONTRADICTS) and R3 (VERDICT-driven dispatch + feedback close-the-loop) land separately.

## Surface

### New module — `src/aelfrice/reason.py`

Pure derivation, stdlib-only, deterministic. No graph traversal of its own; only consults `store.edges_from` for GAP leaf detection.

- `Verdict` enum: `SUFFICIENT` / `INSUFFICIENT` / `CONTRADICTORY` / `UNCERTAIN` / `PARTIAL`.
- `ImpasseKind` enum: `TIE` / `GAP` / `CONSTRAINT_FAILURE` / `NO_CHANGE`.
- `Impasse(kind, belief_ids, note)` — frozen dataclass; hashable; JSON-friendly via `str`-valued enums.
- `classify(seeds, hops, store) -> (Verdict, list[Impasse])` — the deriver.

### Derivation rules (deterministic, two named thresholds)

| Impasse | Trigger |
| --- | --- |
| `NO_CHANGE` | every visited belief (seeds ∪ hop endpoints) has `alpha + beta < CONFIDENT_TRIALS_MIN` (default 4) |
| `CONSTRAINT_FAILURE` | a hop path ends on `EDGE_CONTRADICTS` and the destination is `LOCK_USER` |
| `TIE` | two contradiction-arrived hops whose posterior means differ by `< CLOSE_MEAN_DELTA` (default 0.15) |
| `GAP` | a hop endpoint is a leaf (no `edges_from`) AND low-evidence (`alpha + beta < 4`) |

Verdict priority: `TIE` → `CONTRADICTORY`; `NO_CHANGE` → `INSUFFICIENT`; `CONSTRAINT_FAILURE` → `PARTIAL`; `GAP`-only without confident hop → `UNCERTAIN`; impasses + confident hop → `PARTIAL`; else `SUFFICIENT`.

Constants:
- `CONFIDENT_TRIALS_MIN = 4` — a fresh `Beta(1, 1)` has `alpha + beta = 2`; +2 observations is the smallest sample meaningfully narrower than the prior.
- `CLOSE_MEAN_DELTA = 0.15` — empirical noise floor for `Beta(2, 4)` vs `Beta(3, 3)`-class comparisons.

### CLI wiring — `aelf reason`

JSON (`--json`) — payload gains:
```json
{
  "verdict": "SUFFICIENT",
  "impasses": [
    {"kind": "GAP", "belief_ids": ["leaf-id"], "note": "path ends at high-uncertainty leaf"}
  ]
}
```
Existing keys (`query`, `seeds`, `hops` with `score`/`depth`/`path`) unchanged so downstream consumers don't break.

Text mode — trailing footer:
```
verdict: PARTIAL
impasses:
  CONSTRAINT_FAILURE [b1]: path blocked by a locked belief via CONTRADICTS
  GAP [b3]: path ends at high-uncertainty leaf
```
Grep-friendly so R3's slash-skill dispatch policy can pick the verdict out of stdout.

## Acceptance check (vs #645)

From the umbrella acceptance list, this PR delivers:

- [x] `aelf reason` adds `VERDICT` classifier (5 values).
- [x] `aelf reason` adds `IMPASSES` list with all four kinds.
- [x] `aelf reason --json` exposes verdict + impasses in structured form.
- [ ] Compound confidence decay + weakest-link — **R2** (separate PR).
- [ ] Fork on `CONTRADICTS` — **R2** (separate PR).
- [ ] VERDICT-driven dispatch in `slash_commands/reason.md` — **R3** (separate PR).
- [ ] `feedback()` close-the-loop — **R3** (separate PR).

## Verification

```
uv run pytest tests/test_reason_classify.py tests/test_cli_reason_wonder.py -v
# 32 passed in 5.82s

uv run pytest -x --timeout=30
# 3395 passed, 55 skipped in 73s
```

## Closes

Does not close #645 — umbrella spans R1/R2/R3 + wonder default-flip. Implements the R1 portion.

Refs: #645 § Decisions ratified (2026-05-11).

## Summary by Sourcery

Add verdict and impasse classification to `aelf reason` and surface the results in both JSON and text outputs.

New Features:
- Introduce a pure `reason` module that classifies reasoning walks into verdicts and impasse kinds based on belief evidence and graph structure.
- Expose verdict and impasse metadata in the `aelf reason --json` payload for downstream consumers.
- Extend `aelf reason` text-mode output with a trailing verdict and impasses footer for human and tooling consumption.

Tests:
- Add unit tests covering the `classify` derivation logic for all verdict and impasse combinations and ensuring determinism.
- Extend CLI tests to validate the presence and shape of verdict and impasses in both JSON and text outputs.