### PR TITLE
feat(reason): compound confidence + CONTRADICTS fork on aelf reason (#658 R2)

### DIFF
--- a/src/aelfrice/bfs_multihop.py
+++ b/src/aelfrice/bfs_multihop.py
@@ -85,12 +85,23 @@ class ScoredHop:
     1.0 (no edge weight exceeds 1.0). `depth` is the number of edges
     in the path (1 for a direct neighbour, 2 for a two-hop expansion,
     etc.). `path` is the ordered list of edge-type strings.
+
+    `belief_id_trail` is the ordered tuple of belief ids the BFS
+    walked through to reach this hop, starting with the seed and
+    ending with this hop's belief id. Length is always ``depth + 1``
+    (seed + one id per hop). Empty default for backwards-compat with
+    callers that construct ``ScoredHop`` directly in tests; the
+    production ``expand_bfs`` always emits a populated trail. Added
+    for #645 R2 (#658) — compound-confidence + fork-on-CONTRADICTS
+    derivation needs the per-hop trail of beliefs, not just the
+    terminal endpoint.
     """
 
     belief: Belief
     score: float
     depth: int
     path: list[str]
+    belief_id_trail: tuple[str, ...] = ()
 
 
 def expand_bfs(
@@ -134,16 +145,23 @@ def expand_bfs(
         return []
 
     visited: set[str] = {b.id for b in seeds}
-    # Frontier entries: (belief_id, path_score, depth, path_edge_types).
-    frontier: list[tuple[str, float, int, list[str]]] = [
-        (b.id, 1.0, 0, []) for b in seeds
+    # Frontier entries: (belief_id, path_score, depth, path_edge_types,
+    # belief_id_trail). The trail tracks every belief id the BFS has
+    # walked through to reach `belief_id`, starting from the seed;
+    # consumers downstream (compound-confidence + fork-on-CONTRADICTS,
+    # #645 R2) reconstruct paths from this without re-walking the
+    # graph.
+    frontier: list[tuple[str, float, int, list[str], tuple[str, ...]]] = [
+        (b.id, 1.0, 0, [], (b.id,)) for b in seeds
     ]
     expanded: list[ScoredHop] = []
     nodes_used: int = 0
 
     while frontier and nodes_used < total_budget:
-        next_frontier: list[tuple[str, float, int, list[str]]] = []
-        for current_id, score, depth, path in frontier:
+        next_frontier: list[
+            tuple[str, float, int, list[str], tuple[str, ...]]
+        ] = []
+        for current_id, score, depth, path, trail in frontier:
             if depth >= max_depth:
                 continue
             if nodes_used >= total_budget:
@@ -185,16 +203,18 @@ def expand_bfs(
                     # this query.
                     continue
                 new_path = path + [edge.type]
+                new_trail = trail + (edge.dst,)
                 expanded.append(
                     ScoredHop(
                         belief=belief,
                         score=new_score,
                         depth=depth + 1,
                         path=new_path,
+                        belief_id_trail=new_trail,
                     )
                 )
                 next_frontier.append(
-                    (edge.dst, new_score, depth + 1, new_path)
+                    (edge.dst, new_score, depth + 1, new_path, new_trail)
                 )
                 nodes_used += 1
         frontier = next_frontier

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -75,9 +75,11 @@ from aelfrice.models import (
 )
 from aelfrice.bfs_multihop import expand_bfs
 from aelfrice.reason import (
+    ConsequencePath,
     Impasse,
     Verdict,
     classify as _reason_classify,
+    derive_paths as _reason_derive_paths,
     dispatch_policy as _reason_dispatch_policy,
     suggested_updates as _reason_suggested_updates,
 )
@@ -753,7 +755,8 @@ def _cmd_reason(args: argparse.Namespace, out: object) -> int:
             nodes_per_hop=args.fanout,
             total_budget=args.budget,
         )
-        verdict, impasses = _reason_classify(seeds, hops, store)
+        paths = _reason_derive_paths(seeds, hops)
+        verdict, impasses = _reason_classify(seeds, hops, store, paths=paths)
     finally:
         store.close()
 
@@ -775,6 +778,16 @@ def _cmd_reason(args: argparse.Namespace, out: object) -> int:
                     "path": h.path,
                 }
                 for h in hops
+            ],
+            "paths": [
+                {
+                    "belief_ids": list(p.belief_ids),
+                    "edge_kinds": list(p.edge_kinds),
+                    "compound_confidence": p.compound_confidence,
+                    "weakest_link_belief_id": p.weakest_link_belief_id,
+                    "fork_from": p.fork_from,
+                }
+                for p in paths
             ],
             "verdict": verdict.value,
             "impasses": [
@@ -811,7 +824,7 @@ def _cmd_reason(args: argparse.Namespace, out: object) -> int:
         print(f"  {b.id}: {b.content}", file=out)  # type: ignore[arg-type]
     if not hops:
         print("(no expansions — seeds have no outbound edges within budget)", file=out)  # type: ignore[arg-type]
-        _emit_reason_footer(verdict, impasses, out)
+        _emit_reason_footer(verdict, impasses, paths, out)
         return 0
     print("chain:", file=out)  # type: ignore[arg-type]
     for h in hops:
@@ -823,29 +836,48 @@ def _cmd_reason(args: argparse.Namespace, out: object) -> int:
         )
         if path_str:
             print(f"{indent}  via {path_str}", file=out)  # type: ignore[arg-type]
-    _emit_reason_footer(verdict, impasses, out)
+    _emit_reason_footer(verdict, impasses, paths, out)
     return 0
 
 
 def _emit_reason_footer(
-    verdict: Verdict, impasses: list[Impasse], out: object
+    verdict: Verdict,
+    impasses: list[Impasse],
+    paths: list[ConsequencePath],
+    out: object,
 ) -> None:
-    """Print the verdict + impasses block at the tail of `aelf reason`.
+    """Print the verdict + impasses + forks block at the tail of `aelf reason`.
 
-    Two-line minimum: a `verdict:` line and an `impasses:` line. When
-    impasses are present, each one renders on its own indented row
-    after the header. Format is grep-friendly so downstream tooling
-    (e.g. R3 dispatch policy) can pick the verdict out of stdout.
+    Three sections: a ``verdict:`` line, the impasses block (either
+    ``(none)`` or one indented row per impasse), and a ``forks:``
+    summary that calls out CONTRADICTS-forked paths with their
+    parent-path terminal id and the forked path's compound confidence.
+    Format is grep-friendly so downstream tooling (e.g. R3 dispatch
+    policy) can pick the verdict out of stdout.
     """
     print(f"verdict: {verdict.value}", file=out)  # type: ignore[arg-type]
     if not impasses:
         print("impasses: (none)", file=out)  # type: ignore[arg-type]
+    else:
+        print("impasses:", file=out)  # type: ignore[arg-type]
+        for imp in impasses:
+            ids_str = ",".join(imp.belief_ids)
+            print(
+                f"  {imp.kind.value} [{ids_str}]: {imp.note}",
+                file=out,  # type: ignore[arg-type]
+            )
+    forks = [p for p in paths if p.fork_from is not None]
+    if not forks:
+        print("forks: (none)", file=out)  # type: ignore[arg-type]
         return
-    print("impasses:", file=out)  # type: ignore[arg-type]
-    for imp in impasses:
-        ids_str = ",".join(imp.belief_ids)
+    print("forks:", file=out)  # type: ignore[arg-type]
+    for p in forks:
         print(
-            f"  {imp.kind.value} [{ids_str}]: {imp.note}",
+            (
+                f"  {p.fork_from} -> {p.belief_ids[-1]} "
+                f"[compound={p.compound_confidence:.3f}, "
+                f"weakest={p.weakest_link_belief_id}]"
+            ),
             file=out,  # type: ignore[arg-type]
         )
 

--- a/src/aelfrice/reason.py
+++ b/src/aelfrice/reason.py
@@ -54,6 +54,41 @@ class ImpasseKind(str, Enum):
 
 
 @dataclass(frozen=True)
+class ConsequencePath:
+    """One root-to-leaf consequence chain over the belief graph (#645 R2).
+
+    A ``ConsequencePath`` is the path-centric view of a BFS expansion
+    that R1's hop-centric :class:`~aelfrice.bfs_multihop.ScoredHop`
+    encodes endpoint-first. The fields:
+
+    - ``belief_ids`` — ordered ``root → leaf`` belief ids; first element
+      is the originating seed, last is the path's terminal belief.
+    - ``edge_kinds`` — ordered list of edge-type strings; length is
+      always ``len(belief_ids) - 1``. Length-zero edge_kinds means the
+      path is a seed-only "path" (the seed itself before any expansion).
+    - ``compound_confidence`` — ``∏ posterior_mean(belief) for belief in
+      belief_ids``. Multiplicative decay along the chain: a single
+      weak intermediate belief attenuates the whole path.
+    - ``weakest_link_belief_id`` — id of the belief with the lowest
+      posterior mean over ``belief_ids``. Ties broken by hop index,
+      deepest wins (later occurrence in the trail).
+    - ``fork_from`` — when this path was forked because its terminal
+      edge is ``EDGE_CONTRADICTS``, the belief id at the
+      parent-path's terminal (i.e. ``belief_ids[-2]``). ``None`` on
+      non-forked paths.
+
+    Frozen + hashable so two derivations from the same evidence are
+    byte-identical and the path can be used as a dict key.
+    """
+
+    belief_ids: tuple[str, ...]
+    edge_kinds: tuple[str, ...]
+    compound_confidence: float
+    weakest_link_belief_id: str
+    fork_from: str | None = None
+
+
+@dataclass(frozen=True)
 class Impasse:
     """One reasoning impasse observed over the walk.
 
@@ -348,3 +383,91 @@ def suggested_updates(
             )
 
     return rows
+
+
+def derive_paths(
+    seeds: list[Belief],
+    hops: list[ScoredHop],
+) -> list[ConsequencePath]:
+    """Derive :class:`ConsequencePath` records from walk evidence.
+
+    Pure function — no graph traversal, no store lookups. Reconstructs
+    each path from each hop's ``belief_id_trail`` (populated by
+    :func:`aelfrice.bfs_multihop.expand_bfs`) and the posterior means
+    of beliefs reachable through ``seeds`` and ``hops``.
+
+    Emits:
+
+    1. One length-1 ``ConsequencePath`` per seed (the "no-expansion"
+       baseline path; ``edge_kinds == ()``).
+    2. One ``ConsequencePath`` per hop, mirroring its trail.
+
+    Fork detection: a hop whose terminal edge is ``EDGE_CONTRADICTS``
+    surfaces with ``fork_from`` set to the parent-path's terminal
+    belief (``belief_id_trail[-2]``). Both the parent and the forked
+    branch are present in the returned list — the parent is just the
+    earlier hop (or seed) whose terminal id matches.
+
+    Order is preserved from the input ``hops`` (which is itself
+    deterministic per :func:`expand_bfs`'s sort contract). Seeds are
+    emitted first, in seed-input order; hops after, in
+    sorted-result order.
+
+    Skips hops whose ``belief_id_trail`` is empty (test fixtures that
+    don't bother to populate it) so the function is defensive against
+    older callers without crashing.
+    """
+    belief_by_id: dict[str, Belief] = {s.id: s for s in seeds}
+    for h in hops:
+        belief_by_id[h.belief.id] = h.belief
+
+    paths: list[ConsequencePath] = []
+
+    for s in seeds:
+        m = _mean(s)
+        paths.append(
+            ConsequencePath(
+                belief_ids=(s.id,),
+                edge_kinds=(),
+                compound_confidence=m,
+                weakest_link_belief_id=s.id,
+                fork_from=None,
+            )
+        )
+
+    for h in hops:
+        trail = h.belief_id_trail
+        if not trail:
+            continue
+        beliefs_along: list[Belief] = []
+        for bid in trail:
+            b = belief_by_id.get(bid)
+            if b is None:
+                break
+            beliefs_along.append(b)
+        if len(beliefs_along) != len(trail):
+            continue
+        compound = 1.0
+        for b in beliefs_along:
+            compound *= _mean(b)
+        weakest_id = beliefs_along[0].id
+        weakest_mean = _mean(beliefs_along[0])
+        for b in beliefs_along[1:]:
+            m = _mean(b)
+            if m <= weakest_mean:
+                weakest_mean = m
+                weakest_id = b.id
+        fork_from: str | None = None
+        if h.path and h.path[-1] == EDGE_CONTRADICTS and len(trail) >= 2:
+            fork_from = trail[-2]
+        paths.append(
+            ConsequencePath(
+                belief_ids=tuple(trail),
+                edge_kinds=tuple(h.path),
+                compound_confidence=compound,
+                weakest_link_belief_id=weakest_id,
+                fork_from=fork_from,
+            )
+        )
+
+    return paths

--- a/src/aelfrice/reason.py
+++ b/src/aelfrice/reason.py
@@ -138,6 +138,8 @@ def classify(
     seeds: list[Belief],
     hops: list[ScoredHop],
     store: MemoryStore,
+    *,
+    paths: list[ConsequencePath] | None = None,
 ) -> tuple[Verdict, list[Impasse]]:
     """Derive ``(verdict, impasses)`` from walk evidence.
 
@@ -151,6 +153,14 @@ def classify(
     then ``TIE``, then ``GAP``); within each kind impasses are emitted
     in hop-list order (which itself is deterministic per
     :func:`aelfrice.bfs_multihop.expand_bfs`'s ordering contract).
+
+    ``paths`` (R2, #658): when supplied, the classifier additionally
+    emits a ``TIE`` impasse when two CONTRADICTS-forked paths share a
+    common parent and have compound-confidence values within
+    :data:`CLOSE_MEAN_DELTA` of one another. This is in addition to
+    the R1 posterior-mean TIE rule and trips ``CONTRADICTORY`` per the
+    #658 acceptance criterion. Backwards-compat: when ``paths`` is
+    ``None`` the R1-only behaviour holds.
     """
     impasses: list[Impasse] = []
 
@@ -213,6 +223,36 @@ def classify(
                     note="path ends at high-uncertainty leaf",
                 )
             )
+
+    if paths:
+        forks = [p for p in paths if p.fork_from is not None]
+        by_parent: dict[str, list[ConsequencePath]] = {}
+        for p in forks:
+            assert p.fork_from is not None
+            by_parent.setdefault(p.fork_from, []).append(p)
+        for parent_id, siblings in by_parent.items():
+            for i in range(len(siblings)):
+                for j in range(i + 1, len(siblings)):
+                    a = siblings[i]
+                    b = siblings[j]
+                    if (
+                        abs(a.compound_confidence - b.compound_confidence)
+                        < CLOSE_MEAN_DELTA
+                    ):
+                        impasses.append(
+                            Impasse(
+                                kind=ImpasseKind.TIE,
+                                belief_ids=tuple(
+                                    sorted(
+                                        [a.belief_ids[-1], b.belief_ids[-1]]
+                                    )
+                                ),
+                                note=(
+                                    "forked CONTRADICTS branches with "
+                                    "comparable compound_confidence"
+                                ),
+                            )
+                        )
 
     has_tie = any(i.kind == ImpasseKind.TIE for i in impasses)
     has_cf = any(i.kind == ImpasseKind.CONSTRAINT_FAILURE for i in impasses)

--- a/tests/test_bfs_multihop.py
+++ b/tests/test_bfs_multihop.py
@@ -36,6 +36,7 @@ varies; the assertion is a regression band, not a benchmark target.
 from __future__ import annotations
 
 import time
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 import pytest
@@ -694,7 +695,7 @@ def test_scoredhop_dataclass_shape() -> None:
     assert h.path == [EDGE_SUPPORTS]
     # belief_id_trail defaults to empty for backwards-compat constructors.
     assert h.belief_id_trail == ()
-    with pytest.raises(Exception):
+    with pytest.raises(FrozenInstanceError):
         h.score = 0.9  # type: ignore[misc]
 
 

--- a/tests/test_bfs_multihop.py
+++ b/tests/test_bfs_multihop.py
@@ -692,8 +692,46 @@ def test_scoredhop_dataclass_shape() -> None:
     assert h.score == 0.5
     assert h.depth == 1
     assert h.path == [EDGE_SUPPORTS]
+    # belief_id_trail defaults to empty for backwards-compat constructors.
+    assert h.belief_id_trail == ()
     with pytest.raises(Exception):
         h.score = 0.9  # type: ignore[misc]
+
+
+def test_belief_id_trail_threaded_through_two_hop_walk() -> None:
+    """#645 R2: ``expand_bfs`` emits a per-hop ``belief_id_trail`` that
+    starts at the seed and ends at the hop's belief id, with length
+    ``depth + 1``."""
+    s = MemoryStore(":memory:")
+    _seed_decisional_chain(s)  # S0 -- RELATES_TO --> S1 -- SUPERSEDES --> S2
+    seed = s.get_belief("S0")
+    assert seed is not None
+    hops = expand_bfs([seed], s)
+    by_id = {h.belief.id: h for h in hops}
+    assert by_id["S1"].belief_id_trail == ("S0", "S1")
+    assert by_id["S2"].belief_id_trail == ("S0", "S1", "S2")
+    for h in hops:
+        assert len(h.belief_id_trail) == h.depth + 1
+        assert h.belief_id_trail[-1] == h.belief.id
+
+
+def test_belief_id_trail_with_multiple_seeds_pins_to_originating_seed() -> None:
+    """Each hop's trail begins at the seed it expanded from, not the
+    first seed in the input list."""
+    s = MemoryStore(":memory:")
+    # Two disjoint micro-chains: A -> B and X -> Y.
+    s.insert_belief(_mk("A", "a"))
+    s.insert_belief(_mk("B", "b"))
+    s.insert_belief(_mk("X", "x"))
+    s.insert_belief(_mk("Y", "y"))
+    s.insert_edge(_edge("A", "B", EDGE_SUPPORTS))
+    s.insert_edge(_edge("X", "Y", EDGE_SUPPORTS))
+    seeds = [s.get_belief("A"), s.get_belief("X")]
+    assert all(seed is not None for seed in seeds)
+    hops = expand_bfs([sd for sd in seeds if sd is not None], s)
+    by_id = {h.belief.id: h for h in hops}
+    assert by_id["B"].belief_id_trail == ("A", "B")
+    assert by_id["Y"].belief_id_trail == ("X", "Y")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_reason_wonder.py
+++ b/tests/test_cli_reason_wonder.py
@@ -143,12 +143,41 @@ def test_reason_json_dispatch_empty_when_verdict_sufficient(
 
 def test_reason_text_output_includes_verdict_footer(_isolated_db: Path) -> None:
     """#645 R1: text mode trails the chain with a `verdict:` line and
-    an `impasses:` line (grep-friendly for downstream R3 dispatch)."""
+    an `impasses:` line (grep-friendly for downstream R3 dispatch).
+    #645 R2: also includes a `forks:` block (none on this fixture)."""
     a, _, _ = _seed_chain(_isolated_db)
     code, out = _run("reason", "indentation", "--seed-id", a)
     assert code == 0, out
     assert "verdict:" in out
     assert "impasses:" in out
+    assert "forks:" in out
+
+
+def test_reason_json_payload_includes_paths(_isolated_db: Path) -> None:
+    """#645 R2: `--json` payload exposes a `paths` list whose entries
+    carry the ConsequencePath shape (belief_ids, edge_kinds,
+    compound_confidence, weakest_link_belief_id, fork_from)."""
+    a, _, _ = _seed_chain(_isolated_db)
+    code, out = _run("reason", "indentation", "--seed-id", a, "--json")
+    assert code == 0, out
+    payload = json.loads(out)
+    assert "paths" in payload
+    assert isinstance(payload["paths"], list)
+    assert len(payload["paths"]) >= 1
+    for p in payload["paths"]:
+        assert {
+            "belief_ids",
+            "edge_kinds",
+            "compound_confidence",
+            "weakest_link_belief_id",
+            "fork_from",
+        } <= set(p.keys())
+        assert isinstance(p["belief_ids"], list)
+        assert isinstance(p["edge_kinds"], list)
+        assert isinstance(p["compound_confidence"], float)
+        assert p["fork_from"] is None or isinstance(p["fork_from"], str)
+        # Trail length == edge count + 1 invariant.
+        assert len(p["belief_ids"]) == len(p["edge_kinds"]) + 1
 
 
 def test_reason_unknown_seed_id_exits_nonzero(_isolated_db: Path) -> None:

--- a/tests/test_reason_classify.py
+++ b/tests/test_reason_classify.py
@@ -217,3 +217,93 @@ def test_verdict_and_impasse_kind_are_string_valued() -> None:
     # Required for JSON serialisation downstream.
     assert Verdict.SUFFICIENT.value == "SUFFICIENT"
     assert ImpasseKind.NO_CHANGE.value == "NO_CHANGE"
+
+
+# --- R2 (#658) — fork-aware TIE detection -------------------------------
+
+
+def test_classify_fork_aware_tie_with_confident_hop(store: MemoryStore) -> None:
+    """#645 R2: two CONTRADICTS-forked paths sharing a parent and
+    with compound_confidence within CLOSE_MEAN_DELTA produce a TIE
+    impasse, tripping CONTRADICTORY."""
+    from aelfrice.reason import ConsequencePath
+
+    seed = _mk("seed", alpha=5.0, beta=2.0)
+    confident = _mk("conf", alpha=8.0, beta=2.0)
+    # Non-leaf so GAP doesn't fire.
+    store.insert_edge(
+        Edge(src="conf", dst="x", type=EDGE_RELATES_TO, weight=1.0)
+    )
+    h = _hop(confident, [EDGE_CONTRADICTS])
+    paths = [
+        ConsequencePath(
+            belief_ids=("seed", "B1"),
+            edge_kinds=("CONTRADICTS",),
+            compound_confidence=0.50,
+            weakest_link_belief_id="B1",
+            fork_from="seed",
+        ),
+        ConsequencePath(
+            belief_ids=("seed", "B2"),
+            edge_kinds=("CONTRADICTS",),
+            compound_confidence=0.55,  # delta 0.05 < CLOSE_MEAN_DELTA
+            weakest_link_belief_id="B2",
+            fork_from="seed",
+        ),
+    ]
+    verdict, impasses = classify([seed], [h], store, paths=paths)
+    fork_tie = [
+        i for i in impasses
+        if i.kind == ImpasseKind.TIE and i.belief_ids == ("B1", "B2")
+    ]
+    assert len(fork_tie) == 1
+    assert verdict == Verdict.CONTRADICTORY
+
+
+def test_classify_fork_aware_tie_skips_far_apart_compound(store: MemoryStore) -> None:
+    """Two forks with compound_confidence delta >= CLOSE_MEAN_DELTA do
+    not produce a fork-TIE."""
+    from aelfrice.reason import ConsequencePath
+
+    seed = _mk("seed", alpha=5.0, beta=2.0)
+    confident = _mk("conf", alpha=8.0, beta=2.0)
+    store.insert_edge(
+        Edge(src="conf", dst="x", type=EDGE_RELATES_TO, weight=1.0)
+    )
+    h = _hop(confident, [EDGE_CONTRADICTS])
+    paths = [
+        ConsequencePath(
+            belief_ids=("seed", "B1"),
+            edge_kinds=("CONTRADICTS",),
+            compound_confidence=0.90,
+            weakest_link_belief_id="B1",
+            fork_from="seed",
+        ),
+        ConsequencePath(
+            belief_ids=("seed", "B2"),
+            edge_kinds=("CONTRADICTS",),
+            compound_confidence=0.10,  # delta 0.80 >> CLOSE_MEAN_DELTA
+            weakest_link_belief_id="B2",
+            fork_from="seed",
+        ),
+    ]
+    verdict, impasses = classify([seed], [h], store, paths=paths)
+    fork_tie = [
+        i for i in impasses
+        if i.kind == ImpasseKind.TIE and i.belief_ids == ("B1", "B2")
+    ]
+    assert len(fork_tie) == 0
+
+
+def test_classify_paths_none_preserves_r1_behaviour(store: MemoryStore) -> None:
+    """When `paths` is None, classify() yields R1 output unchanged."""
+    seed = _mk("seed", alpha=5.0, beta=2.0)
+    confident = _mk("conf", alpha=8.0, beta=2.0)
+    store.insert_edge(
+        Edge(src="conf", dst="x", type=EDGE_RELATES_TO, weight=1.0)
+    )
+    h = _hop(confident, [EDGE_SUPERSEDES])
+    v_no_paths, i_no_paths = classify([seed], [h], store)
+    v_explicit_none, i_explicit_none = classify([seed], [h], store, paths=None)
+    assert v_no_paths == v_explicit_none
+    assert i_no_paths == i_explicit_none

--- a/tests/test_reason_paths.py
+++ b/tests/test_reason_paths.py
@@ -1,0 +1,219 @@
+"""Pure-derivation tests for :func:`aelfrice.reason.derive_paths` (#645 R2).
+
+Covers the :class:`~aelfrice.reason.ConsequencePath` shape and the
+``derive_paths`` reducer over synthetic seeds + ScoredHops:
+
+  - compound_confidence = product of per-hop posterior means.
+  - weakest_link = argmin posterior mean, deepest-wins tiebreak.
+  - fork_from set when terminal edge is EDGE_CONTRADICTS, points at
+    parent path's terminal belief id.
+  - Seed-only paths emitted alongside hop paths.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aelfrice.bfs_multihop import ScoredHop
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CONTRADICTS,
+    EDGE_RELATES_TO,
+    EDGE_SUPERSEDES,
+    LOCK_NONE,
+    ORIGIN_AGENT_INFERRED,
+    Belief,
+)
+from aelfrice.reason import (
+    ConsequencePath,
+    derive_paths,
+)
+
+
+def _mk(
+    bid: str,
+    *,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=bid,
+        content_hash=f"h-{bid}",
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        demotion_pressure=0,
+        created_at="2026-05-11T00:00:00Z",
+        last_retrieved_at=None,
+        origin=ORIGIN_AGENT_INFERRED,
+    )
+
+
+def _hop(
+    b: Belief,
+    path: list[str],
+    trail: tuple[str, ...],
+    depth: int | None = None,
+    score: float = 0.8,
+) -> ScoredHop:
+    if depth is None:
+        depth = len(trail) - 1
+    return ScoredHop(
+        belief=b,
+        score=score,
+        depth=depth,
+        path=path,
+        belief_id_trail=trail,
+    )
+
+
+def test_seed_only_emits_length_one_path() -> None:
+    seed = _mk("S", alpha=4.0, beta=1.0)  # mean = 0.8
+    paths = derive_paths([seed], [])
+    assert len(paths) == 1
+    p = paths[0]
+    assert p.belief_ids == ("S",)
+    assert p.edge_kinds == ()
+    assert p.compound_confidence == pytest.approx(0.8)
+    assert p.weakest_link_belief_id == "S"
+    assert p.fork_from is None
+
+
+def test_compound_confidence_is_product_of_posterior_means() -> None:
+    s = _mk("S", alpha=4.0, beta=1.0)   # 0.8
+    a = _mk("A", alpha=3.0, beta=1.0)   # 0.75
+    b = _mk("B", alpha=2.0, beta=2.0)   # 0.5
+    hops = [
+        _hop(a, [EDGE_RELATES_TO], ("S", "A")),
+        _hop(b, [EDGE_RELATES_TO, EDGE_SUPERSEDES], ("S", "A", "B")),
+    ]
+    paths = derive_paths([s], hops)
+    # Seed + 2 hops = 3 paths.
+    assert len(paths) == 3
+    by_terminal = {p.belief_ids[-1]: p for p in paths}
+    # path S→A: 0.8 * 0.75 = 0.6
+    assert by_terminal["A"].compound_confidence == pytest.approx(0.6)
+    # path S→A→B: 0.8 * 0.75 * 0.5 = 0.3
+    assert by_terminal["B"].compound_confidence == pytest.approx(0.3)
+
+
+def test_weakest_link_argmin_with_deepest_tiebreak() -> None:
+    # All three beliefs at posterior mean = 0.5 → tie. Tiebreak: deepest.
+    # Real BFS emits a hop per intermediate; mirror that in the fixture.
+    s = _mk("S", alpha=1.0, beta=1.0)
+    a = _mk("A", alpha=1.0, beta=1.0)
+    b = _mk("B", alpha=1.0, beta=1.0)
+    hops = [
+        _hop(a, [EDGE_RELATES_TO], ("S", "A")),
+        _hop(b, [EDGE_RELATES_TO, EDGE_RELATES_TO], ("S", "A", "B")),
+    ]
+    paths = derive_paths([s], hops)
+    by_terminal = {p.belief_ids[-1]: p for p in paths}
+    # Three-belief tied trail: weakest_link = "B" (deepest).
+    assert by_terminal["B"].weakest_link_belief_id == "B"
+
+
+def test_weakest_link_picks_actual_min_not_just_terminal() -> None:
+    s = _mk("S", alpha=4.0, beta=1.0)    # 0.8
+    a = _mk("A", alpha=1.0, beta=4.0)    # 0.2   ← weakest
+    b = _mk("B", alpha=3.0, beta=1.0)    # 0.75
+    hops = [
+        _hop(a, [EDGE_RELATES_TO], ("S", "A")),
+        _hop(b, [EDGE_RELATES_TO, EDGE_RELATES_TO], ("S", "A", "B")),
+    ]
+    paths = derive_paths([s], hops)
+    by_terminal = {p.belief_ids[-1]: p for p in paths}
+    assert by_terminal["B"].weakest_link_belief_id == "A"
+
+
+def test_fork_from_set_on_contradicts_terminal_edge() -> None:
+    s = _mk("S", alpha=5.0, beta=2.0)
+    b = _mk("B", alpha=5.0, beta=2.0)
+    c = _mk("C", alpha=4.0, beta=3.0)
+    hops = [
+        _hop(b, [EDGE_RELATES_TO], ("S", "B")),
+        _hop(c, [EDGE_RELATES_TO, EDGE_CONTRADICTS], ("S", "B", "C")),
+    ]
+    paths = derive_paths([s], hops)
+    by_terminal = {p.belief_ids[-1]: p for p in paths}
+    # Parent path (terminating at B): fork_from is None.
+    assert by_terminal["B"].fork_from is None
+    # Forked branch (terminating at C via CONTRADICTS): fork_from == "B".
+    assert by_terminal["C"].fork_from == "B"
+    assert by_terminal["C"].edge_kinds[-1] == EDGE_CONTRADICTS
+
+
+def test_fork_from_none_when_contradicts_not_terminal() -> None:
+    """A CONTRADICTS edge in the middle of the path is not a fork —
+    only when it's the terminal edge does the fork rule fire."""
+    s = _mk("S", alpha=5.0, beta=2.0)
+    a = _mk("A", alpha=5.0, beta=2.0)
+    b = _mk("B", alpha=5.0, beta=2.0)
+    hops = [
+        _hop(a, [EDGE_CONTRADICTS], ("S", "A")),
+        _hop(b, [EDGE_CONTRADICTS, EDGE_RELATES_TO], ("S", "A", "B")),
+    ]
+    paths = derive_paths([s], hops)
+    by_terminal = {p.belief_ids[-1]: p for p in paths}
+    # First hop (terminal CONTRADICTS) forks from "S".
+    assert by_terminal["A"].fork_from == "S"
+    # Second hop continues from A via RELATES_TO; terminal edge is not
+    # CONTRADICTS so no fork_from on this path.
+    assert by_terminal["B"].fork_from is None
+
+
+def test_empty_hops_yields_only_seed_paths() -> None:
+    seeds = [_mk("S1"), _mk("S2")]
+    paths = derive_paths(seeds, [])
+    assert len(paths) == 2
+    assert {p.belief_ids for p in paths} == {("S1",), ("S2",)}
+    for p in paths:
+        assert p.edge_kinds == ()
+        assert p.fork_from is None
+
+
+def test_skip_hop_with_empty_trail_does_not_crash() -> None:
+    """ScoredHops constructed without belief_id_trail (older fixture
+    style) are silently skipped rather than asserted, since the
+    deriver can't reconstruct a path from depth/path-of-edges alone."""
+    s = _mk("S")
+    a = _mk("A")
+    legacy_hop = ScoredHop(
+        belief=a, score=0.8, depth=1, path=[EDGE_RELATES_TO]
+    )  # belief_id_trail defaults to ()
+    paths = derive_paths([s], [legacy_hop])
+    # One seed path only; legacy hop is skipped.
+    assert len(paths) == 1
+    assert paths[0].belief_ids == ("S",)
+
+
+def test_consequencepath_is_frozen_and_hashable() -> None:
+    p1 = ConsequencePath(
+        belief_ids=("A", "B"),
+        edge_kinds=(EDGE_RELATES_TO,),
+        compound_confidence=0.6,
+        weakest_link_belief_id="B",
+        fork_from=None,
+    )
+    p2 = ConsequencePath(
+        belief_ids=("A", "B"),
+        edge_kinds=(EDGE_RELATES_TO,),
+        compound_confidence=0.6,
+        weakest_link_belief_id="B",
+        fork_from=None,
+    )
+    assert p1 == p2
+    assert hash(p1) == hash(p2)
+    with pytest.raises(Exception):
+        p1.compound_confidence = 0.9  # type: ignore[misc]
+
+
+def test_derive_paths_is_deterministic() -> None:
+    s = _mk("S", alpha=4.0, beta=1.0)
+    a = _mk("A", alpha=3.0, beta=1.0)
+    hops = [_hop(a, [EDGE_RELATES_TO], ("S", "A"))]
+    p1 = derive_paths([s], hops)
+    p2 = derive_paths([s], hops)
+    assert p1 == p2


### PR DESCRIPTION
R2 of the #645 umbrella per the 2026-05-11 ratification — adds the path-centric view of a BFS expansion (compound confidence + weakest-link marker + fork-on-CONTRADICTS) on top of R1's verdict / impasses.

## Surface

### New module surface — `src/aelfrice/reason.py`

```python
@dataclass(frozen=True)
class ConsequencePath:
    belief_ids: tuple[str, ...]            # root → leaf
    edge_kinds: tuple[str, ...]            # len == len(belief_ids) - 1
    compound_confidence: float             # ∏ posterior_mean over the trail
    weakest_link_belief_id: str            # argmin posterior_mean (deepest wins ties)
    fork_from: str | None = None           # parent path's terminal id when CONTRADICTS-forked

def derive_paths(
    seeds: list[Belief],
    hops: list[ScoredHop],
) -> list[ConsequencePath]: ...
```

Pure derivation — no graph traversal, no store lookups. Reconstructs trails from each hop's `belief_id_trail` (added to `ScoredHop` in commit 1) plus the posterior means of seeds and hop endpoints already in scope.

### BFS surface — `src/aelfrice/bfs_multihop.py`

`ScoredHop` gains a `belief_id_trail: tuple[str, ...] = ()` field, populated by `expand_bfs` as it walks. Trail length is always `depth + 1`; first element is the originating seed, last is the hop's endpoint. Frontier tuples carry the trail in a fifth slot. Default `()` keeps existing test fixtures (which construct `ScoredHop` directly) working.

### Fork-aware classifier — `src/aelfrice/reason.py::classify`

```python
def classify(
    seeds: list[Belief],
    hops: list[ScoredHop],
    store: MemoryStore,
    *,
    paths: list[ConsequencePath] | None = None,
) -> tuple[Verdict, list[Impasse]]: ...
```

When `paths` is supplied, additionally emits a `TIE` impasse when two CONTRADICTS-forked paths share a common parent and have `compound_confidence` values within `CLOSE_MEAN_DELTA` (0.15) of one another. Trips `CONTRADICTORY` per #658 acceptance. `paths=None` (default) preserves R1 behaviour exactly — guarded by a regression test.

### CLI surface — `aelf reason`

- **JSON (`--json`)** gains a `paths` array; entries shaped `{belief_ids, edge_kinds, compound_confidence, weakest_link_belief_id, fork_from}`. Existing keys (`query`, `seeds`, `hops`, `verdict`, `impasses`) unchanged.
- **Text mode** appends a `forks:` block after `impasses:`. When empty: `forks: (none)`. When populated: one indented row per forked path: `<parent_id> -> <leaf_id> [compound=<0.000>, weakest=<id>]`. Grep-friendly for R3's dispatch policy.

## Acceptance check (vs #658)

- [x] `ConsequencePath.compound_confidence` is the multiplicative product of per-hop posterior means.
- [x] `ConsequencePath.weakest_link_belief_id` points at the lowest-confidence belief along the path (ties broken by deepest hop, pinned in test).
- [x] A `CONTRADICTS`-edge synthetic corpus produces two paths in the result — parent (terminating at B) and forked (terminating at C with `fork_from = B`). Both surfaced through `--json`.
- [x] R1 verdict / impasse logic consumes the new fields correctly — `CONTRADICTORY` trips when forked paths have comparable compound_confidence.
- [x] `--json` output schema documents the new fields (via dataclass + test pin).

## Out of scope

- VERDICT-driven slash dispatch + `feedback()` close-the-loop — **R3** (#659), separate PR.
- Wonder default-flip — separate slice on #645.

## Verification

```
uv run pytest tests/test_bfs_multihop.py tests/test_reason_paths.py \
              tests/test_reason_classify.py tests/test_cli_reason_wonder.py -v
# 94 passed in 1.23s

uv run pytest -x --timeout=30
# 3427 passed, 55 skipped in 73s
```

## Atomic commits

1. `feat(retrieval): trail belief-ids through BFS frontier (#658 R2 prereq)` — `ScoredHop.belief_id_trail` + frontier threading + 2 new BFS tests.
2. `feat(reason): ConsequencePath + derive_paths with fork-on-CONTRADICTS (#658 R2)` — pure deriver + 10 unit tests.
3. `feat(reason): fork-aware classify + paths in aelf reason output (#658 R2)` — classify `paths=` kwarg, JSON + text wiring, 1 CLI test + 3 classifier tests + R1 regression guard.

## Closes

Does not close #658 — the issue's own follow-up acceptance items (verdict-driven dispatch in R3) ship separately. Closes nothing; refs the sub-task issue.

Refs: #658 (R2 sub-task), #645 (umbrella), PR #660 (R1, merged).

## Summary by Sourcery

Introduce path-level reasoning artifacts and fork-aware contradiction handling in the reasoning pipeline and CLI.

New Features:
- Add ConsequencePath records and a derive_paths helper to represent root-to-leaf consequence chains with compound confidence and weakest-link metadata.
- Track per-hop belief_id_trail in BFS expansions to reconstruct full belief paths from seeds to hop endpoints.
- Expose derived consequence paths and fork metadata in the aelf reason CLI JSON and text outputs.

Enhancements:
- Extend classify to accept pre-derived paths and detect TIE impasses between CONTRADICTS-forked branches with comparable compound confidence while preserving prior behaviour when paths are omitted.

Tests:
- Add unit tests for ConsequencePath derivation semantics, including compound confidence, weakest-link selection, fork detection, determinism, and legacy hop handling.
- Add BFS tests to verify belief_id_trail threading from seeds through multi-hop walks and across multiple seeds.
- Add classifier tests for fork-aware TIE detection and a regression guard for the paths=None case.
- Extend CLI tests to pin the new forks text block and paths list in the JSON payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reasoning output (human and JSON) now includes explicit consequence paths: ordered belief chains, edge kinds, compound confidence, weakest-link belief ID, and fork linkage; human-readable footer shows a "forks:" section.
* **Bug Fixes / Reliability**
  * Multi-hop expansion now preserves per-path origin so derived paths reflect correct seed-to-hop trails.
* **Tests**
  * Added extensive tests validating path derivation, fork-aware tie detection, immutability, and deterministic behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/664)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->