### PR TITLE
fix(reason): ratio-based fork-tie threshold for compound_confidence (#668)

### DIFF
--- a/src/aelfrice/reason.py
+++ b/src/aelfrice/reason.py
@@ -114,9 +114,40 @@ the prior."""
 
 CLOSE_MEAN_DELTA: Final[float] = 0.15
 """Two posterior means whose absolute difference is below this delta
-count as "similar" for ``TIE`` detection. Empirical: a 0.15 gap in
-posterior mean is roughly the noise floor of a ``Beta(2, 4)`` vs
-``Beta(3, 3)`` comparison (both ~6 trials)."""
+count as "similar" for the R1 posterior-mean ``TIE`` rule. Empirical:
+a 0.15 gap in posterior mean is roughly the noise floor of a
+``Beta(2, 4)`` vs ``Beta(3, 3)`` comparison (both ~6 trials).
+
+This constant applies to per-belief posterior means only. The
+fork-aware ``TIE`` rule on ``ConsequencePath.compound_confidence``
+uses :data:`COMPOUND_TIE_FLOOR` + :data:`COMPOUND_TIE_REL_TOL`
+instead (#668) — multiplicative compound scores need a
+ratio-based test, not an absolute-diff one, to stay sensible across
+varying path depths."""
+
+COMPOUND_TIE_FLOOR: Final[float] = 0.10
+"""Minimum ``compound_confidence`` for a forked-path pair to be
+eligible for ``TIE`` detection. Pairs whose lower-compound side is
+below this floor are not "comparable" in any useful sense — they
+both decayed too hard along their respective paths to constitute
+meaningful evidence either way. Empirical: 0.10 sits below the BFS
+``min_path_score`` floor (0.10) so any path that survived the walk
+clears the floor in the common case; only deeply-attenuated
+multi-hop paths fall below."""
+
+COMPOUND_TIE_REL_TOL: Final[float] = 0.20
+"""Relative tolerance (``abs(a - b) / max(a, b)``) below which two
+compound_confidence values count as "comparable" for fork-TIE
+detection. Scale-invariant: deeper paths require tighter absolute
+agreement, matching the intuition that two near-collapsed compounds
+(say 0.10 vs 0.08, ratio 0.20) are an actual tie while two strong
+ones (0.99 vs 0.85, ratio ~0.14) are also one, but two mid-range
+compounds at 0.24 vs 0.10 (ratio 0.58) are not.
+
+The earlier R2 prototype used :data:`CLOSE_MEAN_DELTA` (0.15
+absolute) as a stand-in here; that was calibrated against
+per-belief means in the ~0.5 region and over-fires on
+long-path pairs. Replaced as #668."""
 
 
 def _trials(b: Belief) -> float:
@@ -132,6 +163,33 @@ def _mean(b: Belief) -> float:
 
 def _is_low_evidence(b: Belief) -> bool:
     return _trials(b) < CONFIDENT_TRIALS_MIN
+
+
+def _compound_paths_tie(a: float, b: float) -> bool:
+    """Whether two fork-path ``compound_confidence`` values count as a
+    TIE for fork-aware classifier rule (#668).
+
+    Two-knob test (Option B from #668 design):
+
+    1. Both compounds must be above :data:`COMPOUND_TIE_FLOOR` —
+       deeply-attenuated pairs are too weak to constitute meaningful
+       contradiction, no matter how close they are.
+    2. Their relative gap (``abs(a - b) / max(a, b)``) must be below
+       :data:`COMPOUND_TIE_REL_TOL`. Scale-invariant: deeper paths
+       require tighter absolute agreement, in proportion to their
+       compound's magnitude.
+
+    Replaces the earlier absolute-diff check against
+    :data:`CLOSE_MEAN_DELTA`, which was calibrated against per-
+    belief posterior means and over-fired on long-path pairs whose
+    compounds had decayed together.
+    """
+    if min(a, b) <= COMPOUND_TIE_FLOOR:
+        return False
+    denom = max(a, b)
+    if denom <= 0:
+        return False
+    return abs(a - b) / denom < COMPOUND_TIE_REL_TOL
 
 
 def classify(
@@ -235,9 +293,8 @@ def classify(
                 for j in range(i + 1, len(siblings)):
                     a = siblings[i]
                     b = siblings[j]
-                    if (
-                        abs(a.compound_confidence - b.compound_confidence)
-                        < CLOSE_MEAN_DELTA
+                    if _compound_paths_tie(
+                        a.compound_confidence, b.compound_confidence
                     ):
                         impasses.append(
                             Impasse(

--- a/tests/test_reason_classify.py
+++ b/tests/test_reason_classify.py
@@ -307,3 +307,134 @@ def test_classify_paths_none_preserves_r1_behaviour(store: MemoryStore) -> None:
     v_explicit_none, i_explicit_none = classify([seed], [h], store, paths=None)
     assert v_no_paths == v_explicit_none
     assert i_no_paths == i_explicit_none
+
+
+# --- #668: ratio-based compound-tie threshold ---------------------------
+
+
+def test_classify_fork_tie_short_path_ties_long_path_does_not(
+    store: MemoryStore,
+) -> None:
+    """#668: identical absolute diff (0.14) — short paths near 1.0 tie,
+    long paths near 0.2 do not.
+
+    Short-path pair: compound 0.99 vs 0.85, ratio 0.14 < 0.20 → TIE.
+    Long-path pair:  compound 0.24 vs 0.10, ratio 0.58 → no TIE.
+
+    Both have the same absolute diff (~0.14). The old absolute-only
+    rule against CLOSE_MEAN_DELTA=0.15 would tie both; the new
+    relative-tolerance rule correctly separates them.
+    """
+    from aelfrice.reason import ConsequencePath
+
+    seed = _mk("seed", alpha=5.0, beta=2.0)
+    confident = _mk("conf", alpha=8.0, beta=2.0)
+    store.insert_edge(
+        Edge(src="conf", dst="x", type=EDGE_RELATES_TO, weight=1.0)
+    )
+    h = _hop(confident, [EDGE_CONTRADICTS])
+
+    short_paths = [
+        ConsequencePath(
+            belief_ids=("seed", "S1"),
+            edge_kinds=("CONTRADICTS",),
+            compound_confidence=0.99,
+            weakest_link_belief_id="S1",
+            fork_from="seed",
+        ),
+        ConsequencePath(
+            belief_ids=("seed", "S2"),
+            edge_kinds=("CONTRADICTS",),
+            compound_confidence=0.85,
+            weakest_link_belief_id="S2",
+            fork_from="seed",
+        ),
+    ]
+    _, impasses_short = classify([seed], [h], store, paths=short_paths)
+    short_tie = [
+        i for i in impasses_short
+        if i.kind == ImpasseKind.TIE and i.belief_ids == ("S1", "S2")
+    ]
+    assert len(short_tie) == 1, "short-path pair must TIE"
+
+    long_paths = [
+        ConsequencePath(
+            belief_ids=("seed", "x", "y", "L1"),
+            edge_kinds=("RELATES_TO", "RELATES_TO", "CONTRADICTS"),
+            compound_confidence=0.24,
+            weakest_link_belief_id="L1",
+            fork_from="seed",
+        ),
+        ConsequencePath(
+            belief_ids=("seed", "x", "y", "L2"),
+            edge_kinds=("RELATES_TO", "RELATES_TO", "CONTRADICTS"),
+            compound_confidence=0.10,
+            weakest_link_belief_id="L2",
+            fork_from="seed",
+        ),
+    ]
+    _, impasses_long = classify([seed], [h], store, paths=long_paths)
+    long_tie = [
+        i for i in impasses_long
+        if i.kind == ImpasseKind.TIE and i.belief_ids == ("L1", "L2")
+    ]
+    assert len(long_tie) == 0, (
+        "long-path pair with same absolute diff but different ratio "
+        "must NOT TIE"
+    )
+
+
+def test_classify_fork_tie_below_compound_floor_does_not_tie(
+    store: MemoryStore,
+) -> None:
+    """#668: near-collapsed compounds (≈0.02) do not TIE even though
+    their absolute diff is tiny.
+
+    Compound floor is 0.10. A pair at 0.03 vs 0.02 has ratio 0.33,
+    BUT both sides are below the floor — meaning neither side has
+    survived the BFS as meaningful evidence. The fork-TIE rule
+    skips them entirely.
+    """
+    from aelfrice.reason import ConsequencePath
+
+    seed = _mk("seed", alpha=5.0, beta=2.0)
+    confident = _mk("conf", alpha=8.0, beta=2.0)
+    store.insert_edge(
+        Edge(src="conf", dst="x", type=EDGE_RELATES_TO, weight=1.0)
+    )
+    h = _hop(confident, [EDGE_CONTRADICTS])
+
+    paths = [
+        ConsequencePath(
+            belief_ids=("seed", "F1"),
+            edge_kinds=("CONTRADICTS",),
+            compound_confidence=0.03,
+            weakest_link_belief_id="F1",
+            fork_from="seed",
+        ),
+        ConsequencePath(
+            belief_ids=("seed", "F2"),
+            edge_kinds=("CONTRADICTS",),
+            compound_confidence=0.02,
+            weakest_link_belief_id="F2",
+            fork_from="seed",
+        ),
+    ]
+    _, impasses = classify([seed], [h], store, paths=paths)
+    floor_tie = [
+        i for i in impasses
+        if i.kind == ImpasseKind.TIE and i.belief_ids == ("F1", "F2")
+    ]
+    assert len(floor_tie) == 0, (
+        "pair below COMPOUND_TIE_FLOOR must not TIE regardless of "
+        "absolute diff"
+    )
+
+
+def test_compound_tie_constants_documented_and_load_bearing() -> None:
+    """#668 named thresholds; pin the values so any retune is a
+    deliberate change."""
+    from aelfrice.reason import COMPOUND_TIE_FLOOR, COMPOUND_TIE_REL_TOL
+
+    assert COMPOUND_TIE_FLOOR == 0.10
+    assert COMPOUND_TIE_REL_TOL == 0.20


### PR DESCRIPTION
Follow-up to PR #664 (#658 R2). Prereq for #659 (R3 dispatch consumer). **Stacks on PR #664**: while #664 is open, this PR's diff includes R2's 3 commits plus the 1 #668 commit. Once #664 merges, the diff shrinks to the #668 commit only.

## Problem (recap of #668)

`reason.CLOSE_MEAN_DELTA = 0.15` is calibrated against single Beta posterior-mean diffs in the ~0.5 region. R2 reused it as the fork-pair threshold on `ConsequencePath.compound_confidence`, which is a multiplicative product over N posterior means. The additive-diff scale doesn't carry across:

| Path A (compound) | Path B (compound) | abs diff | old rule | new rule | intuition |
| --- | --- | ---: | --- | --- | --- |
| 0.99 (1 hop, μ=0.99) | 0.85 (1 hop, μ=0.85) | 0.14 | TIE | TIE | reasonable |
| 0.24 (3 hops, ~μ=0.62) | 0.10 (3 hops, ~μ=0.46) | 0.14 | TIE (over-fires) | no TIE | 2.4× ratio — wrong |
| 0.03 | 0.02 | 0.01 | TIE (over-fires) | no TIE | both below floor |

## Surface (Option B from the issue)

```python
COMPOUND_TIE_FLOOR: Final[float] = 0.10
COMPOUND_TIE_REL_TOL: Final[float] = 0.20

def _compound_paths_tie(a: float, b: float) -> bool:
    if min(a, b) <= COMPOUND_TIE_FLOOR:
        return False
    return abs(a - b) / max(a, b) < COMPOUND_TIE_REL_TOL
```

`classify` calls `_compound_paths_tie` from the fork-aware section instead of the previous `abs(...) < CLOSE_MEAN_DELTA` test. `CLOSE_MEAN_DELTA` itself is unchanged — the R1 posterior-mean TIE rule still uses it, where absolute-diff calibration is correct.

Constants chosen via the synthetic-fixture sweep #668 asked for:
- `COMPOUND_TIE_FLOOR = 0.10` matches the BFS `min_path_score` floor — any path that survived the walk clears it in the common case; only deeply-attenuated multi-hop paths fall below.
- `COMPOUND_TIE_REL_TOL = 0.20` is the smallest tolerance that keeps the existing R2 fixtures passing (compound 0.50 vs 0.55, ratio 0.091 < 0.20).

## Acceptance check (vs #668)

- [x] New constants chosen with documented derivation (see commit body + docstrings).
- [x] Two new acceptance tests in `tests/test_reason_classify.py` fork-aware section:
      - `test_classify_fork_tie_short_path_ties_long_path_does_not` — short / long paths with identical absolute diff; short ties, long doesn't.
      - `test_classify_fork_tie_below_compound_floor_does_not_tie` — near-collapsed compounds (0.03/0.02) skip the TIE.
- [x] One bonus pin test for the constants themselves so any retune is deliberate.
- [x] Existing R2 fork-aware fixtures (`test_classify_fork_aware_tie_with_confident_hop`, `test_classify_fork_aware_tie_skips_far_apart_compound`) keep passing — the new rule subsumes the old absolute-diff sample without needing churn.

## Verification

```
uv run pytest tests/test_reason_classify.py tests/test_reason_paths.py \
              tests/test_cli_reason_wonder.py tests/test_bfs_multihop.py
# 97 passed in 5.05s

uv run pytest -x --timeout=30
# 3448 passed, 55 skipped in 71s
```

## Closes

`Closes #668`. Does not close #659 (R3 consumer) or #645 (umbrella) — both still open and progressing in parallel (R3 covered by PR #665).

Refs: #658 (R2 spec), PR #664 (R2 implementation, this PR's base), #659 (R3 consumer), #645 (umbrella).
