### PR TITLE
docs(v3.0): release-gate documentation hygiene — ROADMAP + CHANGELOG + federation-primitives + LIMITATIONS (#663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+## [3.0.0] - Unreleased
+
 ### Added
 
 - **`#N` literal boost in L1 BM25 scoring** ([#677](https://github.com/robotrocketscience/aelfrice/issues/677)). The L1 BM25 tokenizer drops `#`, so plain `#NNN` prompts used to collide on the bare digit with every other `#NNN` in the corpus — audit-log survey of 88 substantive `#NNN`-bearing prompts measured ~20% mean topical-hit rate; 5/88 got zero relevant hits. `_l1_hits` now extracts `#\d+` literals from the prompt via `_extract_hash_n_literals` and, in both the FTS5 and BM25F lanes, adds `log(HASH_N_BOOST_MULTIPLIER)` (default `log(2.0)`) to the final per-belief log score when belief content contains any prompt literal. The shift is log-additive in the same space `partial_bayesian_score` / `combine_log_scores` produce, equivalent to multiplying the BM25 relevance magnitude by the multiplier. Prompts without `#N` literals take the existing byte-identical FTS5 / BM25F short-circuit unchanged — only `#N`-bearing prompts route through the rerank loop, so the v1.0.x `posterior_weight=0.0` byte-identical contract holds for every other query shape. The substring check is literal `lit in content` rather than tokenised, because the whole disambiguation hinges on the `#` anchor the tokenizer otherwise strips. Eleven unit + end-to-end tests cover extraction (multi-literal, bare-digit rejection), the boost helper (presence-of-any semantics, single boost even with multiple matching literals), and the acceptance-bullet ranking case from the issue body.

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -31,7 +31,7 @@ Classification on the CLI path defaults to regex-based priors. Higher-quality cl
 
 The v1.3.0 BFS multi-hop expansion (see [bfs_multihop.md](bfs_multihop.md)) resolves each hop to the globally latest serial of its target belief independently. For audit-shaped queries ("what did the agent believe at the time it made this decision?") this can surface a chain whose intermediate hops postdate the seed's session — a fidelity loss against a corpus where supersessions accumulated after the seed was written.
 
-The default retrieval mode (recall, not audit) is correctly served by latest-serial-per-hop. The temporal-coherence fix was originally targeted at v2.0.0 alongside the reproducibility harness; the harness shipped (#437) but the temporal fix slipped past v2.0/v2.1 and is now deferred to v2.x. The spec § Open question: temporal coherence documents why deferring is the right call for v1.3.
+The default retrieval mode (recall, not audit) is correctly served by latest-serial-per-hop. The temporal-coherence fix was originally targeted at v2.0.0 alongside the reproducibility harness; the harness shipped (#437) but the temporal fix slipped past v2.0/v2.1 and is not scheduled on a current milestone. The spec § Open question: temporal coherence documents why deferring is the right call for v1.3.
 
 ## Sharp edges
 
@@ -52,13 +52,15 @@ The default retrieval mode (recall, not audit) is correctly served by latest-ser
 
 These are scope choices that follow from aelfrice's commitments. They are *not* roadmap items.
 
-### Sharing, sync, or federation
+### Sharing, sync, or distributed-write federation
 
-aelfrice ships no mechanism for exporting, syncing, or distributing memory contents between users, machines, or projects. The brain graph stays on the machine it was written on.
+aelfrice ships no mechanism for syncing, distributing-by-write, or otherwise replicating memory contents between users or machines. The brain graph stays on the machine it was written on.
 
 This is a privacy and audit choice. A graph derived from real session activity contains filesystem paths, hostnames, internal URLs, names from git config, project architecture details, and content the agent inferred from chat. None of that is suitable for cross-machine distribution by default. Per-belief allowlists are not reliable enough to make automated export safe.
 
 To bootstrap a new clone or collaborator: run `aelf onboard .`. The graph is re-extracted from publicly-visible repo content. To share rules: lock them in CLAUDE.md, CONTRIBUTING.md, or other repo-tracked prose, and the onboard scanner picks them up.
+
+**Read-only cross-project federation is in v3.0 scope** (#650, #655, ratified read-only-only under #661): a local DB can declare peer DBs via `knowledge_deps.json` and surface their beliefs in retrieval, but the per-project DB is the sole writer for its own beliefs and mutation tools reject foreign belief IDs. That mechanism is read-only by construction — no cross-machine write replication, no distributed-write CRDT layer — so the privacy and audit story above is preserved. Multi-writer federation is not on the roadmap.
 
 ### Multi-session aggregation
 
@@ -68,7 +70,7 @@ The principled response is to add aggregative-query routing at the structural-an
 
 ### Multi-project query
 
-One DB at a time. Beliefs from project A do not surface in project B (different `.git/` directories). Use `AELFRICE_DB` to scope per-project explicitly.
+One DB writes at a time. Beliefs written in project A do not get *written* into project B (different `.git/` directories); use `AELFRICE_DB` to scope per-project explicitly. v3.0's read-only federation (above) is the path for *reading* peer-project beliefs into a local query without merging the underlying stores.
 
 ## Compatibility
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -60,7 +60,7 @@ This is a privacy and audit choice. A graph derived from real session activity c
 
 To bootstrap a new clone or collaborator: run `aelf onboard .`. The graph is re-extracted from publicly-visible repo content. To share rules: lock them in CLAUDE.md, CONTRIBUTING.md, or other repo-tracked prose, and the onboard scanner picks them up.
 
-**Read-only cross-project federation is in v3.0 scope** (#650, #655, ratified read-only-only under #661): a local DB can declare peer DBs via `knowledge_deps.json` and surface their beliefs in retrieval, but the per-project DB is the sole writer for its own beliefs and mutation tools reject foreign belief IDs. That mechanism is read-only by construction — no cross-machine write replication, no distributed-write CRDT layer — so the privacy and audit story above is preserved. Multi-writer federation is not on the roadmap.
+**Read-only cross-project federation is in v3.0 scope** (#650, #655, ratified as read-only under #661): a local DB can declare peer DBs via `knowledge_deps.json` and surface their beliefs in retrieval, but the per-project DB is the sole writer for its own beliefs and mutation tools reject foreign belief IDs. That mechanism is read-only by construction — no cross-machine write replication, no distributed-write CRDT layer — so the privacy and audit story above is preserved. Multi-writer federation is not on the roadmap.
 
 ### Multi-session aggregation
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -140,6 +140,25 @@ After v2.0.0, `benchmarks/` reproduces every published headline number on a fres
 - Expanded surface: `wonder`, `reason`, `core`, `unlock`, `delete`, `confirm`, plus graph-metrics and document-linking.
 - Reproducibility harness: `benchmarks/results/v2.0.0.json` is canonical; CI runs the academic suite nightly.
 
+### v3.0.0 — completion + design cut
+
+v3.0 closes the wonder-lifecycle wave, ships HRR persistence with split-format migration, ships type-aware compression at the rebuilder gate, and ratifies four v3-level design decisions. Replaces the prior v2.2 row, whose three referenced issues turned out to be stale (#197 WONTFIX; #193 evaluation shipped without hook successor; #194 was `ingest_turn(bulk=)`, also shipped). Milestone tracker: [#608](https://github.com/robotrocketscience/aelfrice/issues/608).
+
+Substrate completion:
+
+- **HRR persistence default-ON + split-format migration** ([#553](https://github.com/robotrocketscience/aelfrice/issues/553)). On-disk format moves from monolithic to split `.npy` + `.npz`; persistence defaults to on with an opt-out flag for disk-cost-sensitive installs.
+- **Wonder lifecycle completion** ([#542](https://github.com/robotrocketscience/aelfrice/issues/542) umbrella). Substrate + lifecycle + dispatch. Sub-tasks: phantom promotion trigger ([#550](https://github.com/robotrocketscience/aelfrice/issues/550), shipping Surfaces A+B per the 2026-05-11 ratification — no count-trigger); skill-layer subagent dispatch → `wonder_ingest` ([#552](https://github.com/robotrocketscience/aelfrice/issues/552)); bake-off re-run ([#547](https://github.com/robotrocketscience/aelfrice/issues/547), shipped).
+- **Type-aware compression** ([#434](https://github.com/robotrocketscience/aelfrice/issues/434), shipped). A2 recall@k bench gate landed; rebuilder continuation-fidelity (A4) remains the flip-default gate.
+- **HRR structural-query retrieve_v2 phase-2** ([#152](https://github.com/robotrocketscience/aelfrice/issues/152)). Substrate landed v1.7, phase 1 wiring v2.x; phase 2 remains `attn:bench-needed`.
+- **Eval-harness wire for #587 hot-start scoring** ([#592](https://github.com/robotrocketscience/aelfrice/issues/592)). Judge stage, replay path, and hot-start fixture all shipped on main (PR #613, #601, #639). Remaining work is bench-only — run the harness with judges enabled and capture hot-start ≥ 80% and cold-start no-regression. `attn:bench-needed`.
+
+Design ratifications (all closed, doc-only follow-through):
+
+- **NL-relatedness philosophy** ([#605](https://github.com/robotrocketscience/aelfrice/issues/605), ratified 2026-05-10). Option 1 — stay deterministic, narrow surface. Dedup, contradiction, and relatedness gates live in the consuming agent, not aelfrice.
+- **Sentiment-feedback hook production wire-up** ([#606](https://github.com/robotrocketscience/aelfrice/issues/606), ratified 2026-05-10). `UserPromptSubmit` lane, default-off opt-in, most-recent-window decay policy.
+- **Multimodel scope** ([#607](https://github.com/robotrocketscience/aelfrice/issues/607), deferred 2026-05-11). No maintainer validation path for third-party LLM CLIs; the wonder-dispatch lane (#542/#551) covers the in-tree story.
+- **Federation write model** ([#661](https://github.com/robotrocketscience/aelfrice/issues/661), ratified 2026-05-11). Option B — read-only federation. Per-project DB is sole writer; peers open foreign DBs read-only (SQLite ATTACH) and UNION FTS5 results. Mutation tools reject foreign belief IDs at the API surface. Closes CRDT-primitives sub-issues (#651-#654) WONTFIX; rescopes #650 + #655 to read-only mechanics (scope field, promote/demote verbs, `knowledge_deps.json`, read-time overlay, foreign-ID rejection). See [`docs/design/federation-primitives.md`](design/federation-primitives.md) §1 for the forward-compat version-vector substrate; §2-§5 are flagged as deferred multi-writer extension.
+
 ## Recovery inventory
 
 What the research line had, when each piece returns:

--- a/docs/design/federation-primitives.md
+++ b/docs/design/federation-primitives.md
@@ -2,6 +2,10 @@
 
 **Status:** v3 architectural direction. Pre-implementation; identifies the shape of the work and the one schema change worth landing forward-compatibly in v1.x to avoid losing user data later.
 
+> **Update 2026-05-11 (#661 ratification).** v3.0 ships **read-only federation only** (Option B): the per-project DB is the sole writer; peers open foreign DBs read-only (SQLite ATTACH) and UNION FTS5 results, and mutation tools (`feedback` / `lock` / `delete`) reject foreign belief IDs at the API surface. Under that model there are no concurrent writers, so the CRDT primitives in §2–§5 below are **not in v3.0 scope**: `CONTRADICTS` / lock / counter / GC mechanics stay on their current single-writer encoding. §2–§5 are retained as forward reference if multi-writer federation is ever reopened. **§1 (version vectors) remains valid forward-compat substrate** per the v1.x ship plan in #204 / #205; it is harmless under read-only federation and avoids a painful migration if the model ever changes.
+>
+> Closes the CRDT-primitive sub-issues #651 / #652 / #653 / #654 WONTFIX. Read-only mechanics tracked under #650 (umbrella) and #655 (transport).
+
 ---
 
 ## Frame
@@ -52,6 +56,8 @@ version_vector = { scope_id: monotonic_counter }
 ---
 
 ## 2. CONTRADICTS → MV-Register
+
+> **Deferred (2026-05-11, #661).** §2–§5 describe multi-writer CRDT primitives that are not in v3.0 scope under the read-only federation model. Retained as forward reference.
 
 A `CONTRADICTS` edge expresses "two concurrent values, neither subsumes." That is exactly an MV-Register (Multi-Value Register). The cleaner shape is to make the contradiction a property of the *belief*, not a relationship between two resolved beliefs:
 


### PR DESCRIPTION
Closes #663.

## What ships

Documentation hygiene for the v3.0 cut. Four atomic commits, no code change.

1. **`docs/ROADMAP.md`** — new `### v3.0.0 — completion + design cut` section under `## Planned`, listing the substrate completion items (#553 / #542 / #434 / #152 / #592) and the four design ratifications (#605 / #606 / #607 / #661) with cross-refs to umbrella tracker #608. The note about the stale v2.2 row's three references (#197 WONTFIX / #193 / #194) goes in the new section so the audit trail stays attached to the supersession, not orphaned in the table footer.

2. **`CHANGELOG.md`** — opens `## [3.0.0] - Unreleased` under the existing `## [Unreleased]` header. All current `[Unreleased]` entries (#677 BM25 #N-literal boost, #659 R3 dispatch, #434 type-aware compression A2 gate, #592 hot-start fixture, #667 coverage clamp, #645 wonder default-flip + shorthand, etc.) are v3.0 work and now read under the new heading without any per-entry shuffle. New post-v3.0 work can land under the bare `[Unreleased]` line at the top.

3. **`docs/design/federation-primitives.md`** — top-of-file callout marks §2–§5 (multi-writer CRDT primitives: MV-Register, 2P-Set with provenance, PN-Counter, causal-stable GC) as **deferred extension, not v3.0 scope** per the #661 read-only ratification. §1 (version vectors) is explicitly affirmed as forward-compat substrate per #204 / #205. Per §2 also gets an inline "Deferred" banner so a reader landing mid-document doesn't miss the rescope. Sections are retained, not deleted, so they remain forward reference if multi-writer federation is ever reopened.

4. **`docs/LIMITATIONS.md`** — three localised edits:
   - "Sharing, sync, or federation" renamed to "Sharing, sync, or distributed-write federation" with a paragraph clarifying that **read-only cross-project federation is in v3.0 scope** (#650 / #655 under #661); multi-writer federation is not on the roadmap. Privacy / audit framing preserved.
   - "Multi-project query" updated: writes are still one-DB-at-a-time; reading peer-project beliefs is the read-only federation path.
   - "BFS multi-hop temporal coherence" — stale "deferred to v2.x" target replaced with "not scheduled on a current milestone" (the original v2.0/v2.1 target slipped and there's no v2.x milestone any more under the v3.0 cut).

## What did NOT change

- **`README.md`** — issue body said "Line ~31 'Versions at a glance' table" needed a v2.2 → v3.0 flip, but there is no versions table in README. The README "Next" line at L168 was already flipped to v3.0 by `8b49df8` ("replace stale v2.2 Next line with v3.0 scope") before #663 was filed. The actual versions table lives in `docs/ROADMAP.md` and its v2.2 row was already replaced by `3368e88` ("replace v2.2 row with v3.0 scope cut"). Acceptance bullets 1 and 2 are therefore already satisfied on main; the remaining work (ROADMAP body section, CHANGELOG, federation-primitives, LIMITATIONS) is what this PR ships.
- **#608 umbrella body** — out of scope for #663; it stays open as the milestone tracker.

## Acceptance bullets (#663)

- [x] README versions table flipped v2.2 → v3.0 with accurate scope — _already on main; no README table exists, but the equivalent ROADMAP table row is current and the README "Next" line points at v3.0._
- [x] README "Next" line updated — _already on main (8b49df8)._
- [x] docs/ROADMAP.md has a v3.0 section with the In-Scope items from #608 — _added in commit 1._
- [x] CHANGELOG has `## [3.0.0]` and existing `[Unreleased]` items reconciled — _commit 2._
- [x] docs/design/federation-primitives.md §2–§5 marked deferred per #661 — _commit 3._
- [x] LIMITATIONS.md scan + edits where needed — _commit 4._

## Verification

- `git log --format='%h %G? %s' github/main..HEAD` — four commits, all signed (`G`).
- Discretion grep on diff: clean against the `aelf-pr-open.sh` ban list.
- No code change → no test-shape change. Existing pytest suite is unaffected.
- All linked decisions (#605 / #606 / #607 / #661) are CLOSED; #608 stays open as the milestone tracker.

## Summary by Sourcery

Document v3.0.0 scope, roadmap, and design decisions, and align limitations and federation docs with the read-only federation model, without changing any code.

Documentation:
- Add a v3.0.0 roadmap section outlining completion items, design ratifications, and linking to the milestone tracker.
- Clarify that read-only cross-project federation is in v3.0 scope while multi-writer federation remains out of scope, and update limitations on multi-project queries and temporal coherence wording accordingly.
- Update federation primitives design docs to mark multi-writer CRDT primitives as deferred and affirm version vectors as the forward-compatible substrate for read-only federation.
- Open a 3.0.0 section in the changelog and group existing unreleased items under it in preparation for the v3.0 cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified limitations documentation regarding retrieval modes and cross-project federation capabilities
  * Published v3.0 roadmap detailing planned feature completions and design decisions
  * Documented that v3.0 introduces read-only federation for accessing peer-project data while maintaining privacy

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/682)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->