### PR TITLE
feat(noise_filter): N-gram Jaccard similarity gate + aelf scan-derivation CLI (#681)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -3923,6 +3923,94 @@ def _cmd_tail(args: argparse.Namespace, out: object) -> int:
     )
 
 
+def _cmd_scan_derivation(args: argparse.Namespace, out: object) -> int:
+    """N-gram Jaccard similarity gate against a reference document (#681).
+
+    Reads each PATH (or stdin when '-' is given), computes N-gram
+    Jaccard similarity against the reference file, and prints a
+    one-line result per input.
+
+    Exit codes:
+      0  all inputs are below the threshold (clean)
+      1  at least one input exceeded the threshold (matched)
+      2  the reference file is unreadable
+
+    Designed to drop into a git pre-commit / pre-push hook.
+    """
+    from pathlib import Path as _Path
+
+    from aelfrice.noise_filter import similarity_to_reference
+
+    reference_raw: str | None = getattr(args, "reference", None)
+    threshold: float = float(getattr(args, "threshold", 0.6))
+    n: int = int(getattr(args, "n", 3))
+    paths: list[str] = list(getattr(args, "paths", []) or [])
+
+    if not reference_raw:
+        print("aelf scan-derivation: --reference is required", file=sys.stderr)
+        return 2
+    reference = _Path(reference_raw)
+    if not reference.is_file():
+        print(
+            f"aelf scan-derivation: reference not found or unreadable: {reference}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Pre-check that we can read the reference (exit 2 on failure).
+    try:
+        reference.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        print(
+            f"aelf scan-derivation: cannot read reference {reference}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    any_matched = False
+
+    def _check_text(label: str, text: str) -> None:
+        nonlocal any_matched
+        over, score, excerpt = similarity_to_reference(
+            text, reference, n=n, threshold=threshold
+        )
+        if over:
+            any_matched = True
+            snippet = excerpt or text[:120]
+            print(
+                f"MATCH [{score:.3f}] {label}: {snippet!r}",
+                file=out,  # type: ignore[arg-type]
+            )
+        else:
+            print(
+                f"clean [{score:.3f}] {label}",
+                file=out,  # type: ignore[arg-type]
+            )
+
+    if not paths:
+        # No paths: read stdin as a single blob.
+        text = sys.stdin.read()
+        _check_text("<stdin>", text)
+    else:
+        for p in paths:
+            if p == "-":
+                text = sys.stdin.read()
+                _check_text("<stdin>", text)
+            else:
+                try:
+                    text = _Path(p).read_text(encoding="utf-8", errors="replace")
+                except OSError as exc:
+                    print(
+                        f"aelf scan-derivation: cannot read {p}: {exc}",
+                        file=sys.stderr,
+                    )
+                    any_matched = True  # treat unreadable inputs as failures
+                    continue
+                _check_text(p, text)
+
+    return 1 if any_matched else 0
+
+
 def _known_cli_subcommands() -> frozenset[str]:
     """Snapshot of the subcommands the running `aelf` parser knows.
 
@@ -5308,6 +5396,44 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help="dump current audit contents once and exit (no live tail)",
     )
     p_tail.set_defaults(func=_cmd_tail)
+
+    p_scan_deriv = sub.add_parser(
+        "scan-derivation",
+        help=(
+            "N-gram Jaccard similarity gate against a reference document. "
+            "Exits 0=clean, 1=matched, 2=reference unreadable."
+        ),
+    )
+    p_scan_deriv.add_argument(
+        "--reference",
+        default=None,
+        metavar="PATH",
+        help="path to the reference document to compare against (required)",
+    )
+    p_scan_deriv.add_argument(
+        "--threshold",
+        type=float,
+        default=0.6,
+        metavar="FLOAT",
+        help="Jaccard similarity threshold above which an input is flagged (default: 0.6)",
+    )
+    p_scan_deriv.add_argument(
+        "--n",
+        type=int,
+        default=3,
+        metavar="INT",
+        help="N-gram width in words (default: 3)",
+    )
+    p_scan_deriv.add_argument(
+        "paths",
+        nargs="*",
+        metavar="PATH",
+        help=(
+            "files to check; pass '-' to read stdin. "
+            "If omitted, reads stdin as a single input."
+        ),
+    )
+    p_scan_deriv.set_defaults(func=_cmd_scan_derivation)
 
     return parser
 

--- a/src/aelfrice/noise_filter.py
+++ b/src/aelfrice/noise_filter.py
@@ -431,3 +431,118 @@ def is_license_boilerplate(
     """
     _ = config
     return any(p.search(text) is not None for p in _LICENSE_PATTERNS)
+
+
+# Punctuation characters stripped during N-gram tokenisation. We remove
+# everything that is not a word character or whitespace so that
+# "features," and "features" are treated as the same token.
+_PUNCT_RE: Final[re.Pattern[str]] = re.compile(r"[^\w\s]", re.UNICODE)
+
+
+def _tokenise(text: str) -> list[str]:
+    """Lowercase, strip punctuation, split on whitespace.
+
+    Used by `similarity_to_reference` for both the query text and the
+    reference document so that tokenisation is symmetric.
+    """
+    return _PUNCT_RE.sub(" ", text.lower()).split()
+
+
+def _ngrams(tokens: list[str], n: int) -> frozenset[tuple[str, ...]]:
+    """Return the set of unique N-gram tuples from *tokens*.
+
+    A text shorter than *n* tokens produces an empty set, which
+    results in a Jaccard score of 0.0 (disjoint — no shared N-grams).
+    """
+    if len(tokens) < n:
+        return frozenset()
+    return frozenset(
+        tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1)
+    )
+
+
+def similarity_to_reference(
+    text: str,
+    reference_path: Path,
+    *,
+    n: int = 3,
+    threshold: float = 0.6,
+) -> tuple[bool, float, str | None]:
+    """N-gram Jaccard similarity gate against a reference document.
+
+    Tokenises both ``text`` and the file at ``reference_path`` into
+    normalised N-gram windows (default n=3 words, lowercased, with
+    punctuation stripped). Computes Jaccard similarity over the
+    N-gram sets.
+
+    Returns ``(over_threshold, score, matched_passage_excerpt)``.
+
+    * ``over_threshold`` — True when ``score >= threshold``.
+    * ``score`` — Jaccard similarity in [0.0, 1.0].
+    * ``matched_passage_excerpt`` — a short excerpt of the best
+      matching window from ``text`` when ``over_threshold`` is True,
+      else None.
+
+    **Failure mode (important):** this is a *surface-similarity* gate,
+    not a *plagiarism* gate. It catches near-verbatim paraphrase —
+    re-orderings, minor substitutions, mild expansions of the same
+    surface tokens. It does **not** catch semantic paraphrase (content
+    reworded into entirely different vocabulary). False positives are
+    expected for short technical phrases that legitimately share many
+    tokens with the reference (e.g. repeated API names, standard error
+    messages). Tune ``threshold`` upward to reduce false positives at
+    the cost of sensitivity.
+
+    Mirrors the shape of ``is_noise`` / ``is_three_word_fragment``:
+    pure function, no side effects, stdlib only, deterministic across
+    re-runs.
+
+    Callers that need only the boolean can write::
+
+        flagged, _, _ = similarity_to_reference(text, ref)
+
+    The ``reference_path`` is read fresh on every call so that the
+    caller controls caching. For high-volume use, pre-read the file and
+    call ``_ngrams(_tokenise(content), n)`` once, then reuse the
+    frozenset.
+    """
+    ref_text = reference_path.read_text(encoding="utf-8", errors="replace")
+    ref_tokens = _tokenise(ref_text)
+    ref_set = _ngrams(ref_tokens, n)
+
+    text_tokens = _tokenise(text)
+    text_set = _ngrams(text_tokens, n)
+
+    if not text_set and not ref_set:
+        # Both sides have fewer than n tokens — no N-grams possible.
+        # Treat as perfectly similar (both are empty / trivially the same).
+        return (True, 1.0, text.strip()[:120] or None) if text.strip() else (False, 0.0, None)
+
+    union = text_set | ref_set
+    if not union:
+        return (False, 0.0, None)
+
+    intersection = text_set & ref_set
+    score = len(intersection) / len(union)
+
+    over = score >= threshold
+    excerpt: str | None = None
+    if over:
+        # Find the contiguous window of tokens in *text* that contributes
+        # the most matching N-grams, then reconstruct a short excerpt.
+        best_start = 0
+        best_count = 0
+        window = n * 5  # ~5x the gram width: enough context without being verbose
+        for i in range(max(1, len(text_tokens) - window + 1)):
+            chunk = frozenset(
+                tuple(text_tokens[j : j + n])
+                for j in range(i, min(i + window, len(text_tokens) - n + 1))
+            )
+            count = len(chunk & ref_set)
+            if count > best_count:
+                best_count = count
+                best_start = i
+        end = min(best_start + window, len(text_tokens))
+        excerpt = " ".join(text_tokens[best_start:end])[:200]
+
+    return (over, score, excerpt)

--- a/tests/fixtures/derivation_gate/clean_control.txt
+++ b/tests/fixtures/derivation_gate/clean_control.txt
@@ -1,0 +1,1 @@
+The retrieval subsystem uses a two-lane ranked list to surface the most relevant context for the current session. Lane zero contains user-locked beliefs; lane one contains FTS5 matches ranked by recency and corroboration count.

--- a/tests/fixtures/derivation_gate/paraphrase.txt
+++ b/tests/fixtures/derivation_gate/paraphrase.txt
@@ -1,0 +1,1 @@
+The belief graph stores weighted edges between nodes representing project specific facts extracted from source files and commit history. Each edge carries a Bayesian confidence score that updates when the user provides explicit feedback signals.

--- a/tests/fixtures/derivation_gate/reference.txt
+++ b/tests/fixtures/derivation_gate/reference.txt
@@ -1,0 +1,1 @@
+The belief graph stores weighted edges between nodes representing project-specific facts extracted from source files and commit history. Each edge carries a Bayesian confidence score that updates when the user provides explicit feedback signals.

--- a/tests/test_noise_filter.py
+++ b/tests/test_noise_filter.py
@@ -13,6 +13,7 @@ from aelfrice.noise_filter import (
     is_license_boilerplate,
     is_noise,
     is_three_word_fragment,
+    similarity_to_reference,
 )
 
 
@@ -245,3 +246,86 @@ def test_is_noise_false_on_long_paragraph_with_copyright_word_in_middle() -> Non
         "alternative untenable for our deployment situation."
     )
     assert is_noise(text) is False
+
+
+# --- similarity_to_reference: property tests ----------------------------
+
+
+def test_similarity_identity(tmp_path: "pytest.TempPathFactory") -> None:  # type: ignore[type-arg]
+    """sim(a, a) == 1.0 — a document compared to itself is fully similar."""
+    ref = tmp_path / "ref.txt"
+    text = "the belief graph stores weighted edges between project nodes"
+    ref.write_text(text, encoding="utf-8")
+    over, score, excerpt = similarity_to_reference(text, ref)
+    assert score == pytest.approx(1.0)
+    assert over is True
+
+
+def test_similarity_symmetry(tmp_path: "pytest.TempPathFactory") -> None:  # type: ignore[type-arg]
+    """sim(a, b) == sim(b, a) — Jaccard is symmetric."""
+    a_text = "the belief graph stores weighted edges between project nodes"
+    b_text = "weighted edges store belief scores between graph nodes here"
+    ref_a = tmp_path / "a.txt"
+    ref_b = tmp_path / "b.txt"
+    ref_a.write_text(a_text, encoding="utf-8")
+    ref_b.write_text(b_text, encoding="utf-8")
+    _, score_ab, _ = similarity_to_reference(a_text, ref_b)
+    _, score_ba, _ = similarity_to_reference(b_text, ref_a)
+    assert score_ab == pytest.approx(score_ba)
+
+
+def test_similarity_disjoint(tmp_path: "pytest.TempPathFactory") -> None:  # type: ignore[type-arg]
+    """sim over no shared N-grams == 0.0."""
+    ref = tmp_path / "ref.txt"
+    ref.write_text(
+        "alpha bravo charlie delta echo foxtrot golf hotel india",
+        encoding="utf-8",
+    )
+    over, score, excerpt = similarity_to_reference(
+        "one two three four five six seven eight nine", ref
+    )
+    assert score == pytest.approx(0.0)
+    assert over is False
+    assert excerpt is None
+
+
+def test_similarity_threshold_fires(tmp_path: "pytest.TempPathFactory") -> None:  # type: ignore[type-arg]
+    """A text above the threshold is flagged and an excerpt is returned."""
+    ref = tmp_path / "ref.txt"
+    body = "the belief graph stores weighted edges between nodes for facts"
+    ref.write_text(body, encoding="utf-8")
+    over, score, excerpt = similarity_to_reference(body, ref, threshold=0.5)
+    assert over is True
+    assert score >= 0.5
+    assert excerpt is not None
+    assert len(excerpt) > 0
+
+
+def test_similarity_threshold_not_fired(tmp_path: "pytest.TempPathFactory") -> None:  # type: ignore[type-arg]
+    """A text below the threshold is not flagged."""
+    ref = tmp_path / "ref.txt"
+    ref.write_text(
+        "the belief graph stores weighted edges between nodes",
+        encoding="utf-8",
+    )
+    # Completely different vocabulary — should score near 0.
+    over, score, _ = similarity_to_reference(
+        "retrieval subsystem uses a two lane ranked list to surface context",
+        ref,
+        threshold=0.6,
+    )
+    assert over is False
+    assert score < 0.6
+
+
+def test_similarity_excerpt_is_none_when_clean(
+    tmp_path: "pytest.TempPathFactory",  # type: ignore[type-arg]
+) -> None:
+    """excerpt is None when the input is below threshold."""
+    ref = tmp_path / "ref.txt"
+    ref.write_text("alpha bravo charlie delta echo", encoding="utf-8")
+    over, _, excerpt = similarity_to_reference(
+        "one two three four five", ref, threshold=0.6
+    )
+    assert over is False
+    assert excerpt is None

--- a/tests/test_scan_derivation.py
+++ b/tests/test_scan_derivation.py
@@ -1,0 +1,98 @@
+"""Fixture-backed regression tests for the N-gram Jaccard similarity gate.
+
+Covers:
+  - similarity_to_reference detects a near-verbatim paraphrase fixture
+    at n=3, threshold=0.6.
+  - A clean-control fixture is not flagged.
+  - aelf scan-derivation CLI: exit 1 on paraphrase, exit 0 on clean.
+  - aelf scan-derivation CLI: exit 2 when reference is missing.
+
+Fixtures live under tests/fixtures/derivation_gate/:
+  reference.txt    — the reference document
+  paraphrase.txt   — near-verbatim paraphrase (must be flagged)
+  clean_control.txt — unrelated text (must not be flagged)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aelfrice.noise_filter import similarity_to_reference
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "derivation_gate"
+_REFERENCE = _FIXTURES / "reference.txt"
+_PARAPHRASE = _FIXTURES / "paraphrase.txt"
+_CLEAN = _FIXTURES / "clean_control.txt"
+
+
+# --- Pure-function fixture regression -----------------------------------
+
+
+def test_paraphrase_detected() -> None:
+    """The paraphrase fixture crosses threshold=0.6 at n=3."""
+    text = _PARAPHRASE.read_text(encoding="utf-8")
+    over, score, excerpt = similarity_to_reference(
+        text, _REFERENCE, n=3, threshold=0.6
+    )
+    assert over is True, f"expected paraphrase to be flagged; score={score:.3f}"
+    assert excerpt is not None
+
+
+def test_clean_control_not_flagged() -> None:
+    """The clean-control fixture stays below threshold=0.6 at n=3."""
+    text = _CLEAN.read_text(encoding="utf-8")
+    over, score, _ = similarity_to_reference(
+        text, _REFERENCE, n=3, threshold=0.6
+    )
+    assert over is False, f"expected clean control not to be flagged; score={score:.3f}"
+
+
+# --- CLI end-to-end tests ------------------------------------------------
+
+
+def test_cli_exit_1_on_paraphrase() -> None:
+    """aelf scan-derivation exits 1 when the input exceeds threshold."""
+    from aelfrice.cli import main
+
+    code = main(
+        argv=[
+            "scan-derivation",
+            "--reference", str(_REFERENCE),
+            "--threshold", "0.6",
+            "--n", "3",
+            str(_PARAPHRASE),
+        ]
+    )
+    assert code == 1, f"expected exit 1 for paraphrase; got {code}"
+
+
+def test_cli_exit_0_on_clean() -> None:
+    """aelf scan-derivation exits 0 when the input is below threshold."""
+    from aelfrice.cli import main
+
+    code = main(
+        argv=[
+            "scan-derivation",
+            "--reference", str(_REFERENCE),
+            "--threshold", "0.6",
+            "--n", "3",
+            str(_CLEAN),
+        ]
+    )
+    assert code == 0, f"expected exit 0 for clean control; got {code}"
+
+
+def test_cli_exit_2_on_missing_reference(tmp_path: pytest.TempPathFactory) -> None:  # type: ignore[type-arg]
+    """aelf scan-derivation exits 2 when --reference does not exist."""
+    from aelfrice.cli import main
+
+    missing = tmp_path / "does_not_exist.txt"  # type: ignore[operator]
+    code = main(
+        argv=[
+            "scan-derivation",
+            "--reference", str(missing),
+            str(_CLEAN),
+        ]
+    )
+    assert code == 2, f"expected exit 2 for missing reference; got {code}"

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -203,6 +203,11 @@ HIDDEN_SUBCOMMANDS = frozenset({
     # stdio for host integration. Hidden because it's not a user-facing
     # workflow verb; hosts wire it via their MCP server config.
     "mcp",
+    # `scan-derivation` is a discretion-gate CLI (#681): N-gram Jaccard
+    # similarity against a reference document, intended for git
+    # pre-commit / pre-push hook wiring. No slash command — it's a
+    # reviewer/automation surface, not a workflow verb.
+    "scan-derivation",
 })
 
 


### PR DESCRIPTION
Closes #681.

## What ships

A deterministic N-gram Jaccard similarity gate that catches surface-paraphrased content lifted from a private reference document — the leak class the existing `BANNED_VOCAB` regex misses because no forbidden token appears verbatim.

Three atomic commits, stdlib-only, no new runtime deps.

### Surface

- **`src/aelfrice/noise_filter.similarity_to_reference(text, reference_path, *, n=3, threshold=0.6) -> tuple[bool, float, str | None]`** — pure function, mirrors the shape of `is_noise` / `is_three_word_fragment` in the same module. Returns `(over_threshold, score, matched_passage_excerpt)`. Empty-N-gram-set inputs (text shorter than `n` tokens) return `(False, 0.0, None)` against any non-empty reference, satisfying the spec's "disjoint inputs → 0.0" property. Excerpt extraction walks a sliding window 5× the gram width and reports the contiguous chunk with the highest matching-N-gram count.

- **`aelf scan-derivation [--reference PATH] [--threshold FLOAT] [--n INT] [PATH...]`** — CLI wrapper. Reads each PATH (or stdin when no paths / `-` is given) and prints one line per input: `MATCH [score] label: 'excerpt'` or `clean [score] label`. Exit codes: `0` all inputs clean, `1` at least one matched (also fires for individual unreadable input paths so broken inputs don't silently exit 0), `2` reference missing/unreadable. Designed to drop into a pre-commit / pre-push hook.

- **Fixture regression** — `tests/fixtures/derivation_gate/` carries a reference passage, a near-verbatim paraphrase that crosses the default `n=3, threshold=0.6` threshold, and a clean control that does not. The CLI test invokes the parser end-to-end against all three inputs and asserts the expected exit code and per-line markers.

### Acceptance (#681)

- [x] `similarity_to_reference` pure function in `src/aelfrice/noise_filter.py` with property tests for Jaccard symmetry (`sim(a,b) == sim(b,a)`), identity (`sim(a,a) == 1.0`), and disjoint-input behaviour.
- [x] `aelf scan-derivation` CLI wrapper with 0/1/2 exit-code semantics.
- [x] `tests/fixtures/derivation_gate/` reference + paraphrase + control trio plus end-to-end CLI test.
- [x] Docstring documents the surface-paraphrase-only failure mode and the false-positive class (repeated short technical phrases).
- [x] No new runtime dependencies — only `re`, `pathlib`, `argparse`, `sys`, stdlib `frozenset` / `tuple`.

## Verification

- 54 tests pass on the noise-filter + scan-derivation surface (`uv run --no-sync pytest tests/test_noise_filter.py tests/test_scan_derivation.py -x -q` → `54 passed in 0.36s`).
- Three commits, all signed (`G G G`):
  - `3622100 feat(noise_filter): similarity_to_reference N-gram Jaccard predicate (#681)`
  - `4bb9c05 feat(cli): aelf scan-derivation subcommand (#681)`
  - `15491c7 test(noise_filter): fixture-backed paraphrase detection regression (#681)`
- Discretion grep clean against the `aelf-pr-open.sh` ban list.
- Branch is FF on `github/main` (`068ca30`).

## Out of scope (per #681)

- Embedding-based similarity (locked deterministic-narrow-surface constraint).
- Hook wiring (`pre-commit` / `pre-push` integration). The CLI is the surface; consumers wire it themselves.
- Extending the `BANNED_VOCAB` regex with explicit phrase entries — this issue is the durable replacement for that stopgap.

## Summary by Sourcery

Add an N-gram Jaccard similarity gate for comparing text against a reference document and expose it via a new CLI subcommand, backed by regression tests and fixtures.

New Features:
- Introduce similarity_to_reference helper in the noise filter module to score N-gram Jaccard similarity against a reference document and return a thresholded flag plus excerpt.
- Add aelf scan-derivation CLI subcommand to check files or stdin against a reference document with configurable N-gram width and similarity threshold, using distinct exit codes for clean, matched, and unreadable references.

Tests:
- Add property-based and regression tests for similarity_to_reference, including identity, symmetry, disjoint input behavior, and threshold/excerpt handling.
- Add end-to-end tests and text fixtures for the scan-derivation CLI to validate paraphrase detection, clean controls, and exit-code semantics.