### PR TITLE
docs: fix 6 broken doc links from link-check report (#683)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,7 +187,7 @@ The README roadmap row for v1.7 also lists signed-Laplacian (#149), heat-kernel 
 
 - **Dedup audit pass + `aelf doctor dedup` CLI** ([#197](https://github.com/robotrocketscience/aelfrice/issues/197) R1). Round-1 dedup ships: core algorithm with a configurable `[dedup]` config block, audit pass that surfaces near-duplicates without acting, and `aelf doctor dedup` CLI for one-shot operator runs. User surface and `LIMITATIONS.md` shrink documented at [`docs/dedup.md`](docs/dedup.md).
 
-- **Wonder-consolidation bake-off — three phantom-generation strategies** ([#228](https://github.com/robotrocketscience/aelfrice/issues/228)). Three candidate strategies for phantom-belief generation evaluated head-to-head on a synthetic corpus: bake-off runner, evaluator, and ship-decision memo recorded at [`docs/wonder_consolidation_R_final.md`](docs/wonder_consolidation_R_final.md).
+- **Wonder-consolidation bake-off — three phantom-generation strategies** ([#228](https://github.com/robotrocketscience/aelfrice/issues/228)). Three candidate strategies for phantom-belief generation evaluated head-to-head on a synthetic corpus: bake-off runner, evaluator, and ship-decision memo recorded at [`docs/v2_wonder_consolidation_R_final.md`](docs/v2_wonder_consolidation_R_final.md).
 
 - **Sentiment-from-prose feedback detector** ([#193](https://github.com/robotrocketscience/aelfrice/issues/193)). Regex-based sentiment-from-prose detector emits implicit posterior-feedback signal from inbound prose. `aelf health` surfaces the enabled/disabled state. Privacy doc updated to call out the inbound prose inspection scope ([`docs/PRIVACY.md`](docs/PRIVACY.md)).
 
@@ -197,7 +197,7 @@ The README roadmap row for v1.7 also lists signed-Laplacian (#149), heat-kernel 
 
 - **Rebuild-log instrumentation on `UserPromptSubmit`** ([#288](https://github.com/robotrocketscience/aelfrice/issues/288) phase-1a). The rebuild diagnostic log added in v1.6.0 gains coverage of the `UserPromptSubmit` hook path. Each per-prompt rebuild now appends a JSONL record; the audit script in `scripts/audit_rebuild_log.py` (also from v1.6.0) handles UPS records uniformly with the existing PreCompact records.
 
-- **Directive-detection — Path A intent-prefix filter** ([#374](https://github.com/robotrocketscience/aelfrice/issues/374), [#199](https://github.com/robotrocketscience/aelfrice/issues/199) H1). H1 ship of the v2.0 enforcement reading: a regex-based intent-prefix filter that detects directive-shaped input on `UserPromptSubmit`. Bench gate + candidate detector land first, then the prefix-filter behavior. Spec memo at [`docs/directive_detection.md`](docs/directive_detection.md).
+- **Directive-detection — Path A intent-prefix filter** ([#374](https://github.com/robotrocketscience/aelfrice/issues/374), [#199](https://github.com/robotrocketscience/aelfrice/issues/199) H1). H1 ship of the v2.0 enforcement reading: a regex-based intent-prefix filter that detects directive-shaped input on `UserPromptSubmit`. Bench gate + candidate detector land first, then the prefix-filter behavior. Spec memo at [`docs/v2_directive_detection.md`](docs/v2_directive_detection.md).
 
 - **`uri_baki` post-rank score adjuster — N=10k/50k retest** ([#153](https://github.com/robotrocketscience/aelfrice/issues/153)). Post-rank score adjusters (URI-aware boost/dampen) reland with a retest harness at N=10k and N=50k. Experimental — opt-in via `[retrieval] use_uri_baki = true`.
 
@@ -207,7 +207,7 @@ The README roadmap row for v1.7 also lists signed-Laplacian (#149), heat-kernel 
 
 - **Testing-strategy unit/integration/E2E split + `attn:e2e-failure` workflow** ([#370](https://github.com/robotrocketscience/aelfrice/issues/370)). Documents the unit / integration / E2E split at [`docs/testing-strategy.md`](docs/testing-strategy.md). E2E workflow triggers on `push:main` and opens an `attn:e2e-failure` issue if the suite fails — main-branch-only, so PRs aren't on the hook.
 
-- **Close-the-loop measurement harness — spec memo** ([#317](https://github.com/robotrocketscience/aelfrice/issues/317)). Spec memo at [`docs/close-the-loop.md`](docs/close-the-loop.md) for the close-the-loop measurement pipeline; implementation in a future cut.
+- **Close-the-loop measurement harness — spec memo** ([#317](https://github.com/robotrocketscience/aelfrice/issues/317)). Spec memo at [`docs/v2_close_the_loop.md`](docs/v2_close_the_loop.md) for the close-the-loop measurement pipeline; implementation in a future cut.
 
 - **PR-title conventional-commit prefix gate** ([#413](https://github.com/robotrocketscience/aelfrice/issues/413)). New `pr-title-prefix` job in `staging-gate.yml` mirrors the existing `commit-msg-prefix` job but validates the PR title. Fails the PR if the title does not start with `feat:`, `fix:`, `docs:`, or another approved prefix. Prefix list is delegated to `scripts/check-commit-msg.py` so it stays in sync with commits and CLAUDE.md.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,5 +203,5 @@ The following were previously listed here and have since shipped:
 - Entity index / NER → **shipped v1.3.0** ([entity_index.md](entity_index.md))
 - LLM in the hot path (optional onboard classifier) → **shipped v1.3.0** ([llm_classifier.md](llm_classifier.md))
 - BM25F anchor-text retrieval → **shipped v1.7.0**, default-on (#148/#154; +0.6650 NDCG@k uplift on the v0.1 retrieve_uplift fixture)
-- HRR primitives + structural lane → **shipped v1.7.0**, default-on as of v2.1 ([hrr_structural_query_lane.md](hrr_structural_query_lane.md); closes the vocabulary-gap-recovery claim, #154 composition tracker, #437 reproducibility-harness 11/11)
+- HRR primitives + structural lane → **shipped v1.7.0**, default-on as of v2.1 ([feature-hrr-integration.md](feature-hrr-integration.md); source at `src/aelfrice/hrr_index.py`; closes the vocabulary-gap-recovery claim, #154 composition tracker, #437 reproducibility-harness 11/11)
 - Heat-kernel authority scorer → **shipped v1.7.0**, default-on as of v2.1 (#154 composition tracker)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -132,7 +132,7 @@ The release where ranking moves beyond BM25 + L2.5 + BFS into graph-authority an
 
 After v2.0.0, `benchmarks/` reproduces every published headline number on a fresh clone with `uv sync && aelf bench all`, within documented tolerance bands.
 
-- ~~HRR vocabulary bridge~~ — **closed by the structural-query lane (#152, default-on as of v2.1)**. The lab campaign (`exp/hrr-vocabulary-bridge`) reframed "vocabulary bridge" as "typed-edge structural retrieval" and that mechanism shipped via `src/aelfrice/hrr_index.py`. See [hrr_structural_query_lane.md](hrr_structural_query_lane.md). #433 closed; #536 (the parallel `vocab_bridge.py` query-rewrite module) removed.
+- ~~HRR vocabulary bridge~~ — **closed by the structural-query lane (#152, default-on as of v2.1)**. The lab campaign (`exp/hrr-vocabulary-bridge`) reframed "vocabulary bridge" as "typed-edge structural retrieval" and that mechanism shipped via `src/aelfrice/hrr_index.py`. See [feature-hrr-integration.md](feature-hrr-integration.md). #433 closed; #536 (the parallel `vocab_bridge.py` query-rewrite module) removed.
 - Type-aware compression — tokens-per-belief reductions on retrieved output.
 - Intentional clustering — co-locating related beliefs for higher coherence on multi-fact queries.
 - Correction-detection eval — five-codebase labeled fixture, scored by both the zero-LLM detector and the LLM-judge path.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,6 +1,6 @@
 # NNNN — Title
 
-- **Status:** Proposed | Accepted | Superseded by [NNNN](NNNN-other.md)
+- **Status:** Proposed | Accepted | Superseded by `[NNNN](NNNN-other.md)`
 - **Date:** YYYY-MM-DD
 - **Deciders:** @handle, @handle
 


### PR DESCRIPTION
Closes #683.

## What ships

Three atomic commits, no code change. Resolves all 6 broken-link errors from the link-check report.

1. **`CHANGELOG.md`** — three doc links missing the `v2_` prefix (L190, L200, L210):
   - `docs/wonder_consolidation_R_final.md` → `docs/v2_wonder_consolidation_R_final.md`
   - `docs/directive_detection.md` → `docs/v2_directive_detection.md`
   - `docs/close-the-loop.md` → `docs/v2_close_the_loop.md`

2. **`docs/ARCHITECTURE.md` + `docs/ROADMAP.md`** — `docs/hrr_structural_query_lane.md` was a forward-reference doc that never landed (`git log --all --oneline -- docs/hrr_structural_query_lane.md` returns nothing; no rename in history). Both references point to `docs/feature-hrr-integration.md` instead — the actual landed HRR spec (#553) — with the existing `src/aelfrice/hrr_index.py` mention preserved.

3. **`docs/adr/template.md`** — `[NNNN](NNNN-other.md)` in the Status line is intentional template prose showing the supersession-link pattern, but the link-checker parses it as a real link and fails. Wrapped it in backticks so it renders as code literal and the checker skips it.

## Verification

- All three commits signed (`G G G`):
  - `e7f172c docs(changelog): fix three broken doc links (v2_ prefix) (#683)`
  - `71bb4d1 docs(arch+roadmap): replace never-existed hrr_structural_query_lane link with feature-hrr-integration (#683)`
  - `8ad0570 docs(adr): escape NNNN-other.md placeholder so link-check skips template (#683)`
- Branch is FF on `github/main` (`068ca30`).
- Discretion grep clean.
- No code change → no test-shape change.

## Acceptance

All 6 errors from the link-check report are resolved:
- [x] CHANGELOG.md → close-the-loop.md (now `v2_close_the_loop.md` — exists)
- [x] CHANGELOG.md → directive_detection.md (now `v2_directive_detection.md` — exists)
- [x] CHANGELOG.md → wonder_consolidation_R_final.md (now `v2_wonder_consolidation_R_final.md` — exists)
- [x] docs/adr/template.md → NNNN-other.md (now escaped as code literal — link-checker skips)
- [x] docs/ARCHITECTURE.md → hrr_structural_query_lane.md (now `feature-hrr-integration.md` — exists)
- [x] docs/ROADMAP.md → hrr_structural_query_lane.md (now `feature-hrr-integration.md` — exists)
