### PR TITLE
feat(hrr): HRRStructIndexCache persist-aware load+save+mmap (#691)

### DIFF
--- a/src/aelfrice/hrr_index.py
+++ b/src/aelfrice/hrr_index.py
@@ -461,4 +461,8 @@ class HRRStructIndexCache:
         try:
             persist_dir.rmdir()
         except OSError:
+            # Best-effort cleanup: the persist dir may still hold foreign
+            # files (a co-located store metadata file, an editor swap, a
+            # concurrent reader's mmap handle on Linux). Leaving the dir
+            # in place is harmless — the next get() will repopulate it.
             pass

--- a/src/aelfrice/hrr_index.py
+++ b/src/aelfrice/hrr_index.py
@@ -368,6 +368,10 @@ class HRRStructIndex:
         return idx
 
 
+_PERSIST_DIRNAME: Final[str] = ".hrr_struct_index"
+_ENV_PERSIST: Final[str] = "AELFRICE_HRR_PERSIST"
+
+
 @dataclass
 class HRRStructIndexCache:
     """Lazy, invalidation-aware wrapper around a single ``HRRStructIndex``.
@@ -375,6 +379,15 @@ class HRRStructIndexCache:
     Subscribes to the store's invalidation callback registry on
     construction, so any belief / edge mutation drops the cached
     index. The next ``get()`` rebuilds.
+
+    Persistence (#691, sub-task of #553): when ``store_path`` is set and
+    ``AELFRICE_HRR_PERSIST`` is not ``"0"``, the cache also persists the
+    built index to ``<store_dir>/.hrr_struct_index/`` and tries to load
+    it via ``mmap_mode='r'`` on subsequent process starts. Invalidation
+    drops both the in-memory cache and the on-disk blob so the next
+    ``get()`` rebuilds from current store state. In-memory stores
+    (``store_path=None``) and the explicit opt-out keep pure in-memory
+    behavior.
 
     Per-instance: two caches pointing at different stores never share
     state. Thread safety is the caller's responsibility.
@@ -392,14 +405,60 @@ class HRRStructIndexCache:
             self.store.add_invalidation_callback(self.invalidate)
             self._subscribed = True
 
+    def _resolve_persist_dir(self) -> Path | None:
+        if self.store_path is None:
+            return None
+        if os.environ.get(_ENV_PERSIST, "1") == "0":
+            return None
+        return Path(self.store_path).parent / _PERSIST_DIRNAME
+
     def get(self) -> HRRStructIndex:
         """Return the current index, building or rebuilding as needed."""
-        if self._index is None:
-            idx = HRRStructIndex(dim=self.dim)
-            idx.build(self.store, store_path=self.store_path, seed=self.seed)
-            self._index = idx
+        if self._index is not None:
+            return self._index
+        persist_dir = self._resolve_persist_dir()
+        if persist_dir is not None and (persist_dir / _STRUCT_FILENAME).is_file():
+            try:
+                self._index = HRRStructIndex.load(persist_dir, mmap=True)
+                return self._index
+            except (FileNotFoundError, OSError, KeyError, ValueError) as e:
+                _logger.warning(
+                    "HRRStructIndexCache: persist load failed at %s: %s; rebuilding",
+                    persist_dir,
+                    e,
+                )
+        idx = HRRStructIndex(dim=self.dim)
+        idx.build(self.store, store_path=self.store_path, seed=self.seed)
+        if persist_dir is not None:
+            try:
+                idx.save(persist_dir)
+            except OSError as e:
+                _logger.warning(
+                    "HRRStructIndexCache: persist save failed at %s: %s; continuing in-memory",
+                    persist_dir,
+                    e,
+                )
+        self._index = idx
         return self._index
 
     def invalidate(self) -> None:
         """Drop the cached index. Wired to the store mutation hook."""
         self._index = None
+        persist_dir = self._resolve_persist_dir()
+        if persist_dir is None or not persist_dir.is_dir():
+            return
+        for filename in (_STRUCT_FILENAME, _META_FILENAME):
+            f = persist_dir / filename
+            if f.exists():
+                try:
+                    f.unlink()
+                except OSError as e:
+                    _logger.warning(
+                        "HRRStructIndexCache: persist unlink failed at %s: %s",
+                        f,
+                        e,
+                    )
+        try:
+            persist_dir.rmdir()
+        except OSError:
+            pass

--- a/tests/test_hrr_struct_index.py
+++ b/tests/test_hrr_struct_index.py
@@ -378,6 +378,143 @@ def test_cache_explicit_invalidate_drops_index() -> None:
     assert cache._index is None
 
 
+# --- #691 persistence wiring ---------------------------------------------
+
+
+def _store_path(tmp_path: Path) -> str:
+    return str(tmp_path / "memory.db")
+
+
+def _persist_dir(tmp_path: Path) -> Path:
+    return tmp_path / ".hrr_struct_index"
+
+
+def test_cache_persists_to_disk_after_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+    s = _toy_store()
+    cache = HRRStructIndexCache(
+        store=s, dim=256, seed=7, store_path=_store_path(tmp_path)
+    )
+    cache.get()
+    pd = _persist_dir(tmp_path)
+    assert (pd / "struct.npy").is_file()
+    assert (pd / "meta.npz").is_file()
+
+
+def test_cache_loads_from_disk_on_second_construct(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+    sp = _store_path(tmp_path)
+    s1 = _toy_store()
+    cache1 = HRRStructIndexCache(store=s1, dim=256, seed=7, store_path=sp)
+    a = cache1.get()
+    s2 = _toy_store()
+    cache2 = HRRStructIndexCache(store=s2, dim=256, seed=7, store_path=sp)
+    b = cache2.get()
+    # Different instances, identical structural content (load round-trip).
+    assert a is not b
+    np.testing.assert_array_equal(a.struct, b.struct)
+    assert a.belief_ids == b.belief_ids
+
+
+def test_cache_load_uses_mmap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+    sp = _store_path(tmp_path)
+    s1 = _toy_store()
+    HRRStructIndexCache(store=s1, dim=256, seed=7, store_path=sp).get()
+    s2 = _toy_store()
+    loaded = HRRStructIndexCache(
+        store=s2, dim=256, seed=7, store_path=sp
+    ).get()
+    # np.memmap subclasses ndarray; check via type rather than .base
+    # (which is None when the file is the direct backing store).
+    assert isinstance(loaded.struct, np.memmap), (
+        f"expected mmap-backed struct, got {type(loaded.struct).__name__}"
+    )
+
+
+def test_cache_invalidate_removes_disk_blob(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+    s = _toy_store()
+    cache = HRRStructIndexCache(
+        store=s, dim=256, seed=7, store_path=_store_path(tmp_path)
+    )
+    cache.get()
+    pd = _persist_dir(tmp_path)
+    assert pd.is_dir()
+    cache.invalidate()
+    assert not (pd / "struct.npy").exists()
+    assert not (pd / "meta.npz").exists()
+    # Directory removed when empty
+    assert not pd.exists()
+
+
+def test_cache_env_persist_zero_disables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AELFRICE_HRR_PERSIST", "0")
+    s = _toy_store()
+    cache = HRRStructIndexCache(
+        store=s, dim=256, seed=7, store_path=_store_path(tmp_path)
+    )
+    cache.get()
+    assert not _persist_dir(tmp_path).exists()
+
+
+def test_cache_no_store_path_disables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+    s = _toy_store()
+    cache = HRRStructIndexCache(store=s, dim=256, seed=7, store_path=None)
+    cache.get()
+    # No store_path → no persistence dir anywhere under tmp_path.
+    assert not _persist_dir(tmp_path).exists()
+
+
+def test_cache_load_failure_falls_through_to_rebuild(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+    sp = _store_path(tmp_path)
+    s1 = _toy_store()
+    HRRStructIndexCache(store=s1, dim=256, seed=7, store_path=sp).get()
+    # Corrupt the persisted struct.npy
+    pd = _persist_dir(tmp_path)
+    (pd / "struct.npy").write_bytes(b"not a numpy file")
+    s2 = _toy_store()
+    cache2 = HRRStructIndexCache(store=s2, dim=256, seed=7, store_path=sp)
+    with caplog.at_level("WARNING", logger="aelfrice.hrr_index"):
+        idx = cache2.get()
+    assert idx is not None
+    assert any("persist load failed" in rec.message for rec in caplog.records)
+    # Rebuild also re-saved a valid file
+    HRRStructIndex.load(pd)  # would raise if still corrupt
+
+
+def test_cache_byte_equality_persist_round_trip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+    sp = _store_path(tmp_path)
+    s1 = _toy_store()
+    cold = HRRStructIndexCache(store=s1, dim=256, seed=7, store_path=sp).get()
+    s2 = _toy_store()
+    warm = HRRStructIndexCache(store=s2, dim=256, seed=7, store_path=sp).get()
+    a = cold.probe("CONTRADICTS", "b2", top_k=5)
+    b = warm.probe("CONTRADICTS", "b2", top_k=5)
+    assert a == b
+
+
 # --- AC6 / AC7 (perf-gated) ----------------------------------------------
 
 


### PR DESCRIPTION
Closes #691 (sub-task of #553).

## Summary

`HRRStructIndexCache` (used by long-running callers in `aelf search` / `retrieve_v2`) now persists the built `HRRStructIndex` to `<store_dir>/.hrr_struct_index/` and reloads it via `mmap_mode='r'` on subsequent process starts. This is the cache-wiring layer on top of the split-format save/load that #553 shipped under 9cbbdfa; it's the gating capability for the #553 default-ON ship.

## What changed

- `get()`: if `<persist_dir>/struct.npy` exists, call `HRRStructIndex.load(persist_dir, mmap=True)` first. On miss or any of `(FileNotFoundError, OSError, KeyError, ValueError)`, log a WARNING and fall through to rebuild + save.
- `invalidate()`: drop both the in-memory index and the on-disk `struct.npy` / `meta.npz`. Best-effort `rmdir()` on the directory; foreign files are tolerated.
- New module-level constants: `_PERSIST_DIRNAME = ".hrr_struct_index"`, `_ENV_PERSIST = "AELFRICE_HRR_PERSIST"`.
- `_resolve_persist_dir()` helper: returns `None` if `store_path` is unset OR `AELFRICE_HRR_PERSIST=0`; otherwise `<store_path>.parent / .hrr_struct_index`.

No public API change. No new constructor field. `HRRStructIndex.load` / `save` were already shipped — this only wires the cache to call them.

## Test plan

8 new tests in `tests/test_hrr_struct_index.py`:
- [x] persists to disk after build (struct.npy + meta.npz exist)
- [x] second cache instance loads from disk (different identity, identical content)
- [x] loaded struct is `np.memmap`-backed
- [x] invalidate removes disk blob and empties the persist dir
- [x] `AELFRICE_HRR_PERSIST=0` disables persistence
- [x] `store_path=None` disables persistence (in-memory stores)
- [x] corrupted `struct.npy` falls through to rebuild with WARNING log
- [x] byte-equal structural probe across cold-build and warm-load instances

Existing cache tests (lazy-build, store-mutation invalidation, explicit invalidate) and the `retrieve_v2_hrr_structural` suite all still pass.

## Out of scope (separate #553 sub-issues)

- Ephemeral-path auto-disable for `/tmp`, `/var/tmp`, `/dev/shm`, `/run`
- `aelf doctor` rows reporting `hrr.persist_enabled`, `hrr.on_disk_bytes`, `hrr.last_build_seconds`
- `aelf bench` cold-start gate (≤ 1 s at N=50k)
- `[hrr] persist = false` TOML key
- `docs/CONFIG.md` / `docs/COMMANDS.md` updates (bundle once all #553 sub-issues land)
