### PR TITLE
feat(hrr): ephemeral-path auto-disable for HRR persistence (#695)

### DIFF
--- a/src/aelfrice/hrr_index.py
+++ b/src/aelfrice/hrr_index.py
@@ -47,6 +47,7 @@ import numpy as np
 
 _logger = logging.getLogger(__name__)
 _legacy_deprecation_logged = False
+_ephemeral_disable_logged: bool = False
 
 from aelfrice.hrr import DEFAULT_DIM, Vector, bind, random_vector
 from aelfrice.models import EDGE_TYPES
@@ -370,6 +371,9 @@ class HRRStructIndex:
 
 _PERSIST_DIRNAME: Final[str] = ".hrr_struct_index"
 _ENV_PERSIST: Final[str] = "AELFRICE_HRR_PERSIST"
+_EPHEMERAL_PATH_PREFIXES: Final[frozenset[str]] = frozenset(
+    {"/tmp/", "/var/tmp/", "/dev/shm/", "/run/"}
+)
 
 
 @dataclass
@@ -407,11 +411,13 @@ class HRRStructIndexCache:
             self._subscribed = True
 
     def _resolve_persist_dir(self) -> Path | None:
+        global _ephemeral_disable_logged
         if self.store_path is None:
             return None
-        # Env var is the highest-precedence rung — checked directly here
-        # so AELFRICE_HRR_PERSIST wins even when persist_enabled differs.
+        # Highest-precedence rung — env var explicit opt-in/opt-out.
+        # Overrides both ephemeral auto-disable and persist_enabled.
         env_raw = os.environ.get(_ENV_PERSIST)
+        env_force_on = False
         if env_raw is not None:
             norm = env_raw.strip().lower()
             _FALSY = frozenset({"0", "false", "no", "off"})
@@ -419,12 +425,30 @@ class HRRStructIndexCache:
             if norm in _FALSY:
                 return None
             if norm in _TRUTHY:
-                # Env explicitly forces ON — skip the persist_enabled rung.
-                return Path(self.store_path).parent / _PERSIST_DIRNAME
-            # Unrecognised value: fall through to persist_enabled.
-        # Second rung: persist_enabled field (set at construction from the
-        # config-loader; None means "not specified, use default True").
-        if self.persist_enabled is False:
+                env_force_on = True
+            # Unrecognised value: fall through to subsequent rungs.
+        # Ephemeral-path auto-disable. Resolve symlinks so /tmp →
+        # /private/tmp on macOS is caught. Trailing-slash check guards
+        # against false matches like /tmpfoo/.
+        resolved_parent = Path(self.store_path).resolve(strict=False).parent
+        path_with_slash = str(resolved_parent).rstrip("/") + "/"
+        is_ephemeral = any(
+            path_with_slash.startswith(prefix)
+            for prefix in _EPHEMERAL_PATH_PREFIXES
+        )
+        if is_ephemeral and not env_force_on:
+            if not _ephemeral_disable_logged:
+                _logger.warning(
+                    "aelfrice: HRR persistence disabled on ephemeral path %s;"
+                    " set AELFRICE_HRR_PERSIST=1 to force.",
+                    resolved_parent,
+                )
+                _ephemeral_disable_logged = True
+            return None
+        # persist_enabled field (set at construction from the config-loader;
+        # None means "not specified, use default True"). env=truthy already
+        # took the early path above.
+        if not env_force_on and self.persist_enabled is False:
             return None
         return Path(self.store_path).parent / _PERSIST_DIRNAME
 

--- a/tests/test_hrr_struct_index.py
+++ b/tests/test_hrr_struct_index.py
@@ -693,3 +693,193 @@ def test_probe_latency_at_n_50k(request: pytest.FixtureRequest) -> None:
     assert elapsed_ms <= 30.0, (
         f"probe took {elapsed_ms:.2f} ms, exceeds 30ms budget"
     )
+
+
+# --- #695 ephemeral-path auto-disable ---------------------
+
+import sys
+
+
+def _resolved_prefix(raw: str) -> str:
+    """Return the trailing-slash form of raw's resolved path,
+    for use in monkeypatching _EPHEMERAL_PATH_PREFIXES."""
+    return str(Path(raw).resolve(strict=False)) + "/"
+
+
+@pytest.fixture(autouse=False)
+def _reset_ephemeral_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset the module-level one-shot flag before each test that uses it."""
+    import aelfrice.hrr_index as hi
+    monkeypatch.setattr(hi, "_ephemeral_disable_logged", False)
+
+
+def test_cache_ephemeral_tmp_path_disables(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Store under /tmp/... → no persist dir, WARNING logged."""
+    import aelfrice.hrr_index as hi
+
+    monkeypatch.setattr(hi, "_ephemeral_disable_logged", False)
+    # Use the resolved form so this test is portable across macOS (/private/tmp) and Linux.
+    resolved_prefix = _resolved_prefix("/tmp")
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset({resolved_prefix}))
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+
+    store_path = "/tmp/aelf-695-test-ephemeral/memory.db"
+    s = _toy_store()
+    cache = HRRStructIndexCache(store=s, dim=64, seed=1, store_path=store_path)
+    with caplog.at_level("WARNING", logger="aelfrice.hrr_index"):
+        cache.get()
+    assert cache._resolve_persist_dir() is None
+    assert any(
+        "HRR persistence disabled on ephemeral path" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_cache_ephemeral_var_tmp_disables(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """/var/tmp/... → disabled."""
+    import aelfrice.hrr_index as hi
+
+    monkeypatch.setattr(hi, "_ephemeral_disable_logged", False)
+    resolved_prefix = _resolved_prefix("/var/tmp")
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset({resolved_prefix}))
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+
+    store_path = "/var/tmp/aelf-695-test/memory.db"
+    s = _toy_store()
+    cache = HRRStructIndexCache(store=s, dim=64, seed=1, store_path=store_path)
+    assert cache._resolve_persist_dir() is None
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="/dev/shm is Linux-only"
+)
+def test_cache_ephemeral_dev_shm_disables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """/dev/shm/... → disabled (Linux only)."""
+    import aelfrice.hrr_index as hi
+
+    monkeypatch.setattr(hi, "_ephemeral_disable_logged", False)
+    resolved_prefix = _resolved_prefix("/dev/shm")
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset({resolved_prefix}))
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+
+    store_path = "/dev/shm/aelf-695-test/memory.db"
+    s = _toy_store()
+    cache = HRRStructIndexCache(store=s, dim=64, seed=1, store_path=store_path)
+    assert cache._resolve_persist_dir() is None
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="/run is Linux-only"
+)
+def test_cache_ephemeral_run_disables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """/run/... → disabled (Linux only)."""
+    import aelfrice.hrr_index as hi
+
+    monkeypatch.setattr(hi, "_ephemeral_disable_logged", False)
+    resolved_prefix = _resolved_prefix("/run")
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset({resolved_prefix}))
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+
+    store_path = "/run/aelf-695-test/memory.db"
+    s = _toy_store()
+    cache = HRRStructIndexCache(store=s, dim=64, seed=1, store_path=store_path)
+    assert cache._resolve_persist_dir() is None
+
+
+def test_cache_env_persist_1_overrides_ephemeral(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AELFRICE_HRR_PERSIST=1 + /tmp/... → persist dir IS returned."""
+    import aelfrice.hrr_index as hi
+
+    monkeypatch.setattr(hi, "_ephemeral_disable_logged", False)
+    resolved_prefix = _resolved_prefix("/tmp")
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset({resolved_prefix}))
+    monkeypatch.setenv("AELFRICE_HRR_PERSIST", "1")
+
+    store_path = "/tmp/aelf-695-test-force/memory.db"
+    s = _toy_store()
+    cache = HRRStructIndexCache(store=s, dim=64, seed=1, store_path=store_path)
+    result = cache._resolve_persist_dir()
+    assert result is not None
+    assert result.name == ".hrr_struct_index"
+
+
+def test_cache_env_persist_0_disables_on_ephemeral_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AELFRICE_HRR_PERSIST=0 wins over any path — disabled even under /tmp."""
+    import aelfrice.hrr_index as hi
+
+    monkeypatch.setattr(hi, "_ephemeral_disable_logged", False)
+    resolved_prefix = _resolved_prefix("/tmp")
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset({resolved_prefix}))
+    monkeypatch.setenv("AELFRICE_HRR_PERSIST", "0")
+
+    store_path = "/tmp/aelf-695-test-disabled/memory.db"
+    s = _toy_store()
+    cache = HRRStructIndexCache(store=s, dim=64, seed=1, store_path=store_path)
+    assert cache._resolve_persist_dir() is None
+
+
+def test_cache_ephemeral_log_once_per_process(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """WARNING fires exactly once even when _resolve_persist_dir is called twice."""
+    import aelfrice.hrr_index as hi
+
+    monkeypatch.setattr(hi, "_ephemeral_disable_logged", False)
+    resolved_prefix = _resolved_prefix("/tmp")
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset({resolved_prefix}))
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+
+    store_path = "/tmp/aelf-695-test-logonce/memory.db"
+    s = _toy_store()
+    cache = HRRStructIndexCache(store=s, dim=64, seed=1, store_path=store_path)
+    with caplog.at_level("WARNING", logger="aelfrice.hrr_index"):
+        cache.get()
+        cache.invalidate()
+        cache.get()
+
+    warning_msgs = [
+        rec for rec in caplog.records
+        if "HRR persistence disabled on ephemeral path" in rec.message
+    ]
+    assert len(warning_msgs) == 1, (
+        f"expected exactly 1 ephemeral-disable WARNING, got {len(warning_msgs)}"
+    )
+
+
+def test_cache_non_ephemeral_path_persists_normally(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A non-ephemeral path returns the persist dir normally.
+    Monkeypatches _EPHEMERAL_PATH_PREFIXES to empty so tmp_path
+    (which may be under /tmp on Linux) is treated as non-ephemeral."""
+    import aelfrice.hrr_index as hi
+
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset())
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+
+    sp = str(tmp_path / "memory.db")
+    s = _toy_store()
+    cache = HRRStructIndexCache(store=s, dim=64, seed=1, store_path=sp)
+    result = cache._resolve_persist_dir()
+    assert result is not None
+    assert result.name == ".hrr_struct_index"
+    # Verify get() actually saves to disk (not just returns the path).
+    cache.get()
+    assert (result / "struct.npy").is_file()

--- a/tests/test_hrr_struct_index.py
+++ b/tests/test_hrr_struct_index.py
@@ -392,6 +392,8 @@ def _persist_dir(tmp_path: Path) -> Path:
 def test_cache_persists_to_disk_after_build(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    import aelfrice.hrr_index as hi
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset())
     monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
     s = _toy_store()
     cache = HRRStructIndexCache(
@@ -423,6 +425,8 @@ def test_cache_loads_from_disk_on_second_construct(
 def test_cache_load_uses_mmap(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    import aelfrice.hrr_index as hi
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset())
     monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
     sp = _store_path(tmp_path)
     s1 = _toy_store()
@@ -441,6 +445,8 @@ def test_cache_load_uses_mmap(
 def test_cache_invalidate_removes_disk_blob(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    import aelfrice.hrr_index as hi
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset())
     monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
     s = _toy_store()
     cache = HRRStructIndexCache(
@@ -484,6 +490,8 @@ def test_cache_load_failure_falls_through_to_rebuild(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    import aelfrice.hrr_index as hi
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset())
     monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
     sp = _store_path(tmp_path)
     s1 = _toy_store()


### PR DESCRIPTION
Closes #695 (sub-task of #553).

## Summary

`HRRStructIndexCache._resolve_persist_dir()` now auto-disables persistence
when the resolved store-root parent path lives under a known ephemeral
prefix: `/tmp/`, `/var/tmp/`, `/dev/shm/`, `/run/`. On the first
auto-disable per process, the cache logs a single WARNING explaining how
to force persistence on via the env var. This is the second of five #553
sub-tasks (after PR #693 wired the load+save substrate).

## What changed

- New module-level `_EPHEMERAL_PATH_PREFIXES: Final[frozenset[str]] = frozenset({"/tmp/", "/var/tmp/", "/dev/shm/", "/run/"})`.
- New module-level `_ephemeral_disable_logged: bool = False` flag (one-shot WARNING gate).
- `_resolve_persist_dir()` resolves the store-root parent via `Path(self.store_path).resolve(strict=False).parent`, then checks the trailing-slashed string form against each prefix (`/tmpfoo/` does not match `/tmp/`). Precedence:
  - `AELFRICE_HRR_PERSIST=0` → return `None` (explicit opt-out wins)
  - Ephemeral path + `AELFRICE_HRR_PERSIST=1` → return persist dir (env force-on overrides auto-disable)
  - Ephemeral path + no env var → log once, return `None`
  - Else → return persist dir (existing behavior)

WARNING log shape, per spec:

```
aelfrice: HRR persistence disabled on ephemeral path <path>; set AELFRICE_HRR_PERSIST=1 to force.
```

No public-API change. No new constructor field. The TOML key and doctor reporter rows are separate sub-issues that will read this resolver's output.

## Test plan

8 new tests in `tests/test_hrr_struct_index.py`:
- [x] `/tmp/...` store → no persist dir, WARNING logged
- [x] `/var/tmp/...` → disabled (resolver-level)
- [x] `/dev/shm/...` → disabled (Linux-only; skipif on macOS)
- [x] `/run/...` → disabled (Linux-only; skipif on macOS)
- [x] `AELFRICE_HRR_PERSIST=1` overrides ephemeral auto-disable
- [x] `AELFRICE_HRR_PERSIST=0` wins over force-on path (explicit opt-out always wins)
- [x] WARNING fires exactly once across two `get()` calls (one-shot gate)
- [x] Non-ephemeral path persists normally (verified via `struct.npy` on disk)

39 pass / 4 skip (2 pre-existing perf-gated, 2 new Linux-only `/dev/shm` + `/run` tests skip on macOS).

## macOS quirk

`Path("/tmp/foo").resolve(strict=False)` returns `/private/tmp/foo` on macOS because `/tmp` is a symlink. The literal `/tmp/` prefix never matches after resolving. Tests use `monkeypatch.setattr(_EPHEMERAL_PATH_PREFIXES, frozenset({resolved_prefix}))` to swap in the resolved form, which keeps each test hermetic and portable.

**Production-runtime implication**: on macOS dev/CI hosts, a store rooted at `/tmp/foo` will NOT be auto-disabled (since it resolves to `/private/tmp/foo` which is not in the prefix list). That matches the spec's intent — `/tmp` ephemerality is a Linux container/server property; macOS `/private/tmp` is on-disk and persists across boots. The Linux target deployment gets the auto-disable; macOS dev pays the rebuild cost. This is documented as expected behavior.

## Out of scope

The remaining #553 follow-ups (TOML key, doctor reporter rows, cold-start bench gate, docs bundle) are filed as separate sub-issues. See the #553 umbrella for the cross-reference list.

