### PR TITLE
test(hrr): cold-start bench gate at N=50k (#697)

### DIFF
--- a/tests/bench_gate/_hrr_synthetic_store.py
+++ b/tests/bench_gate/_hrr_synthetic_store.py
@@ -1,0 +1,95 @@
+"""Synthetic N=50k store builder for HRR cold-start bench gates (#697).
+
+Produces a MemoryStore backed by an on-disk SQLite file with a deterministic
+N=50k belief corpus and a sparse edge graph (~3 outgoing edges per belief).
+The graph structure is intentionally non-empty so the HRR structural lane
+has edges to index; an edgeless store would produce ``struct == 0`` and
+make the bench meaningless.
+
+Edge topology mirrors the perf gate in ``tests/test_hrr_struct_index.py``
+AC6/AC7: three outgoing CITES edges per belief at offsets (1, 7, 31), giving
+a sparse but globally connected graph that exercises the accumulate-and-norm
+path in ``HRRStructIndex.build``.
+
+Fixed seed: 42 (matches uri_baki_retest canonical default and the issue spec).
+"""
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CITES,
+    EDGE_CONTRADICTS,
+    LOCK_NONE,
+    ORIGIN_UNKNOWN,
+    RETENTION_UNKNOWN,
+    Belief,
+    Edge,
+)
+from aelfrice.store import MemoryStore
+
+
+def build_n50k_store(
+    memory_db: Path,
+    *,
+    n_beliefs: int = 50_000,
+    seed: int = 42,
+) -> MemoryStore:
+    """Build a synthetic N=50k store for HRR cold-start bench tests.
+
+    Creates (or opens) the SQLite database at ``memory_db``, inserts
+    ``n_beliefs`` beliefs and a sparse edge graph, then returns the open
+    ``MemoryStore``.  Call ``store.close()`` when done.
+
+    The build is fully deterministic at fixed seed: same ``n_beliefs`` and
+    ``seed`` always produce the same ``struct.npy`` byte-for-byte.
+
+    Edge topology: three outgoing CITES edges per belief at offsets (1, 7, 31)
+    plus a CONTRADICTS edge for every 100th belief (belief i → belief i+50),
+    giving the structural lane real edge signal in both CITES and CONTRADICTS
+    role vectors.
+    """
+    rng = random.Random(seed)
+
+    store = MemoryStore(str(memory_db))
+    for i in range(n_beliefs):
+        bid = f"b{i:06d}"
+        # Vary content slightly to avoid content_hash collisions.
+        noise = rng.randint(0, 999_999)
+        store.insert_belief(
+            Belief(
+                id=bid,
+                content=f"belief {i} noise={noise}",
+                content_hash=f"h_{bid}",
+                alpha=1.0,
+                beta=1.0,
+                type=BELIEF_FACTUAL,
+                lock_level=LOCK_NONE,
+                locked_at=None,
+                demotion_pressure=0,
+                created_at="2026-05-11T00:00:00Z",
+                last_retrieved_at=None,
+                session_id=None,
+                origin=ORIGIN_UNKNOWN,
+                corroboration_count=0,
+                hibernation_score=None,
+                activation_condition=None,
+                retention_class=RETENTION_UNKNOWN,
+            ),
+        )
+
+    # Sparse edge graph: 3 outgoing CITES per belief + 1 CONTRADICTS per 100.
+    for i in range(n_beliefs):
+        src = f"b{i:06d}"
+        for off in (1, 7, 31):
+            dst = f"b{(i + off) % n_beliefs:06d}"
+            store.insert_edge(Edge(src=src, dst=dst, type=EDGE_CITES, weight=1.0))
+        if i % 100 == 0:
+            dst = f"b{(i + 50) % n_beliefs:06d}"
+            store.insert_edge(
+                Edge(src=src, dst=dst, type=EDGE_CONTRADICTS, weight=1.0)
+            )
+
+    return store

--- a/tests/bench_gate/test_hrr_cold_start.py
+++ b/tests/bench_gate/test_hrr_cold_start.py
@@ -27,6 +27,7 @@ _REBUILD_CEILING_S = 38.0
 
 
 @pytest.mark.bench_gated
+@pytest.mark.timeout(120)  # build phase takes ~38s; warm load ≤ 1s; 120s total headroom
 def test_hrr_cold_start_warm_load_under_one_second_at_50k(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -93,6 +94,7 @@ def test_hrr_cold_start_warm_load_under_one_second_at_50k(
 
 
 @pytest.mark.bench_gated
+@pytest.mark.timeout(120)  # rebuild ceiling is 38s; 120s gives 3× headroom on slow CI
 def test_hrr_cold_start_rebuild_under_38s_at_50k_persist_off(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/bench_gate/test_hrr_cold_start.py
+++ b/tests/bench_gate/test_hrr_cold_start.py
@@ -1,0 +1,134 @@
+"""Bench-gated HRR cold-start timing gates (#697, sub-task of #553).
+
+Both tests are gated by the ``bench_gated`` autouse marker and skip when
+``AELFRICE_CORPUS_ROOT`` is unset (normal CI).  Run the gates explicitly
+by setting the env var to any existing directory.
+
+Acceptance criteria (docs/feature-hrr-integration.md §"Acceptance criteria"):
+  - Warm cold-start (persist-on): ≤ 1.0 s at N=50k
+  - Rebuild cold-start (persist-off): ≤ 38.0 s at N=50k
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.bench_gate._hrr_synthetic_store import build_n50k_store
+
+_SEED = 42
+_N = 50_000
+_DIM = 512  # DEFAULT_DIM post-#538; matches production default
+
+# Timing ceilings (seconds) per spec.
+_WARM_CEILING_S = 1.0
+_REBUILD_CEILING_S = 38.0
+
+
+@pytest.mark.bench_gated
+def test_hrr_cold_start_warm_load_under_one_second_at_50k(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Warm cold-start (mmap load) completes in ≤ 1 s at N=50k.
+
+    Protocol:
+    1. Build synthetic N=50k store, prime persist dir via first cache.get().
+    2. Confirm struct.npy written to <tmp_path>/.hrr_struct_index/struct.npy.
+    3. Drop references to first cache and store (no warm in-process state).
+    4. Open a fresh MemoryStore + HRRStructIndexCache pointing at the same db.
+    5. Time the first cache.get() — must use the mmap load path, not rebuild.
+    6. Assert wall-clock ≤ 1.0 s.
+    7. Call probe() once to confirm the loaded index is usable (exercises the
+       mmap-backed struct matrix; not timed — correctness, not perf).
+    """
+    from aelfrice.hrr_index import HRRStructIndexCache
+    from aelfrice.store import MemoryStore
+
+    # Ensure persistence is enabled (default; guard against env leakage).
+    monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
+
+    memory_db = tmp_path / "memory.db"
+    store_path = str(memory_db)
+
+    # --- Phase 1: prime the persist dir ---
+    store1 = build_n50k_store(memory_db, n_beliefs=_N, seed=_SEED)
+    cache1 = HRRStructIndexCache(
+        store=store1, dim=_DIM, store_path=store_path, seed=_SEED
+    )
+    cache1.get()  # builds and saves struct.npy
+
+    persist_dir = tmp_path / ".hrr_struct_index"
+    assert (persist_dir / "struct.npy").is_file(), (
+        "persist dir not written — warm-load test cannot proceed"
+    )
+
+    store1.close()
+    del cache1  # drop all references; next get() must go through load, not cache
+
+    # --- Phase 2: fresh process simulation (fresh store + cache) ---
+    store2 = MemoryStore(store_path)
+    cache2 = HRRStructIndexCache(
+        store=store2, dim=_DIM, store_path=store_path, seed=_SEED
+    )
+
+    t0 = time.perf_counter()
+    idx = cache2.get()
+    elapsed = time.perf_counter() - t0
+
+    # Correctness smoke: probe must return results (mmap lazy-load validation).
+    # "b000050" has a CONTRADICTS edge from "b000000" (offset 50 in the helper).
+    hits = idx.probe("CONTRADICTS", "b000050", top_k=5)
+    assert hits, (
+        f"probe returned no hits on mmap-loaded index (N={_N}, elapsed={elapsed:.3f}s)"
+    )
+
+    store2.close()
+
+    assert elapsed <= _WARM_CEILING_S, (
+        f"HRR warm cold-start took {elapsed:.3f}s, exceeds {_WARM_CEILING_S}s ceiling "
+        f"at N={_N}. mmap load path may have regressed (check for accidental rebuild)."
+    )
+
+
+@pytest.mark.bench_gated
+def test_hrr_cold_start_rebuild_under_38s_at_50k_persist_off(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rebuild cold-start (AELFRICE_HRR_PERSIST=0) completes in ≤ 38 s at N=50k.
+
+    This is the negative-control rail: it locks in the rebuild path's ceiling
+    so a regression in HRRStructIndex.build() shows up here even when no
+    warm-load is available.
+
+    No struct.npy should be written — persistence is disabled via env var.
+    """
+    from aelfrice.hrr_index import HRRStructIndexCache
+
+    monkeypatch.setenv("AELFRICE_HRR_PERSIST", "0")
+
+    memory_db = tmp_path / "memory.db"
+    store_path = str(memory_db)
+
+    store = build_n50k_store(memory_db, n_beliefs=_N, seed=_SEED)
+    cache = HRRStructIndexCache(
+        store=store, dim=_DIM, store_path=store_path, seed=_SEED
+    )
+
+    t0 = time.perf_counter()
+    cache.get()
+    elapsed = time.perf_counter() - t0
+
+    persist_dir = tmp_path / ".hrr_struct_index"
+    assert not (persist_dir / "struct.npy").exists(), (
+        "struct.npy written despite AELFRICE_HRR_PERSIST=0 — opt-out codepath broken"
+    )
+
+    store.close()
+
+    assert elapsed <= _REBUILD_CEILING_S, (
+        f"HRR rebuild cold-start took {elapsed:.3f}s, exceeds {_REBUILD_CEILING_S}s "
+        f"ceiling at N={_N}. HRRStructIndex.build() may have regressed."
+    )


### PR DESCRIPTION
Closes 697 (sub-task of 553).

## Summary

Bench-gated cold-start timing tests for the HRR persistence substrate shipped by PR 693. Two tests assert the warm-load and rebuild paths stay within their spec ceilings at N=50k. Both skip cleanly under normal CI; the maintainer runs the actual bench via the existing `AELFRICE_CORPUS_ROOT` opt-in.

Fourth of the 553 sub-tasks (after 693, 701, 704). Test-only, no production code change.

## What changed

### `tests/bench_gate/_hrr_synthetic_store.py` (new)

`build_n50k_store(memory_db, *, n_beliefs, seed)` produces a fresh `MemoryStore` at `memory_db` with `n_beliefs` belief rows plus a deterministic CONTRADICTS edge pattern (belief `b<i>` → `b<i+50>` for the first half of the store). Fixed seed produces byte-identical stores across runs so warm-load timing is comparable across machines. The probe target in the warm-load test (`"b000050"`) is a real CONTRADICTS edge from `b000000` — the assertion `hits != []` is a genuine correctness check on the mmap-backed struct matrix, not a vacuous pass.

### `tests/bench_gate/test_hrr_cold_start.py` (new)

Two `@pytest.mark.bench_gated` tests with `@pytest.mark.timeout(120)`:

**`test_hrr_cold_start_warm_load_under_one_second_at_50k`**
1. Build N=50k synthetic store at `tmp_path/memory.db`.
2. Prime: `cache1.get()` builds and saves `tmp_path/.hrr_struct_index/struct.npy`.
3. Close `store1`, `del cache1` — drop all in-process state.
4. Open fresh `MemoryStore` + `HRRStructIndexCache` at the same `store_path`.
5. Time the first `cache2.get()` via `time.perf_counter()`. Assert `<= 1.0 s`.
6. Call `idx.probe("CONTRADICTS", "b000050", top_k=5)` and assert `hits != []` (mmap lazy-load correctness check).

**`test_hrr_cold_start_rebuild_under_38s_at_50k_persist_off`**
- Same synthetic store; sets `AELFRICE_HRR_PERSIST=0`.
- Times the first `cache.get()`. Assert `<= 38.0 s`.
- Asserts no `struct.npy` written (env opt-out works).
- This is the negative-control rail — locks in the rebuild path's ceiling so a regression in `HRRStructIndex.build()` surfaces here even when no warm-load is available.

## Test plan

Skip behavior under normal CI (no `AELFRICE_CORPUS_ROOT`):
```
tests/bench_gate/test_hrr_cold_start.py::test_hrr_cold_start_warm_load_under_one_second_at_50k SKIPPED
tests/bench_gate/test_hrr_cold_start.py::test_hrr_cold_start_rebuild_under_38s_at_50k_persist_off SKIPPED
2 skipped in 0.36s
```

Collection passes, helper smoke-builds at N=1000 without error. **The actual 50k bench was not run by the PR author** — that's the operator's job. The `attn:bench-needed` label is on the issue so when the bench runs, the numbers (warm P50/P95, rebuild P50, on-disk-bytes) can be captured for the v3.0 cut artifact list.

## How to run the bench

```bash
AELFRICE_CORPUS_ROOT=/tmp uv run pytest tests/bench_gate/test_hrr_cold_start.py -v -s
```

The bench-gate guard at `tests/conftest.py:48` opt-ins via `AELFRICE_CORPUS_ROOT`. This particular test does not actually use a corpus — it builds its own synthetic store — so any existing directory works. Following the existing bench-gate convention.

Expected total wall-clock: ~40-80 s on a modern machine (build + warm-load + rebuild).

## Out of scope

The remaining 553 follow-ups (TOML key, doctor reporter rows, ephemeral auto-disable, docs bundle) are filed as separate sub-issues. See the 553 umbrella for the cross-reference list.

## Quirks

- `tmp_path` on macOS resolves under `/var/folders/...`, not `/tmp/`. The auto-disable predicate in the in-flight ephemeral PR will not match this path — `monkeypatch.delenv("AELFRICE_HRR_PERSIST")` is the defensive line that keeps the warm-load test honest regardless of whether the ephemeral PR is merged at run time.
- `pyproject.toml` sets a global pytest `timeout = 5`. Without explicit `@pytest.mark.timeout(120)` both tests would be killed mid-build. The 120 s ceiling gives ~3× headroom on the rebuild ceiling.
