### PR TITLE
test(hrr): harden 2 vacuous-pass cache-persistence assertions (#707)

### DIFF
--- a/tests/test_hrr_struct_index.py
+++ b/tests/test_hrr_struct_index.py
@@ -413,6 +413,11 @@ def test_cache_loads_from_disk_on_second_construct(
     s1 = _toy_store()
     cache1 = HRRStructIndexCache(store=s1, dim=256, seed=7, store_path=sp)
     a = cache1.get()
+    # Persistence must have written the struct file before the warm load.
+    pd = _persist_dir(tmp_path)
+    assert (pd / "struct.npy").is_file(), (
+        "struct.npy not found after cold build — persistence is disabled"
+    )
     s2 = _toy_store()
     cache2 = HRRStructIndexCache(store=s2, dim=256, seed=7, store_path=sp)
     b = cache2.get()
@@ -420,6 +425,10 @@ def test_cache_loads_from_disk_on_second_construct(
     assert a is not b
     np.testing.assert_array_equal(a.struct, b.struct)
     assert a.belief_ids == b.belief_ids
+    # Warm load must be mmap-backed, proving a disk round-trip occurred.
+    assert isinstance(b.struct, np.memmap), (
+        f"expected mmap-backed struct on warm load, got {type(b.struct).__name__}"
+    )
 
 
 def test_cache_load_uses_mmap(
@@ -516,8 +525,17 @@ def test_cache_byte_equality_persist_round_trip(
     sp = _store_path(tmp_path)
     s1 = _toy_store()
     cold = HRRStructIndexCache(store=s1, dim=256, seed=7, store_path=sp).get()
+    # Persistence must have written the struct file before the warm load.
+    pd = _persist_dir(tmp_path)
+    assert (pd / "struct.npy").is_file(), (
+        "struct.npy not found after cold build — persistence is disabled"
+    )
     s2 = _toy_store()
     warm = HRRStructIndexCache(store=s2, dim=256, seed=7, store_path=sp).get()
+    # Warm load must be mmap-backed, proving a disk round-trip occurred.
+    assert isinstance(warm.struct, np.memmap), (
+        f"expected mmap-backed struct on warm load, got {type(warm.struct).__name__}"
+    )
     a = cold.probe("CONTRADICTS", "b2", top_k=5)
     b = warm.probe("CONTRADICTS", "b2", top_k=5)
     assert a == b

--- a/tests/test_hrr_struct_index.py
+++ b/tests/test_hrr_struct_index.py
@@ -408,6 +408,8 @@ def test_cache_persists_to_disk_after_build(
 def test_cache_loads_from_disk_on_second_construct(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    import aelfrice.hrr_index as hi
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset())
     monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
     sp = _store_path(tmp_path)
     s1 = _toy_store()
@@ -521,6 +523,8 @@ def test_cache_load_failure_falls_through_to_rebuild(
 def test_cache_byte_equality_persist_round_trip(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    import aelfrice.hrr_index as hi
+    monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset())
     monkeypatch.delenv("AELFRICE_HRR_PERSIST", raising=False)
     sp = _store_path(tmp_path)
     s1 = _toy_store()


### PR DESCRIPTION
Closes #707.

## What

Hardens two HRR cache-persistence tests in `tests/test_hrr_struct_index.py`
that pass vacuously when persistence is silently disabled:

- `test_cache_loads_from_disk_on_second_construct`
- `test_cache_byte_equality_persist_round_trip`

Both tests previously asserted only `np.testing.assert_array_equal` /
`probe(...)` equality between cold and warm caches. Under the in-memory
rebuild path (deterministic seed=7), those equalities hold even when no
disk round-trip happened. A future regression that silently disables
persistence would not be caught.

## Hardening shape

Mirrors prior art in the same file (`test_cache_persists_to_disk_after_build`,
`test_cache_load_uses_mmap`):

1. After the cold construct, assert `(persist_dir / "struct.npy").is_file()`
   — proves the cold path actually wrote to disk.
2. After the warm construct, assert `isinstance(b.struct, np.memmap)` —
   proves the warm path loaded from disk via mmap rather than rebuilding
   in-memory.

## Two atomic commits

1. `test: harden vacuous-cache persistence assertions (#707)` — the two
   strict assertions on each test.
2. `test(hrr): isolate #707 hardened tests from ephemeral-path auto-disable`
   — adds `monkeypatch.setattr(hi, "_EPHEMERAL_PATH_PREFIXES", frozenset())`
   to both tests, mirroring PR #701's pattern for the other 4 persist
   tests in this file. Required because `tmp_path` on Linux CI resolves
   under `/tmp/`, which after PR #701 triggers persist auto-disable —
   the new strict assertions would then fail loudly in CI without this
   neutralisation.

## Verification

- `uv run pytest tests/test_hrr_struct_index.py -q` → 49 passed, 4
  skipped (Linux-only ephemeral-path tests skipped on macOS).
- Acceptance property verified locally: temporarily injecting
  `monkeypatch.setenv("AELFRICE_HRR_PERSIST", "0")` into each hardened
  test makes it fail at the new `(pd / "struct.npy").is_file()`
  assertion with the expected message. Reverted before commit.
- Both commits SSH-signed (G).
- Discretion grep on full diff vs `github/main` → clean.

## Out of scope

- Refactoring the persistence substrate (issue scope).
- macOS `/private/tmp` quirk docs — slated for `docs/CONFIG.md` as
  part of the #553 docs bundle (issue #699).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced struct index cache persistence tests with stronger validation to verify that cached data is properly persisted to disk and subsequently loaded efficiently for continued access.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/709)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->