### PR TITLE
docs(wonder): refresh slash dedup-behaviour paragraph for shipped #644 v2 key

### DIFF
--- a/src/aelfrice/slash_commands/wonder.md
+++ b/src/aelfrice/slash_commands/wonder.md
@@ -39,5 +39,5 @@ Run: `uv run aelf wonder $ARGUMENTS`. Display the output verbatim. Do not add co
 
 4. **Persist.** Run `uv run aelf wonder --persist-docs /tmp/aelf-wonder-dispatch-<unix-ts>.jsonl`. Display the resulting `inserted=N skipped=N edges_created=N` summary verbatim.
 
-**Known dedup behaviour:** `wonder_ingest` keys idempotency on the sorted constituent belief IDs alone. Since every axis row shares the same `speculative_anchor_ids`, only the first row's document persists as a phantom; subsequent rows count as `skipped`. This is current C1 contract behaviour; extending the dedup key to include `generator` so per-axis phantoms can coexist is tracked as a follow-up to #552.
+**Dedup behaviour:** `wonder_ingest` keys idempotency on the sorted constituent belief IDs **and** the generator string (key prefix `wonder_ingest:v2:`, shipped in #644). An N-axis dispatch over the same `speculative_anchor_ids` therefore persists as N distinct phantoms (one per axis-derived generator), not one. Re-running the same dispatch is still a no-op.
 </process>


### PR DESCRIPTION
## Summary

Tiny doc-only fix surfaced while closing out umbrella #645 (wonder/reason agentmemory parity).

`src/aelfrice/slash_commands/wonder.md` ended its dispatch-flow process block with a "Known dedup behaviour" paragraph describing the pre-#644 contract:

> `wonder_ingest` keys idempotency on the sorted constituent belief IDs alone. Since every axis row shares the same `speculative_anchor_ids`, only the first row's document persists as a phantom; subsequent rows count as `skipped`. … extending the dedup key to include `generator` … is tracked as a follow-up to #552.

#644 shipped on `github/main` (sub-task of #552 / umbrella #645): `lifecycle._wonder_ingest_idempotency_key` now hashes sorted constituent IDs **and** the generator string with prefix `wonder_ingest:v2:`. CHANGELOG `## [Unreleased]` entry "**Dedup contract — option 2 (#644)**" documents the new shape; the slash doc was the only place still describing the old contract.

Replaced the paragraph with an accurate "Dedup behaviour" note that matches the shipped key. Operators reading `/aelf:wonder` after the `--axes` dispatch will no longer expect N-1 rows to silently `skipped` away.

## Test plan

- [x] `pytest tests/test_wonder_skill_integration_e2e.py tests/test_lifecycle.py -q` → 47 passed, 2 skipped (no behavior change; doc only)
- [x] Discretion grep on diff vs `github/main` → clean
- [x] `aelf-pr-open.sh` rebase + pytest + discretion gate

Closes part of #645 acceptance ("`slash_commands/wonder.md` mirrors the agentmemory 7-step process adapted for the merged CLI"); umbrella close-out tracked separately.

## Summary by Sourcery

Documentation:
- Refresh the deduplication behaviour note in wonder slash command docs to describe the v2 idempotency key including the generator string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified dispatch idempotency: dedup now considers both the sorted constituent belief IDs and the generator string, so N-axis dispatches can create distinct phantom beliefs per axis-derived generator, while re-running the identical dispatch is a no-op.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/715)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->