### PR TITLE
fix(bench): debug fixture meta — eval_turns point at canonical answers (#687)

### DIFF
--- a/benchmarks/context-rebuilder/fixtures/synthetic/debugging_session_001.meta.json
+++ b/benchmarks/context-rebuilder/fixtures/synthetic/debugging_session_001.meta.json
@@ -1,6 +1,6 @@
 {
   "task_type": "debug",
   "fork_turn": 8,
-  "eval_turns": [8, 10, 12, 14],
-  "notes": "Midpoint fork on the 16-turn synthetic debugging-session fixture. Post-fork eval turns are the four user prompts at file indices 8, 10, 12, 14. Pairs with debugging_session_001.jsonl; load_corpus() resolves this via with_suffix('.meta.json')."
+  "eval_turns": [9, 11, 13, 15],
+  "notes": "Midpoint fork on the 16-turn synthetic debugging-session fixture. Post-fork eval turns are the four assistant continuations at file indices 9, 11, 13, 15. The harness pulls `user_turn` from each eval_turn's most-recent-user-role text (8/10/12/14) and `expected` from the eval_turn itself (assistant continuations at 9/11/13/15). This makes `expected` the canonical answer the post-rebuild agent should produce, so judge-vs-baseline κ compares answer-against-answer (calibration ratification #687). Prior shape used eval_turns=[8,10,12,14] which set expected=user_question_text: substring path always missed and the judge prompt split on Q/A speech-act mismatches (mirrors the hot_start fixture's #687 failure evidence, fixed alongside in PR #639). Pairs with debugging_session_001.jsonl; load_corpus() resolves this via with_suffix('.meta.json')."
 }


### PR DESCRIPTION
## Summary

Closes [#687](https://github.com/robotrocketscience/aelfrice/issues/687) and unblocks [#592](https://github.com/robotrocketscience/aelfrice/issues/592).

Two-part change for the v3.0 release gate:

1. **Code:** flip `debugging_session_001.meta.json` `eval_turns` from `[8, 10, 12, 14]` (user-prompt indices, `expected = user_question_text`) to `[9, 11, 13, 15]` (assistant-continuation indices, `expected = canonical answer`). Mirrors PR #639's analogous fix to the `hot_start` fixture.

2. **Bench artifact** for #687 calibration (run on the patched corpus, posted below as the closing evidence). Bench artifacts remain uncommitted per project policy.

## Why

Without the fixture-meta flip, the LLM judge was being asked to compare candidate answers against user questions — the speech-act split that drove `inter_judge_kappa=0.0` on the prior single-judge hot_start run, documented in #687's body and the hot_start meta `notes` field. The earlier hot_start patch (PR #639) noted the debug fixture would be flipped alongside once the cold-start sweep was re-ratified separately; this is that follow-up.

## κ artifact — `687_hot_start_t_le_0.6` (calibrated cut)

3 independent Sonnet 4.6 judges, hot-start rows at `trigger_threshold ≤ 0.6`, 6 pairs aligned. `--judge-model "claude-sonnet-4-6 (anchor tier per llm_judge.py)"`. Baseline: `score_substring_exact_match`.

```json
{
  "run_id": "687_hot_start_t_le_0.6",
  "n_runs": 3,
  "n_pairs": 6,
  "judge_model": "claude-sonnet-4-6 (anchor tier per llm_judge.py)",
  "baseline": "score_substring_exact_match",
  "inter_judge_kappa": {
    "judge_run1_hot_t06_vs_judge_run2_hot_t06": 1.0,
    "judge_run1_hot_t06_vs_judge_run3_hot_t06": 1.0,
    "judge_run2_hot_t06_vs_judge_run3_hot_t06": 1.0,
    "mean": 1.0,
    "min": 1.0
  },
  "judge_vs_baseline_kappa": {
    "judge_run1_hot_t06": 0.0,
    "judge_run2_hot_t06": 0.0,
    "judge_run3_hot_t06": 0.0,
    "mean": 0.0
  },
  "per_run_hot_start_fidelity": [1.0, 1.0, 1.0],
  "hot_start_fidelity_mean": 1.0,
  "calibrated": true,
  "failure_reasons": []
}
```

### Calibration gates

| gate (per `docs/BENCHMARKS.md §Eval-judge calibration` + `kappa.py` thresholds) | result |
|---|---|
| `inter_judge_kappa.min ≥ 0.70` | **1.0** ✓ |
| `hot_start_fidelity_mean ≥ 0.80` | **1.0** ✓ |
| `n_runs ≥ 3` | **3** ✓ |
| `calibrated` | **true** ✓ |

Judge-vs-baseline κ = 0.0 across all runs because the substring baseline matched zero rows (every candidate paraphrases rather than substring-quoting the reference), while the judges agreed on 10/35 matches. This is the expected "the judge is earning its API cost" pattern documented in `kappa.py`'s docstring — judge-vs-baseline is report-only, not a gate.

## κ artifact — `687_all_35_rows` (informational)

Full 35-row sweep across both fixtures and all 5 trigger_threshold values:

```json
{
  "run_id": "687_all_35_rows",
  "n_runs": 3,
  "n_pairs": 35,
  "inter_judge_kappa": {
    "judge_responses_run1_vs_judge_responses_run2": 1.0,
    "judge_responses_run1_vs_judge_responses_run3": 1.0,
    "judge_responses_run2_vs_judge_responses_run3": 1.0,
    "mean": 1.0,
    "min": 1.0
  },
  "judge_vs_baseline_kappa": {"mean": 0.0},
  "per_run_hot_start_fidelity": [0.2857, 0.2857, 0.2857],
  "hot_start_fidelity_mean": 0.2857,
  "calibrated": false,
  "failure_reasons": ["hot_start_fidelity_mean=0.2857 < threshold 0.8"]
}
```

The informational run intentionally fails the calibration gate — at `trigger_threshold ∈ {0.7, 0.8, 0.9}` the rebuilder doesn't fire and the candidate hedges with "I don't have that in context." This is the expected behaviour the #587 AC qualifies with "at threshold ≤0.6"; the calibrated artifact above is the AC-aligned cut.

## Per-(task, threshold) fidelity (mean across 3 judge runs)

| config | n_rows | mean_fidelity | notes |
|---|---|---|---|
| hot_start t=0.5 | 3 | **1.00** | rebuilder fires, all 3 questions answered |
| hot_start t=0.6 | 3 | **1.00** | rebuilder fires, all 3 questions answered |
| hot_start t=0.7 | 3 | 0.00 | rebuilder doesn't fire, candidate hedges |
| hot_start t=0.8 | 3 | 0.00 | rebuilder doesn't fire |
| hot_start t=0.9 | 3 | 0.00 | rebuilder doesn't fire |
| cold_start (debug) t=0.5 | 4 | 0.25 | XML-format Q matched; idempotency/determinism/release-version Qs hedged |
| cold_start (debug) t=0.6 | 4 | 0.25 | same |
| cold_start (debug) t=0.7 | 4 | 0.25 | same |
| cold_start (debug) t=0.8 | 4 | 0.25 | same |
| cold_start (debug) t=0.9 | 4 | 0.00 | rebuilder empty, all hedged |

Cold-start (debug) fidelity is 25% at low thresholds and 0% at t=0.9 — substantially below the patched-fixture pass rate the prior single-judge run reported (~75%) because the patched `expected` is the canonical assistant answer rather than the user prompt. This is the **calibration improvement** the #687 fixture-meta work was designed to deliver: cold-start scores now reflect actual continuation fidelity, not subject-match leniency. Cold-start AC isn't gated on a specific number for v3.0; this PR re-establishes the cold-start baseline at `25% at t≤0.8, 0% at t=0.9` for #592 future reference.

## Methodology

1. Patched `debugging_session_001.meta.json` (this PR's single commit).
2. Ran the eval harness against `benchmarks/context-rebuilder/fixtures/synthetic/` with `--mode threshold-sweep --run-dir`, producing 10 case-config dirs × 35 `replay_requests.jsonl` rows total.
3. Replay step: 1 Sonnet 4.6 host-subagent generated all 35 `actual` continuations from each row's `rebuilt_block + user_turn` under explicit no-cross-row-contamination instructions per `judges/llm_judge.py` §"Contamination protocol".
4. Re-ran harness to score replay (substring step: 0 substring-exact matches; all 35 rows tagged `needs_llm_judge`).
5. Dispatched 3 independent Sonnet 4.6 host-subagents over the same `judge_requests.jsonl` (35 rows × 3 = 105 judge calls). Each saw only `(turn_idx, expected, actual)` per the contamination protocol.
6. Built deterministic baseline via `benchmarks/qa_scoring.score_substring_exact_match`.
7. Ran `python -m benchmarks.context_rebuilder.kappa` on the AC-aligned subset (hot-start at `t≤0.6`) and on the full 35-row sweep.

All 3 judge runs produced **identical** verdicts (10/35 matched, same `turn_idx` set: 1, 5, 9, 13, 20, 21, 22, 23, 24, 25). The κ=1.0 across all run-pairs reflects that determinism within the Sonnet 4.6 judge tier for these prompts — agents on this fixture's signal/noise distribution land on the same verdict.

## Sample-size caveat

The `docs/BENCHMARKS.md §Eval-judge calibration` doc already flags: at N=3 over ~18 deduplicated pairs the 95% CI on a 0.70 point estimate spans ≈ 0.45–0.90. The hot-start calibrated cut here is 6 pairs (3 turns × 2 thresholds), even tighter. A pre-release N=5 ratification run is still recommended as future work; this PR ships the gate-pass for v3.0 only.

## Local verification

```
uv run pytest tests/test_context_rebuilder_eval_harness_wiring.py tests/test_context_rebuilder_harness.py tests/test_continuation_fidelity_scorer.py tests/test_rebuilder_triggers.py tests/test_eval_harness.py tests/test_eval_baseline.py -q
99 passed in 1.02s
```

No assertion in tests references the debug fixture's `eval_turns` shape (only the hot_start shape is asserted at `test_context_rebuilder_eval_harness_wiring.py:534`); the patch is invariant under the existing test suite.

## Refs

- Closes #687
- Unblocks #592 (gate-prereq satisfied)
- Mirrors PR #639 fixture-meta methodology
- Tracker line: #608 "Bench-only items #152, #592 (gated on #687), #697 have captured run artifacts"
- Release PR: #717 substantive checklist item

Bench artifacts (run dirs, judge JSONLs, kappa JSONs) are local-only at `/tmp/592_run/` per project policy of "uncommitted run artifacts".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test fixture metadata to reflect changes in evaluation indexing semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/727)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->