### PR TITLE
feat: collapse install/upgrade surface to uv-only (#730)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+### Changed
+
+- **Install / upgrade surface collapsed to `uv tool` only** ([#730](https://github.com/robotrocketscience/aelfrice/issues/730)). `aelf upgrade-cmd` (and the `/aelf:upgrade` slash) now emit a single in-place upgrade form (`uv tool upgrade aelfrice`) for uv-managed installs and a migration chain (`pipx uninstall aelfrice && uv tool install aelfrice`, or the pip equivalent) for any other installer. `UpgradeAdvice.context` collapses from four values (`uv_tool` / `pipx` / `venv` / `system`) to two (`uv_tool` / `non_uv`). Per-installer context notes are gone; `_UPGRADE_CONTEXT_NOTE` retains a single uv entry plus one explicit migration note. The pipx/venv/system detection helpers in `lifecycle.py` are still used internally to pick the right uninstall verb, but they no longer surface as distinct supported channels. README and `docs/INSTALL.md` rewritten around `uv tool install`. **Migration for existing pipx / pip users:** run `pipx uninstall aelfrice && uv tool install aelfrice` (or `pip uninstall -y aelfrice && uv tool install aelfrice`) once. The next `aelf upgrade-cmd` against a non-uv install emits the same line.
+
 ## [3.0.0] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ aelfrice is a memory substrate that runs in the background of your coding agent.
 ## Install
 
 ```bash
-pipx install aelfrice    # or: uv tool install aelfrice
-aelf setup               # wire the UserPromptSubmit hook into your agent
-aelf onboard .           # one-shot project scan: filesystem, git log, AST
+uv tool install aelfrice    # requires uv — https://docs.astral.sh/uv/
+aelf setup                  # wire the UserPromptSubmit hook into your agent
+aelf onboard .              # one-shot project scan: filesystem, git log, AST
 aelf lock "never push directly to main; use scripts/publish.sh"
 ```
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,25 +2,19 @@
 
 ## Prerequisites
 
-- Python 3.12 or 3.13.
-- [`uv`](https://docs.astral.sh/uv/) (recommended) or `pip`. `uv` handles the Python version for you.
+- Python 3.12 or 3.13. (`uv` handles the Python version for you — no need to install Python separately.)
+- [`uv`](https://docs.astral.sh/uv/). The supported install channel (#730). If you don't have it: `curl -LsSf https://astral.sh/uv/install.sh | sh`.
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code), or any agent that can spawn a hook on `UserPromptSubmit`.
 
 ## 1. Install the package
 
 ```bash
-pip install aelfrice                # core, zero runtime deps
-pip install "aelfrice[mcp]"         # add the MCP server (fastmcp)
-pip install "aelfrice[archive]"     # add the encrypted-archive uninstall path
+uv tool install aelfrice                # core, zero runtime deps
+uv tool install "aelfrice[mcp]"         # add the MCP server (fastmcp)
+uv tool install "aelfrice[archive]"     # add the encrypted-archive uninstall path
 ```
 
-Or with `uv`:
-
-```bash
-uv tool install aelfrice
-```
-
-Or from source:
+Or from source (developer install):
 
 ```bash
 git clone https://github.com/robotrocketscience/aelfrice.git
@@ -28,6 +22,8 @@ cd aelfrice && uv sync
 ```
 
 This installs two console scripts: `aelf` (the CLI) and `aelf-hook` (the hook entry-point Claude Code spawns on each prompt).
+
+> **Migrating from pipx / pip?** As of v3.0.x aelfrice is uv-only (#730). If you previously installed via pipx, run `pipx uninstall aelfrice && uv tool install aelfrice` once. `aelf upgrade-cmd` will surface the same migration line on the next upgrade check. pip-installed users: `pip uninstall -y aelfrice && uv tool install aelfrice`.
 
 Verify:
 
@@ -52,7 +48,7 @@ Auto-detection picks the right scope and command path:
 | Run from… | `--scope` | `--command` |
 |---|---|---|
 | inside a project venv | `project` (writes `<project>/.claude/settings.json`) | `<project>/.venv/bin/aelf-hook` |
-| a `pipx`-installed `aelf` outside any venv | `user` (writes `~/.claude/settings.json`) | first `aelf-hook` on `$PATH` |
+| a `uv tool`-installed `aelf` outside any venv | `user` (writes `~/.claude/settings.json`) | first `aelf-hook` on `$PATH` |
 | a venv unrelated to `cwd` | `user` | first `aelf-hook` on `$PATH`, falls back to the active venv |
 
 Override with `--scope user|project` and `--command /abs/path/aelf-hook` when you need to.
@@ -170,7 +166,7 @@ All hooks are non-blocking. Every failure path returns exit 0 — a hook problem
 
 ### Self-installing hook manifest (v3.0+)
 
-The list of default-on hooks above is declared in `src/aelfrice/data/hook_manifest.json` and ships in the wheel. The first `aelf <cmd>` invocation after a fresh install or a bare `pipx upgrade aelfrice` (or `uv tool upgrade aelfrice` / `pip install -U aelfrice`) reconciles the installed manifest version against `~/.aelfrice/installed-manifest-version` and merges any new entries into `~/.claude/settings.json` automatically. This closes the loop on bare package-manager upgrades — you no longer have to remember to re-run `aelf setup` to pick up hooks added in newer releases.
+The list of default-on hooks above is declared in `src/aelfrice/data/hook_manifest.json` and ships in the wheel. The first `aelf <cmd>` invocation after a fresh install or a bare `uv tool upgrade aelfrice` reconciles the installed manifest version against `~/.aelfrice/installed-manifest-version` and merges any new entries into `~/.claude/settings.json` automatically. This closes the loop on bare package-manager upgrades — you no longer have to remember to re-run `aelf setup` to pick up hooks added in newer releases.
 
 What auto-install does:
 
@@ -240,11 +236,12 @@ The dormant scan is schema-agnostic — both pre-v1.x and modern-schema DBs are 
 ## Update notifier
 
 ```bash
-aelf upgrade           # prints the right pip-upgrade line for your env
-aelf upgrade --check   # yes/no, no command line printed
+aelf upgrade-cmd          # prints the canonical upgrade command (`run: …`)
+aelf upgrade-cmd --check  # same output, no behaviour difference
+/aelf:upgrade             # imperative slash: detect + run + re-setup
 ```
 
-`aelf upgrade` detects venv vs pipx vs system and tells you the line. It does not run pip itself — replacing the running interpreter mid-process is unreliable on Windows.
+`aelf upgrade-cmd` emits `run: uv tool upgrade aelfrice` on a uv-managed install. If aelfrice was installed via another tool (pipx, pip, system), the `run:` line is the migration chain (`pipx uninstall aelfrice && uv tool install aelfrice`, or the pip equivalent) — uv is the single supported install channel (#730). The CLI does not execute the upgrade itself: replacing the running interpreter mid-process is unreliable on Windows.
 
 The orange statusline banner appears automatically when an update is available. Disable with `export AELF_NO_UPDATE_CHECK=1`.
 
@@ -258,7 +255,7 @@ You must pick a disposition for the DB:
 aelf uninstall --keep-db              # leave the DB in place (safe default)
 aelf uninstall --archive backup.aenc  # encrypt to file then delete
 aelf uninstall --purge                # permanently delete (three confirmation gates)
-pip uninstall aelfrice                # finally remove the wheel
+uv tool uninstall aelfrice            # finally remove the wheel
 ```
 
 `--archive` uses Fernet (AES-128-CBC + HMAC, scrypt-derived key). Recover later:
@@ -276,7 +273,7 @@ Requires the `[archive]` extra.
 
 | Symptom | Fix |
 |---|---|
-| `aelf: command not found` | Confirm `~/.local/bin` (pipx) or `<venv>/bin` is on `$PATH`. |
+| `aelf: command not found` | Confirm `~/.local/bin` (uv tool shim dir) is on `$PATH`. `uv tool update-shell` adds it for you. |
 | Hook fires but no `<aelfrice-memory>` block appears | `aelf doctor` — usually the hook command points at a deleted script. |
 | `aelf doctor` says "skipped (shell metacharacters)" on a hook line | Stale install. `aelf setup` rewrites the hook in place. |
 | Two worktrees of the same repo see the same beliefs | Working as designed — they share `--git-common-dir`. Pin one with `AELFRICE_DB`. |

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2998,9 +2998,13 @@ def _cmd_mcp(args: argparse.Namespace, out: object) -> int:
 
 _UPGRADE_CONTEXT_NOTE: dict[str, str] = {
     "uv_tool": "installed via uv tool — use uv to upgrade",
-    "pipx": "installed via pipx — use pipx to upgrade",
-    "venv": "running inside a virtual environment — use pip to upgrade",
-    "system": "system / user install — use pip to upgrade",
+    # #730: every non-uv install (pipx/venv/system) is routed to a
+    # migration command. The note tells the user this isn't an in-place
+    # upgrade — they're switching install channels.
+    "non_uv": (
+        "aelfrice is supported via `uv tool` only (#730); the `run:` "
+        "line below migrates this install to uv"
+    ),
 }
 
 

--- a/src/aelfrice/lifecycle.py
+++ b/src/aelfrice/lifecycle.py
@@ -318,10 +318,16 @@ def format_update_banner(
 
 @dataclass(frozen=True)
 class UpgradeAdvice:
-    """How to upgrade aelfrice in the user's specific install context."""
+    """How to upgrade aelfrice in the user's specific install context.
+
+    Per #730 aelfrice is supported on a single install channel: `uv tool`.
+    `context` therefore collapses to two values: `uv_tool` for a uv-managed
+    install (in-place upgrade) and `non_uv` for any other install path
+    (migration command — uninstall the old + `uv tool install`).
+    """
 
     command: str
-    context: str  # 'uv_tool' | 'pipx' | 'venv' | 'system'
+    context: str  # 'uv_tool' | 'non_uv'
 
 
 def _is_uv_tool_install() -> bool:
@@ -380,16 +386,18 @@ def _is_venv() -> bool:
 
 
 def upgrade_advice() -> UpgradeAdvice:
-    """Return the correct upgrade command for the running install context.
+    """Return the upgrade command for the running install context.
+
+    aelfrice is supported on a single install channel: `uv tool` (#730).
+    When the running install came from a different installer we emit a
+    migration command (uninstall the old + `uv tool install`) rather
+    than an in-place upgrade — the supported upgrade path is uv.
 
     Detection order matters: uv-tool and pipx are both virtualenvs, so
-    they must be identified before the generic venv check.
-
-    Contexts and their upgrade commands:
-      uv_tool  — uv tool upgrade aelfrice
-      pipx     — pipx upgrade aelfrice
-      venv     — pip install --upgrade aelfrice  (active venv's pip)
-      system   — pip install --user --upgrade aelfrice
+    they must be identified before the generic venv check. The pipx /
+    venv / system branches are kept because we still need to know *what*
+    to tell the user to uninstall before the uv install — but they all
+    collapse to `context="non_uv"` at the API surface.
     """
     if _is_uv_tool_install():
         return UpgradeAdvice(
@@ -397,22 +405,20 @@ def upgrade_advice() -> UpgradeAdvice:
             context="uv_tool",
         )
     if _is_pipx_install():
-        return UpgradeAdvice(
-            command=f"pipx upgrade {PACKAGE_NAME}",
-            context="pipx",
+        migrate = (
+            f"pipx uninstall {PACKAGE_NAME} "
+            f"&& uv tool install {PACKAGE_NAME}"
         )
-    if _is_venv():
-        return UpgradeAdvice(
-            command=f"pip install --upgrade {PACKAGE_NAME}",
-            context="venv",
+    else:
+        # venv and system installs: pip uninstall, then uv tool install.
+        # `-y` skips the pip confirmation prompt; the user opted in by
+        # running the slash. `uv tool install` itself sets up the shim
+        # in ~/.local/bin so no further PATH plumbing is needed.
+        migrate = (
+            f"pip uninstall -y {PACKAGE_NAME} "
+            f"&& uv tool install {PACKAGE_NAME}"
         )
-    # Fall through: system / user-site install. --user is the safest
-    # default since system-site requires root and most users don't
-    # want to sudo pip install.
-    return UpgradeAdvice(
-        command=f"pip install --user --upgrade {PACKAGE_NAME}",
-        context="system",
-    )
+    return UpgradeAdvice(command=migrate, context="non_uv")
 
 
 # --- Multi-install detection -------------------------------------------

--- a/src/aelfrice/slash_commands/upgrade.md
+++ b/src/aelfrice/slash_commands/upgrade.md
@@ -1,30 +1,34 @@
 ---
 name: aelf:upgrade
-description: Upgrade aelfrice to the latest published version using the right tool for this install context.
+description: Upgrade aelfrice to the latest published version using uv.
 allowed-tools:
   - Bash
 ---
 <objective>
-Imperative upgrade. This slash is the *end-to-end* upgrade flow:
-detect the install method (uv tool / pipx / venv / system pip),
-**run the upgrade itself**, then re-run `aelf setup` so any
-slash-command bundle changes that shipped in the new release land
-cleanly (orphan-pruned, new files written).
+Imperative upgrade. This slash is the *end-to-end* upgrade flow: ask
+the CLI for the canonical command, **run the upgrade itself**, then
+re-run `aelf setup` so any slash-command bundle changes that shipped
+in the new release land cleanly (orphan-pruned, new files written).
 
-The user invoked this slash because they want aelfrice on a new
+Per #730 aelfrice is supported on a single install channel: `uv tool`.
+If the active install was set up via a different installer (pipx, pip,
+system), `aelf upgrade-cmd` emits a migration command (uninstall the
+old + `uv tool install aelfrice`) — execute it verbatim, same as a
+plain upgrade.
+
+The user invoked this slash because they want aelfrice on the new
 version when it's done. Producing the detection output and stopping
 is the wrong outcome — that is what `aelf upgrade-cmd` does on its
 own. This slash exists to take the next step.
 
 Why Bash and not in-process: replacing the running package
 mid-process is unreliable on Windows and can leave a broken
-interpreter. The Bash block runs `pipx upgrade` / `uv tool upgrade`
-(or equivalent) in a subprocess separate from the running `aelf` —
-no mid-process replacement.
+interpreter. The Bash block runs the `run:` command in a subprocess
+separate from the running `aelf` — no mid-process replacement.
 </objective>
 
 <process>
-Step 1 — detect install context.
+Step 1 — fetch the canonical upgrade command.
 
 Run `aelf upgrade-cmd` (no flags) to ask aelfrice itself what command
 would upgrade the active install. Use the no-flag form deliberately:
@@ -38,16 +42,19 @@ the slash silently did nothing (#530). The no-flag form has emitted
 
 - If the output contains `aelfrice is up to date`, print that line
   verbatim and stop. There is nothing to do.
-- Otherwise the output contains a line of the form `run: <command>`
-  (for example `run: pipx upgrade aelfrice` or `run: uv tool upgrade
-  aelfrice`). Extract `<command>` exactly — everything after `run: `.
-  This is the canonical upgrade command for this install. **You must
-  use it verbatim** in step 2.
+- Otherwise the output contains a line of the form `run: <command>`.
+  Extract `<command>` exactly — everything after `run: `. This is the
+  canonical command for this install. It is one of:
+    - `uv tool upgrade aelfrice` (uv-managed install, in-place upgrade)
+    - `pipx uninstall aelfrice && uv tool install aelfrice` (pipx install, migrate to uv)
+    - `pip uninstall -y aelfrice && uv tool install aelfrice` (pip/venv/system, migrate to uv)
+  **You must use it verbatim** in step 2.
 
-Any parenthetical advisory in the output (such as
-`(installed via pipx — use pipx to upgrade)`) is hint text for
-humans reading the CLI directly. It is NOT a substitute for step 2.
-The `run:` line is the canonical instruction; the parenthetical is
+Any parenthetical note in the output (such as
+`(installed via uv tool — use uv to upgrade)` or
+`(aelfrice is supported via 'uv tool' only (#730) …)`) is hint text
+for humans reading the CLI directly. It is NOT a substitute for step
+2. The `run:` line is the canonical instruction; the parenthetical is
 not.
 
 Step 2 — execute the upgrade. This is the step the user is paying
@@ -61,7 +68,9 @@ upgrade. Step 2 is what makes the upgrade happen.
 
 If `<command>` exits non-zero, print the captured output and stop —
 do not proceed to step 3. (Common cause: the install method changed
-since the cached detection; rerun the slash.)
+since the cached detection; rerun the slash. Or: the migration
+chain's first half failed — for example pipx wasn't on PATH when the
+command tried to run it.)
 
 Step 3 — refresh installed slash commands and hooks.
 
@@ -88,12 +97,14 @@ proceed safely).
 
 <failure_modes>
 **Anti-pattern: stopping after step 1.** Some agents read the
-`(installed via pipx — use pipx to upgrade)` advisory and interpret
-it as "the system has told the user what to do, my job is done."
-This is wrong. The slash is `/aelf:upgrade`, not `/aelf:show-me-the-
-upgrade-command`. The user clicked it because they wanted the
-upgrade to happen. If you stop here, the user is no further along
-than when they started, and they will reasonably file a bug
+`(installed via uv tool — use uv to upgrade)` advisory (or the
+`(aelfrice is supported via 'uv tool' only …)` migration note) and
+interpret it as "the system has told the user what to do, my job is
+done." This is wrong. The slash is `/aelf:upgrade`, not
+`/aelf:show-me-the-upgrade-command`. The user clicked it because they
+wanted the upgrade to happen. If you stop here, the user is no
+further along than when they started, and they will reasonably file
+a bug
 ([#611](https://github.com/robotrocketscience/aelfrice/issues/611)
 is the original report of exactly this failure).
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -205,7 +205,7 @@ def test_wheel_sha256_returns_none_when_empty() -> None:
 def test_upgrade_advice_in_venv() -> None:
     # The test runner is in some kind of managed environment.
     advice = lifecycle.upgrade_advice()
-    assert advice.context in {"uv_tool", "venv", "pipx", "system"}
+    assert advice.context in {"uv_tool", "non_uv"}
     assert "aelfrice" in advice.command
 
 

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -164,9 +164,9 @@ def test_upgrade_slash_keeps_step_2_imperative() -> None:
 
     - the word `verbatim` appears in step 2 (signals "don't substitute
       a guess of what to run").
-    - the body anticipates the parenthetical advisory by name
-      (`(installed via pipx — use pipx to upgrade)`) and tells the
-      agent it is not a substitute for executing the `run:` line.
+    - the body anticipates the parenthetical advisory by name (the
+      `installed via uv tool` form, post-#730) and tells the agent it
+      is not a substitute for executing the `run:` line.
 
     If a future edit softens either, this test fires. The point of the
     test is to keep the imperative load-bearing under copy edits.
@@ -176,10 +176,11 @@ def test_upgrade_slash_keeps_step_2_imperative() -> None:
         "/aelf:upgrade step 2 must instruct the agent to run the `run:` "
         "command verbatim (see #611 — guess-substitution failure mode)."
     )
-    assert "installed via pipx" in text, (
+    assert "installed via uv tool" in text, (
         "/aelf:upgrade must call out the parenthetical advisory by name "
         "so the agent does not treat it as a substitute for step 2 "
-        "(see #611 — stop-after-step-1 failure mode)."
+        "(see #611 — stop-after-step-1 failure mode; #730 collapses the "
+        "advisory wording to uv-tool only)."
     )
 
 

--- a/tests/test_upgrade_ux.py
+++ b/tests/test_upgrade_ux.py
@@ -312,16 +312,44 @@ def _patch_detection(
 
 
 @pytest.mark.parametrize(
-    "uv_tool,pipx,venv,expected_context,expected_cmd_fragment",
+    "uv_tool,pipx,venv,expected_context,expected_cmd",
     [
+        # uv_tool: in-place upgrade.
         (True, False, False, "uv_tool", "uv tool upgrade aelfrice"),
-        (False, True, False, "pipx", "pipx upgrade aelfrice"),
-        (False, False, True, "venv", "pip install --upgrade aelfrice"),
-        (False, False, False, "system", "pip install --user --upgrade aelfrice"),
+        # pipx: migrate to uv via pipx uninstall.
+        (
+            False,
+            True,
+            False,
+            "non_uv",
+            "pipx uninstall aelfrice && uv tool install aelfrice",
+        ),
+        # venv: migrate to uv via pip uninstall.
+        (
+            False,
+            False,
+            True,
+            "non_uv",
+            "pip uninstall -y aelfrice && uv tool install aelfrice",
+        ),
+        # system / user-site: same as venv (pip uninstall + uv install).
+        (
+            False,
+            False,
+            False,
+            "non_uv",
+            "pip uninstall -y aelfrice && uv tool install aelfrice",
+        ),
         # uv_tool wins even if venv is also true (order check).
         (True, False, True, "uv_tool", "uv tool upgrade aelfrice"),
-        # pipx wins over plain venv.
-        (False, True, True, "pipx", "pipx upgrade aelfrice"),
+        # pipx wins over plain venv (pipx is detected first).
+        (
+            False,
+            True,
+            True,
+            "non_uv",
+            "pipx uninstall aelfrice && uv tool install aelfrice",
+        ),
     ],
 )
 def test_upgrade_advice_routing(
@@ -330,12 +358,15 @@ def test_upgrade_advice_routing(
     pipx: bool,
     venv: bool,
     expected_context: str,
-    expected_cmd_fragment: str,
+    expected_cmd: str,
 ) -> None:
+    """#730: contexts collapse to uv_tool|non_uv; non_uv commands are
+    migration commands (uninstall + uv tool install), not in-place
+    upgrades via the foreign installer."""
     _patch_detection(monkeypatch, uv_tool=uv_tool, pipx=pipx, venv=venv)
     advice = lifecycle.upgrade_advice()
     assert advice.context == expected_context
-    assert advice.command == expected_cmd_fragment
+    assert advice.command == expected_cmd
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Collapse the install/upgrade surface to `uv tool` only. Closes #730.

`UpgradeAdvice.context` drops from four values (`uv_tool` / `pipx` / `venv` / `system`) to two (`uv_tool` / `non_uv`). The `run:` line on a uv-managed install is the in-place `uv tool upgrade`; on any non-uv install it is the migration chain (`pipx uninstall aelfrice && uv tool install aelfrice` or the pip equivalent). README and `docs/INSTALL.md` are rewritten around `uv tool install`. The `/aelf:upgrade` slash file enumerates the three forms the CLI can now emit but the imperative shape (step 2 runs `run:` verbatim — #611) is unchanged.

## Why

The multi-installer detection surface in `aelf upgrade-cmd` has been the source of #318, #345, #427, #522, #530, #611, and the live "use pipx to upgrade" footgun in the issue's screenshot. Each is downstream of one decision: aelfrice tried to support every installer instead of picking one. With a single maintainer (#605, #607), the cost of supporting N install methods is not worth paying. uv is the single canonical install channel from this PR onward.

## Scope deviation from the issue body

Issue #730 proposed collapsing `_INSTALL_SITE_LABEL` to `"uv tool"` + `"other (unsupported)"`. I kept the granular labels (`uv tool`, `pipx`, `user-local`) because the multi-install warning's job is to help the user *clean up*, and "other (unsupported)" loses the on-disk path hint. This is orthogonal to the upgrade-channel decision (which collapsed as specified). Happy to revisit if you'd rather see the labels collapsed too.

## Commits

1. `refactor(lifecycle):` collapse `upgrade_advice` contexts to `uv_tool|non_uv` + test routing
2. `refactor(cli):` collapse `_UPGRADE_CONTEXT_NOTE` to uv-only with migration note
3. `docs(slash):` rewrite `/aelf:upgrade` for uv-only install channel
4. `docs(readme):` install command is `uv tool install aelfrice`
5. `docs(install):` collapse INSTALL.md install/upgrade sections to uv-only
6. `docs(changelog):` note uv-only consolidation + migration step

## Migration for existing users (including the maintainer)

One-time, runs without further interaction:

```
pipx uninstall aelfrice && uv tool install aelfrice
# or, for pip-installed users:
pip uninstall -y aelfrice && uv tool install aelfrice
```

The next `aelf upgrade-cmd --check` against a non-uv install surfaces exactly that line; the `/aelf:upgrade` slash will execute it verbatim per the existing step-2-imperative contract.

## Test plan

- [x] `uv run pytest -x -q` — 3801 passed, 59 skipped, 75 xfailed (unchanged from main)
- [x] `tests/test_upgrade_ux.py::test_upgrade_advice_routing` — parametric table updated for the new uv_tool|non_uv surface
- [x] `tests/test_slash_commands.py::test_upgrade_slash_keeps_step_2_imperative` — asserts the new `installed via uv tool` advisory wording
- [ ] Manual smoke: `aelf upgrade-cmd` on a uv-managed install emits `run: uv tool upgrade aelfrice`
- [ ] Manual smoke: `aelf upgrade-cmd` on the pipx-managed install in the user's screenshot emits `run: pipx uninstall aelfrice && uv tool install aelfrice` (verify after merge by upgrading the user's local pipx install and re-running)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Install docs now standardize on uv: use `uv tool install aelfrice`, `uv tool uninstall`, and `uv tool upgrade` in examples.
  * Added migration steps for users moving from pipx/pip installs and updated troubleshooting and notifier examples.
  * `/aelf:upgrade` guidance clarified to extract and run the canonical uv/migration command shown.

* **Bug Fixes**
  * Upgrade messaging and CLI upgrade guidance tightened to avoid ambiguous installer-specific instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/732)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->