### PR TITLE
feat(retrieval): adaptive expansion-gate for broad prompts (#741)

### DIFF
--- a/src/aelfrice/expansion_gate.py
+++ b/src/aelfrice/expansion_gate.py
@@ -1,0 +1,300 @@
+"""Adaptive expansion-gate for retrieval (#741).
+
+Cheap deterministic prompt-shape gate that decides whether to run the
+expensive expansion layers (BFS multi-hop, HRR structural) for a given
+query. Broad natural-language prompts that lack structural markers are
+unlikely to benefit from graph expansion and pay the highest latency
+cost on those lanes — the gate short-circuits expansion on them while
+keeping L0 / L1 / L2.5-entity always on.
+
+Honors v3.0 PHILOSOPHY (#605): deterministic narrow surface, stdlib
+only, no embeddings, no model calls.
+
+Resolver precedence (first decisive wins):
+  1. ``AELFRICE_FORCE_EXPANSION=1`` env var → always run expansion
+     (escape hatch for testing and bench).
+  2. ``AELFRICE_NO_EXPANSION_GATE=1`` env var → disable the gate
+     entirely; behaves as pre-gate (all expansion lanes run).
+  3. ``[retrieval] expansion_gate_enabled`` in ``.aelfrice.toml``.
+     Default ``True``.
+  4. Run heuristics; return decision.
+
+Heuristics (all deterministic, stdlib-only):
+  - Length: prompt token count > ``BROAD_PROMPT_TOKEN_THRESHOLD``
+    (default 80) → broad signal.
+  - Structural-marker absence: no ``#NNN`` issue refs, no file paths
+    (``src/...``, ``tests/...``, ``docs/...``, ``benchmarks/...``),
+    no snake_case / camelCase identifiers, no edge-type names
+    (``SUPPORTS``, ``CONTRADICTS``, ...) → broad signal.
+  - Question-form prefix: starts with ``what``, ``why``, ``how``,
+    ``which``, ``who``, ``tell me``, ``explain`` → broad signal.
+
+If ANY signal fires "broad", expansion is skipped. Conservative by
+design: prefer skipping when in doubt; users with a narrow query that
+the heuristic misclassifies can opt back into the full stack via
+``AELFRICE_FORCE_EXPANSION=1`` or ``aelf reason`` (which never gates).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from aelfrice.models import EDGE_TYPES
+
+# --- Config keys ----------------------------------------------------------
+
+CONFIG_FILENAME: Final[str] = ".aelfrice.toml"
+RETRIEVAL_SECTION: Final[str] = "retrieval"
+EXPANSION_GATE_FLAG: Final[str] = "expansion_gate_enabled"
+
+ENV_FORCE_EXPANSION: Final[str] = "AELFRICE_FORCE_EXPANSION"
+ENV_NO_EXPANSION_GATE: Final[str] = "AELFRICE_NO_EXPANSION_GATE"
+
+_ENV_TRUTHY: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+_ENV_FALSY: Final[frozenset[str]] = frozenset({"0", "false", "no", "off"})
+
+# --- Heuristic thresholds -------------------------------------------------
+
+BROAD_PROMPT_TOKEN_THRESHOLD: Final[int] = 80
+
+_QUESTION_FORM_PREFIXES: Final[tuple[str, ...]] = (
+    "what",
+    "why",
+    "how",
+    "which",
+    "who",
+    "tell me",
+    "explain",
+)
+
+# Patterns for structural-marker detection. Any match counts as "narrow"
+# evidence (the prompt references specific code / belief structure).
+_ISSUE_REF_RE: Final[re.Pattern[str]] = re.compile(r"#\d+\b")
+_FILE_PATH_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b(?:src|tests|docs|benchmarks|scripts)/[A-Za-z0-9_./\-]+",
+)
+# snake_case identifiers (at least one underscore between word chars).
+_SNAKE_CASE_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b",
+)
+# camelCase identifiers (lowercase prefix followed by an internal capital).
+_CAMEL_CASE_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b[a-z][a-z0-9]*[A-Z][A-Za-z0-9]+\b",
+)
+# Edge-type names live in models.EDGE_TYPES. Compile once at import time.
+_EDGE_TYPE_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b(?:" + "|".join(sorted(EDGE_TYPES, key=len, reverse=True)) + r")\b",
+)
+
+
+@dataclass(frozen=True)
+class ExpansionDecision:
+    """Per-call decision from :func:`should_run_expansion`.
+
+    Attributes
+    ----------
+    run_bfs:
+        When ``False`` the BFS multi-hop lane is skipped in
+        :func:`aelfrice.retrieval.retrieve`. L0 / L2.5-entity / L1
+        always stay on.
+    run_hrr_structural:
+        When ``False`` the HRR structural-query lane is skipped.
+        v3.0 default keeps this on regardless of gate verdict; the
+        field is reserved for forward-compat once the bench shows
+        broad-prompt HRR-structural cost is load-bearing.
+    reason:
+        Short human-readable tag used by telemetry / ``aelf doctor``
+        to explain *why* the gate fired. Always populated.
+    """
+
+    run_bfs: bool
+    run_hrr_structural: bool
+    reason: str
+
+
+def _env_force_expansion() -> bool | None:
+    """``True`` when AELFRICE_FORCE_EXPANSION is truthy, ``False`` when
+    explicitly falsy, ``None`` when unset / unrecognised.
+    """
+    raw = os.environ.get(ENV_FORCE_EXPANSION)
+    if raw is None:
+        return None
+    norm = raw.strip().lower()
+    if norm in _ENV_TRUTHY:
+        return True
+    if norm in _ENV_FALSY:
+        return False
+    return None
+
+
+def _env_no_expansion_gate() -> bool | None:
+    """``True`` when AELFRICE_NO_EXPANSION_GATE is truthy, ``False``
+    when explicitly falsy, ``None`` when unset / unrecognised.
+    """
+    raw = os.environ.get(ENV_NO_EXPANSION_GATE)
+    if raw is None:
+        return None
+    norm = raw.strip().lower()
+    if norm in _ENV_TRUTHY:
+        return True
+    if norm in _ENV_FALSY:
+        return False
+    return None
+
+
+def _read_toml_flag(start: Path | None = None) -> bool | None:
+    """Read ``[retrieval] expansion_gate_enabled`` from
+    ``.aelfrice.toml``. Returns ``None`` when the file / section /
+    key is absent or the value is not a bool. Fail-soft: malformed
+    TOML returns ``None``.
+    """
+    try:
+        import tomllib
+    except ImportError:  # Python <3.11 fallback; aelfrice ships >=3.11
+        return None
+    cur = (start or Path.cwd()).resolve()
+    seen: set[Path] = set()
+    while True:
+        candidate = cur / CONFIG_FILENAME
+        if candidate.is_file():
+            try:
+                with candidate.open("rb") as fh:
+                    data = tomllib.load(fh)
+            except (OSError, ValueError, tomllib.TOMLDecodeError):
+                return None
+            section = data.get(RETRIEVAL_SECTION)
+            if isinstance(section, dict):
+                value = section.get(EXPANSION_GATE_FLAG)
+                if isinstance(value, bool):
+                    return value
+            return None
+        if cur in seen or cur.parent == cur:
+            return None
+        seen.add(cur)
+        cur = cur.parent
+
+
+def _has_structural_markers(text: str) -> bool:
+    """Return ``True`` if ``text`` contains at least one structural
+    marker — an issue ref, file path, identifier, or edge-type name.
+    """
+    if _ISSUE_REF_RE.search(text):
+        return True
+    if _FILE_PATH_RE.search(text):
+        return True
+    if _SNAKE_CASE_RE.search(text):
+        return True
+    if _CAMEL_CASE_RE.search(text):
+        return True
+    if _EDGE_TYPE_RE.search(text):
+        return True
+    return False
+
+
+def _starts_with_question_form(text: str) -> bool:
+    """Return ``True`` if ``text`` begins with a recognised
+    question-form prefix (case-insensitive).
+    """
+    lowered = text.lstrip().lower()
+    for prefix in _QUESTION_FORM_PREFIXES:
+        if lowered.startswith(prefix):
+            # Require a word boundary so ``whatever`` doesn't match
+            # ``what``. End-of-string or any non-alnum char qualifies.
+            tail_pos = len(prefix)
+            if tail_pos >= len(lowered):
+                return True
+            tail = lowered[tail_pos]
+            if not tail.isalnum() and tail != "_":
+                return True
+    return False
+
+
+def should_run_expansion(
+    query: str,
+    *,
+    start: Path | None = None,
+) -> ExpansionDecision:
+    """Decide whether to run BFS / HRR-structural expansion for ``query``.
+
+    Resolver precedence: env-force > env-disable-gate > TOML > heuristics.
+
+    Parameters
+    ----------
+    query:
+        The user prompt or retrieval query. Whitespace-only / empty
+        queries short-circuit to ``run_bfs=True`` (no gating; the
+        upstream retrieve() returns L0-only on empty input anyway).
+    start:
+        Optional directory to start the ``.aelfrice.toml`` walk from.
+        Defaults to ``Path.cwd()``.
+
+    Returns
+    -------
+    ExpansionDecision
+        Populated decision with ``reason`` set for telemetry.
+    """
+    env_force = _env_force_expansion()
+    if env_force is True:
+        return ExpansionDecision(
+            run_bfs=True,
+            run_hrr_structural=True,
+            reason="env-force-expansion",
+        )
+
+    env_no_gate = _env_no_expansion_gate()
+    if env_no_gate is True:
+        return ExpansionDecision(
+            run_bfs=True,
+            run_hrr_structural=True,
+            reason="env-no-gate",
+        )
+
+    toml_value = _read_toml_flag(start)
+    if toml_value is False:
+        return ExpansionDecision(
+            run_bfs=True,
+            run_hrr_structural=True,
+            reason="toml-disabled",
+        )
+
+    text = query.strip()
+    if not text:
+        return ExpansionDecision(
+            run_bfs=True,
+            run_hrr_structural=True,
+            reason="empty-query",
+        )
+
+    # Gate evaluation. Any "broad" signal trips it.
+    tokens = text.split()
+    long_prompt = len(tokens) > BROAD_PROMPT_TOKEN_THRESHOLD
+    has_markers = _has_structural_markers(text)
+    question_form = _starts_with_question_form(text)
+
+    reasons: list[str] = []
+    if long_prompt:
+        reasons.append(f"long({len(tokens)}>{BROAD_PROMPT_TOKEN_THRESHOLD})")
+    if not has_markers:
+        reasons.append("no-markers")
+    if question_form:
+        reasons.append("question-form")
+
+    if reasons:
+        # HRR-structural stays on for v1 — only BFS is gated. The
+        # field is present so a future flag can toggle it without
+        # an API break.
+        return ExpansionDecision(
+            run_bfs=False,
+            run_hrr_structural=True,
+            reason="broad:" + ",".join(reasons),
+        )
+
+    return ExpansionDecision(
+        run_bfs=True,
+        run_hrr_structural=True,
+        reason="narrow",
+    )

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -642,6 +642,8 @@ def _write_hook_audit_record(
     beliefs: list["Belief"] | None = None,
     latency_ms: int | None = None,
     prompt_shape_gate_skip: str | None = None,
+    expansion_gate_reason: str | None = None,
+    expansion_gate_skipped_bfs: bool | None = None,
     config: HookAuditConfig | None = None,
     stderr: IO[str] | None = None,
 ) -> None:
@@ -662,6 +664,14 @@ def _write_hook_audit_record(
     #674 additive field:
     `prompt_shape_gate_skip` — set to the gate reason string when
     the prompt-shape gate fired and BM25 retrieval was skipped.
+
+    #741 additive fields:
+    `expansion_gate_reason` — short tag from
+    :func:`aelfrice.expansion_gate.should_run_expansion` (e.g.
+    ``"narrow"``, ``"broad:long,no-markers"``, ``"env-force-expansion"``).
+    `expansion_gate_skipped_bfs` — True when the adaptive expansion-gate
+    forced BFS off on this retrieve() call (only meaningful when the
+    BFS lane was otherwise enabled).
     """
     cfg = config if config is not None else load_hook_audit_config(stderr=stderr)
     if not cfg.enabled:
@@ -688,6 +698,10 @@ def _write_hook_audit_record(
         record["latency_ms"] = int(latency_ms)
     if prompt_shape_gate_skip is not None:
         record["prompt_shape_gate_skip"] = prompt_shape_gate_skip
+    if expansion_gate_reason is not None:
+        record["expansion_gate_reason"] = expansion_gate_reason
+    if expansion_gate_skipped_bfs is not None:
+        record["expansion_gate_skipped_bfs"] = bool(expansion_gate_skipped_bfs)
     _append_audit(audit_path, record, cfg.max_bytes, stderr=stderr)
 
 
@@ -875,6 +889,14 @@ def user_prompt_submit(
             )
             # #280 mitigation 3: per-turn audit of the rendered block.
             # #321 additive fields: beliefs[], latency_ms, tokens.
+            # #741 additive fields: expansion_gate_reason +
+            # expansion_gate_skipped_bfs — read off the per-process
+            # LaneTelemetry snapshot left by the most recent retrieve()
+            # call so `aelf tail` can show what got gated and why.
+            from aelfrice.retrieval import (  # noqa: PLC0415
+                last_lane_telemetry,
+            )
+            tel = last_lane_telemetry()
             _write_hook_audit_record(
                 hook=AUDIT_HOOK_USER_PROMPT_SUBMIT,
                 prompt=prompt,
@@ -884,6 +906,8 @@ def user_prompt_submit(
                 session_id=session_id,
                 beliefs=hits,
                 latency_ms=latency_ms,
+                expansion_gate_reason=tel.expansion_gate_reason or None,
+                expansion_gate_skipped_bfs=tel.expansion_gate_skipped_bfs,
                 stderr=serr,
             )
         elif gate_skip:

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -1043,6 +1043,15 @@ class LaneTelemetry:
     bfs: int = 0
     bm25f_used: bool = False
     posterior_weight: float = 0.0
+    # #741 adaptive expansion-gate. ``expansion_gate_reason`` is the
+    # tag returned by :func:`aelfrice.expansion_gate.should_run_expansion`
+    # (e.g. ``"narrow"``, ``"broad:long,no-markers"``,
+    # ``"env-force-expansion"``). ``expansion_gate_skipped_bfs`` is True
+    # when the gate forced ``bfs_on=False`` on this call. Both fields
+    # default to safe values so callers built against the pre-#741
+    # LaneTelemetry surface keep working.
+    expansion_gate_reason: str = ""
+    expansion_gate_skipped_bfs: bool = False
 
 
 # Per-process snapshot of the most recent retrieval call. Test-
@@ -1456,6 +1465,15 @@ def retrieve(
     bm25f_on = resolve_use_bm25f_anchors(use_bm25f_anchors)
     weight = resolve_posterior_weight(posterior_weight)
     heat_on = is_heat_kernel_enabled(heat_kernel_enabled)
+    # #741 adaptive expansion-gate: cheap deterministic prompt-shape
+    # check that short-circuits BFS expansion on broad natural-language
+    # prompts. L0 / L1 / L2.5-entity stay on regardless. The gate
+    # has its own env / TOML escape hatches; see
+    # :mod:`aelfrice.expansion_gate` for resolver precedence.
+    from aelfrice.expansion_gate import should_run_expansion
+    gate_decision = should_run_expansion(query)
+    gate_skipped_bfs = bfs_on and not gate_decision.run_bfs
+    bfs_on = bfs_on and gate_decision.run_bfs
     # v1.5.0 #154: emit one stderr line per placeholder lane the
     # user has set True in `.aelfrice.toml`. Fail-soft, once-per-
     # process per flag.
@@ -1557,6 +1575,8 @@ def retrieve(
         bfs=len(out) - len(locked) - len(l25) - len(l1_packed),
         bm25f_used=bm25f_on,
         posterior_weight=weight,
+        expansion_gate_reason=gate_decision.reason,
+        expansion_gate_skipped_bfs=gate_skipped_bfs,
     )
 
     # v1.6.0 #191: enqueue one retrieval_exposure row per surfaced
@@ -1637,6 +1657,12 @@ def retrieve_with_tiers(
     bm25f_on = resolve_use_bm25f_anchors(use_bm25f_anchors)
     weight = resolve_posterior_weight(posterior_weight)
     heat_on = is_heat_kernel_enabled(heat_kernel_enabled)
+    # #741 adaptive expansion-gate. Same shape as retrieve(): short-
+    # circuit BFS on broad prompts; L0 / L1 / L2.5-entity unaffected.
+    from aelfrice.expansion_gate import should_run_expansion
+    gate_decision = should_run_expansion(query)
+    gate_skipped_bfs = bfs_on and not gate_decision.run_bfs
+    bfs_on = bfs_on and gate_decision.run_bfs
     compress_on = resolve_use_type_aware_compression(
         use_type_aware_compression,
     )
@@ -1773,6 +1799,8 @@ def retrieve_with_tiers(
         bfs=len(bfs_chains),
         bm25f_used=bm25f_on,
         posterior_weight=weight,
+        expansion_gate_reason=gate_decision.reason,
+        expansion_gate_skipped_bfs=gate_skipped_bfs,
     )
     return out, locked_ids_list, l25_ids_list, l1_ids_list, bfs_chains
 

--- a/tests/test_bfs_multihop.py
+++ b/tests/test_bfs_multihop.py
@@ -120,6 +120,13 @@ def isolated_env(
     """
     monkeypatch.delenv(ENV_BFS, raising=False)
     monkeypatch.delenv(ENV_ENTITY_INDEX, raising=False)
+    # #741 adaptive expansion-gate: these tests cover the BFS lane
+    # itself and use single-token / unmarked queries that the gate
+    # would otherwise classify as "broad" and short-circuit. Force
+    # expansion on so the BFS-internal contracts (AC1-AC11) keep
+    # asserting BFS behaviour, not gate behaviour. The gate has its
+    # own test surface in tests/test_expansion_gate.py.
+    monkeypatch.setenv("AELFRICE_FORCE_EXPANSION", "1")
     monkeypatch.chdir(tmp_path)
     return tmp_path
 

--- a/tests/test_expansion_gate.py
+++ b/tests/test_expansion_gate.py
@@ -1,0 +1,303 @@
+"""Unit + integration tests for the adaptive expansion-gate (#741).
+
+Covers four layers:
+
+1. Resolver precedence — env-force > env-no-gate > TOML > heuristics.
+2. Heuristic gates — length, structural markers, question-form prefix.
+3. Integration with :func:`aelfrice.retrieval.retrieve` — broad queries
+   short-circuit the BFS lane; narrow queries (with markers) keep BFS.
+4. Telemetry — :class:`LaneTelemetry` exposes the gate reason and
+   skipped-BFS flag for downstream surfaces (``aelf doctor``, ``aelf tail``).
+
+PHILOSOPHY (#605) check: every heuristic in
+``src/aelfrice/expansion_gate.py`` is deterministic stdlib-only — no
+embeddings, no model calls. The tests below pin the verdict for each
+distinct surface so any drift toward non-deterministic gating fails CI.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from aelfrice.expansion_gate import (
+    BROAD_PROMPT_TOKEN_THRESHOLD,
+    ENV_FORCE_EXPANSION,
+    ENV_NO_EXPANSION_GATE,
+    ExpansionDecision,
+    should_run_expansion,
+)
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.retrieval import (
+    LaneTelemetry,
+    last_lane_telemetry,
+    retrieve,
+)
+from aelfrice.store import MemoryStore
+
+
+# --- Fixtures -------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_gate_env() -> Iterator[None]:
+    """Ensure neither env override is set during a test unless the
+    test sets it explicitly.
+    """
+    saved = {
+        k: os.environ.pop(k, None)
+        for k in (ENV_FORCE_EXPANSION, ENV_NO_EXPANSION_GATE)
+    }
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is not None:
+                os.environ[k] = v
+            else:
+                os.environ.pop(k, None)
+
+
+def _mk(
+    bid: str,
+    content: str,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        demotion_pressure=0,
+        created_at="2026-05-13T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+# --- Heuristic gates ------------------------------------------------------
+
+
+def test_narrow_query_with_issue_ref_runs_expansion() -> None:
+    d = should_run_expansion("can we fix #741")
+    assert d.run_bfs is True
+    assert d.reason == "narrow"
+
+
+def test_narrow_query_with_file_path_runs_expansion() -> None:
+    d = should_run_expansion("update src/aelfrice/retrieval.py")
+    assert d.run_bfs is True
+
+
+def test_narrow_query_with_snake_case_identifier_runs_expansion() -> None:
+    d = should_run_expansion("look at should_run_expansion")
+    assert d.run_bfs is True
+
+
+def test_narrow_query_with_camel_case_identifier_runs_expansion() -> None:
+    d = should_run_expansion("debug retrieveWithTiers behavior")
+    assert d.run_bfs is True
+
+
+def test_narrow_query_with_edge_type_runs_expansion() -> None:
+    # No question-form prefix — only the edge-type marker. The
+    # structural-marker gate satisfies "has markers" so all three
+    # broad signals are silent.
+    d = should_run_expansion("trace SUPPORTS chain from belief root")
+    assert d.run_bfs is True
+
+
+def test_question_form_prefix_skips_expansion() -> None:
+    d = should_run_expansion("what is the meaning of life")
+    assert d.run_bfs is False
+    assert "question-form" in d.reason
+
+
+def test_no_markers_skips_expansion() -> None:
+    d = should_run_expansion("hello there")
+    assert d.run_bfs is False
+    assert "no-markers" in d.reason
+
+
+def test_long_prompt_without_markers_skips_expansion() -> None:
+    body = " ".join(["word"] * (BROAD_PROMPT_TOKEN_THRESHOLD + 5))
+    d = should_run_expansion(body)
+    assert d.run_bfs is False
+    assert "long" in d.reason
+
+
+def test_question_word_inside_word_does_not_trip_gate() -> None:
+    # `whatever` must not match the `what` prefix gate. The query has
+    # no markers though, so it still skips on "no-markers" alone — we
+    # only check the question-form sub-reason here.
+    d = should_run_expansion("whatever happens next")
+    assert "question-form" not in d.reason
+
+
+def test_empty_query_returns_narrow_passthrough() -> None:
+    d = should_run_expansion("")
+    assert d == ExpansionDecision(
+        run_bfs=True,
+        run_hrr_structural=True,
+        reason="empty-query",
+    )
+
+
+def test_whitespace_query_returns_narrow_passthrough() -> None:
+    d = should_run_expansion("   \t  \n  ")
+    assert d.run_bfs is True
+    assert d.reason == "empty-query"
+
+
+def test_decision_dataclass_is_frozen() -> None:
+    d = should_run_expansion("what is X")
+    with pytest.raises(Exception):
+        d.run_bfs = True  # type: ignore[misc]
+
+
+# --- Resolver precedence --------------------------------------------------
+
+
+def test_env_force_expansion_overrides_broad_signals() -> None:
+    os.environ[ENV_FORCE_EXPANSION] = "1"
+    d = should_run_expansion("what is happiness")
+    assert d.run_bfs is True
+    assert d.reason == "env-force-expansion"
+
+
+def test_env_no_gate_disables_gate_entirely() -> None:
+    os.environ[ENV_NO_EXPANSION_GATE] = "1"
+    d = should_run_expansion("how does this work")
+    assert d.run_bfs is True
+    assert d.reason == "env-no-gate"
+
+
+def test_env_force_beats_env_no_gate() -> None:
+    # Both set → force wins (precedence #1).
+    os.environ[ENV_FORCE_EXPANSION] = "1"
+    os.environ[ENV_NO_EXPANSION_GATE] = "1"
+    d = should_run_expansion("what is X")
+    assert d.reason == "env-force-expansion"
+
+
+def test_env_force_falsy_falls_through_to_heuristics() -> None:
+    os.environ[ENV_FORCE_EXPANSION] = "0"
+    d = should_run_expansion("how does this work")
+    assert d.run_bfs is False  # gate still fires
+
+
+def test_env_garbage_value_falls_through() -> None:
+    os.environ[ENV_FORCE_EXPANSION] = "maybe"
+    d = should_run_expansion("how does this work")
+    assert d.run_bfs is False
+
+
+def test_toml_disable_overrides_heuristics(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[retrieval]\nexpansion_gate_enabled = false\n"
+    )
+    d = should_run_expansion("what is X", start=tmp_path)
+    assert d.run_bfs is True
+    assert d.reason == "toml-disabled"
+
+
+def test_toml_enable_explicit_runs_heuristics(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[retrieval]\nexpansion_gate_enabled = true\n"
+    )
+    d = should_run_expansion("what is X", start=tmp_path)
+    # TOML=True is the default; heuristics still fire.
+    assert d.run_bfs is False
+    assert "question-form" in d.reason
+
+
+def test_toml_absent_runs_heuristics(tmp_path: Path) -> None:
+    # No TOML file → fall through to heuristics.
+    d = should_run_expansion("how does this work", start=tmp_path)
+    assert d.run_bfs is False
+
+
+def test_malformed_toml_fails_soft(tmp_path: Path) -> None:
+    (tmp_path / ".aelfrice.toml").write_text("not = valid = toml = at all\n")
+    d = should_run_expansion("what is X", start=tmp_path)
+    # Malformed TOML must not crash; gate still runs heuristics.
+    assert d.run_bfs is False
+
+
+# --- Integration with retrieve() -----------------------------------------
+
+
+def test_retrieve_broad_query_skips_bfs_even_when_enabled() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("L1", "user-pinned cats fact",
+                        lock_level=LOCK_USER, locked_at="2026-05-13T00:00:00Z"))
+    s.insert_belief(_mk("F1", "rainbow elephants graze quietly"))
+
+    retrieve(s, query="what is the answer", bfs_enabled=True)
+    tel = last_lane_telemetry()
+    assert tel.expansion_gate_skipped_bfs is True
+    assert "broad" in tel.expansion_gate_reason
+
+
+def test_retrieve_narrow_query_keeps_bfs_when_enabled() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("F1", "RELATES_TO marker stays narrow"))
+
+    retrieve(s, query="show beliefs that SUPPORTS this thread", bfs_enabled=True)
+    tel = last_lane_telemetry()
+    assert tel.expansion_gate_skipped_bfs is False
+    assert tel.expansion_gate_reason == "narrow"
+
+
+def test_retrieve_gate_noop_when_bfs_disabled() -> None:
+    # bfs_enabled=False explicitly → gate's verdict is irrelevant for
+    # the BFS lane (nothing to suppress). Telemetry should report
+    # skipped_bfs=False (no actual suppression happened).
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("F1", "some content"))
+
+    retrieve(s, query="what is X", bfs_enabled=False)
+    tel = last_lane_telemetry()
+    assert tel.expansion_gate_skipped_bfs is False
+
+
+def test_retrieve_force_env_keeps_bfs_on_broad_query() -> None:
+    os.environ[ENV_FORCE_EXPANSION] = "1"
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("F1", "some content"))
+
+    retrieve(s, query="what is X", bfs_enabled=True)
+    tel = last_lane_telemetry()
+    assert tel.expansion_gate_skipped_bfs is False
+    assert tel.expansion_gate_reason == "env-force-expansion"
+
+
+def test_retrieve_empty_query_does_not_set_skipped_flag() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("L1", "locked",
+                        lock_level=LOCK_USER, locked_at="2026-05-13T00:00:00Z"))
+
+    retrieve(s, query="", bfs_enabled=True)
+    tel = last_lane_telemetry()
+    # Empty query short-circuits before BFS would run anyway; gate
+    # reports "empty-query" and no suppression.
+    assert tel.expansion_gate_skipped_bfs is False
+    assert tel.expansion_gate_reason == "empty-query"
+
+
+# --- LaneTelemetry contract ----------------------------------------------
+
+
+def test_lane_telemetry_defaults_preserve_backcompat() -> None:
+    # A LaneTelemetry built with no #741 kwargs must still construct
+    # cleanly. This guards callers that pin against the pre-#741
+    # field set.
+    tel = LaneTelemetry()
+    assert tel.expansion_gate_reason == ""
+    assert tel.expansion_gate_skipped_bfs is False


### PR DESCRIPTION
## Summary

Adds the adaptive expansion-gate from #741: a cheap deterministic
prompt-shape check that short-circuits the BFS multi-hop lane on
broad natural-language prompts while leaving L0 / L1 / L2.5-entity
always on. Sets up the precondition #739's BFS default-flip needs —
once the BFS flip ratifies, broad prompts won't blow the latency
band because the gate suppresses BFS on them.

Closes #741.

## What landed

- `src/aelfrice/expansion_gate.py` — new module with
  `should_run_expansion(query)` → `ExpansionDecision(run_bfs,
  run_hrr_structural, reason)`.
- `src/aelfrice/retrieval.py` — `retrieve()` and
  `retrieve_with_tiers()` consult the gate after
  `is_bfs_enabled()`; `bfs_on = bfs_on and gate_decision.run_bfs`.
  Two additive fields on `LaneTelemetry`
  (`expansion_gate_reason`, `expansion_gate_skipped_bfs`) for
  downstream surfaces.
- `src/aelfrice/hook.py` — `_write_hook_audit_record` accepts the
  two new fields; UPS callsite reads `last_lane_telemetry()` post-
  retrieve and threads them into `hook_audit.jsonl` (visible via
  `aelf tail`).
- `tests/test_expansion_gate.py` — 27 tests covering heuristics,
  resolver precedence, TOML fail-soft, retrieve() integration,
  LaneTelemetry contract.
- `tests/test_bfs_multihop.py` — BFS-internal tests set
  `AELFRICE_FORCE_EXPANSION=1` in their `isolated_env` fixture so
  the gate doesn't interfere with assertions about BFS behaviour.

## Heuristics

Deterministic, stdlib-only (honors PHILOSOPHY #605):

1. **Length** — prompt > `BROAD_PROMPT_TOKEN_THRESHOLD` (default 80
   tokens) → broad.
2. **Structural-marker absence** — no `#NNN`, no `src/...`, no
   `tests/...`, no snake_case / camelCase identifier, no edge-type
   name (`SUPPORTS`, `CONTRADICTS`, …) → broad.
3. **Question-form prefix** — starts with `what`, `why`, `how`,
   `which`, `who`, `tell me`, `explain` → broad.

Any "broad" signal → `run_bfs=False`. Conservative by design;
escape hatches via env override or `aelf reason`.

## Resolver precedence

`AELFRICE_FORCE_EXPANSION=1` > `AELFRICE_NO_EXPANSION_GATE=1` >
`[retrieval] expansion_gate_enabled` in `.aelfrice.toml` (default
True) > heuristics.

Malformed TOML fails soft.

## Bench (deferred)

Per the issue body, the load-bearing bench (labelled-corpus
broad/narrow split with p95 improvement target ≥30%) is layered on
top of #739's BFS-flip bench re-run. This PR ships the code +
unit/integration tests; the bench is wired separately when #739's
gate ratification runs. The code path is observable via
`aelf doctor` (LaneTelemetry) and `aelf tail` (hook_audit.jsonl)
in the meantime.

## Test plan

- [x] `uv run pytest tests/test_expansion_gate.py` — 27/27 pass
- [x] `uv run pytest tests/test_bfs_multihop.py tests/test_retrieve_v2.py`
      — 39/39 pass (BFS-internal contracts unchanged with
      `AELFRICE_FORCE_EXPANSION=1` fixture)
- [x] Full unit suite (excluding unrelated pre-existing fastmcp
      NameError) — 3775 pass / 57 skipped / 75 xfail
- [ ] #739 broad/narrow bench (deferred; gated on BFS-flip
      ratification per issue body)

## Risk

- **Heuristic drift.** False positives on prompts that would have
  benefited from expansion. Mitigated by env escape hatch +
  telemetry surface (`aelf tail` shows what got gated and why).
- **API surface.** `LaneTelemetry` gains two additive fields with
  safe defaults; pre-#741 callers keep working.
- **Existing BFS suites.** Fixed inline by setting
  `AELFRICE_FORCE_EXPANSION=1` in the affected test module's
  isolated-env fixture so the gate doesn't shadow what those tests
  are actually asserting.
