### PR TITLE
release: v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,7 +883,8 @@ Foundation milestone — store, models, config.
 - Initial repo scaffold: pyproject, README, GitHub Actions workflows,
   scan configs (commit `67b4343`).
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v3.0.1...HEAD
+[3.0.1]: https://github.com/robotrocketscience/aelfrice/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/robotrocketscience/aelfrice/compare/v2.1.0...v3.0.0
 [2.1.0]: https://github.com/robotrocketscience/aelfrice/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/robotrocketscience/aelfrice/compare/v2.0.0...v2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-05-13
+
 ### Security
 
 - **Bump transitive `authlib` 1.7.0 → 1.7.2 to address CVE-2026-44681** ([GHSA-r95x-qfjj-fjj2](https://github.com/advisories/GHSA-r95x-qfjj-fjj2), [Dependabot #4](https://github.com/robotrocketscience/aelfrice/security/dependabot/4)). Medium-severity (CVSS 6.1) open-redirect in Authlib's OIDC server flows (`OpenIDImplicitGrant` / `OpenIDHybridGrant`) — `redirect_uri` validation runs after scope validation, so a malformed authorization request with `response_type=id_token` and `openid` omitted from scope can cause a `302` to an attacker-controlled URL. aelfrice's exposure: effectively zero — `authlib` is pulled transitively via `fastmcp` (the optional `[mcp]` extra) and the aelfrice MCP server does not implement an OIDC authorization endpoint or register the affected grant types. Fix shipped because it's free; runtime impact is one transitive bump. Lockfile-only change; `pyproject.toml` unaffected. 61 MCP-server tests pass against `authlib==1.7.2`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "3.0.0"
+version = "3.0.1"
 description = "Persistent memory for AI agents. Set up once. Stays out of your way. Local SQLite, auditable, no GPU, no network."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "3.0.0"
+version = "3.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

Cut **v3.0.1** from `main` at `8ea9ab5`. Patch release rolling up the
post-3.0.0 work that's already merged plus the transitive CVE bump.

## What's in this release

### Security
- CVE-2026-44681 — transitive `authlib` 1.7.0 → 1.7.2 bump (lockfile-only).
  No runtime impact on aelfrice (effectively zero exposure; we don't
  implement OIDC).

### Added
- **#733** — `aelf setup` auto-migrates non-uv installs to `uv tool` on
  first 3.0.1 run via `lifecycle.maybe_migrate_to_uv()`. Closes the
  2.1.0/pipx → 3.0.x/uv user upgrade path in one click.

### Changed
- **#738** — `search-tool` / `search-tool-bash` hooks now default-on.
  README's "four parallel retrieval lanes" claim was previously
  aspirational; the agent's own search calls now route through aelfrice
  by default. Opt-out via `aelf setup --no-search-tool[-bash]`.
- **#730** — Install / upgrade surface collapsed to `uv tool` only.
  `UpgradeAdvice.context` reduces from four values to two (`uv_tool` /
  `non_uv`).

### Docs
- v3.0 README rewrite — value-prop framing, plain-English hero, "What
  it does for you" section, jargon trims.

## Pre-flight

- [x] `pyproject.toml` bumped 3.0.0 → 3.0.1
- [x] `uv lock` refreshed
- [x] `CHANGELOG.md` `[Unreleased]` → `[3.0.1] - 2026-05-13`
- [x] `aelfrice 3.0.1` reports correctly via `importlib.metadata.version`
- [x] Full pytest suite green at the release commit: 3818 pass, 59
      skipped, 75 xfailed (2 deselected: pre-existing local-venv fastmcp
      NameError unrelated to release)

## Test plan

- [ ] CI staging-gate clears on this PR (secrets-scan, pii-scan,
      commit-history-audit, pytest matrix)
- [ ] On merge: tag `v3.0.1` from main HEAD and `git push github
      v3.0.1` — `.github/workflows/publish.yml` fires automatically
      and publishes to PyPI via Trusted Publishing
- [ ] Post-publish smoke: `uv tool install --force aelfrice && aelf
      --version` reports 3.0.1
