### PR TITLE
feat(rebuilder): default trigger_mode threshold (#746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ installable release; see the roadmap in [README.md](README.md).
 
 ## [Unreleased]
 
+### Changed
+
+- **PreCompact rebuilder now fires by default** ([#746](https://github.com/robotrocketscience/aelfrice/issues/746)). Flips `DEFAULT_TRIGGER_MODE` in `src/aelfrice/context_rebuilder.py` from `"manual"` to `"threshold"`. The v1.4.0 ship-default of `manual` was a conservative hold pending production telemetry: with that posture the rebuilder was a no-op on every harness compaction unless the user added `[rebuilder] trigger_mode = "threshold"` to `.aelfrice.toml`. Both bench gates have now cleared: [#592](https://github.com/robotrocketscience/aelfrice/issues/592) (eval-harness commit-3, closed 2026-05-13: hot-start 100% at `trigger_threshold <= 0.6`, cold-start 75% across t in {0.5..0.8}) and [#687](https://github.com/robotrocketscience/aelfrice/issues/687) (Cohen's-κ multi-run ratification, closed 2026-05-13). Fresh installs now experience augment-mode rebuild without configuration. Opt out via `[rebuilder] trigger_mode = "manual"` in `.aelfrice.toml` — the config-load and hook-dispatch paths already honor the override; no plumbing changes. Per-compaction token spend rises by the rebuild block size (~5-6 KB observed); for token-sensitive workflows the opt-out remains available.
+
 ## [3.0.1] - 2026-05-13
 
 ### Security

--- a/docs/context_rebuilder.md
+++ b/docs/context_rebuilder.md
@@ -32,7 +32,7 @@ rebuilder hood).
 | Augment-mode coordination with the harness | Shipped |
 | `additionalContext` JSON envelope on stdout | Shipped |
 | Manual fire via `aelf rebuild` / `/aelf:rebuild` | Shipped (#141) |
-| Trigger modes — manual + threshold | Shipped (#141; default `manual`) |
+| Trigger modes — manual + threshold | Shipped (#141; default `threshold` since #746) |
 | Threshold default sourced from calibration data | Shipped (#141; `benchmarks/context-rebuilder/calibration_v1_4_0.json`) |
 | Trigger mode — dynamic | **Parked for v1.5** (#141; see § Dynamic mode (parked v1.5) below) |
 | Suppress-mode coordination with the harness | **Parked for v2.x** |
@@ -128,11 +128,11 @@ investigated separately. Configured via `.aelfrice.toml`:
 
 ```toml
 [rebuilder]
-# v1.4 ship default. The PreCompact hook no-ops unless the user
-# explicitly fires the rebuilder via `aelf rebuild` or
-# `/aelf:rebuild`. Opt into auto-firing by switching to
-# `trigger_mode = "threshold"`.
-trigger_mode = "manual"
+# Ship default since #746. The PreCompact hook fires when the
+# harness compacts; opt out by setting this to "manual" if you
+# only want the rebuilder to run on explicit `aelf rebuild` /
+# `/aelf:rebuild` invocations.
+trigger_mode = "threshold"
 
 # Calibrated default from
 # benchmarks/context-rebuilder/calibration_v1_4_0.json. Only
@@ -143,12 +143,13 @@ trigger_mode = "manual"
 threshold_fraction = 0.6
 ```
 
-- **`manual`** *(default at v1.4.0)*: PreCompact hook never fires
+- **`manual`** *(opt-out since #746)*: PreCompact hook never fires
   the rebuild block. Only explicit invocations
-  (`aelf rebuild` / `/aelf:rebuild`) emit a block. This is the
-  ship default until production telemetry confirms threshold-mode
-  is safe to default-on.
-- **`threshold`**: PreCompact hook fires when called by Claude
+  (`aelf rebuild` / `/aelf:rebuild`) emit a block. Use this if the
+  augment-mode token-spend bump (~5-6 KB per compaction) is not
+  worth the context-preservation win for your workflow.
+- **`threshold`** *(default since #746; bench gates #592 + #687
+  cleared 2026-05-13)*: PreCompact hook fires when called by Claude
   Code's harness. The harness's own threshold gating is the trigger
   signal; `threshold_fraction` documents the *calibrated operating
   point* and is the reproducible source-of-truth for the default

--- a/src/aelfrice/context_rebuilder.py
+++ b/src/aelfrice/context_rebuilder.py
@@ -194,13 +194,18 @@ VALID_TRIGGER_MODES: Final[tuple[str, ...]] = (
              Setting this raises a clear error in the hook path.
 """
 
-DEFAULT_TRIGGER_MODE: Final[str] = TRIGGER_MODE_MANUAL
-"""Ship-default trigger mode at v1.4.0.
+DEFAULT_TRIGGER_MODE: Final[str] = TRIGGER_MODE_THRESHOLD
+"""Ship-default trigger mode.
 
-Manual is the default until production telemetry confirms the
-calibrated threshold. The threshold-mode default value is set by
-`benchmarks/context_rebuilder/calibration_v1_4_0.json`; the user
-opts in via `[rebuilder] trigger_mode = "threshold"`.
+Threshold (#746). v1.4.0 shipped with `manual` as a conservative
+default pending production telemetry; the eval-harness commit-3
+bench (#592) cleared on 2026-05-13 (hot-start 100% at
+`trigger_threshold <= 0.6`, cold-start 75% across t in {0.5..0.8}),
+ratified by the Cohen's-kappa multi-run gate (#687) the same day.
+With both gates closed the rebuilder now fires by default; the
+calibrated operating point is set by `DEFAULT_THRESHOLD_FRACTION`.
+
+Opt out: `[rebuilder] trigger_mode = "manual"` in `.aelfrice.toml`.
 """
 
 DEFAULT_THRESHOLD_FRACTION: Final[float] = 0.6

--- a/tests/test_hook_pre_compact.py
+++ b/tests/test_hook_pre_compact.py
@@ -76,8 +76,9 @@ def _aelfrice_log(cwd: Path, lines: list[dict[str, object]]) -> Path:
     p = cwd / ".git" / "aelfrice" / "transcripts" / "turns.jsonl"
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
-    # The v1.4 ship default for `trigger_mode` is "manual"; these
-    # tests exercise the auto-fire path, so opt them into "threshold".
+    # Auto-fire is the ship default since #746; we still write the
+    # threshold mode explicitly so the test is self-documenting and
+    # robust to any future default flip.
     cfg = cwd / ".aelfrice.toml"
     if not cfg.exists():
         # Disable v1.7 (#364) relevance floor in tests by default;
@@ -223,9 +224,10 @@ def test_pre_compact_falls_back_to_claude_transcript(
     _set_db(monkeypatch, db)
     no_git = tmp_path / "no_git"
     no_git.mkdir()
-    # v1.4 default trigger_mode is "manual"; opt into auto-fire. Floor
-    # disabled so this test's assertion ("kitchen check" appears in
-    # rebuild output) is not gated on FTS5 indexing of the fixture.
+    # threshold is the ship default since #746 but we set it explicitly
+    # so the fixture documents intent. Floor disabled so this test's
+    # assertion ("kitchen check" appears in rebuild output) is not gated
+    # on FTS5 indexing of the fixture.
     (no_git / ".aelfrice.toml").write_text(
         '[rebuilder]\ntrigger_mode = "threshold"\n'
         "[rebuild_floor]\nsession = 0.0\nl1 = 0.0\n",

--- a/tests/test_rebuilder_triggers.py
+++ b/tests/test_rebuilder_triggers.py
@@ -126,18 +126,32 @@ def _write_config(cwd: Path, body: str) -> None:
     (cwd / ".aelfrice.toml").write_text(body, encoding="utf-8")
 
 
-# --- TM1: manual mode is the default ------------------------------------
+# --- TM1: threshold mode is the default (#746) --------------------------
 
 
-def test_tm1_default_trigger_mode_is_manual() -> None:
-    """Ship default at v1.4.0 must be manual.
+def test_tm1_default_trigger_mode_is_threshold() -> None:
+    """Ship default is threshold after #746.
 
-    The spec is explicit: threshold mode is opt-in until production
-    telemetry. If this test fails, someone has flipped the ship
-    default without re-reading the issue's "hard rules".
+    The v1.4.0 ship-default of manual was a conservative hold pending
+    production telemetry. Bench gates #592 (eval-harness commit-3)
+    and #687 (Cohen's-kappa multi-run validation) both closed on
+    2026-05-13, so #746 flipped the default to threshold. If this
+    test fails, re-read #746 before flipping back.
     """
-    assert DEFAULT_TRIGGER_MODE == TRIGGER_MODE_MANUAL
-    assert RebuilderConfig().trigger_mode == TRIGGER_MODE_MANUAL
+    assert DEFAULT_TRIGGER_MODE == TRIGGER_MODE_THRESHOLD
+    assert RebuilderConfig().trigger_mode == TRIGGER_MODE_THRESHOLD
+
+
+def test_tm1_no_config_file_defaults_to_threshold(tmp_path: Path) -> None:
+    """A fresh install with no .aelfrice.toml lands on threshold.
+
+    This is the user-visible promise of #746: nothing to configure for
+    auto-rebuild to fire. Belt + suspenders alongside the constant
+    check — the constant could be right while the loader returns
+    something else if a future refactor wires its own fallback.
+    """
+    cfg = load_rebuilder_config(start=tmp_path)
+    assert cfg.trigger_mode == TRIGGER_MODE_THRESHOLD
 
 
 def test_tm1_manual_mode_pre_compact_hook_no_ops(


### PR DESCRIPTION
Closes #746.

## What this PR does

Flips `DEFAULT_TRIGGER_MODE` in `src/aelfrice/context_rebuilder.py` from `TRIGGER_MODE_MANUAL` to `TRIGGER_MODE_THRESHOLD`. Fresh installs now experience the PreCompact augment-mode rebuild without configuration; opt-out remains available via `[rebuilder] trigger_mode = "manual"` in `.aelfrice.toml`.

## Why now

Both bench gates referenced by the v1.4.0 ship-default conservatism note have closed:

- **#592** (eval-harness commit-3, closed 2026-05-13). Hot-start 100% at `trigger_threshold <= 0.6`, cold-start 75% across t ∈ {0.5..0.8}.
- **#687** (Cohen's-κ multi-run ratification, closed 2026-05-13). Post-bench validation gate.

The original `manual` default was explicitly framed as "until production telemetry confirms the calibrated threshold" — the telemetry is in, the threshold cleared, the gate exists to be flipped.

## Commits (atomic)

1. `feat(rebuilder): default trigger_mode threshold (#746)` — one-line constant flip + docstring rewrite citing #592/#687 closure.
2. `test(rebuilder): default trigger_mode threshold (#746)` — renames `test_tm1_default_trigger_mode_is_manual` → `_is_threshold`, asserts threshold at both the constant and `RebuilderConfig()` default; adds new `test_tm1_no_config_file_defaults_to_threshold` exercising the user-visible promise (no TOML present → threshold); updates obsolete v1.4-vintage comments in `test_hook_pre_compact.py` that described threshold as opt-in.
3. `docs(rebuilder): default trigger_mode is threshold (#746)` — `docs/context_rebuilder.md` roadmap row + TOML example + mode descriptions reordered so threshold leads with gate-clearance history.
4. `docs(changelog): note rebuilder default trigger_mode flip (#746)` — `[Unreleased] > Changed` entry.

## Acceptance coverage (#746 checklist)

- [x] `DEFAULT_TRIGGER_MODE` flipped to `TRIGGER_MODE_THRESHOLD` (`context_rebuilder.py:197`)
- [x] Docstring at `context_rebuilder.py:198-209` updated to reflect gate clearance
- [x] Opt-out via `[rebuilder] trigger_mode = "manual"` verified working — existing `test_tm1_manual_mode_pre_compact_hook_no_ops` covers this path; the config-load + hook-dispatch paths already honor the override.
- [x] `AELFRICE_NO_REBUILDER` env override — checked: no such env var exists in the codebase (`grep -rn 'AELFRICE_NO_REBUILDER\|NO_REBUILDER'` returns nothing). TOML-based opt-out is the only opt-out and was already the documented surface. The acceptance bullet appears to be aspirational; not adding one in this PR since the issue body itself frames it as "decide whether to add one" and TOML opt-out is sufficient.
- [x] `docs/context_rebuilder.md` updated. README scan showed no remaining "opt-in via .aelfrice.toml" wording in the v3 revision, so no README change required.
- [x] CHANGELOG entry added under `[Unreleased] > Changed`.
- [x] Tests updated for new default.

## Out of scope (per the issue body)

- Suppress-mode (parked for v2.x).
- Dynamic trigger-mode (parked at v1.4.0).
- Token-budget recalibration (gated on captured production corpus).
- Stop-hook cadence checkpoint (different design space).

## Risk

- **Per-compaction token spend rises by the rebuild block size** (~5-6 KB observed). CHANGELOG entry sets the expectation explicitly. For token-sensitive workflows the opt-out remains a one-line TOML write.
- **Calibration drift.** `threshold_fraction = 0.6` is fixture-bound. Users opting into custom calibration already have the override path (`[rebuilder] threshold_fraction = X`); this flip doesn't change that.

## Test plan

- [x] `uv run pytest tests/test_rebuilder_triggers.py tests/test_hook_pre_compact.py` → 24 passed.
- [x] `uv run pytest -q -x` (full suite) → 3821 passed, 59 skipped, 75 xfailed.
- [x] Discretion grep on diff → clean.
