### PR TITLE
fix(transcript): filter harness-wrapper user turns at logger + broaden noise filter for <summary>Monitor (#747)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ installable release; see the roadmap in [README.md](README.md).
 
 - **PreCompact rebuilder now fires by default** ([#746](https://github.com/robotrocketscience/aelfrice/issues/746)). Flips `DEFAULT_TRIGGER_MODE` in `src/aelfrice/context_rebuilder.py` from `"manual"` to `"threshold"`. The v1.4.0 ship-default of `manual` was a conservative hold pending production telemetry: with that posture the rebuilder was a no-op on every harness compaction unless the user added `[rebuilder] trigger_mode = "threshold"` to `.aelfrice.toml`. Both bench gates have now cleared: [#592](https://github.com/robotrocketscience/aelfrice/issues/592) (eval-harness commit-3, closed 2026-05-13: hot-start 100% at `trigger_threshold <= 0.6`, cold-start 75% across t in {0.5..0.8}) and [#687](https://github.com/robotrocketscience/aelfrice/issues/687) (Cohen's-κ multi-run ratification, closed 2026-05-13). Fresh installs now experience augment-mode rebuild without configuration. Opt out via `[rebuilder] trigger_mode = "manual"` in `.aelfrice.toml` — the config-load and hook-dispatch paths already honor the override; no plumbing changes. Per-compaction token spend rises by the rebuild block size (~5-6 KB observed); for token-sensitive workflows the opt-out remains available.
 
+### Fixed
+
+- **Filter harness-wrapper prompts at the transcript-write path** ([#747](https://github.com/robotrocketscience/aelfrice/issues/747)). `transcript_logger.py` now drops prompts rejected by `noise_filter.is_transcript_noise` (synthetic `<task-notification>`, `<summary>Monitor`, `<tool-result>`, etc.) before append to `<git-common-dir>/aelfrice/transcripts/turns.jsonl`. Companion broadening: `_TRANSCRIPT_XML_PREFIXES` now matches `<summary>Monitor` in addition to `<summary>Background`, closing the gap that let Monitor stream-end renderings reach `ingest.py` and land as `agent_inferred` beliefs. Session-id detection and upstream fire counters are unaffected; only the JSONL append is gated. Cleanup of the existing noise rows in `turns.jsonl` and noise beliefs in the store is out of scope here (issue notes a follow-up).
+
 ## [3.0.1] - 2026-05-13
 
 ### Security

--- a/src/aelfrice/noise_filter.py
+++ b/src/aelfrice/noise_filter.py
@@ -182,6 +182,7 @@ _TRANSCRIPT_XML_PREFIXES: Final[tuple[str, ...]] = (
     "<output-file",
     "<task-",
     "<summary>Background",
+    "<summary>Monitor",
 )
 
 # Single-word capitalised gerund followed by a full stop: "Polling.", "Running."
@@ -505,7 +506,8 @@ def is_transcript_noise(sentence: str) -> bool:
        Match is case-sensitive and position-anchored at index 0.
     2. **Tool-call rendering glyph** — starts with ⏺ (U+23FA).
     3. **Pseudo-XML structural tags** — starts with `<worktree`,
-       `<output-file`, `<task-`, or `<summary>Background`.
+       `<output-file`, `<task-`, `<summary>Background`, or
+       `<summary>Monitor`.
     4. **Single-word progress emit** — matches `^[A-Z][a-z]+ing\\.$`
        (a lone capitalised gerund and a full stop, nothing else).
     5. **Agent ack emit** — matches

--- a/src/aelfrice/transcript_logger.py
+++ b/src/aelfrice/transcript_logger.py
@@ -215,6 +215,10 @@ def _handle_user_prompt_submit(payload: dict[str, object]) -> None:
         if is_transcript_noise(prompt):
             return
     except Exception:
+        # Fail-soft: any noise_filter regression falls through to the
+        # plain-append path. Silent by design — this hook runs on every
+        # user prompt and its stderr leaks into the harness output, so
+        # logging here would be worse UX than rare unfiltered rows.
         pass
     session_id = payload.get("session_id")
     sid = session_id if isinstance(session_id, str) else None

--- a/src/aelfrice/transcript_logger.py
+++ b/src/aelfrice/transcript_logger.py
@@ -4,6 +4,8 @@ Wires four hook events into a project-scoped append-only JSONL log
 under `<git-common-dir>/aelfrice/transcripts/turns.jsonl`:
 
 - `UserPromptSubmit` -> append `{"role": "user", "text": <prompt>, ...}`.
+  Harness-wrapper prompts (rejected by `noise_filter.is_transcript_noise`)
+  are dropped before append per #747.
 - `Stop` -> append `{"role": "assistant", "text": <last assistant turn>, ...}`.
 - `PreCompact` -> write a `compaction_start` marker, rotate
   `turns.jsonl` to `archive/turns-<ts>.jsonl`, spawn
@@ -202,6 +204,18 @@ def _handle_user_prompt_submit(payload: dict[str, object]) -> None:
     prompt = payload.get("prompt")
     if not isinstance(prompt, str) or not prompt.strip():
         return
+    # #747: harness-wrapper prompts (<task-notification>, <summary>Monitor,
+    # <tool-result>, etc.) carry no user intent and crowd real turns out of
+    # the rebuilder's recent-turns window. Gate the append on the same
+    # noise predicate ingest.py uses; fail-soft so a noise_filter import
+    # error never breaks the logger.
+    try:
+        from aelfrice.noise_filter import is_transcript_noise  # noqa: PLC0415
+
+        if is_transcript_noise(prompt):
+            return
+    except Exception:
+        pass
     session_id = payload.get("session_id")
     sid = session_id if isinstance(session_id, str) else None
     line = _build_turn_line(

--- a/tests/test_noise_filter.py
+++ b/tests/test_noise_filter.py
@@ -402,6 +402,20 @@ def test_transcript_noise_summary_background_tag() -> None:
     assert is_transcript_noise("<summary>Background context here.") is True
 
 
+def test_transcript_noise_summary_monitor_tag() -> None:
+    """<summary>Monitor stream-end render: #747 regression guard.
+
+    The harness wraps stream-end notifications as
+    `<summary>Monitor "..." stream ended</summary>`. Prior to #747
+    only `<summary>Background` was in `_TRANSCRIPT_XML_PREFIXES`, so
+    these slipped past `is_transcript_noise` and landed in
+    `ingest.py` as `agent_inferred` beliefs.
+    """
+    assert is_transcript_noise(
+        '<summary>Monitor "PR 743" stream ended</summary>'
+    ) is True
+
+
 def test_transcript_noise_prose_not_starting_with_xml_tag() -> None:
     assert is_transcript_noise("The worktree contains three branches.") is False
 

--- a/tests/test_transcript_logger.py
+++ b/tests/test_transcript_logger.py
@@ -62,6 +62,29 @@ def test_user_prompt_submit_skips_empty_prompt(tdir: Path) -> None:
     assert not (tdir / "turns.jsonl").is_file()
 
 
+def test_user_prompt_submit_skips_transcript_noise_prompt(tdir: Path) -> None:
+    """#747: harness-wrapper prompts must not be appended to turns.jsonl.
+
+    `<task-notification>` and `<summary>Monitor` shapes are scaffolding,
+    not user intent — they crowd the rebuilder's recent-turns window and
+    pollute downstream ingest. The logger now consults
+    `noise_filter.is_transcript_noise` before append.
+    """
+    rc1 = _run_main({
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "<task-notification>worker idle</task-notification>",
+        "session_id": "sess-noise-1",
+    })
+    rc2 = _run_main({
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": '<summary>Monitor "PR 743" stream ended</summary>',
+        "session_id": "sess-noise-2",
+    })
+    assert rc1 == 0
+    assert rc2 == 0
+    assert not (tdir / "turns.jsonl").is_file()
+
+
 def test_user_prompt_submit_no_session_id_writes_null(tdir: Path) -> None:
     rc = _run_main({
         "hook_event_name": "UserPromptSubmit",


### PR DESCRIPTION
Closes #747.

## Summary

Fix two related noise-filtering gaps in the transcript-write path:

1. `transcript_logger.py` now consults `noise_filter.is_transcript_noise` before appending UPS prompts to `turns.jsonl`. Synthetic harness wrappers (`<task-notification>`, `<summary>Monitor`, `<tool-result>`, etc.) are dropped before write. Session-id detection and upstream fire counters are unaffected; only the `_append_jsonl` call is gated.
2. `_TRANSCRIPT_XML_PREFIXES` now matches `<summary>Monitor` in addition to `<summary>Background`. Monitor stream-end renderings previously slipped past `is_transcript_noise`, reached `ingest._ingest_turn_ids`, and landed in the belief store as `agent_inferred` rows.

Both fixes are upstream of multiple downstream symptoms (rebuild-window pollution, belief-store pollution, UPS-injection pollution). Approach matches the precedent set by `hook.py:_SYSTEM_TAG_PREFIXES` (#674) and `ingest.py` `is_transcript_noise` wiring (#675).

## Atomic commits

1. `fix(noise_filter): add <summary>Monitor to transcript XML prefixes` — tuple extension + docstring update + regression test in `test_noise_filter.py`.
2. `fix(transcript_logger): drop harness-wrapper prompts before append` — lazy-imported `is_transcript_noise` call in `_handle_user_prompt_submit` with fail-soft try/except; regression test in `test_transcript_logger.py`.

## Acceptance coverage (#747)

- [x] **Item 1** — logger-side filter wired via `is_transcript_noise`; counter exposure was noted in the issue as "nice-to-have, not required" and is not implemented here.
- [x] **Item 2** — `<summary>Monitor` added to `_TRANSCRIPT_XML_PREFIXES`. Regression test covers both `<summary>Monitor` (new) and `<summary>Background` (existing).
- Disposition recorded: skipped prompts still let session-id sentinel logic upstream flip; only the JSONL append is gated.

## Out of scope (per issue)

- Cleanup of existing noise beliefs (one-shot SQL `DELETE`) — separate work.
- Counter exposure via `aelf doctor` — issue called this nice-to-have.

## Test plan

- [x] `uv run pytest tests/test_noise_filter.py tests/test_transcript_logger.py tests/test_ingest.py` → 113 pass.
- [x] New regression tests pin the Monitor pattern and the transcript_logger noise-skip behavior so future drift fails CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced noise filtering to detect and exclude additional system-generated scaffolding messages from transcripts, including monitor status notifications and summary tags that were previously missed.

* **Tests**
  * Added test coverage verifying that transcript noise filtering correctly excludes system notifications and internal framework messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/751)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->