### PR TITLE
docs: correct stale Default-OFF claim in retrieve_v2 docstring

### DIFF
--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -1873,9 +1873,12 @@ def retrieve_v2(
       lane fires and returns instead of the textual lane. Parallel,
       not blended (per spec): on marker hit the BM25F + heat-kernel
       stack is bypassed entirely; on miss the call falls through to
-      the textual lane unchanged. Default-OFF until the #437
-      reproducibility harness clears, per the #154 composition
-      tracker.
+      the textual lane unchanged. Default-ON post #154 composition
+      tracker — the #437 reproducibility-harness gate cleared at
+      11/11 and `is_hrr_structural_enabled()` resolves to True when
+      no env / kwarg / TOML override is set. Opt out via
+      `AELFRICE_HRR_STRUCTURAL=0`, `use_hrr_structural=False`, or
+      `[retrieval] use_hrr_structural = false` in `.aelfrice.toml`.
     - `hrr_struct_index_cache` (#152) — explicit
       `HRRStructIndexCache` to reuse an already-built index across
       calls. None falls through to a fresh build per call.


### PR DESCRIPTION
## Summary

`retrieval.py:1870-1872` (inside the `retrieve_v2` docstring, `use_hrr_structural` parameter description) still claimed "Default-OFF until the #437 reproducibility harness clears." That gate cleared at 11/11 and `is_hrr_structural_enabled()` (`retrieval.py:818-848`) has resolved to `True` for the no-override case since the #154 composition-tracker flip. The resolver's own docstring at lines 829-833 already documents this — only the consumer-side block in `retrieve_v2` was stale.

Discovered while auditing v3.0.1 adapter defaults: the stale comment caused a false read that the structural lane shipped OFF.

## Change

- Update the `use_hrr_structural` parameter block to state Default-ON, reference the cleared gate, and list the three opt-out paths (env var, kwarg, TOML).
- No behavior change.

## Test plan

- [x] `git diff` shows docstring-only change.
- [x] grep confirms no test pins the old "Default-OFF until the #437" wording.
- [ ] CI: staging-gate green (no code path touched).