### PR TITLE
docs: sweep stale Default-OFF claims for already-flipped retrieval flags

### DIFF
--- a/docs/feature-hrr-integration.md
+++ b/docs/feature-hrr-integration.md
@@ -14,10 +14,10 @@
 
 ## Problem
 
-v1.7+ ships HRR machinery still default-OFF behind a flag awaiting bench evidence:
+At v1.7 ship time, HRR machinery was still default-OFF behind a flag awaiting bench evidence (v2.1 closed this — see Solution below):
 
 - `hrr.py` — Plate (1995) primitives.
-- `hrr_index.py` — `HRRStructIndex` for `KIND:target_id` structural-marker queries. Default-OFF behind `use_hrr_structural`.
+- `hrr_index.py` — `HRRStructIndex` for `KIND:target_id` structural-marker queries. Default-ON behind `use_hrr_structural` since v2.1, after the #154 composition-tracker / #437 reproducibility-harness gate cleared 11/11.
 
 Three blocking items stand between the current state and a default-ON ship:
 
@@ -172,7 +172,7 @@ False negatives: legitimate test setups under `/tmp/` get the auto-disable. Miti
 
 ### Default-flip flag (gated by labeled-corpus evidence, not this spec's blocker)
 
-The persistence work above is the **substrate** that makes default-ON viable. The actual **default-flip** of `use_hrr_structural` (`retrieve_v2(..., use_hrr_structural=...)`) stays gated on labeled-corpus evidence per the existing #154 composition tracker policy. v2.1 ships persistence + format migration regardless. The flag ships default-OFF until the bench clears; once it does, a separate atomic PR flips it.
+The persistence work above is the **substrate** that makes default-ON viable. The actual **default-flip** of `use_hrr_structural` (`retrieve_v2(..., use_hrr_structural=...)`) shipped in v2.1 after the #154 composition-tracker / #437 reproducibility-harness gate cleared 11/11. v2.1 also ships persistence + format migration; the persistence substrate keeps cold-start cost off the user-felt path now that the lane is default-ON. Opt-out paths (env `AELFRICE_HRR_STRUCTURAL=0`, kwarg `use_hrr_structural=False`, `[retrieval] use_hrr_structural = false`) remain available for parity with the pre-flip ranking.
 
 ### What v2.1 does NOT change
 

--- a/docs/feature-intentional-clustering.md
+++ b/docs/feature-intentional-clustering.md
@@ -1,6 +1,6 @@
 # Feature spec: Intentional clustering (#436)
 
-**Status:** wired into `retrieve_v2` behind `use_intentional_clustering` (default-OFF at v2.0.0); bench-gate evidence (A2) is the gate to flip the default
+**Status:** wired into `retrieve_v2` behind `use_intentional_clustering`; default-ON since v3.0 after the #436 R6 A4 latency gate cleared 60/60 PASS at p99 0.328ms on the multi-store production sweep
 **Issue:** #436
 **Recovery-inventory line:** [`docs/ROADMAP.md`](ROADMAP.md) — *"Intentional clustering | v2.0.0"*
 **Substrate prereqs:** edge graph (foundation), `dedup.DuplicateCluster` union-find pattern (`src/aelfrice/dedup.py:155-185`, shipped #197), heat kernel authority (#150, shipped v1.7.0), BFS multi-hop (#143, shipped v1.3.0)
@@ -146,10 +146,10 @@ When the flag is OFF, the existing pack loop runs unchanged. When ON, both `clus
 
 `use_intentional_clustering` follows the convention at `retrieval.py:118-131`:
 
-1. `retrieve(..., use_intentional_clustering=True)` kwarg.
-2. `AELFRICE_INTENTIONAL_CLUSTERING=1` env var.
-3. `[retrieval] use_intentional_clustering = true` in `.aelfrice.toml`.
-4. Default OFF at v2.0.0 until bench-gate clears.
+1. `retrieve(..., use_intentional_clustering=True|False)` kwarg.
+2. `AELFRICE_INTENTIONAL_CLUSTERING=1|0` env var.
+3. `[retrieval] use_intentional_clustering = true|false` in `.aelfrice.toml`.
+4. Default ON since v3.0 (#436 R6, 60/60 PASS at p99 0.328ms — ~15-30x margin under the 5ms A4 budget). Opt out via any of the three paths above for v2.0.x ranking parity.
 
 Two adjacent knobs (also TOML-only, no env var):
 

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -129,9 +129,11 @@ RETRIEVAL_SECTION: Final[str] = "retrieval"
 ENTITY_INDEX_FLAG: Final[str] = "entity_index_enabled"
 BFS_FLAG: Final[str] = "bfs_enabled"
 POSTERIOR_WEIGHT_FLAG: Final[str] = "posterior_weight"
-# v1.5.0 BM25F flag. Default-OFF: FTS5 BM25 stays the L1 path until a
-# benchmark gate (#154 composition tracker) flips the default. Opt-in
-# via the kwarg, AELFRICE_BM25F=1, or `[retrieval] use_bm25f_anchors = true`.
+# v1.5.0 BM25F flag. Default-ON since v1.7.0: the #154 composition-
+# tracker bench cleared with +0.6650 NDCG@k uplift on the v0.1
+# retrieve_uplift fixture, so the FTS5 BM25 path is no longer the L1
+# default. Opt out via the kwarg, AELFRICE_BM25F=0, or
+# `[retrieval] use_bm25f_anchors = false`.
 BM25F_FLAG: Final[str] = "use_bm25f_anchors"
 
 # v1.5.0 #154 composition-tracker placeholder flags. The components
@@ -151,13 +153,17 @@ HRR_STRUCTURAL_FLAG: Final[str] = "use_hrr_structural"
 # CompressedBelief renderings; OFF leaves the field empty for byte-identical
 # behavior with v1.x adapters.
 TYPE_AWARE_COMPRESSION_FLAG: Final[str] = "use_type_aware_compression"
-# v2.0 #436 intentional-clustering flag. Default-OFF at v2.0.0 until the
-# lab-side bench gate (A2 in docs/feature-intentional-clustering.md)
-# clears. When ON, the L1 pack loop is replaced with a diversity-aware
-# greedy fill that biases the top-K toward distinct graph-connected
-# clusters; locked + L2.5 are pre-included unchanged. Mutually exclusive
-# with use_type_aware_compression at v2.0.0 — the cluster pack uses raw
-# token cost, composing it with compressed cost is a v2.x follow-up.
+# v2.0 #436 intentional-clustering flag. Default-ON since v3.0: the
+# A4 latency gate cleared on the multi-store production sweep (#436
+# R6, 60/60 PASS at p99 0.328ms — ~15-30x margin under the 5ms
+# budget). When ON, the L1 pack loop is replaced with a diversity-
+# aware greedy fill that biases the top-K toward distinct graph-
+# connected clusters; locked + L2.5 are pre-included unchanged.
+# Mutually exclusive with use_type_aware_compression at v2.0.0 — the
+# cluster pack uses raw token cost, composing it with compressed cost
+# is a v2.x follow-up. Opt out via the kwarg,
+# AELFRICE_INTENTIONAL_CLUSTERING=0, or
+# `[retrieval] use_intentional_clustering = false`.
 INTENTIONAL_CLUSTERING_FLAG: Final[str] = "use_intentional_clustering"
 
 PLACEHOLDER_FLAGS: Final[tuple[str, ...]] = (


### PR DESCRIPTION
## Summary

Three retrieval flags flipped from default-OFF to default-ON in past minors but stale Default-OFF wording lingered in source comments and feature docs. Companion to #768 (which fixed the same drift inside `retrieve_v2`'s docstring).

| Flag | Flip release | Gate cleared |
|---|---|---|
| `use_bm25f_anchors` | v1.7.0 | #154 +0.6650 NDCG@k on v0.1 retrieve_uplift fixture |
| `use_hrr_structural` | v2.1 | #154 / #437 reproducibility-harness 11/11 |
| `use_intentional_clustering` | v3.0 | #436 R6 A4 latency, 60/60 PASS at p99 0.328ms |

## Changes (3 atomic commits)

1. **`src/aelfrice/retrieval.py`** — `BM25F_FLAG` and `INTENTIONAL_CLUSTERING_FLAG` block-comments updated. Cite the cleared gate, list opt-out paths.
2. **`docs/feature-hrr-integration.md`** — three spots reframed: "Problem" lede (now historical), `hrr_index.py` bullet, and "Default-flip flag" §. The doc was a v2.1 spec proposal; its pre-flip framing is now historical.
3. **`docs/feature-intentional-clustering.md`** — Status header + Configuration §4 precedence-list item updated to cite the cleared gate.

**Out of scope (intentionally not touched):**
- CHANGELOG / ROADMAP / LIMITATIONS / BENCHMARKS — they narrate the per-version journey and the historical default-OFF state at v1.5 / v1.7 / v2.0 is accurate context.
- `bfs_enabled` — still default-OFF, gated on #739.
- `use_type_aware_compression` — still default-OFF, gated on #769.

## Test plan

- [x] `git diff` shows comment- and prose-only changes; no logic touched.
- [x] grep confirms no test pins any of the old Default-OFF wording for the three flipped flags.
- [ ] CI: staging-gate green (no code path touched).

## Refs
- #768 — sibling docstring fix in `retrieve_v2`.
- #154 — composition tracker; the umbrella gate for BM25F + heat-kernel + HRR-structural.
- #437 — reproducibility harness.
- #436 — intentional clustering; R6 sweep cleared the A4 latency gate.