### PR TITLE
refactor(store): install_meta_belief → INSERT OR IGNORE for atomic idempotence (#772)

### DIFF
--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -3287,21 +3287,16 @@ class MemoryStore:
         for cls in signal_weights:
             if not is_valid_signal_class(cls):
                 raise ValueError(f"unknown signal class: {cls!r}")
-        cur = self._conn.execute(
-            "SELECT 1 FROM meta_beliefs WHERE key = ?", (key,)
-        )
-        if cur.fetchone() is not None:
-            return False
         encoded = encode_signal_weights(signal_weights)
-        self._conn.execute(
-            "INSERT INTO meta_beliefs "
+        cur = self._conn.execute(
+            "INSERT OR IGNORE INTO meta_beliefs "
             "(key, static_default, half_life_seconds, last_updated_ts, signal_classes) "
             "VALUES (?, ?, ?, ?, ?)",
             (key, float(static_default), int(half_life_seconds),
              int(now_ts), encoded),
         )
         self._conn.commit()
-        return True
+        return cur.rowcount > 0
 
     def update_meta_belief(
         self,

--- a/tests/test_meta_beliefs.py
+++ b/tests/test_meta_beliefs.py
@@ -392,6 +392,38 @@ def test_doctor_meta_beliefs_json_is_parseable(tmp_path, monkeypatch):
     assert any(p["signal_class"] == SIGNAL_RELEVANCE for p in row["posteriors"])
 
 
+def test_install_concurrent_race_returns_false_not_raises(tmp_path):
+    """INSERT OR IGNORE path: second install returns False without raising.
+
+    Simulates the outcome of two concurrent writers where the first write
+    wins.  Single-threaded; exercises the rowcount > 0 return path rather
+    than actual concurrency.
+    """
+    import sqlite3
+    db_path = tmp_path / "race.sqlite"
+    s = MemoryStore(str(db_path))
+    try:
+        first = s.install_meta_belief(
+            "meta:race", static_default=0.5, half_life_seconds=3600,
+            signal_weights={SIGNAL_RELEVANCE: 1.0}, now_ts=1,
+        )
+        assert first is True
+
+        # Second call: row already present — must return False, NOT raise.
+        try:
+            second = s.install_meta_belief(
+                "meta:race", static_default=0.5, half_life_seconds=3600,
+                signal_weights={SIGNAL_RELEVANCE: 1.0}, now_ts=2,
+            )
+        except sqlite3.IntegrityError as exc:
+            raise AssertionError(
+                f"install_meta_belief raised IntegrityError on duplicate key: {exc}"
+            ) from exc
+        assert second is False
+    finally:
+        s.close()
+
+
 def test_doctor_meta_beliefs_empty_store_reports_none(tmp_path, monkeypatch):
     import os
     db_path = tmp_path / "empty.sqlite"


### PR DESCRIPTION
Closes #772. Follow-up to #755 (PR #771) per the disposition in https://github.com/robotrocketscience/aelfrice/issues/772.

## What this PR does

Refactors `MemoryStore.install_meta_belief` from a SELECT-then-INSERT
idempotency check to the project's established `INSERT OR IGNORE` +
`rowcount` idiom (10 existing call sites in `store.py`). Eliminates the
TOCTOU window between SELECT and INSERT.

## Surface

- **`src/aelfrice/store.py`** — `install_meta_belief` body. Validation
  (`ValueError` raises for invalid `static_default` / `half_life_seconds`
  / unknown signal classes) runs unchanged before the INSERT. Net
  reduction: 11 lines → 8 lines, one fewer SQLite round-trip.

- **`tests/test_meta_beliefs.py`** — new test
  `test_install_concurrent_race_returns_false_not_raises` exercises the
  `rowcount == 0` return path: second install on the same key returns
  False, does not raise `sqlite3.IntegrityError`. Single-threaded
  (deterministic); the existing
  `test_install_meta_belief_is_idempotent_returns_false_on_reinstall`
  covers the no-race idempotency case.

## Behaviour deltas

| Case | Before | After |
|---|---|---|
| First install | True | True |
| Re-install (same key, sequential) | False | False |
| Concurrent install race (would-have-raced) | `IntegrityError` raised on loser | False returned on loser |
| Invalid config (out-of-range / unknown class) | `ValueError` | `ValueError` (unchanged) |

## Acceptance mapping (#772)

| Acceptance item | Where covered |
|---|---|
| `install_meta_belief` switches to `INSERT OR IGNORE` + `rowcount` check | `store.py` body (commit 55e5764a) |
| Existing `test_install_meta_belief_is_idempotent_returns_false_on_reinstall` still passes | `pytest tests/test_meta_beliefs.py` → 20 passed |
| Existing `test_install_rejects_invalid_config` still passes (validation order unchanged) | Same |
| New test exercises the would-have-raced path | `test_install_concurrent_race_returns_false_not_raises` (commit b9f7c0d1) |

## Verification

- `uv run pytest tests/test_meta_beliefs.py` — 20 passed.
- `git log --format='%h %G? %s' github/main..HEAD` — both commits signed (G).
- `git merge-base --is-ancestor github/main HEAD` — FF on `github/main`.
- Discretion grep on the diff — clean.

## Out of scope

- `BEGIN IMMEDIATE` for `update_meta_belief`'s read-decay-write cycle.
  Per #772 disposition: single-writer federation rule (#661,
  `d0c5ecdebb3f0f4d`) makes the race not manifest, and no other
  `store.py` method uses `BEGIN IMMEDIATE`. Consistency over local
  fix.
- `encode_signal_weights` canonicality (int vs float bytes). Separate
  follow-up if surfaced.
