### PR TITLE
feat(bench): wire A4 continuation-fidelity bench gate for type-aware compression (#775)

### DIFF
--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -1426,6 +1426,7 @@ def retrieve(
     bm25f_cache: BM25IndexCache | None = None,
     heat_kernel_enabled: bool | None = None,
     eigenbasis_cache: GraphEigenbasisCache | None = None,
+    use_type_aware_compression: bool | None = None,
 ) -> list[Belief]:
     """Return L0 locked + L2.5 entity + L1 BM25 + L3 BFS expansions.
 
@@ -1464,6 +1465,17 @@ def retrieve(
     tier are dropped (the visited-set in `expand_bfs` prevents
     seeds from being re-surfaced; we additionally guard against
     overlap with L1 hits the seeds didn't include).
+
+    `use_type_aware_compression` (#776, v3.1): when True, L2.5 / L1 /
+    BFS pack accounting uses each belief's compressed
+    `rendered_tokens` (via `compress_for_retrieval`) instead of
+    `_belief_tokens(b)`. Locks render verbatim per the strategy
+    table, so L0 accounting is unchanged. Default-OFF — resolver
+    returns False unless env / kwarg / TOML overrides it — so
+    existing callers see byte-identical output. Mirrors the wiring
+    `retrieve_with_tiers` has carried since v2.0 (#434); added to
+    bare `retrieve()` so `rebuild_v14`'s call site observes the
+    toggle that A4 (#775) measures.
     """
     global _LAST_TELEMETRY
     enabled = is_entity_index_enabled(entity_index_enabled)
@@ -1471,6 +1483,19 @@ def retrieve(
     bm25f_on = resolve_use_bm25f_anchors(use_bm25f_anchors)
     weight = resolve_posterior_weight(posterior_weight)
     heat_on = is_heat_kernel_enabled(heat_kernel_enabled)
+    compress_on = resolve_use_type_aware_compression(
+        use_type_aware_compression,
+    )
+
+    def _cost(b: Belief) -> int:
+        """Per-belief pack cost. Compressed render when flag ON,
+        else raw token estimate. Locks render verbatim either way."""
+        if not compress_on:
+            return _belief_tokens(b)
+        cb = compress_for_retrieval(
+            b, locked=(b.lock_level == LOCK_USER),
+        )
+        return cb.rendered_tokens
     # #741 adaptive expansion-gate: cheap deterministic prompt-shape
     # check that short-circuits BFS expansion on broad natural-language
     # prompts. L0 / L1 / L2.5-entity stay on regardless. The gate
@@ -1538,11 +1563,11 @@ def retrieve(
 
     # Token accounting. L0 always survives. L2.5 lands above L1 in
     # the output. L1 trims from the tail.
-    used: int = locked_used + sum(_belief_tokens(b) for b in l25)
+    used: int = locked_used + sum(_cost(b) for b in l25)
     out: list[Belief] = list(locked) + list(l25)
     l1_packed: list[Belief] = []
     for b in l1:
-        cost: int = _belief_tokens(b)
+        cost: int = _cost(b)
         if used + cost > effective_budget:
             break
         out.append(b)
@@ -1568,7 +1593,7 @@ def retrieve(
             for hop in hops:
                 if hop.belief.id in seen_ids:
                     continue
-                cost = _belief_tokens(hop.belief)
+                cost = _cost(hop.belief)
                 if used + cost > effective_budget:
                     break
                 out.append(hop.belief)

--- a/tests/bench_gate/test_compression_a4_fidelity.py
+++ b/tests/bench_gate/test_compression_a4_fidelity.py
@@ -1,0 +1,143 @@
+"""Bench gate for #769 / #775 type-aware compression — A4 rebuilder fidelity.
+
+Spec § A4 in ``docs/feature-type-aware-compression.md``:
+
+    continuation_fidelity(use_type_aware_compression=ON)
+    >= continuation_fidelity(=OFF) - 0.005
+
+at fixed ``[rebuilder] token_budget``, on a transcript-prefix +
+expected-post-clear-answer corpus. The 0.005 tolerance band mirrors
+the BM25F gate-band model at #154 (a half-point of the fidelity-score
+noise floor).
+
+Sibling to ``tests/bench_gate/test_compression_a2_recall.py``: A2 is
+the retrieval-side gate (recall@k at fixed token_budget); A4 is the
+rebuilder-side gate (continuation fidelity at fixed rebuilder
+token_budget). #769's flip-default decision requires both axes to
+clear.
+
+Fidelity proxy. The runner uses a deterministic token-coverage proxy
+in lieu of captured agent answers (see
+``tests.retrieve_uplift_runner`` § A4 block comment). When the
+lab corpus later carries ``captured_post_clear_answers_{off,on}``
+arrays, the runner can swap to the #138 exact-method scorer without
+touching this test's contract.
+
+Public CI skips when ``AELFRICE_CORPUS_ROOT`` is unset, per the
+directory-of-origin rule (labelled corpus rows live only in the
+private companion repo at
+``<corpus_root>/compression_a4_fidelity/*.jsonl`` — the public repo
+carries only the schema contract and harness scaffold).
+
+Expected row schema (`tests/corpus/v2_0/compression_a4_fidelity/*.jsonl`):
+
+  {
+    "id": "row-id",
+    "transcript_pre_clear": [
+      {"role": "user" | "assistant", "text": "...",
+       "session_id": "...", "ts": "..."}
+    ],
+    "beliefs": [
+      {"id": "...", "content": "...",
+       "retention_class": "fact" | "snapshot" | "transient" | "unknown",
+       "lock_level": "none" | "user"}
+    ],
+    "expected_post_clear_answers": ["answer-text-1", ...],
+    "rebuilder_token_budget": 4000
+  }
+
+``rebuilder_token_budget`` is optional; falls back to
+``DEFAULT_REBUILDER_TOKEN_BUDGET`` from
+``aelfrice.context_rebuilder`` when absent.
+
+Flip-default policy: this gate clears the A4 axis only. The full
+flip-default decision for ``use_type_aware_compression=True`` also
+requires A2 (retrieval recall@k uplift, covered by
+``tests/bench_gate/test_compression_a2_recall.py``) and A3
+(determinism, covered by ``tests/test_compression.py``). See
+``docs/feature-type-aware-compression.md`` § Bench-gate / ship-or-defer
+policy and #769 for the umbrella tracker.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_corpus_module
+
+
+@pytest.mark.bench_gated
+def test_compression_a4_corpus_round_trip(
+    aelfrice_corpus_root: Path,
+) -> None:
+    """Smoke check: the compression_a4_fidelity corpus parses and every row
+    exposes the spec § A4 fields. Skips when the directory is empty."""
+    rows = load_corpus_module(aelfrice_corpus_root, "compression_a4_fidelity")
+    assert rows, "compression_a4_fidelity corpus produced zero rows"
+
+    for row in rows:
+        assert "id" in row, f"row missing id: {row}"
+        assert "transcript_pre_clear" in row, (
+            f"row {row['id']} missing transcript_pre_clear"
+        )
+        assert "beliefs" in row, f"row {row['id']} missing beliefs"
+        assert "expected_post_clear_answers" in row, (
+            f"row {row['id']} missing expected_post_clear_answers"
+        )
+        assert isinstance(row["transcript_pre_clear"], list), (
+            f"row {row['id']} transcript_pre_clear is not a list"
+        )
+        assert isinstance(row["beliefs"], list), (
+            f"row {row['id']} beliefs is not a list"
+        )
+        assert isinstance(row["expected_post_clear_answers"], list), (
+            f"row {row['id']} expected_post_clear_answers is not a list"
+        )
+        for i, turn in enumerate(row["transcript_pre_clear"]):
+            assert "role" in turn, (
+                f"row {row['id']} turn {i} missing role"
+            )
+            assert "text" in turn, (
+                f"row {row['id']} turn {i} missing text"
+            )
+            assert turn["role"] in {"user", "assistant"}, (
+                f"row {row['id']} turn {i} role must be user|assistant, "
+                f"got {turn['role']!r}"
+            )
+
+
+@pytest.mark.bench_gated
+@pytest.mark.timeout(120)
+def test_compression_a4_fidelity_band(
+    aelfrice_corpus_root: Path,
+) -> None:
+    """Spec § A4 ship-gate.
+
+    Loads the ``compression_a4_fidelity`` corpus, drives every row through
+    the OFF and ON rebuilder arms via ``run_compression_a4_fidelity``, and
+    asserts the ON arm mean fidelity is at least the OFF arm mean fidelity
+    minus the 0.005 tolerance band.
+    """
+    rows = load_corpus_module(aelfrice_corpus_root, "compression_a4_fidelity")
+    assert rows, "compression_a4_fidelity corpus produced zero rows"
+
+    runner_mod = pytest.importorskip(
+        "tests.retrieve_uplift_runner",
+        reason=(
+            "compression A4 fidelity runner not available "
+            "(operator gate; spec § A4 — pending lab-side corpus)"
+        ),
+    )
+
+    results = runner_mod.run_compression_a4_fidelity(rows)
+    tolerance = 0.005
+    assert results.uplift >= -tolerance, (
+        "type-aware compression must not regress continuation fidelity "
+        f"by more than {tolerance:+.4f}\n"
+        f"  n_rows  = {results.n_rows}\n"
+        f"  OFF     = {results.mean_fidelity_off:.4f}\n"
+        f"  ON      = {results.mean_fidelity_on:.4f}\n"
+        f"  uplift  = {results.uplift:+.4f}\n"
+        f"  band    = {tolerance:+.4f}"
+    )

--- a/tests/bench_gate/test_compression_a4_fidelity.py
+++ b/tests/bench_gate/test_compression_a4_fidelity.py
@@ -105,6 +105,16 @@ def test_compression_a4_corpus_round_trip(
                 f"row {row['id']} turn {i} role must be user|assistant, "
                 f"got {turn['role']!r}"
             )
+        for i, b in enumerate(row["beliefs"]):
+            assert "id" in b, f"row {row['id']} belief {i} missing id"
+            assert "content" in b, (
+                f"row {row['id']} belief {i} missing content"
+            )
+        for i, a in enumerate(row["expected_post_clear_answers"]):
+            assert isinstance(a, str), (
+                f"row {row['id']} expected_post_clear_answers[{i}] "
+                f"must be a string, got {type(a).__name__}"
+            )
 
 
 @pytest.mark.bench_gated

--- a/tests/retrieve_uplift_runner.py
+++ b/tests/retrieve_uplift_runner.py
@@ -858,6 +858,224 @@ def run_compression_a2_uplift(
     )
 
 
+# ---------------------------------------------------------------------
+# Type-aware compression A4 (#434 / #769 / #775) — rebuilder
+# continuation-fidelity bench gate.
+#
+# Consumed by tests/bench_gate/test_compression_a4_fidelity.py.
+# Row schema (`<corpus_root>/compression_a4_fidelity/*.jsonl`):
+#
+#   {
+#     "id": "row-id",
+#     "transcript_pre_clear": [
+#       {"role": "user"|"assistant", "text": "...",
+#        "session_id": "...", "ts": "..."}, ...
+#     ],
+#     "beliefs": [
+#       {"id": "...", "content": "...",
+#        "retention_class": "fact" | "snapshot" | "transient" | "unknown",
+#        "lock_level": "none" | "user"}
+#     ],
+#     "expected_post_clear_answers": ["answer-text-1", ...],
+#     "rebuilder_token_budget": 4000        # optional
+#   }
+#
+# A4 spec (`docs/feature-type-aware-compression.md` § A4): the
+# rebuilder is exercised with `use_type_aware_compression ∈ {OFF, ON}`
+# at the same `[rebuilder] token_budget`; continuation-fidelity for
+# the ON arm must be at least the OFF arm minus a 0.005 noise band
+# (mirroring the BM25F gate-band model at #154).
+#
+# Fidelity-as-token-coverage proxy. The v1.4 exact-method scorer
+# (#138) compares an agent's post-clear answer to ground truth.
+# Capturing real agent answers under both arms requires a live model;
+# instead the runner uses a deterministic proxy: for each
+# expected_post_clear_answer, score the fraction of normalized answer
+# tokens that appear in the normalized rebuild block. Better
+# compression preserves more load-bearing tokens per token of budget,
+# so a passing A4 gate says "compression does not strip the
+# information that post-clear answers depended on, within the 0.005
+# tolerance band." The proxy is documented inline so a later swap to
+# captured-answer scoring (when the lab corpus carries
+# `captured_post_clear_answers_{off,on}` arrays) is a drop-in.
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CompressionA4Fidelity:
+    """Spec § A4 result shape for #769 type-aware compression flip-default.
+
+    Field names parallel ``CompressionA2Uplift`` so the bench-gate
+    failure-message formatter can read ``mean_fidelity_off`` /
+    ``mean_fidelity_on`` / ``uplift`` without per-runner branching.
+    """
+
+    n_rows: int
+    mean_fidelity_off: float
+    mean_fidelity_on: float
+
+    @property
+    def uplift(self) -> float:
+        return self.mean_fidelity_on - self.mean_fidelity_off
+
+
+def _normalize_tokens_for_coverage(text: str) -> list[str]:
+    """Whitespace-split lowercase normalization.
+
+    Same conservative normalization as ``score._normalize_for_exact``
+    in spirit (NFC + casefold + whitespace collapse), but emitted as
+    a token list for set-coverage scoring. Punctuation is stripped at
+    token boundaries; intra-token punctuation is preserved.
+    """
+    import re
+    import unicodedata
+    normalized = unicodedata.normalize("NFC", text).casefold()
+    tokens = re.findall(r"[\w']+", normalized)
+    return tokens
+
+
+def _coverage_score(expected: str, rebuild_block: str) -> float:
+    """Fraction of expected tokens that appear in the rebuild block.
+
+    Returns 1.0 for an empty expected string (vacuously perfect,
+    matching the scorer module's empty-case convention). Returns 0.0
+    when the expected string has tokens but none appear in the
+    rebuild block.
+    """
+    expected_tokens = _normalize_tokens_for_coverage(expected)
+    if not expected_tokens:
+        return 1.0
+    block_tokens = set(_normalize_tokens_for_coverage(rebuild_block))
+    hits = sum(1 for t in expected_tokens if t in block_tokens)
+    return hits / len(expected_tokens)
+
+
+def _set_compression_env(value: bool) -> str | None:
+    """Set ``AELFRICE_TYPE_AWARE_COMPRESSION`` and return the prior value.
+
+    Caller is responsible for restoring the prior value (or ``del``-ing
+    the env var if prior was ``None``). Kept narrow on purpose — the
+    runner uses a try/finally rather than a context manager so the
+    OFF/ON loop body stays a single line per arm.
+    """
+    prior = os.environ.get("AELFRICE_TYPE_AWARE_COMPRESSION")
+    os.environ["AELFRICE_TYPE_AWARE_COMPRESSION"] = "1" if value else "0"
+    return prior
+
+
+def _restore_compression_env(prior: str | None) -> None:
+    if prior is None:
+        os.environ.pop("AELFRICE_TYPE_AWARE_COMPRESSION", None)
+    else:
+        os.environ["AELFRICE_TYPE_AWARE_COMPRESSION"] = prior
+
+
+def _a4_recent_turns_from_row(row: dict) -> list:  # type: ignore[type-arg]
+    """Build the rebuilder's recent_turns list from a row's transcript.
+
+    Lazy import of ``RecentTurn`` to keep the runner module importable
+    even on environments where ``aelfrice.context_rebuilder`` is not
+    available at collection time.
+    """
+    from aelfrice.context_rebuilder import RecentTurn
+    turns = []
+    for t in row.get("transcript_pre_clear", []):
+        turns.append(
+            RecentTurn(
+                role=str(t.get("role", "user")),
+                text=str(t.get("text", "")),
+                session_id=t.get("session_id"),
+                ts=t.get("ts"),
+            )
+        )
+    return turns
+
+
+def run_compression_a4_fidelity(
+    rows: list[dict],  # type: ignore[type-arg]
+) -> CompressionA4Fidelity:
+    """Spec § A4 rebuilder continuation-fidelity driver.
+
+    Per row: build a transient ``MemoryStore`` from the row's beliefs
+    (locks + retention classes preserved, same as A2). Build the
+    rebuilder's ``recent_turns`` list from ``transcript_pre_clear``.
+    Call ``rebuild_v14`` twice — once with
+    ``AELFRICE_TYPE_AWARE_COMPRESSION=0``, once ``=1`` — at the row's
+    ``rebuilder_token_budget`` (or the rebuilder's default). Score
+    each arm by the token-coverage proxy described in the module-level
+    block comment.
+
+    Empty rows produce ``CompressionA4Fidelity(0, 0.0, 0.0)``. Rows
+    whose expected_post_clear_answers list is empty contribute a
+    per-arm score of 1.0 (vacuously perfect, matching the #138
+    scorer's empty-case convention).
+    """
+    from aelfrice.context_rebuilder import (
+        DEFAULT_REBUILDER_TOKEN_BUDGET,
+        rebuild_v14,
+    )
+
+    n = len(rows)
+    if n == 0:
+        return CompressionA4Fidelity(0, 0.0, 0.0)
+
+    off_total = 0.0
+    on_total = 0.0
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_root = Path(tmp)
+        for row in rows:
+            budget = int(
+                row.get(
+                    "rebuilder_token_budget",
+                    DEFAULT_REBUILDER_TOKEN_BUDGET,
+                )
+            )
+            expected_answers = [
+                str(a) for a in row.get("expected_post_clear_answers", [])
+            ]
+            recent_turns = _a4_recent_turns_from_row(row)
+
+            for compress_on in (False, True):
+                _db_counter[0] += 1
+                db = (
+                    tmp_root
+                    / f"a4_{row['id']}_{int(compress_on)}_{_db_counter[0]}.db"
+                )
+                store = MemoryStore(str(db))
+                try:
+                    for b in row.get("beliefs", []):
+                        store.insert_belief(_a2_belief_from_row(b))
+                    prior = _set_compression_env(compress_on)
+                    try:
+                        rebuild_block = rebuild_v14(
+                            recent_turns, store, token_budget=budget,
+                        )
+                    finally:
+                        _restore_compression_env(prior)
+                finally:
+                    store.close()
+
+                if not expected_answers:
+                    score = 1.0
+                else:
+                    per_answer = [
+                        _coverage_score(a, rebuild_block)
+                        for a in expected_answers
+                    ]
+                    score = sum(per_answer) / len(per_answer)
+
+                if compress_on:
+                    on_total += score
+                else:
+                    off_total += score
+
+    return CompressionA4Fidelity(
+        n_rows=n,
+        mean_fidelity_off=off_total / n,
+        mean_fidelity_on=on_total / n,
+    )
+
+
 def _format_table(results: list[FlagUplift]) -> str:
     lines = [
         f"{'flag':<28} {'n':>4} {'NDCG_off':>10} {'NDCG_on':>10} {'uplift':>10}",

--- a/tests/test_compression_integration.py
+++ b/tests/test_compression_integration.py
@@ -24,6 +24,7 @@ from aelfrice.models import (
 from aelfrice.retrieval import (
     ENV_TYPE_AWARE_COMPRESSION,
     resolve_use_type_aware_compression,
+    retrieve,
     retrieve_v2,
 )
 from aelfrice.store import MemoryStore
@@ -301,3 +302,97 @@ def test_pack_locked_unchanged_when_flag_on(
     assert [b.id for b in off.beliefs] == [b.id for b in on.beliefs]
     # Locked render is verbatim under compression.
     assert on.compressed_beliefs[0].strategy == STRATEGY_VERBATIM
+
+
+# --- Bare `retrieve()` flag wiring (#776) ------------------------------
+#
+# The same toggle that #434 wired into `retrieve_with_tiers` and
+# `retrieve_v2` was missing from `retrieve()` — and `rebuild_v14` calls
+# `retrieve()`. Without this wiring the A4 bench gate (#775) is a no-op
+# because the OFF/ON arms produce byte-identical output. These tests
+# lock the wiring: default-OFF byte-identity, env-var / kwarg observability,
+# and locks-render-verbatim.
+
+
+def test_retrieve_pack_widens_when_flag_on(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    s = _populate_pack_widening_store()
+    off = retrieve(
+        s, "sqlite system",
+        token_budget=80,
+        entity_index_enabled=False,
+        use_type_aware_compression=False,
+    )
+    on = retrieve(
+        s, "sqlite system",
+        token_budget=80,
+        entity_index_enabled=False,
+        use_type_aware_compression=True,
+    )
+    assert len(on) > len(off)
+
+
+def test_retrieve_pack_byte_identical_when_flag_off(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    """Default-OFF: id list matches an explicit OFF call byte-for-byte."""
+    s = _populate_pack_widening_store()
+    explicit_off = retrieve(
+        s, "sqlite system",
+        token_budget=80,
+        entity_index_enabled=False,
+        use_type_aware_compression=False,
+    )
+    default_off = retrieve(
+        s, "sqlite system",
+        token_budget=80,
+        entity_index_enabled=False,
+    )
+    assert [b.id for b in explicit_off] == [b.id for b in default_off]
+
+
+def test_retrieve_env_var_enables_compression(
+    monkeypatch: pytest.MonkeyPatch, _isolated_cwd: Path
+) -> None:
+    """`AELFRICE_TYPE_AWARE_COMPRESSION=1` flips the pack via the resolver.
+
+    This is the path the A4 bench harness uses: it sets the env var around
+    `rebuild_v14`, and `rebuild_v14` calls `retrieve()`. Without the
+    wiring this test guards, the env var has no effect.
+    """
+    s = _populate_pack_widening_store()
+    monkeypatch.delenv(ENV_TYPE_AWARE_COMPRESSION, raising=False)
+    off = retrieve(
+        s, "sqlite system", token_budget=80, entity_index_enabled=False,
+    )
+    monkeypatch.setenv(ENV_TYPE_AWARE_COMPRESSION, "1")
+    on = retrieve(
+        s, "sqlite system", token_budget=80, entity_index_enabled=False,
+    )
+    assert len(on) > len(off)
+
+
+def test_retrieve_locked_unchanged_when_flag_on(
+    _no_env_override: None, _isolated_cwd: Path
+) -> None:
+    """Locks render verbatim under bare `retrieve()` too."""
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk(
+        "L1",
+        "user-pinned: sqlite is the chosen substrate. immutable.",
+        retention_class=RETENTION_SNAPSHOT,
+        lock_level=LOCK_USER,
+        locked_at="2026-05-08T00:00:00Z",
+    ))
+    off = retrieve(
+        s, "sqlite",
+        entity_index_enabled=False,
+        use_type_aware_compression=False,
+    )
+    on = retrieve(
+        s, "sqlite",
+        entity_index_enabled=False,
+        use_type_aware_compression=True,
+    )
+    assert [b.id for b in off] == [b.id for b in on]


### PR DESCRIPTION
## Summary

Wires the A4 bench gate for `use_type_aware_compression` flip-default (precursor to #769). Mirrors A2's harness shape: schema validator + strict-band assertion against a lab-side corpus, runner in `tests/retrieve_uplift_runner.py`, skips cleanly on public CI when `AELFRICE_CORPUS_ROOT` is unset.

## Changes

1. **`tests/retrieve_uplift_runner.py`** — adds `CompressionA4Fidelity` + `run_compression_a4_fidelity`. Per row: build a transient `MemoryStore` from row beliefs, build `recent_turns` from `transcript_pre_clear`, call `rebuild_v14` under `AELFRICE_TYPE_AWARE_COMPRESSION=0` then `=1` at the row's `rebuilder_token_budget`. Score each arm via a deterministic token-coverage proxy against `expected_post_clear_answers` — fraction of normalized answer tokens present in the normalized rebuild block. Proxy documented inline so a later swap to captured-answer scoring (when corpus rows carry `captured_post_clear_answers_{off,on}`) is a drop-in.
2. **`tests/bench_gate/test_compression_a4_fidelity.py`** — bench-gate test. Schema validator checks row contract (`id`, `transcript_pre_clear`, `beliefs`, `expected_post_clear_answers`, optional `rebuilder_token_budget`). Strict-band test asserts `mean_fidelity_on >= mean_fidelity_off - 0.005` per spec § A4 (band mirrors BM25F #154 model).

## Spec source

`docs/feature-type-aware-compression.md` § A4:

> The continuation-fidelity scorer (#141 v1.4 deliverable) is run on the rebuild_logs corpus with `use_type_aware_compression={OFF, ON}`. Bench-gate: ON ≥ OFF on continuation-fidelity score at the same `[rebuilder] token_budget`. Tolerance band: `≥ baseline − 0.005`.

## Corpus contract

Corpus rows live in the private companion repo at `<corpus_root>/compression_a4_fidelity/*.jsonl` (directory-of-origin rule — public repo carries only the schema contract).

```
{
  "id": "row-id",
  "transcript_pre_clear": [
    {"role": "user"|"assistant", "text": "...",
     "session_id": "...", "ts": "..."}
  ],
  "beliefs": [
    {"id": "...", "content": "...",
     "retention_class": "fact"|"snapshot"|"transient"|"unknown",
     "lock_level": "none"|"user"}
  ],
  "expected_post_clear_answers": ["answer-text-1", ...],
  "rebuilder_token_budget": 4000
}
```

`rebuilder_token_budget` is optional; falls back to `DEFAULT_REBUILDER_TOKEN_BUDGET` (4000).

## Fidelity proxy

The #138 exact-method scorer was designed for transcript replay with captured agent answers post-clear; capturing real agent answers under both compression arms requires a live model. The runner instead uses a deterministic token-coverage proxy: for each `expected_post_clear_answer`, score the fraction of normalized answer tokens present in the normalized rebuild block.

Rationale: better compression preserves more load-bearing tokens per token of budget, so a passing A4 gate says "compression does not strip the information that post-clear answers depended on, within the 0.005 tolerance band."

The proxy is documented inline (`tests/retrieve_uplift_runner.py` § A4 block comment) so a later swap to captured-answer scoring via #138's `score_continuation_fidelity` is a drop-in when corpus rows include `captured_post_clear_answers_{off,on}` arrays.

## Verification

- `uv run pytest tests/bench_gate/ -q` → `24 passed, 29 skipped`.
- New file collects + skips cleanly via the `_skip_bench_gated_without_corpus` autouse fixture when `AELFRICE_CORPUS_ROOT` is unset.
- Synthetic-row smoke test: runner imports, exercises real `rebuild_v14` under both arms, returns `CompressionA4Fidelity(n_rows, mean_fidelity_off, mean_fidelity_on)` with sane numbers.

## Out of scope (separate work)

- Populating the lab-side `compression_a4_fidelity` corpus.
- Running the actual A4 bench (only possible after corpus is populated).
- Flipping `use_type_aware_compression` default (that's #769, gated on both A2 and A4 runs clearing).
- Swapping the proxy for captured-answer exact-method scoring (drop-in once corpus carries `captured_post_clear_answers_{off,on}`).

Closes #775.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle for type-aware compression that adjusts how content is budgeted during retrieval, affecting packing behavior.

* **Tests**
  * Added bench-gated fidelity benchmarks and integration tests validating compression ON/OFF behaviour, pack widening, and that locked content remains verbatim.
  
* **Chores**
  * Added a runner to compute and report mean fidelity metrics (OFF vs ON) and uplift for corpus-level comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/776)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->