### PR TITLE
feat(status): show aelfrice version in stats snapshot

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2107,6 +2107,8 @@ def _cmd_feedback(args: argparse.Namespace, out: object) -> int:
 
 def _cmd_stats(args: argparse.Namespace, out: object) -> int:
     _ = args
+    from aelfrice import __version__ as _aelf_version  # noqa: PLC0415
+
     store = _open_store()
     try:
         n_beliefs = store.count_beliefs()
@@ -2115,6 +2117,7 @@ def _cmd_stats(args: argparse.Namespace, out: object) -> int:
         n_history = store.count_feedback_events()
     finally:
         store.close()
+    print(f"version:           {_aelf_version}", file=out)  # type: ignore[arg-type]
     print(f"beliefs:           {n_beliefs}", file=out)  # type: ignore[arg-type]
     # v1.1.0 user-facing rename: "edges" -> "threads". Internal schema
     # keeps `edges`. MCP `aelf:stats` emits both keys for one minor.

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -186,6 +186,7 @@ def _render_locked_markdown(payload: dict[str, Any]) -> str:
 def _render_stats_markdown(payload: dict[str, Any]) -> str:
     return (
         "# Aelfrice store snapshot\n\n"
+        f"- Version: {payload.get('version', 'unknown')}\n"
         f"- Beliefs: {payload.get('beliefs', 0)}\n"
         f"- Threads: {payload.get('threads', payload.get('edges', 0))}\n"
         f"- Locked: {payload.get('locked', 0)}\n"
@@ -805,9 +806,12 @@ def tool_stats(
     *,
     response_format: str = _RESPONSE_FORMAT_JSON,
 ) -> dict[str, Any]:
+    from aelfrice import __version__ as _aelf_version  # noqa: PLC0415
+
     n_edges = store.count_edges()
     payload: dict[str, Any] = {
         "kind": "stats.snapshot",
+        "version": _aelf_version,
         "beliefs": store.count_beliefs(),
         # `edges` is the v1.0 key. v1.1.0 adds `threads` as the
         # forward-compatible alias and emits both for one minor; v1.2.0


### PR DESCRIPTION
## Summary
- `aelf status` / `aelf stats` now print a `version:` line above the counts so users can see at a glance which aelfrice they are running.
- MCP `tool_stats` adds a `version` field to the JSON payload and a `Version:` line to the markdown render — keeps the CLI and MCP surfaces in parity.

## Test plan
- [x] `uv run aelf status` shows the new `version:` line
- [x] `uv run pytest -k "stats or status" tests/test_cli.py tests/test_mcp_server.py` (9 passed)