### PR TITLE
fix(setup): collapse hook accumulation + prune dead aelf-* entries (#781)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -3800,6 +3800,8 @@ def _cmd_doctor(args: argparse.Namespace, out: object) -> int:
         _print_doctor_store_check(out)
         if report.broken:
             exit_code = 1
+        if getattr(args, "fix", False):
+            _cmd_doctor_fix_hooks(args, report, out)
     if scope in (None, "graph"):
         if scope is None:
             print("", file=out)  # type: ignore[arg-type]
@@ -3807,6 +3809,53 @@ def _cmd_doctor(args: argparse.Namespace, out: object) -> int:
         if graph_exit != 0:
             exit_code = graph_exit
     return exit_code
+
+
+def _cmd_doctor_fix_hooks(
+    args: argparse.Namespace, report: object, out: object,
+) -> None:
+    """Apply `prune_broken_aelf_hooks` to every settings.json doctor scanned.
+
+    Called from `_cmd_doctor` when `--fix` is set. Reads the list of
+    scopes/paths off the already-built `DoctorReport` so the prune
+    decision matches what doctor just reported. `args.dry_run` flips
+    the prune into report-only mode.
+
+    Custom hooks (non-`aelf-` basename) are never touched by the
+    prune helper itself — this wrapper only handles I/O.
+    """
+    from typing import cast
+
+    dry_run = bool(getattr(args, "dry_run", False))
+    scopes_scanned = cast(
+        list[tuple[str, Path]],
+        getattr(report, "scopes_scanned", []),
+    )
+    if not scopes_scanned:
+        return
+    print("", file=out)  # type: ignore[arg-type]
+    any_removed = False
+    for _scope, path in scopes_scanned:
+        prune = prune_broken_aelf_hooks(path, dry_run=dry_run)
+        if not prune.total_removed:
+            continue
+        any_removed = True
+        events = ", ".join(
+            f"{event}={count}"
+            for event, count in sorted(prune.removed_per_event.items())
+        )
+        verb = "would prune" if dry_run else "pruned"
+        noun = "entry" if prune.total_removed == 1 else "entries"
+        print(
+            f"--fix: {verb} {prune.total_removed} stale aelf-* hook "
+            f"{noun} ({events}) from {path}",
+            file=out,  # type: ignore[arg-type]
+        )
+    if not any_removed:
+        print(
+            "--fix: no stale aelf-* hook entries to prune",
+            file=out,  # type: ignore[arg-type]
+        )
 
 
 def _cmd_doctor_meta_beliefs(args: argparse.Namespace, out: object) -> int:
@@ -5676,6 +5725,18 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help=(
             "with --meta-beliefs: emit JSON instead of a human-readable "
             "table. No effect on other doctor sub-modes today."
+        ),
+    )
+    p_doctor.add_argument(
+        "--fix",
+        dest="fix",
+        action="store_true",
+        default=False,
+        help=(
+            "with hooks scope: remove `aelf-*` hook entries whose program "
+            "no longer resolves (#781). Custom shell hooks (non-`aelf-` "
+            "basenames) are never touched. Combine with --dry-run to "
+            "print what would be pruned without rewriting settings.json."
         ),
     )
     p_doctor.set_defaults(func=_cmd_doctor)

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -99,6 +99,7 @@ from aelfrice.derivation_worker import run_worker
 from aelfrice.doctor import (
     DORMANT_IDLE_DAYS_DEFAULT,
     DormantDB,
+    HookPruneResult,
     _check_dormant_dbs,
     classify_orphans as _classify_orphans,
     diagnose,
@@ -108,6 +109,7 @@ from aelfrice.doctor import (
     format_report,
     gc_orphan_feedback as _gc_orphan_feedback,
     promote_retention as _promote_retention,
+    prune_broken_aelf_hooks,
 )
 from aelfrice.llm_classifier import (
     ENV_API_KEY as _LLM_ENV_API_KEY,
@@ -2453,6 +2455,23 @@ def _cmd_setup(args: argparse.Namespace, out: object) -> int:
     for removed_path in cleanup.removed:
         print(
             f"cleaned dangling shim: {removed_path}",
+            file=out,  # type: ignore[arg-type]
+        )
+    # #781: prune any `aelf-*` hook entries pointing at vanished venv
+    # paths before reconciling installs. The dedupe-on-install path
+    # (Layer A) only catches collisions on the basename we are about
+    # to write; old stale entries for events we are NOT installing
+    # this run still need to be swept out.
+    prune = prune_broken_aelf_hooks(path)
+    if prune.total_removed:
+        events = ", ".join(
+            f"{event}={count}"
+            for event, count in sorted(prune.removed_per_event.items())
+        )
+        print(
+            f"pruned {prune.total_removed} stale aelf-* hook entr"
+            f"{'y' if prune.total_removed == 1 else 'ies'} "
+            f"({events}) from {prune.settings_path}",
             file=out,  # type: ignore[arg-type]
         )
     result = install_user_prompt_submit_hook(

--- a/src/aelfrice/doctor.py
+++ b/src/aelfrice/doctor.py
@@ -837,6 +837,171 @@ def _check_path(
     )
 
 
+# ---------------------------------------------------------------------------
+# Prune dead `aelf-*` hook entries from settings.json (#781).
+# ---------------------------------------------------------------------------
+
+# Basename prefix that marks an entry as one this package installed.
+# Custom hooks (user-installed shell scripts, third-party integrations)
+# are left strictly alone.
+_AELF_HOOK_BASENAME_PREFIX: Final[str] = "aelf-"
+
+
+@dataclass(frozen=True)
+class HookPruneResult:
+    """Outcome of `prune_broken_aelf_hooks`.
+
+    `removed_per_event` maps each hook event name (e.g. `"PreToolUse"`)
+    to the number of parent entries removed from it. Events with no
+    removals are absent.
+
+    `total_removed` is the sum across events — zero when the file is
+    already clean.
+    """
+
+    settings_path: Path
+    removed_per_event: dict[str, int]
+    total_removed: int
+
+
+def prune_broken_aelf_hooks(
+    settings_path: Path, *, dry_run: bool = False,
+) -> HookPruneResult:
+    """Drop hook entries whose `aelf-*` program no longer resolves.
+
+    Walks every `hooks.<event>[i].hooks[j]` command in `settings_path`.
+    An entry is removed when ALL of:
+
+    * its inner command's first whitespace token has a basename
+      starting with `aelf-` (so `aelf-hook`, `aelf-stop-hook`, etc. are
+      in scope; bare shell scripts, `bash`, custom integrations are
+      not);
+    * `_inspect_command` classifies it `status="broken"` (the program
+      path / `$PATH` lookup fails).
+
+    Custom shell hooks (`gh-pii-guard.sh`, `conversation-logger.sh`,
+    etc.) and statuslines are never touched. Skipped (shell-meta)
+    commands are not pruned — the predicate is conservative.
+
+    When `dry_run=True`, the file is not rewritten; the result still
+    reports what *would* have been removed. Missing files return a
+    zero-removal result.
+    """
+    if not settings_path.exists():
+        return HookPruneResult(
+            settings_path=settings_path, removed_per_event={}, total_removed=0,
+        )
+    try:
+        data = _load_settings_json(settings_path)
+    except (ValueError, OSError):
+        return HookPruneResult(
+            settings_path=settings_path, removed_per_event={}, total_removed=0,
+        )
+    hooks_obj = data.get(_HOOKS_KEY)
+    if not isinstance(hooks_obj, dict):
+        return HookPruneResult(
+            settings_path=settings_path, removed_per_event={}, total_removed=0,
+        )
+    hooks_dict = cast(dict[str, object], hooks_obj)
+    removed_per_event: dict[str, int] = {}
+    for event_name, event_list in list(hooks_dict.items()):
+        if not isinstance(event_list, list):
+            continue
+        entries = cast(list[object], event_list)
+        kept: list[object] = []
+        n_removed = 0
+        for entry in entries:
+            if _entry_is_broken_aelf_hook(settings_path, entry):
+                n_removed += 1
+                continue
+            kept.append(entry)
+        if n_removed:
+            removed_per_event[event_name] = n_removed
+            event_list[:] = kept
+    total = sum(removed_per_event.values())
+    if total and not dry_run:
+        _atomic_rewrite_settings(settings_path, data)
+    return HookPruneResult(
+        settings_path=settings_path,
+        removed_per_event=removed_per_event,
+        total_removed=total,
+    )
+
+
+def _entry_is_broken_aelf_hook(
+    settings_path: Path, entry: object,
+) -> bool:
+    """True iff `entry` is an `aelf-*`-basename hook whose program is broken.
+
+    The settings entry shape is::
+
+        {"hooks": [{"type": "command", "command": "<cmd>"}, ...]}
+
+    An entry is considered broken when ANY of its inner command hooks
+    have an `aelf-*` basename and resolve to `status="broken"`. One
+    broken inner command condemns the whole parent entry — Claude
+    Code's hook runner spawns each inner command per fire, so leaving
+    a half-broken parent in place would still emit ENOENT per call.
+    """
+    if not isinstance(entry, dict):
+        return False
+    entry_dict = cast(dict[str, object], entry)
+    inner = entry_dict.get(_INNER_HOOKS_KEY)
+    if not isinstance(inner, list):
+        return False
+    for hook in cast(list[object], inner):
+        if not isinstance(hook, dict):
+            continue
+        hook_dict = cast(dict[str, object], hook)
+        if hook_dict.get(_TYPE_KEY) != _HOOK_TYPE_COMMAND:
+            continue
+        cmd = hook_dict.get(_COMMAND_KEY)
+        if not isinstance(cmd, str):
+            continue
+        stripped = cmd.strip()
+        if not stripped:
+            continue
+        first = stripped.split(maxsplit=1)[0]
+        if not Path(first).name.startswith(_AELF_HOOK_BASENAME_PREFIX):
+            continue
+        finding = _inspect_command(settings_path, "<prune>", cmd)
+        if finding.status == "broken":
+            return True
+    return False
+
+
+_HOOK_TYPE_COMMAND: Final[str] = "command"
+
+
+def _atomic_rewrite_settings(path: Path, data: dict[str, object]) -> None:
+    """Atomically replace `path` with the new JSON. Mirrors setup._atomic_write.
+
+    Pulled into doctor so the prune helper can rewrite without taking
+    an import dependency on a private setup symbol. The format matches
+    setup's writer byte-for-byte (indent=2, ensure_ascii=False, trailing
+    newline) so a setup→prune→setup round trip stays diff-stable.
+    """
+    import os
+    import tempfile
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(serialized)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+
 def format_report(report: DoctorReport) -> str:
     """Render a DoctorReport as a human-readable string for the CLI."""
     lines: list[str] = []

--- a/src/aelfrice/setup.py
+++ b/src/aelfrice/setup.py
@@ -322,21 +322,24 @@ def _install_event_hook(
 
     Creates `settings_path` (and parent dirs) if missing. Preserves
     every other key in the file. Idempotent: a second call with the
-    same `command` is a no-op and returns `already_present=True`.
+    same `command` is a no-op and returns `already_present=True`. A
+    call whose `command` shares a basename with an existing entry but
+    points at a different absolute path (typical of venv recreation)
+    replaces the existing entry instead of appending — see #781.
     """
     if not command:
         raise ValueError("command must be a non-empty string")
     data = _load_settings(settings_path)
     entries = _get_event_list(data, event_key, create=True)
-    if _find_entry_index(entries, command) is not None:
+    if _install_or_replace_entry(
+        entries,
+        command=command,
+        timeout=timeout,
+        status_message=status_message,
+    ):
         return InstallResult(
             path=settings_path, installed=False, already_present=True
         )
-    entries.append(
-        _build_entry(
-            command=command, timeout=timeout, status_message=status_message
-        )
-    )
     _atomic_write(settings_path, data)
     return InstallResult(
         path=settings_path, installed=True, already_present=False
@@ -504,13 +507,12 @@ def install_transcript_ingest_hooks(
     already: list[str] = []
     for event in TRANSCRIPT_INGEST_EVENTS:
         entries = _get_event_list(data, event, create=True)
-        if _find_entry_index(entries, command) is not None:
+        if _install_or_replace_entry(
+            entries, command=command, timeout=timeout, status_message=None,
+        ):
             already.append(event)
-            continue
-        entries.append(_build_entry(
-            command=command, timeout=timeout, status_message=None,
-        ))
-        installed.append(event)
+        else:
+            installed.append(event)
     if installed:
         _atomic_write(settings_path, data)
     return TranscriptIngestInstallResult(
@@ -603,14 +605,16 @@ def install_commit_ingest_hook(
         raise ValueError("command must be a non-empty string")
     data = _load_settings(settings_path)
     entries = _get_event_list(data, COMMIT_INGEST_EVENT, create=True)
-    if _find_entry_index(entries, command) is not None:
+    if _install_or_replace_entry(
+        entries,
+        command=command,
+        timeout=timeout,
+        status_message=None,
+        matcher=COMMIT_INGEST_MATCHER,
+    ):
         return InstallResult(
             path=settings_path, installed=False, already_present=True,
         )
-    entries.append(_build_entry(
-        command=command, timeout=timeout, status_message=None,
-        matcher=COMMIT_INGEST_MATCHER,
-    ))
     _atomic_write(settings_path, data)
     return InstallResult(
         path=settings_path, installed=True, already_present=False,
@@ -698,14 +702,16 @@ def install_search_tool_hook(
         raise ValueError("command must be a non-empty string")
     data = _load_settings(settings_path)
     entries = _get_event_list(data, SEARCH_TOOL_EVENT, create=True)
-    if _find_entry_index(entries, command) is not None:
+    if _install_or_replace_entry(
+        entries,
+        command=command,
+        timeout=timeout,
+        status_message=None,
+        matcher=SEARCH_TOOL_MATCHER,
+    ):
         return InstallResult(
             path=settings_path, installed=False, already_present=True,
         )
-    entries.append(_build_entry(
-        command=command, timeout=timeout, status_message=None,
-        matcher=SEARCH_TOOL_MATCHER,
-    ))
     _atomic_write(settings_path, data)
     return InstallResult(
         path=settings_path, installed=True, already_present=False,
@@ -775,22 +781,19 @@ def install_search_tool_bash_hook(
         raise ValueError("command must be a non-empty string")
     data = _load_settings(settings_path)
     entries = _get_event_list(data, SEARCH_TOOL_EVENT, create=True)
-    # Idempotency check: look for an existing entry with the same command
-    # AND matcher="Bash". An entry with the same command under Grep|Glob
-    # is a different hook and must not be conflated.
-    already = any(
-        e.get("matcher") == SEARCH_TOOL_BASH_MATCHER
-        and _entry_matches(e, command)
-        for e in entries
-    )
-    if already:
+    # _install_or_replace_entry's matcher-aware dedup keeps this entry
+    # distinct from the Grep|Glob-matcher search-tool entry (same script
+    # basename, different matcher → different hook per the v1.5.0 spec).
+    if _install_or_replace_entry(
+        entries,
+        command=command,
+        timeout=timeout,
+        status_message=None,
+        matcher=SEARCH_TOOL_BASH_MATCHER,
+    ):
         return InstallResult(
             path=settings_path, installed=False, already_present=True,
         )
-    entries.append(_build_entry(
-        command=command, timeout=timeout, status_message=None,
-        matcher=SEARCH_TOOL_BASH_MATCHER,
-    ))
     _atomic_write(settings_path, data)
     return InstallResult(
         path=settings_path, installed=True, already_present=False,
@@ -890,15 +893,15 @@ def install_session_start_hook(
         raise ValueError("command must be a non-empty string")
     data = _load_settings(settings_path)
     entries = _get_event_list(data, SESSION_START_EVENT_KEY, create=True)
-    if _find_entry_index(entries, command) is not None:
+    if _install_or_replace_entry(
+        entries,
+        command=command,
+        timeout=timeout,
+        status_message=status_message,
+    ):
         return InstallResult(
             path=settings_path, installed=False, already_present=True
         )
-    entries.append(
-        _build_entry(
-            command=command, timeout=timeout, status_message=status_message
-        )
-    )
     _atomic_write(settings_path, data)
     return InstallResult(
         path=settings_path, installed=True, already_present=False
@@ -993,15 +996,15 @@ def install_stop_hook(
         raise ValueError("command must be a non-empty string")
     data = _load_settings(settings_path)
     entries = _get_event_list(data, STOP_EVENT_KEY, create=True)
-    if _find_entry_index(entries, command) is not None:
+    if _install_or_replace_entry(
+        entries,
+        command=command,
+        timeout=timeout,
+        status_message=status_message,
+    ):
         return InstallResult(
             path=settings_path, installed=False, already_present=True
         )
-    entries.append(
-        _build_entry(
-            command=command, timeout=timeout, status_message=status_message
-        )
-    )
     _atomic_write(settings_path, data)
     return InstallResult(
         path=settings_path, installed=True, already_present=False
@@ -1447,6 +1450,70 @@ def _entry_matches_basename(
         first = cmd.strip().split(maxsplit=1)[0] if cmd.strip() else ""
         if first and Path(first).name == basename:
             return True
+    return False
+
+
+def _command_basename(command: str) -> str:
+    """Basename of the first whitespace-stripped path token of `command`.
+
+    Mirrors the rule `_entry_matches_basename` applies on the entry side:
+    the program is the first whitespace token, the basename is what we
+    deduplicate against. Returns `""` for an empty / whitespace-only
+    command (callers treat that as "no basename, append").
+    """
+    stripped = command.strip()
+    if not stripped:
+        return ""
+    first = stripped.split(maxsplit=1)[0]
+    return Path(first).name
+
+
+def _install_or_replace_entry(
+    entries: list[dict[str, object]],
+    *,
+    command: str,
+    timeout: int | None,
+    status_message: str | None,
+    matcher: str | None = None,
+) -> bool:
+    """Install or replace a hook entry, deduping by `(matcher, basename)`.
+
+    Mutates `entries` in place. Dedupe key: any existing entry whose
+    `matcher` field matches `matcher` (both None for events without a
+    matcher) AND whose first inner-command basename matches the
+    basename of `command`'s first whitespace token is the same logical
+    hook — even if the absolute path differs.
+
+    Returns True iff `entries` already contained a byte-identical entry
+    and was NOT mutated; caller can skip the atomic write. Returns
+    False iff `entries` was mutated (new entry appended or path-stale
+    entry replaced); caller must atomic-write.
+
+    Replacement (rather than append) collapses the duplicate-hook
+    accumulation #781 documents: a venv recreation (uv tool upgrade,
+    pipx → uv migration, tmpdir scratch install) changes the absolute
+    path but keeps the basename, so the existing entry is found by
+    basename and overwritten instead of an additional stale-path entry
+    being appended.
+    """
+    new_entry = _build_entry(
+        command=command,
+        timeout=timeout,
+        status_message=status_message,
+        matcher=matcher,
+    )
+    target_base = _command_basename(command)
+    if target_base:
+        for i, entry in enumerate(entries):
+            if entry.get("matcher") != matcher:
+                continue
+            if not _entry_matches_basename(entry, target_base):
+                continue
+            if entry == new_entry:
+                return True
+            entries[i] = new_entry
+            return False
+    entries.append(new_entry)
     return False
 
 

--- a/tests/test_setup_install.py
+++ b/tests/test_setup_install.py
@@ -265,15 +265,27 @@ def test_uninstall_rejects_empty_command(tmp_path: Path) -> None:
 def test_uninstall_basename_match_removes_bare_and_absolute(
     tmp_path: Path,
 ) -> None:
-    """Basename mode catches both 'aelf-hook' and any absolute path
-    whose final component is 'aelf-hook' -- which is the round-trip
-    pairing for the new auto-resolving setup."""
+    """Basename mode catches multiple stacked stale-path entries.
+
+    Settings files from before #781's install-dedup landing may carry
+    several UserPromptSubmit entries with the same basename but
+    different paths (uv/pipx/venv churn). install_user_prompt_submit_hook
+    now collapses those on append, so this test writes the stale shape
+    directly.
+    """
     settings = tmp_path / "settings.json"
-    install_user_prompt_submit_hook(settings, command="aelf-hook")
-    install_user_prompt_submit_hook(
-        settings, command="/Users/me/.venv/bin/aelf-hook"
-    )
-    install_user_prompt_submit_hook(settings, command="/keep/me")
+    settings.write_text(json.dumps({
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{"type": "command", "command": "aelf-hook"}]},
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/Users/me/.venv/bin/aelf-hook",
+                }]},
+                {"hooks": [{"type": "command", "command": "/keep/me"}]},
+            ],
+        },
+    }))
 
     result = uninstall_user_prompt_submit_hook(
         settings, command_basename="aelf-hook"

--- a/tests/test_setup_pre_compact.py
+++ b/tests/test_setup_pre_compact.py
@@ -104,12 +104,25 @@ def test_uninstall_pre_compact_does_not_touch_user_prompt_submit(
 
 
 def test_uninstall_pre_compact_by_basename(tmp_path: Path) -> None:
-    """Basename match cleans up across abs / bare installs."""
+    """Basename match cleans up across stacked stale-path entries.
+
+    Settings files from before #781's install-dedup landing may carry
+    multiple PreCompact entries with the same basename but different
+    paths (uv/pipx/venv churn). install_pre_compact_hook now collapses
+    those on append, so this test writes the stale shape directly.
+    """
     p = tmp_path / "settings.json"
-    install_pre_compact_hook(p, command=_PC_CMD)
-    install_pre_compact_hook(
-        p, command="/different/path/aelf-pre-compact-hook"
-    )
+    p.write_text(json.dumps({
+        "hooks": {
+            "PreCompact": [
+                {"hooks": [{"type": "command", "command": _PC_CMD}]},
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/different/path/aelf-pre-compact-hook",
+                }]},
+            ],
+        },
+    }))
     data = _read(p)
     assert len(data["hooks"]["PreCompact"]) == 2  # type: ignore[index]
     result = uninstall_pre_compact_hook(

--- a/tests/test_setup_prune_stale.py
+++ b/tests/test_setup_prune_stale.py
@@ -1,0 +1,421 @@
+"""Layer A/B/C coverage for #781 — stale-path hook accumulation.
+
+Tests three behaviours that together prevent the ENOENT-spam failure
+mode described in issue #781:
+
+* **Layer A — install dedupe.** `install_*_hook` matches existing
+  entries by `(matcher, basename)`, so a path change replaces the
+  stale entry instead of stacking. Covered as unit tests against
+  `install_user_prompt_submit_hook` (representative of every
+  matcher-less event) and `install_search_tool_bash_hook` (the
+  matcher-keyed surface).
+* **Layer B — `aelf setup` prune.** `prune_broken_aelf_hooks` runs
+  before the install loop in `_cmd_setup`, sweeping out stale
+  entries whose program no longer resolves — but only for
+  `aelf-*`-basename entries. Custom shell hooks are left intact.
+* **Layer C — `aelf doctor --fix`.** Mirrors Layer B on demand from
+  the `doctor` CLI, with a `--dry-run` mode for visibility.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from aelfrice.cli import main
+from aelfrice.doctor import prune_broken_aelf_hooks
+from aelfrice.setup import (
+    install_search_tool_bash_hook,
+    install_user_prompt_submit_hook,
+)
+
+
+def _read(path: Path) -> dict[str, object]:
+    return cast(dict[str, object], json.loads(path.read_text()))
+
+
+def _event_list(data: dict[str, object], event: str) -> list[dict[str, object]]:
+    hooks = data["hooks"]
+    assert isinstance(hooks, dict)
+    entries = cast(dict[str, object], hooks)[event]
+    assert isinstance(entries, list)
+    return cast(list[dict[str, object]], entries)
+
+
+def _make_live_program(tmp_path: Path, basename: str) -> Path:
+    """Drop an executable stub at `tmp_path/basename` and return its abs path."""
+    p = tmp_path / basename
+    p.write_text("#!/bin/sh\nexit 0\n")
+    p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+    return p
+
+
+# --- Layer A ---------------------------------------------------------------
+
+
+def test_install_replaces_basename_match_on_path_change(tmp_path: Path) -> None:
+    """A second install with a different absolute path replaces the entry.
+
+    The accumulation bug: `/old/.venv/bin/aelf-hook` followed by
+    `/new/.venv/bin/aelf-hook` previously left both entries in place.
+    After Layer A, the second call replaces the first.
+    """
+    settings = tmp_path / "settings.json"
+    install_user_prompt_submit_hook(
+        settings, command="/old/.venv/bin/aelf-hook",
+    )
+    install_user_prompt_submit_hook(
+        settings, command="/new/.venv/bin/aelf-hook",
+    )
+    entries = _event_list(_read(settings), "UserPromptSubmit")
+    assert len(entries) == 1
+    cmd = cast(list[dict[str, object]], entries[0]["hooks"])[0]["command"]
+    assert cmd == "/new/.venv/bin/aelf-hook"
+
+
+def test_install_idempotent_same_command_twice(tmp_path: Path) -> None:
+    """Two installs with the same command leave a single entry.
+
+    Regression guard against the dedupe helper accidentally treating
+    `entries[i] == new_entry` as a replace+write rather than a no-op.
+    """
+    settings = tmp_path / "settings.json"
+    r1 = install_user_prompt_submit_hook(
+        settings, command="/usr/local/bin/aelf-hook",
+    )
+    r2 = install_user_prompt_submit_hook(
+        settings, command="/usr/local/bin/aelf-hook",
+    )
+    assert r1.installed and not r1.already_present
+    assert r2.already_present and not r2.installed
+    entries = _event_list(_read(settings), "UserPromptSubmit")
+    assert len(entries) == 1
+
+
+def test_install_replaces_only_within_matcher_partition(tmp_path: Path) -> None:
+    """Matcher-keyed install (Bash vs Grep|Glob) does not cross partitions.
+
+    The search-tool hook ships with two PreToolUse entries that share
+    `aelf-search-tool-hook` as the basename but live under different
+    matchers per the v1.5.0 contract. Layer A's matcher-aware dedupe
+    must not collapse them into one.
+    """
+    settings = tmp_path / "settings.json"
+    # Plant the Grep|Glob matcher entry directly so we can verify the
+    # Bash install does not steamroll it.
+    settings.write_text(json.dumps({
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Grep|Glob",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/usr/local/bin/aelf-search-tool-hook",
+                    }],
+                },
+            ],
+        },
+    }))
+    install_search_tool_bash_hook(
+        settings, command="/different/bin/aelf-search-tool-hook",
+    )
+    entries = _event_list(_read(settings), "PreToolUse")
+    matchers = sorted(cast(str, e.get("matcher", "")) for e in entries)
+    assert matchers == ["Bash", "Grep|Glob"]
+    assert len(entries) == 2
+
+
+# --- Layer B / prune helper ------------------------------------------------
+
+
+def test_prune_collapses_n_stale_to_one_resolvable(tmp_path: Path) -> None:
+    """Acceptance: N stale entries + 1 resolvable, prune leaves only the resolvable.
+
+    Mirrors the issue's repro: a settings.json that accumulated five
+    aelf-hook entries pointing at venvs that no longer exist, plus one
+    pointing at a real binary.
+    """
+    live = _make_live_program(tmp_path, "aelf-hook")
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{"type": "command", "command": "/missing/a/aelf-hook"}]},
+                {"hooks": [{"type": "command", "command": "/missing/b/aelf-hook"}]},
+                {"hooks": [{"type": "command", "command": str(live)}]},
+                {"hooks": [{"type": "command", "command": "/missing/c/aelf-hook"}]},
+                {"hooks": [{"type": "command", "command": "/missing/d/aelf-hook"}]},
+                {"hooks": [{"type": "command", "command": "/missing/e/aelf-hook"}]},
+            ],
+        },
+    }))
+    result = prune_broken_aelf_hooks(settings)
+    assert result.total_removed == 5
+    assert result.removed_per_event == {"UserPromptSubmit": 5}
+    entries = _event_list(_read(settings), "UserPromptSubmit")
+    assert len(entries) == 1
+    cmd = cast(list[dict[str, object]], entries[0]["hooks"])[0]["command"]
+    assert cmd == str(live)
+
+
+def test_prune_leaves_custom_shell_hooks_alone(tmp_path: Path) -> None:
+    """Acceptance: a custom (non-`aelf-`) broken hook is never touched.
+
+    The prune predicate is intentionally narrow — pruning third-party
+    integrations would be a foot-gun. We assert that even a clearly
+    broken custom path survives.
+    """
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/missing/path/aelf-hook",
+                }]},
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/missing/path/gh-pii-guard.sh",
+                }]},
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/missing/path/conversation-logger.sh",
+                }]},
+            ],
+        },
+    }))
+    result = prune_broken_aelf_hooks(settings)
+    assert result.total_removed == 1
+    entries = _event_list(_read(settings), "UserPromptSubmit")
+    cmds = sorted(
+        cast(str, cast(list[dict[str, object]], e["hooks"])[0]["command"])
+        for e in entries
+    )
+    assert cmds == [
+        "/missing/path/conversation-logger.sh",
+        "/missing/path/gh-pii-guard.sh",
+    ]
+
+
+def test_prune_dry_run_does_not_rewrite_file(tmp_path: Path) -> None:
+    """`dry_run=True` reports the would-be prune but leaves the file intact."""
+    settings = tmp_path / "settings.json"
+    original = json.dumps({
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/missing/aelf-hook",
+                }]},
+            ],
+        },
+    }, indent=2)
+    settings.write_text(original)
+    result = prune_broken_aelf_hooks(settings, dry_run=True)
+    assert result.total_removed == 1
+    assert settings.read_text() == original
+
+
+def test_prune_missing_file_is_no_op(tmp_path: Path) -> None:
+    """Prune on a non-existent settings.json reports zero and does not create it."""
+    settings = tmp_path / "never-existed.json"
+    result = prune_broken_aelf_hooks(settings)
+    assert result.total_removed == 0
+    assert result.removed_per_event == {}
+    assert not settings.exists()
+
+
+def test_prune_skips_shell_metacharacter_commands(tmp_path: Path) -> None:
+    """A pipeline / `||` command is `status=skipped`, not `broken`, so prune leaves it.
+
+    Conservative-by-design: the prune predicate only acts on entries
+    that doctor would already report `broken`. Anything wrapped in a
+    shell pipeline is opaque and left to the user to maintain.
+    """
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/missing/aelf-hook || true",
+                }]},
+            ],
+        },
+    }))
+    result = prune_broken_aelf_hooks(settings)
+    assert result.total_removed == 0
+    entries = _event_list(_read(settings), "UserPromptSubmit")
+    assert len(entries) == 1
+
+
+# --- Layer B in _cmd_setup -------------------------------------------------
+
+
+def test_cmd_setup_prunes_before_install(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: `aelf setup` sweeps stale aelf-* entries it didn't write.
+
+    Plants a stale `Stop` entry that `aelf setup` is NOT touching
+    this run (no `--no-stop-hook` involved, but the stale path is for
+    a binary the install will replace anyway). The pre-install prune
+    is what catches stale entries the install loop wouldn't otherwise
+    rewrite.
+    """
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".claude").mkdir()
+    settings = proj / ".claude" / "settings.json"
+    # Stash a stale aelf-* entry on an event that setup will still
+    # reconcile. Two entries here (one resolvable bare-name `aelf-hook`,
+    # one missing absolute path) would normally each leak ENOENT.
+    settings.write_text(json.dumps({
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/very/missing/.venv/bin/aelf-hook",
+                }]},
+            ],
+            "PreCompact": [
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/very/missing/.venv/bin/aelf-pre-compact-hook",
+                }]},
+            ],
+        },
+    }, indent=2))
+    # maybe_migrate_to_uv side-effects must not fire during the test —
+    # pin its sentinel before invoking setup.
+    sentinel_dir = tmp_path / "aelfrice-home"
+    sentinel_dir.mkdir()
+    monkeypatch.setenv("HOME", str(sentinel_dir))
+    (sentinel_dir / ".aelfrice").mkdir()
+    (sentinel_dir / ".aelfrice" / "migrated-to-uv").write_text("")
+    rc = main([
+        "setup",
+        "--scope", "project",
+        "--project-root", str(proj),
+        "--command", "aelf-hook",  # bare-name → resolves via PATH
+        "--no-transcript-ingest",
+        "--no-session-start",
+        "--no-stop-hook",
+        "--no-statusline",
+        "--no-commit-ingest",
+        "--no-search-tool",
+        "--no-search-tool-bash",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "pruned" in out
+    # Only the freshly installed UserPromptSubmit entry should remain,
+    # and the PreCompact slot should be emptied entirely (the prune
+    # ran on a stale aelf-pre-compact-hook abs-path that does not
+    # exist, and the install loop is not touching PreCompact because
+    # --rebuilder was not passed).
+    data = _read(settings)
+    ups = _event_list(data, "UserPromptSubmit")
+    assert len(ups) == 1
+    hooks_map = data["hooks"]
+    assert isinstance(hooks_map, dict)
+    assert cast(dict[str, object], hooks_map).get("PreCompact") == []
+
+
+# --- Layer C / aelf doctor --fix ------------------------------------------
+
+
+def test_doctor_fix_prunes_broken_aelf_entries(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".claude").mkdir()
+    settings = proj / ".claude" / "settings.json"
+    settings.write_text(json.dumps({
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/missing/aelf-hook",
+                }]},
+            ],
+        },
+    }))
+    rc = main([
+        "doctor", "hooks",
+        "--user-settings", str(tmp_path / "no-such-user-settings.json"),
+        "--project-root", str(proj),
+        "--fix",
+    ])
+    # rc reflects pre-fix findings; doctor classified the broken hook
+    # before --fix removed it, which is the documented behaviour.
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "pruned 1 stale aelf-* hook entry" in out
+    assert _event_list(_read(settings), "UserPromptSubmit") == []
+
+
+def test_doctor_fix_dry_run_does_not_write(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".claude").mkdir()
+    settings = proj / ".claude" / "settings.json"
+    original = json.dumps({
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/missing/aelf-hook",
+                }]},
+            ],
+        },
+    }, indent=2) + "\n"
+    settings.write_text(original)
+    rc = main([
+        "doctor", "hooks",
+        "--user-settings", str(tmp_path / "no-such-user-settings.json"),
+        "--project-root", str(proj),
+        "--fix", "--dry-run",
+    ])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "would prune" in out
+    # File untouched byte-for-byte.
+    assert settings.read_text() == original
+
+
+def test_doctor_fix_clean_settings_reports_nothing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".claude").mkdir()
+    settings = proj / ".claude" / "settings.json"
+    live = _make_live_program(tmp_path, "aelf-hook")
+    settings.write_text(json.dumps({
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{"type": "command", "command": str(live)}]},
+            ],
+        },
+    }))
+    rc = main([
+        "doctor", "hooks",
+        "--user-settings", str(tmp_path / "no-such-user-settings.json"),
+        "--project-root", str(proj),
+        "--fix",
+    ])
+    out = capsys.readouterr().out
+    assert "no stale aelf-* hook entries to prune" in out
+    # Live hook untouched.
+    assert len(_event_list(_read(settings), "UserPromptSubmit")) == 1
+    # rc may be 0 or 1 depending on other settings.json complaints;
+    # the live aelf-hook on its own is not a structural failure.
+    _ = rc

--- a/tests/test_setup_prune_stale.py
+++ b/tests/test_setup_prune_stale.py
@@ -19,7 +19,6 @@ mode described in issue #781:
 from __future__ import annotations
 
 import json
-import os
 import stat
 from pathlib import Path
 from typing import cast

--- a/tests/test_setup_session_start.py
+++ b/tests/test_setup_session_start.py
@@ -102,11 +102,25 @@ def test_uninstall_session_start_does_not_touch_user_prompt_submit(
 
 
 def test_uninstall_session_start_by_basename(tmp_path: Path) -> None:
+    """Uninstall-by-basename clears multiple stacked stale-path entries.
+
+    Pre-existing settings.json files may carry stacked stale-path
+    entries from before the #781 install-dedup fix landed. Write that
+    shape directly here — install_session_start_hook now deduplicates
+    by basename and would collapse the two stale entries on append.
+    """
     p = tmp_path / "settings.json"
-    install_session_start_hook(p, command=_SS_CMD)
-    install_session_start_hook(
-        p, command="/different/path/aelf-session-start-hook"
-    )
+    p.write_text(json.dumps({
+        "hooks": {
+            "SessionStart": [
+                {"hooks": [{"type": "command", "command": _SS_CMD}]},
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/different/path/aelf-session-start-hook",
+                }]},
+            ],
+        },
+    }))
     data = _read(p)
     assert len(data["hooks"]["SessionStart"]) == 2  # type: ignore[index]
     result = uninstall_session_start_hook(

--- a/tests/test_setup_stop_hook.py
+++ b/tests/test_setup_stop_hook.py
@@ -128,11 +128,25 @@ def test_uninstall_stop_hook_basename_does_not_remove_transcript_ingest(
 
 
 def test_uninstall_stop_hook_by_basename(tmp_path: Path) -> None:
+    """Uninstall-by-basename clears multiple stale-path entries.
+
+    Pre-existing settings.json files may carry stacked stale-path
+    entries from before the #781 install-dedup fix landed. Write
+    that shape directly here — install_stop_hook now deduplicates by
+    basename and would collapse the two stale entries on append.
+    """
     p = tmp_path / "settings.json"
-    install_stop_hook(p, command=_STOP_CMD)
-    install_stop_hook(
-        p, command="/different/path/aelf-stop-hook"
-    )
+    p.write_text(json.dumps({
+        "hooks": {
+            "Stop": [
+                {"hooks": [{"type": "command", "command": _STOP_CMD}]},
+                {"hooks": [{
+                    "type": "command",
+                    "command": "/different/path/aelf-stop-hook",
+                }]},
+            ],
+        },
+    }))
     data = _read(p)
     assert len(data["hooks"]["Stop"]) == 2  # type: ignore[index]
     result = uninstall_stop_hook(


### PR DESCRIPTION
Closes #781.

## Summary

Three layers that together stop `~/.claude/settings.json` from
accumulating ENOENT-firing `aelf-*` hook entries every time the
package install path changes (uv tool upgrade, pipx → uv migration,
project venv recreation, tmpdir scratch install).

### Layer A — install-side dedupe by `(matcher, basename)`

`install_*_hook` previously checked exact-command match for
idempotency. A second install with a different absolute path
appended instead of replacing, so after a few install events the
file looked like:

```
SessionStart:        7 entries (1 working, 6 stale)
PreToolUse search:   6 entries (1 working, 5 stale)
UserPromptSubmit:   16 entries (4 working, 12 stale)
…
```

New helper `_install_or_replace_entry` collapses on
`(matcher, basename)` so a path change to the same `aelf-*` script
replaces the existing entry. Matcher-aware: the search-tool
Bash matcher and Grep|Glob matcher (same basename, different
matcher) remain separate per the v1.5.0 contract.

### Layer B — `aelf setup` prune step

Layer A only catches collisions on the basename being written *this
run*. Stale entries for events `aelf setup` isn't touching (e.g. a
`--no-stop-hook` opt-out leaving an old Stop entry around) still
leak through.

New `doctor.prune_broken_aelf_hooks(path)` walks every
`hooks.<event>[i].hooks[j]` command, removes parent entries whose
program basename starts with `aelf-` AND whose program fails the
existence / `$PATH` lookup. The predicate is the same
`_inspect_command` doctor already uses for its scan, so the prune
decision matches what `aelf doctor` reports. Custom shell hooks
(non-`aelf-` basenames) are never touched.

`_cmd_setup` invokes this after `clean_dangling_shims` and before
the install loop, printing a single line summarising what was
removed.

### Layer C — `aelf doctor --fix`

Same prune helper, surfaced as `aelf doctor [hooks] --fix`. Combine
with `--dry-run` to see what would be pruned without rewriting the
file. The exit code still reflects the pre-fix findings — re-run
`aelf doctor` after `--fix` to confirm a clean state.

## Why this isn't covered by the existing setup idempotency story

`install_*_hook` was idempotent against *the exact same command
string*. It was never idempotent against the same logical hook with
a path that drifted. #39 ("idempotent UserPromptSubmit hook
install") only covered the equal-string case; venv churn through
the past year of upgrades is what exposed the gap.

## Test plan

- [x] `tests/test_setup_prune_stale.py` — 12 new tests covering A
      (path-change replace, exact idempotency, matcher partitioning),
      B (N stale → 1 resolvable, custom-hook survival, dry-run,
      missing file, shell-meta skip, `aelf setup` integration), and
      C (`aelf doctor --fix` real + dry-run + clean-settings).
- [x] Existing setup/doctor tests pass (`tests/test_setup_*.py`,
      `tests/test_doctor*.py`, `tests/test_cli_setup.py`,
      `tests/test_commit_ingest_hook.py`).
- [x] Full `uv run pytest tests/` clean (4014 passed, 62 skipped,
      75 xfailed).
- [x] Discretion grep on the full diff vs `github/main` clean.

## Acceptance map

- [x] `aelf setup` idempotent across all hook events: running it
      twice produces the same settings.json (Layer A).
- [x] `aelf setup` prunes hook entries whose `command` doesn't
      resolve, scoped to `aelf-*`-basename entries only (Layer B).
- [x] `aelf doctor --fix` performs the same prune on demand
      (Layer C). Read-only `aelf doctor` behaviour unchanged.
- [x] Unit test: build a settings.json with N stale entries, run
      setup, assert only the one resolvable entry remains per event
      (`test_prune_collapses_n_stale_to_one_resolvable`).
- [x] Unit test: settings.json with mixed `aelf-*` and custom shell
      hook commands; assert the custom hooks survive
      (`test_prune_leaves_custom_shell_hooks_alone`).

## Out of scope (deferred)

- Project-scope settings (`<project>/.claude/settings.json`) — same
  mechanism applies but the issue defers it as a follow-up. The
  prune helper already supports project paths; only the
  `aelf doctor` defaults wire to user scope.
- Backwards-compat shim for users with the broken state — they get
  auto-cleaned on next `aelf setup` (Layer B fires) or
  `aelf doctor --fix`. No migration code needed.
