### PR TITLE
fix(test): bfs_latency_v3 smoke flake — bump iterations + decouple from gate verdict (#792)

### DIFF
--- a/tests/test_bfs_latency_v3.py
+++ b/tests/test_bfs_latency_v3.py
@@ -143,8 +143,8 @@ def test_main_end_to_end_smoke(tmp_path: Path):
         "--beliefs", "40",
         "--topics", "4",
         "--queries", "4",
-        "--iterations", "2",
-        "--warmup", "1",
+        "--iterations", "10",
+        "--warmup", "2",
         "--output", str(out),
     ])
     # Tiny-corpus run on a v3.0 stack comfortably clears the gate;

--- a/tests/test_bfs_latency_v3.py
+++ b/tests/test_bfs_latency_v3.py
@@ -147,9 +147,14 @@ def test_main_end_to_end_smoke(tmp_path: Path):
         "--warmup", "2",
         "--output", str(out),
     ])
-    # Tiny-corpus run on a v3.0 stack comfortably clears the gate;
-    # rc==0 also implies the JSON was emitted.
-    assert rc == 0
+    # Smoke contract per file docstring: "Latency numbers are not
+    # asserted — only schema, determinism, and gate-result shape."
+    # rc==1 = gate FAIL on a noisy CI runner; rc==0 = gate PASS. Both
+    # mean the harness ran end-to-end and emitted the JSON. The
+    # gate-verdict path is covered by the dedicated
+    # test_evaluate_gate_* fixtures above with hand-rolled ArmResults
+    # that do not depend on runner timing.
+    assert rc in (0, 1)
     payload = json.loads(out.read_text())
     assert payload["harness"] == "bfs_latency_v3"
     assert payload["corpus"]["beliefs"] == 40
@@ -160,7 +165,19 @@ def test_main_end_to_end_smoke(tmp_path: Path):
         for k in ("p50_ms", "p95_ms", "p99_ms", "max_ms", "min_ms"):
             assert isinstance(a[k], (int, float))
             assert a[k] >= 0
-    assert isinstance(payload["gate"]["passed"], bool)
+    gate = payload["gate"]
+    assert isinstance(gate["passed"], bool)
+    for k in (
+        "delta_p50_ms", "delta_p95_ms", "tail_ratio",
+    ):
+        assert isinstance(gate[k], (int, float))
+    for k in (
+        "delta_p50_pass", "delta_p95_pass", "tail_ratio_pass",
+    ):
+        assert isinstance(gate[k], bool)
+    # rc encodes gate.passed; assert the two agree even though we
+    # don't pin which value either one takes.
+    assert (rc == 0) is gate["passed"]
 
 
 def test_default_belief_count_is_gate_size():


### PR DESCRIPTION
## Closes #792

Two atomic commits unblock the `pytest (3.13)` smoke flake that's been silently blocking PRs (most recently #790).

### Root cause

`test_main_end_to_end_smoke` calls `main([... "--queries", "4", "--iterations", "2", "--warmup", "1", ...])` → 8 timed samples per arm. `_percentile` uses nearest-rank semantics; with n=8 the p95 index resolves to `ceil(0.95*8) = 8` = max sample. So `p95 = p99 = max_sample`, and a single noisy timer reading on a shared CI runner trips the `delta_p95 ≤ 50ms` gate. The test then trips on `assert rc == 0`.

The file docstring already declares the intent:

> "These tests exercise the corpus generator, query generator, percentile helper, and end-to-end CLI flow on a tiny (40 beliefs / 4 topics) corpus. **Latency numbers are not asserted — only schema, determinism, and gate-result shape.**"

But `assert rc == 0` is precisely a latency-numbers assertion. Defence in depth fixes both halves.

### Commit 1 — bump iterations 2→10, warmup 1→2

40 samples per arm → p95 = sample[37], no longer max. Local pytest-3.13 runtime: 0.79s (no measurable regression; the earlier 16.7s was a cold-venv build, not the test itself).

### Commit 2 — decouple smoke from gate verdict

- `assert rc == 0` → `assert rc in (0, 1)` (both = harness ran end-to-end and emitted JSON).
- Add shape assertions on `payload["gate"]`: every key is present, numeric values are numeric, `*_pass` keys are bool.
- Cross-check `(rc == 0) is gate["passed"]` so a flake can't decouple the two without something more interesting going wrong.

Dedicated `test_evaluate_gate_*` fixtures above already cover gate logic deterministically with hand-rolled `ArmResult` objects — gate verdict is not the smoke's job.

### Verification

- `uv run --python 3.13 pytest tests/test_bfs_latency_v3.py -q` → **11 passed in 1.10s**.
- Both commits SSH-signed, no `Co-Authored-By` lines per repo convention.
- Diff: 1 file, +23/-6.
- Discretion grep on diff vs `github/main`: CLEAN.

### Out of scope

- Production-bench gate thresholds (`GATE_DELTA_P50_MS`, `GATE_DELTA_P95_MS`, `GATE_MAX_OVER_MEDIAN_RATIO`) — those are the real benchmark's contract for ≥1000-sample runs.
- `_percentile` semantics — nearest-rank is correct at production sample sizes.
