### PR TITLE
feat(bench): tighten post-clear replay template + ratify 0.80 AC scope (#797 P3)

### DIFF
--- a/benchmarks/context-rebuilder/README.md
+++ b/benchmarks/context-rebuilder/README.md
@@ -305,22 +305,26 @@ operator-driven loop, or a private skill).
    One JSON row per `eval_turn`:
 
    ```json
-   {"turn_idx": 8, "rebuilt_block": "...", "user_turn": "...", "expected": "..."}
+   {"turn_idx": 8, "rebuilt_block": "...", "user_turn": "...",
+    "expected": "...", "prompt": "..."}
    ```
 
    `user_turn` is the most-recent `role=user` text at-or-before the
-   eval index — the prompt the host will replay through the rebuilt
-   context. All rows in the harness JSON output carry
-   `reason=pending_replay`; `score_fidelity` returns 0 on this
-   pass.
+   eval index. `prompt` is the canonical post-clear replay prompt
+   built by `_assemble_post_clear_prompt`, prepending
+   `POST_CLEAR_INSTRUCTION` (the cooperative-reader instruction
+   documented in `docs/BENCHMARKS.md` § "Bench measurement scope"
+   and ratified per #797). All rows in the harness JSON output
+   carry `reason=pending_replay`; `score_fidelity` returns 0 on
+   this pass.
 
 2. **Operator dispatches one child task per row.** From a host
    session (an MCP-enabled host CLI, an operator-driven loop, or a
    private replay-eval skill), iterate over each
    `replay_requests.jsonl` line and dispatch a child task prompted
-   with `rebuilt_block + "\n---\n" + user_turn`. Capture the
-   reply as `actual` and append a JSON line to
-   `replay_responses.jsonl` in the same directory:
+   with the row's `prompt` field directly. Capture the reply as
+   `actual` and append a JSON line to `replay_responses.jsonl` in
+   the same directory:
 
    ```json
    {"turn_idx": 8, "actual": "..."}

--- a/benchmarks/context-rebuilder/eval_harness.py
+++ b/benchmarks/context-rebuilder/eval_harness.py
@@ -232,6 +232,40 @@ match fails. The open-ended fidelity verdict belongs to commit-3 of
 REPLAY_REQUESTS_FILENAME: Final[str] = "replay_requests.jsonl"
 REPLAY_RESPONSES_FILENAME: Final[str] = "replay_responses.jsonl"
 
+POST_CLEAR_INSTRUCTION: Final[str] = (
+    "You are answering a single user question, given rebuilt context "
+    "from a prior session that was cleared. Answer only the question "
+    "the user actually asked. Do not answer adjacent or related "
+    "questions that the rebuilt context might also support. When the "
+    "user's question asks about a specific fact (a file path, an error "
+    "symptom, a root cause, a verification step, a fix), draw that "
+    "fact from the rebuilt context rather than substituting a related "
+    "fact from a neighbouring topic. If the rebuilt context does not "
+    "contain the specific fact the user asks for, say so plainly "
+    "rather than guessing or recapitulating an adjacent fact."
+)
+"""Cooperative-reader instruction prepended to every post-clear replay
+prompt (#797). Measurement scope is documented in
+`docs/BENCHMARKS.md` § "Bench measurement scope". Wording is
+deliberately conservative — it tells the reader which atom to anchor
+on, not which atoms to recite. Verbatim-recap wording was rejected
+because it would let any pack containing the named atoms score 1.0
+regardless of pack quality."""
+
+
+def _assemble_post_clear_prompt(rebuilt_block: str, user_turn: str) -> str:
+    """Assemble the canonical post-clear replay prompt.
+
+    Dispatchers SHOULD prompt their child task with this string. The
+    individual `rebuilt_block` and `user_turn` fields remain in the
+    row for inspection / debugging; the `prompt` field is the contract.
+    """
+    return (
+        f"{POST_CLEAR_INSTRUCTION}\n\n"
+        f"--- REBUILT CONTEXT ---\n{rebuilt_block}\n\n"
+        f"--- USER QUESTION ---\n{user_turn}"
+    )
+
 
 def _read_user_and_expected(
     case: TranscriptCase,
@@ -314,20 +348,29 @@ def _write_replay_requests(
 ) -> None:
     """Write `<run_dir>/replay_requests.jsonl`. One row per eval_turn.
 
-    Schema: `{turn_idx, rebuilt_block, user_turn, expected}`. Best-effort
-    — `mkdir` and write failures squash to a no-op so the rest of
-    `run_one` (latency, token cost) still completes.
+    Schema: `{turn_idx, rebuilt_block, user_turn, expected, prompt}`.
+    `prompt` is the canonical post-clear replay prompt assembled by
+    `_assemble_post_clear_prompt`; dispatchers SHOULD prompt their
+    child task with `prompt` directly. The `rebuilt_block` /
+    `user_turn` fields remain for inspection and back-compat reads.
+
+    Best-effort — `mkdir` and write failures squash to a no-op so the
+    rest of `run_one` (latency, token cost) still completes.
     """
     try:
         run_dir.mkdir(parents=True, exist_ok=True)
         path = run_dir / REPLAY_REQUESTS_FILENAME
         with path.open("w", encoding="utf-8") as f:
             for idx in eval_turns:
+                user_turn = user_turn_by_idx.get(idx, "")
                 row = {
                     "turn_idx": idx,
                     "rebuilt_block": rebuilt_context,
-                    "user_turn": user_turn_by_idx.get(idx, ""),
+                    "user_turn": user_turn,
                     "expected": expected_by_idx.get(idx, ""),
+                    "prompt": _assemble_post_clear_prompt(
+                        rebuilt_context, user_turn
+                    ),
                 }
                 f.write(json.dumps(row) + "\n")
     except OSError:
@@ -353,10 +396,14 @@ def replay_post_fork(
     `<run_dir>/replay_requests.jsonl` so an operator-driven dispatcher
     (an MCP-enabled host CLI, an operator loop, or a private
     `aelf:replay-eval` skill) can spawn one child task per row,
-    prompted with `rebuilt_block + "\\n---\\n" + user_turn`, expecting
-    the dispatcher to write `<run_dir>/replay_responses.jsonl`. On the next harness invocation
-    this function reads that response file, joins by `turn_idx`, and
-    fills `actual`:
+    prompted with the row's `prompt` field (the canonical post-clear
+    replay prompt assembled by `_assemble_post_clear_prompt`, prepending
+    `POST_CLEAR_INSTRUCTION`; see #797 and `docs/BENCHMARKS.md`
+    § "Bench measurement scope"). The legacy `rebuilt_block` and
+    `user_turn` fields remain in the row for inspection. Dispatchers
+    are expected to write `<run_dir>/replay_responses.jsonl`. On the
+    next harness invocation this function reads that response file,
+    joins by `turn_idx`, and fills `actual`:
 
       * `actual` empty / row missing  → matched=False, reason=PENDING_REPLAY_REASON.
       * `expected.lower() in actual.lower()` → matched=True (substring half

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -177,8 +177,44 @@ Every multi-judge run produces `benchmarks/results/<run-id>/judge_kappa.json`:
 
 - `inter_judge_kappa.min ≥ 0.70` (the **min** across all run-pairs, not the
   mean — a single noisy run-pair shouldn't be averaged out)
-- `hot_start_fidelity_mean ≥ 0.80` (per #592 AC)
+- `hot_start_fidelity_mean ≥ 0.80` (per #592 AC, ratified under the
+  measurement scope below — see "Bench measurement scope")
 - N≥3 runs
+
+### Bench measurement scope
+
+`hot_start_fidelity` measures **rebuilder-pack quality at the limit of a
+cooperative, instructed reader**. It is *not* a measurement of typical
+post-clear recall by an arbitrary host CLI.
+
+The replay prompt assembled by
+`benchmarks/context-rebuilder/eval_harness.py::_assemble_post_clear_prompt`
+prepends `POST_CLEAR_INSTRUCTION` — a conservative cooperative-reader
+instruction that asks the dispatched child task to:
+
+1. Answer the specific question the user_turn asks (no question
+   conflation across adjacent atoms in the rebuild block).
+2. Cite the specific fact from the rebuild block that the user_turn
+   asks about (no dropped facts when the answer is present in pack).
+3. Stay scoped to the user_turn's atom (no cross-contamination from
+   adjacent atoms even when they are present in the pack).
+
+The instruction is deliberately conservative — it does **not** ask the
+reader to recapitulate named atoms verbatim. Verbatim-recap wording was
+rejected (#797) because it would let any pack containing the named
+atoms score 1.0 regardless of pack quality, defeating the bench as a
+regression-detection signal.
+
+**The 0.80 AC bar is ratified against this instructed-reader
+measurement.** When this number falls, that means rebuilder-pack
+quality has regressed *or* the reader instruction has decohered — both
+are signals worth catching. It does not mean a typical un-instructed
+host CLI will recall 0.80 of the same atoms after a clear; that is a
+separate question that, if needed, belongs in a separate AC and
+instrumentation.
+
+Refs: #592 (original AC), #687 / PR #727 (κ commit-3), #777 (κ Run 2),
+#797 (P3 ratification — instructed-reader scope + AC at 0.80).
 
 ### Sample-size caveat
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -214,7 +214,7 @@ separate question that, if needed, belongs in a separate AC and
 instrumentation.
 
 Refs: #592 (original AC), #687 / PR #727 (κ commit-3), #777 (κ Run 2),
-#797 (P3 ratification — instructed-reader scope + AC at 0.80).
+issue #797 (P3 ratification — instructed-reader scope + AC at 0.80).
 
 ### Sample-size caveat
 

--- a/tests/test_context_rebuilder_eval_harness_wiring.py
+++ b/tests/test_context_rebuilder_eval_harness_wiring.py
@@ -340,6 +340,90 @@ def test_replay_post_fork_writes_requests_jsonl(
     assert by_idx[4]["user_turn"] == "The floor never applies to L0 beliefs."
 
 
+def test_replay_requests_carry_canonical_prompt_field(
+    harness: ModuleType, transcript_path: Path, tmp_path: Path
+) -> None:
+    """#797 P3: each replay_requests row carries a `prompt` field built
+    by `_assemble_post_clear_prompt`. Dispatchers prompt their child
+    task with this field directly; the legacy rebuilt_block / user_turn
+    fields remain for inspection.
+
+    Asserts: (a) every row has a non-empty `prompt`; (b) the prompt
+    embeds the row's user_turn verbatim; (c) the prompt embeds the
+    rebuilt_block verbatim; (d) the prompt starts with the cooperative-
+    reader instruction (the user-turn-anchor instruction documented in
+    docs/BENCHMARKS.md § "Bench measurement scope").
+    """
+    case = harness.TranscriptCase(
+        path=transcript_path, task_type="debug",
+        fork_turn=2, eval_turns=(2, 4),
+    )
+    run_dir = tmp_path / "run"
+    harness.replay_post_fork("REBUILT_BLOCK", case, run_dir=run_dir)
+    rows = [
+        json.loads(line)
+        for line in (run_dir / harness.REPLAY_REQUESTS_FILENAME)
+            .read_text().splitlines()
+        if line.strip()
+    ]
+    by_idx = {r["turn_idx"]: r for r in rows}
+
+    instruction = harness.POST_CLEAR_INSTRUCTION
+    assert instruction, "POST_CLEAR_INSTRUCTION must not be empty"
+
+    for idx, row in by_idx.items():
+        prompt = row["prompt"]
+        assert prompt, f"row idx={idx} missing prompt"
+        assert prompt.startswith(instruction), (
+            f"row idx={idx} prompt must lead with the cooperative-reader "
+            f"instruction (the user-turn-anchor wording)"
+        )
+        assert row["rebuilt_block"] in prompt, (
+            f"row idx={idx} prompt must embed rebuilt_block verbatim"
+        )
+        assert row["user_turn"] in prompt, (
+            f"row idx={idx} prompt must embed user_turn verbatim"
+        )
+
+
+def test_post_clear_instruction_anchors_on_user_turn(
+    harness: ModuleType,
+) -> None:
+    """#797 P3: regression test on the wording itself. The instruction
+    must (a) reference the user's question, (b) warn against answering
+    adjacent / related questions (idx 13 question-conflation failure
+    mode), (c) warn against substituting an adjacent fact (idx 11
+    cross-contamination), and (d) ask for the specific fact the user
+    asked for (idx 9 dropped-facts).
+
+    Wording can drift; this test pins the *load-bearing* properties of
+    the wording, not the exact phrasing.
+    """
+    instruction = harness.POST_CLEAR_INSTRUCTION.lower()
+    # (a) anchors on the user's question
+    assert "user" in instruction and "question" in instruction
+    # (b) discourages question-conflation (idx 13)
+    assert "adjacent" in instruction or "related" in instruction
+    # (c) discourages cross-contamination (idx 11)
+    assert "substituting" in instruction or "substitut" in instruction
+    # (d) asks for the specific fact (idx 9)
+    assert "specific fact" in instruction
+
+
+def test_assemble_post_clear_prompt_is_deterministic(
+    harness: ModuleType,
+) -> None:
+    """Same (rebuilt_block, user_turn) → byte-identical prompt. The
+    bench depends on prompt determinism for κ stability across runs."""
+    a = harness._assemble_post_clear_prompt("R", "U")
+    b = harness._assemble_post_clear_prompt("R", "U")
+    assert a == b
+    # Sensitive to inputs (a smoke-check; prevents accidental constant
+    # return).
+    assert harness._assemble_post_clear_prompt("R", "U") != \
+        harness._assemble_post_clear_prompt("R2", "U")
+
+
 def test_replay_post_fork_pending_reason_when_no_responses(
     harness: ModuleType, transcript_path: Path, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

Closes the operator-ratified P3 path for #797 (v3.1 hot_start fidelity gap):
tighten the post-clear replay template at the harness boundary, ratify the
0.80 AC against the instructed-reader measurement, document the
measurement scope honestly. Keep `HOT_START_FIDELITY_THRESHOLD = 0.80` in
`benchmarks/context_rebuilder/kappa.py` (P3 holds the line; P2's drop
rejected).

The bench changes here are pure-Python and ship under existing CI. The
closing artifact (fresh multi-judge κ run with the new template) is
operator-driven via the host-agent dispatch path documented in
`benchmarks/context-rebuilder/README.md`; the harness itself is
SDK-free, as before. See "Closing artifact" below.

## What changed

### `benchmarks/context-rebuilder/eval_harness.py`

- New `POST_CLEAR_INSTRUCTION` (module-level `Final[str]`) — the
  cooperative-reader instruction prepended to every post-clear replay
  prompt.
- New `_assemble_post_clear_prompt(rebuilt_block, user_turn) -> str`
  helper that produces the canonical prompt:
  `INSTRUCTION\n\n--- REBUILT CONTEXT ---\n<rebuilt>\n\n--- USER QUESTION ---\n<user_turn>`.
- `_write_replay_requests` now emits a `prompt` field per row carrying
  the assembled template. Legacy `rebuilt_block` / `user_turn` /
  `expected` fields stay in the row schema for inspection / debugging /
  back-compat reads.
- `replay_post_fork` docstring updated: dispatchers now prompt their
  child task with the row's `prompt` field directly. Old
  `rebuilt_block + "\n---\n" + user_turn` assembly is no longer the
  contract.

### Wording rationale (per P3 spec)

The instruction tells the reader to:

1. **Anchor on the user_turn** — answer the specific question asked
   (#797 idx 13: question-conflation).
2. **Cite the specific fact** the user asks about, drawn from the
   rebuilt context (#797 idx 9: dropped facts).
3. **Stay scoped to the user_turn's atom**, not adjacent atoms in
   the pack (#797 idx 11: cross-contamination).

Verbatim-recap wording was rejected: it would let any pack containing
the named atoms score 1.0 regardless of pack quality, defeating the
bench as a regression-detection signal.

### `benchmarks/context-rebuilder/README.md`

Schema example + dispatch step updated to show the new `prompt` field
and tell dispatchers to use it directly.

### `docs/BENCHMARKS.md`

New "Bench measurement scope" subsection in §Eval-judge calibration:
documents that `hot_start_fidelity` measures rebuilder-pack quality at
the limit of a cooperative, instructed reader — *not* typical
un-instructed post-clear recall by an arbitrary host CLI. The 0.80 AC
bar is explicitly ratified against this instructed-reader measurement
scope. Cross-referenced from the docstring on `POST_CLEAR_INSTRUCTION`.

### `tests/test_context_rebuilder_eval_harness_wiring.py`

Three new tests, all green:

- `test_replay_requests_carry_canonical_prompt_field` — every row has
  a non-empty `prompt`; prompt leads with `POST_CLEAR_INSTRUCTION`;
  prompt embeds row's `rebuilt_block` + `user_turn` verbatim.
- `test_post_clear_instruction_anchors_on_user_turn` — pins the
  load-bearing properties of the wording (refs to user / question;
  warns against adjacent / related questions; warns against
  substituting a neighbouring fact; asks for "specific fact"). Wording
  can drift; the properties are what protect the bench.
- `test_assemble_post_clear_prompt_is_deterministic` — same inputs
  produce byte-identical prompts; required for κ stability across
  runs.

Existing 25 wiring tests + 181 broader bench/eval tests pass unchanged.

## What did NOT change

- `HOT_START_FIDELITY_THRESHOLD` in `benchmarks/context_rebuilder/kappa.py`
  stays at `0.80`. P3 holds the line.
- The `replay_post_fork` API surface — `rebuilt_block` / `user_turn` /
  `expected` fields remain in each row, so any in-flight dispatcher
  reading the old schema keeps working (just won't get the
  cooperative-reader scoping until it switches to `prompt`).
- The host-agent dispatch contract — aelfrice still imports zero from
  any vendor model SDK on this path.

## Closing artifact (operator-driven)

Per #797 acceptance:

> Closing PR includes a fresh multi-judge κ run with the new template
> demonstrating `calibrated: true` AND `fidelity_mean ≥ 0.80`.

The κ run is operator-driven through the host-agent dispatch flow
documented in `benchmarks/context-rebuilder/README.md` § "Host-agent
eval-replay". Suggested protocol:

1. `uv run python benchmarks/context-rebuilder/eval_harness.py
   --mode threshold-sweep --corpus benchmarks/context-rebuilder/fixtures/synthetic/
   --out /tmp/sweep1.json --run-dir /tmp/sweep_797/` —
   writes per-(case, config) `replay_requests.jsonl` with the new
   `prompt` field on every row.
2. Operator-driven dispatch: for each row, prompt a child task with
   `row["prompt"]` (the canonical post-clear prompt — no
   `rebuilt_block + "\n---\n" + user_turn` assembly). Capture the
   reply; append `{turn_idx, actual}` to `replay_responses.jsonl`
   in the same directory.
3. Re-run the sweep with the same flags to fill `actual` and produce
   the score.
4. N ≥ 3 judge passes through `kappa.py`. Required:
   `inter_judge_kappa.min ≥ 0.70`, `hot_start_fidelity_mean ≥ 0.80`.

Once the κ artifact is in hand:

- Comment on #592 confirming AC is satisfied at statistical power
  under the documented instructed-reader scope.
- Unblock #748 R3 (per the campaign comment on #748 from
  2026-05-14T17:13Z).

## R&D follow-up (flagged, not gate)

The P3 decision noted that the cooperative-reader instruction wording
could over-fit. A small A/B between two instruction wordings (current
vs alternative phrasing) — picking the one with higher κ-stable
fidelity — would reduce the risk of locking in a brittle template.
Tracking that as a v3.x R&D campaign separately if the κ run surfaces
either an over-fit (fidelity → 1.0 trivially) or an under-fit
(fidelity stays < 0.80 even with the instruction).

## Refs

- #797 — issue (operator P3 decision posted 2026-05-14T18:04Z).
- #592 — original AC bar.
- #687 / PR #727 — prior κ Run 2.
- #777 — A2 rubric + B1 fixture (shipped).
- #748 — hot-path campaign R3 (gate-blocked on this issue closing).

Closes #797


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmarking documentation to clarify measurement scope and gating criteria for multi-judge calibration.
  * Updated eval-replay flow documentation to describe standardized prompt construction for benchmark evaluations.

* **Tests**
  * Added test coverage for eval-replay prompt generation and validation.
  * Added tests to ensure prompt construction consistency and correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/802)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->