### PR TITLE
ci(publish): promote release-drafter draft on tag push (#804)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,3 +55,26 @@ jobs:
               --latest \
               --verify-tag
           fi
+      - name: Assert release published as Latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Belt-and-suspenders: fail loudly if the previous step succeeded but
+          # the release isn't actually visible as published + Latest. Prevents
+          # a silent regression of #804 (e.g. a future flag rename leaving the
+          # draft in place but exiting 0). isLatest is not a queryable field
+          # on `gh release view`, so we check via two narrow queries against
+          # their canonical sources: `gh release view --json isDraft` and the
+          # `releases/latest` REST endpoint.
+          tag="${GITHUB_REF#refs/tags/}"
+          is_draft=$(gh release view "$tag" --json isDraft -q .isDraft)
+          latest_tag=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name)
+          echo "post-promote state: isDraft=$is_draft latest_tag=$latest_tag (this tag=$tag)"
+          if [ "$is_draft" != "false" ]; then
+            echo "::error::release $tag is still a draft after promote step"
+            exit 1
+          fi
+          if [ "$latest_tag" != "$tag" ]; then
+            echo "::error::release $tag is not flagged as Latest (latest=$latest_tag)"
+            exit 1
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,16 +29,29 @@ jobs:
         with:
           subject-path: 'dist/*'
       - uses: pypa/gh-action-pypi-publish@release/v1
-      - name: Create GitHub Release
+      - name: Promote or create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # release-drafter pre-creates a DRAFT release for the next resolved
+          # version on every push to main. `gh release view` succeeds against
+          # drafts, so a naive existence-check leaves the new tag's release
+          # stuck in DRAFT and v(N-1) keeps the Latest badge (#804). Promote
+          # the draft when it exists; only `release create` if no release
+          # exists at all. Always assert --latest for the freshly cut tag.
           tag="${GITHUB_REF#refs/tags/}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            echo "release $tag already exists; skipping"
-            exit 0
+          if state=$(gh release view "$tag" --json isDraft -q .isDraft 2>/dev/null); then
+            if [ "$state" = "true" ]; then
+              echo "release $tag exists as DRAFT — promoting to published + latest"
+              gh release edit "$tag" --draft=false --latest --verify-tag
+            else
+              echo "release $tag already published; nothing to do"
+            fi
+          else
+            echo "no release for $tag — creating from generated notes"
+            gh release create "$tag" \
+              --title "$tag" \
+              --generate-notes \
+              --latest \
+              --verify-tag
           fi
-          gh release create "$tag" \
-            --title "$tag" \
-            --generate-notes \
-            --verify-tag


### PR DESCRIPTION
Closes #804.

## Why

`release-drafter.yml` continuously rebuilds a DRAFT release pinned to the next resolved version tag on every push to main. When `publish.yml` fired on the tag push, the prior `gh release view "$tag" >/dev/null 2>&1` check succeeded against that draft and the workflow short-circuited with `skipping`, leaving the new tag stuck in DRAFT and v(N-1) wearing the **Latest** badge. v3.0.1 hit this on 2026-05-13/14 and sat in draft for ~19h until manually promoted via `gh release edit v3.0.1 --draft=false --latest`.

## What

Two new steps in `.github/workflows/publish.yml`, both replacing the legacy single step:

**1. Promote or create GitHub Release** — detect draft state explicitly with `gh release view --json isDraft -q .isDraft`:

- Draft exists → `gh release edit "$tag" --draft=false --latest --verify-tag` (preserves release-drafter's curated body, which is the whole reason release-drafter exists).
- Published release exists → no-op (idempotent, makes the workflow safe to retry).
- No release at all → `gh release create ... --generate-notes --latest --verify-tag` (the original v(N-1) fallback path with `--latest` added).

**2. Assert release published as Latest** — belt-and-suspenders that re-queries `gh release view --json isDraft` and `gh api repos/{repo}/releases/latest --jq .tag_name` and fails the workflow if either flag is wrong. So if the promote step is ever broken in a way `gh release edit` accepts but doesn't actually promote (flag rename, release-drafter changing the tag template, gh CLI breaking change), the next release fails loudly at the tag-push level instead of silently leaving v(N-1) wearing **Latest**. `isLatest` is not queryable on `gh release view`, so the assertion uses two narrow queries against the canonical sources.

## Verification

- YAML round-trips: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` → 10 steps, last two named `Promote or create GitHub Release` + `Assert release published as Latest`.
- `zizmor` finding diff against `github/main` HEAD: zero new findings (pre-existing `unpinned-uses` and `cache-poisoning` warnings on the surrounding steps untouched and out of scope).
- `gh release list --json tagName,isDraft,isLatest` and `gh api repos/{repo}/releases/latest --jq .tag_name` both confirmed working against the live repo before the assertion logic was committed.
- Acceptance is observational on the next tag push (v3.1.0): the GitHub Release for v3.1.0 ends `isDraft=false` and wears Latest with no manual `gh release edit`.

## Out of scope

- Pinning `astral-sh/setup-uv@v5`, `actions/attest-build-provenance@v1`, `pypa/gh-action-pypi-publish@release/v1` to commit hashes (pre-existing zizmor findings, separate hardening pass).
- Touching `release-drafter.yml` itself — its draft-creation behaviour is correct; the bug is purely in `publish.yml`'s promotion path.