### PR TITLE
chore: add scripts/sync-repo-settings.sh to capture canonical repo settings

### DIFF
--- a/scripts/sync-repo-settings.sh
+++ b/scripts/sync-repo-settings.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# sync-repo-settings.sh — apply the canonical GitHub repo settings for aelfrice.
+#
+# Usage:
+#   scripts/sync-repo-settings.sh           # dry-run: print the diff
+#   scripts/sync-repo-settings.sh --apply   # actually write the settings
+#
+# Idempotent. Re-running with --apply is a no-op when state already matches.
+#
+# Surface: this script does NOT touch branch protection, secrets, codeowners,
+# webhooks, deploy keys, or any irreversible permission. It only manages the
+# About blurb, topics, and the four "feature toggles" surfaced under
+# Settings → General → Features (Wiki, Issues, Projects, Discussions).
+#
+# Desired state is the source of truth — adjust the variables below and re-run.
+
+set -euo pipefail
+
+REPO="${REPO:-robotrocketscience/aelfrice}"
+
+# ---- Desired state ---------------------------------------------------------
+DESIRED_DESCRIPTION="Bayesian memory that learns from feedback for LLM agents"
+DESIRED_HOMEPAGE="https://pypi.org/project/aelfrice/"
+DESIRED_WIKI="false"          # in-repo docs/ is the single source of truth
+DESIRED_ISSUES="true"         # primary feedback channel
+DESIRED_PROJECTS="false"      # not used; ROADMAP.md is the planning surface
+DESIRED_DISCUSSIONS="true"    # Q&A forum for users
+# Topics shown on the repo landing page. Order matters for display.
+DESIRED_TOPICS=(
+  agent-memory ai-agents anthropic bayesian bayesian-inference
+  claude-code fts5 llm mcp mcp-server memory python retrieval
+  semantic-memory sqlite
+)
+# ----------------------------------------------------------------------------
+
+APPLY=0
+[ "${1:-}" = "--apply" ] && APPLY=1
+
+bold() { printf '\033[1m%s\033[0m\n' "$1"; }
+diff_line() {
+  local label="$1" current="$2" desired="$3"
+  if [ "$current" = "$desired" ]; then
+    printf '  %-22s %s\n' "$label" "$desired"
+  else
+    printf '  %-22s %s -> %s\n' "$label" "$current" "$desired"
+  fi
+}
+
+bold "Reading current state for $REPO..."
+current=$(gh repo view "$REPO" --json description,homepageUrl,hasWikiEnabled,hasIssuesEnabled,hasProjectsEnabled,hasDiscussionsEnabled,repositoryTopics)
+
+cur_desc=$(jq -r '.description // ""'             <<<"$current")
+cur_home=$(jq -r '.homepageUrl // ""'             <<<"$current")
+cur_wiki=$(jq -r '.hasWikiEnabled'                <<<"$current")
+cur_iss=$(jq -r  '.hasIssuesEnabled'              <<<"$current")
+cur_proj=$(jq -r '.hasProjectsEnabled'            <<<"$current")
+cur_disc=$(jq -r '.hasDiscussionsEnabled'         <<<"$current")
+cur_topics=$(jq -r '.repositoryTopics | map(.name) | sort | join(",")' <<<"$current")
+desired_topics=$(printf '%s\n' "${DESIRED_TOPICS[@]}" | sort | paste -sd, -)
+
+bold "\nDesired vs current:"
+diff_line "description"  "$cur_desc"  "$DESIRED_DESCRIPTION"
+diff_line "homepage"     "$cur_home"  "$DESIRED_HOMEPAGE"
+diff_line "wiki"         "$cur_wiki"  "$DESIRED_WIKI"
+diff_line "issues"       "$cur_iss"   "$DESIRED_ISSUES"
+diff_line "projects"     "$cur_proj"  "$DESIRED_PROJECTS"
+diff_line "discussions"  "$cur_disc"  "$DESIRED_DISCUSSIONS"
+diff_line "topics"       "$cur_topics" "$desired_topics"
+
+if [ "$APPLY" -ne 1 ]; then
+  bold "\nDry-run only. Re-run with --apply to write."
+  exit 0
+fi
+
+bold "\nApplying..."
+
+# About blurb + homepage + features in one call.
+gh repo edit "$REPO" \
+  --description "$DESIRED_DESCRIPTION" \
+  --homepage "$DESIRED_HOMEPAGE" \
+  --enable-wiki="$DESIRED_WIKI" \
+  --enable-issues="$DESIRED_ISSUES" \
+  --enable-projects="$DESIRED_PROJECTS" \
+  --enable-discussions="$DESIRED_DISCUSSIONS" >/dev/null
+
+# Topics: gh repo edit --add-topic doesn't remove unlisted ones, so reset.
+# Read the live list, remove what's not in desired, add what's missing.
+live_topics_csv=$(gh repo view "$REPO" --json repositoryTopics --jq '.repositoryTopics | map(.name) | join(",")')
+to_remove=$(comm -23 <(printf '%s\n' "$live_topics_csv" | tr ',' '\n' | sort -u) <(printf '%s\n' "${DESIRED_TOPICS[@]}" | sort -u))
+to_add=$(comm -13 <(printf '%s\n' "$live_topics_csv" | tr ',' '\n' | sort -u) <(printf '%s\n' "${DESIRED_TOPICS[@]}" | sort -u))
+
+if [ -n "$to_remove" ]; then
+  while IFS= read -r t; do
+    [ -z "$t" ] && continue
+    gh repo edit "$REPO" --remove-topic "$t" >/dev/null
+  done <<<"$to_remove"
+fi
+if [ -n "$to_add" ]; then
+  while IFS= read -r t; do
+    [ -z "$t" ] && continue
+    gh repo edit "$REPO" --add-topic "$t" >/dev/null
+  done <<<"$to_add"
+fi
+
+bold "Done."
+echo ""
+echo "Things this script does NOT touch (do them in the GitHub web UI):"
+echo "  - Social preview image (Settings -> General -> Social preview)."
+echo "    Suggested source: a 1280x640 crop of an image in docs/assets/."
+echo "  - Pinned issues (repo home -> Customize your pins)."
+echo "  - Branch protection rules (deferred per CLAUDE.md until public flip)."


### PR DESCRIPTION
## Summary

Adds `scripts/sync-repo-settings.sh` — an idempotent dry-run-by-default script that captures the canonical GitHub repo settings (Wiki/Issues/Projects/Discussions toggles, About blurb, homepage, topics) as code.

```
$ bash scripts/sync-repo-settings.sh
Reading current state for robotrocketscience/aelfrice...
Desired vs current:
  description            Bayesian memory that learns from feedback for LLM agents
  homepage               https://pypi.org/project/aelfrice/
  wiki                   true -> false
  issues                 true
  projects               true -> false
  discussions            true
  topics                 agent-memory,ai-agents,...,sqlite

Dry-run only. Re-run with --apply to write.
```

## Why

Repo settings drift silently. Capturing them as a checked-in script means the desired state is reviewable, the diff is visible before applying, and re-applying after any GitHub UI mishap is one command.

## Desired changes vs current state

| Setting | Current | Desired | Reason |
| --- | --- | --- | --- |
| Wiki | enabled | **disabled** | `docs/` in-repo is the source of truth; two places to look is confusing |
| Projects | enabled | **disabled** | Not used; `ROADMAP.md` is the planning surface |
| Discussions | enabled | enabled | Q&A forum kept |
| Issues | enabled | enabled | primary feedback channel |
| Description, homepage, topics | already match | unchanged | no drift |

## Not applied yet

This PR ships the script only. After merge, run:

```bash
bash scripts/sync-repo-settings.sh --apply
```

Disabling Wiki/Projects via the GitHub API hides them but does not delete content (they can be re-enabled and content reappears). Still wanted you to drive the apply rather than have it land as a side effect of merge.

## Out of scope (deliberately not in the script)

- **Branch protection rules** — deferred per `~/.claude/CLAUDE.md` until the public-flip phase 3 step 1.
- **Social preview image** — no `gh` CLI surface; do via GitHub web UI (Settings → General → Social preview).
- **Pinned issues** — no `gh` CLI surface; pin from the repo home (Customize your pins).
- **Secrets, codeowners, webhooks, deploy keys** — out of bounds for this script's surface.

## Note on pre-push discretion override

Push triggered `BANNED_VOCAB` on the topic name `anthropic` (line 32) in the desired-topics array. That topic is already on the live repo (`gh repo view --json repositoryTopics` shows it). False positive: the string is verbatim public state. Used `ALLOW_DISCRETION_OVERRIDE=1` (logged to `~/.aelfrice/discretion-override.log`). One genuinely-new line that named an image filename containing a banned vocab token was reworded before push.

## Test plan

- [ ] CI passes (`staging-gate / pytest`, etc.; this is a script-only change with no Python/test impact).
- [ ] Manual: run `bash scripts/sync-repo-settings.sh` post-merge, confirm dry-run output matches expected diff.
- [ ] Manual: run `bash scripts/sync-repo-settings.sh --apply`, confirm Wiki tab disappears from repo nav and Projects tab too.
- [ ] Manual: re-run dry-run; should now print no `->` deltas (idempotent).