### PR TITLE
fix(ci): unescape ${version%%.*} in post-release-docs-issue.yml heredoc

### DIFF
--- a/.github/workflows/post-release-docs-issue.yml
+++ b/.github/workflows/post-release-docs-issue.yml
@@ -46,7 +46,7 @@ jobs:
 
           ## What CI already verified (do not re-check)
 
-          - \`CHANGELOG/v\${version%%.*}.md\` has a \`## [${version}]\` section with a compare-link footnote
+          - \`CHANGELOG/v${version%%.*}.md\` has a \`## [${version}]\` section with a compare-link footnote
           - \`README.md\` roadmap row for v${version} is no longer marked \`next\` or \`planned\`
 
           Close this issue when the sweep is done, or convert remaining items into a tracked PR.


### PR DESCRIPTION
## Summary

Closes #827. One-char fix in `.github/workflows/post-release-docs-issue.yml` line 49 — drops the backslash before `${version%%.*}` inside the unquoted heredoc so the major-version expansion fires instead of emitting literal `${version%%.*}` text into the generated docs-sweep nag issue.

Surrounding `${version}` on the same line and on line 50 is already unescaped; this commit removes the inconsistency.

## Verification

```
$ bash -c 'version="3.1.0"; echo "CHANGELOG/v${version%%.*}.md"'
CHANGELOG/v3.md
```

For a release tagged `v3.1.0`, the post-release-docs issue body will now correctly read `CHANGELOG/v3.md has a ## [3.1.0] section ...` rather than `CHANGELOG/v${version%%.*}.md`.

## Out of scope

The other two CodeRabbit findings on #811 (`file=CHANGELOG.md` annotation, regex-metachar dot escaping) — both noted as defensible / pedantic in #827's body.

Closes #827.
