### PR TITLE
ci(release-docs-check): assert [Unreleased] drained on release PR (#837)

### DIFF
--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -165,6 +165,27 @@ jobs:
               echo "::error file=${changelog_file}::Missing compare-link footnote '[${head_ver}]: https://github.com/...' near bottom of this file."
               fail=1
             fi
+            # #837 — [Unreleased] must be drained on release. Between the
+            # `## [Unreleased]` header and the next `## [` header, only
+            # `### ...` subsection headers and whitespace may remain.
+            # Any bullet / paragraph content = entries that should have
+            # moved into the dated section (per top-level CHANGELOG.md
+            # policy: "On release, move [Unreleased] content into a
+            # dated ## [X.Y.Z] section"). Catches SemVer breaks like a
+            # patch release shipping breaking changes left in
+            # [Unreleased] (the original failure mode that motivated this
+            # check: PR #835 review thread).
+            unreleased_body=$(awk '
+              /^## \[Unreleased\]/ { in_unreleased=1; next }
+              /^## \[/ && in_unreleased { exit }
+              in_unreleased && NF > 0 && !/^###/ { print }
+            ' "$changelog_file")
+            if [ -n "$unreleased_body" ]; then
+              echo "::error file=${changelog_file}::Release PR detected (${base_ver} -> ${head_ver}) but [Unreleased] still contains content. Migrate it into [${head_ver}] (or split the unmigrated entries into a follow-up release) before merging."
+              echo "Offending [Unreleased] content (first 20 lines):"
+              printf '%s\n' "$unreleased_body" | head -20 | sed 's/^/  /'
+              fail=1
+            fi
           fi
           if grep -qE "v?${head_ver}\s*\|\s*(next|planned)\b" README.md; then
             echo "::error file=README.md::Roadmap row for v${head_ver} still says 'next' or 'planned'. Flip status to 'shipped' before cutting the release."


### PR DESCRIPTION
Closes #837.

## Bug

`release-docs-check` in `.github/workflows/staging-gate.yml` detects release PRs and asserts the `## [X.Y.Z]` header and compare-link footnote exist in `CHANGELOG/v{major}.md`, but does **not** assert that `[Unreleased]` was actually drained into the new dated section. The project policy (top-level `CHANGELOG.md`) explicitly says CI checks both; only the dated-section half was implemented.

The gap surfaced on PR #835 (`release: v3.1.1`): the PR reached `attn:review` while five `[Unreleased]` entries — including `#814`'s breaking-change `Removed` block — sat undrained, which would have shipped under a SemVer-patch tag.

## Fix

Extend the `release-docs-check` job with one awk pass over the changelog file:

```awk
/^## \[Unreleased\]/ { in_unreleased=1; next }
/^## \[/ && in_unreleased { exit }
in_unreleased && NF > 0 && !/^###/ { print }
```

- Sets `in_unreleased=1` on the `## [Unreleased]` header
- Exits at the next `## [` header (typically `## [X.Y.Z]`)
- Inside the window: prints any line that is non-whitespace AND not a `### ...` subsection header

Output non-empty → bullet / paragraph content remains in `[Unreleased]` → fail with an actionable error message that points at the policy and previews the offending lines (head -20).

Empty `### Added` / `### Fixed` / `### Removed` scaffolding is preserved (common pattern for clarity); only entries-under-headers count as un-drained.

## Verification

Smoke-tested the awk logic locally against three cases:

| case | input | awk output | verdict |
| --- | --- | --- | --- |
| current `CHANGELOG/v3.md` | non-drained `[Unreleased]` | first 3 bullets surface | would fail a release PR (correctly) |
| synthetic drained | `## [Unreleased]\n\n### Added\n\n### Fixed\n\n## [9.9.9]...` | empty | passes (correctly) |
| synthetic non-drained | as above + `- leftover entry` under `### Added` | `- leftover entry` | fails (correctly) |

The PR itself does not bump `pyproject.toml`, so the existing `head_ver == base_ver` short-circuit at the top of the job means this PR's own `release-docs-check` run will exit 0 (correctly — this is a CI-config PR, not a release PR).

## Out of scope

- SemVer-level guard ("patch bump shipping `Removed` entries with breaking-change language"). Detecting that mechanically requires text classification; the Unreleased-drain check catches the symptom at the release boundary instead.
- Lifting the awk to a standalone `scripts/check-changelog-drained.sh` with its own unit tests. Worth doing if this check grows more clauses; currently 4 lines of awk is small enough to keep inline.
- The independent `release-drafter / publish.yml` draft-promotion gap (separate work).

## Tier

`rook` — single-workflow patch, 21 lines added, no production code touched.
