### PR TITLE
fix(auto-install): bind STAMP_PATH/OPT_OUT_PATH defaults at call time (#839)

### DIFF
--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`maybe_install_manifest` defaults resolve at call time, not function-def time** ([#839](https://github.com/robotrocketscience/aelfrice/issues/839)). `stamp_path` and `opt_out_path` were bound to the module-level `STAMP_PATH` / `OPT_OUT_PATH` constants at function-definition time, so any test that monkeypatched `auto_install.STAMP_PATH` to a temp path was silently ignored — the merge ran against the user's real `~/.aelfrice/` instead. Found while writing tests for [#834](https://github.com/robotrocketscience/aelfrice/issues/834): the bug-reproducer test originally exercised the merge end-to-end and read/wrote the actual `~/.aelfrice/installed-manifest-version`. Fix follows the existing `settings_path` pattern at the top of the same function — defaults are `None`, resolution happens inside the function via the module attribute. Module-attribute monkeypatches now propagate; existing call sites that pass paths explicitly are unaffected. New `test_module_attr_monkeypatch_propagates_to_default_args` in `tests/test_auto_install.py` locks the property in place. Out of scope: same audit for `read_stamp` / `write_stamp` / `read_opt_outs` / `add_opt_out` / `remove_opt_out` (they all default to `STAMP_PATH` / `OPT_OUT_PATH` at def time too, but they are not the load-bearing merge path that ends up writing user state).
+
 ## [3.2.0] - 2026-05-15
 
 ### Added

--- a/src/aelfrice/auto_install.py
+++ b/src/aelfrice/auto_install.py
@@ -349,8 +349,8 @@ def maybe_install_manifest(
     installed_version: str,
     scope: SettingsScope = "user",
     settings_path: Path | None = None,
-    stamp_path: Path = STAMP_PATH,
-    opt_out_path: Path = OPT_OUT_PATH,
+    stamp_path: Path | None = None,
+    opt_out_path: Path | None = None,
     force: bool = False,
     timeout: int | None = None,
 ) -> AutoInstallResult:
@@ -361,11 +361,23 @@ def maybe_install_manifest(
     install dispatch). The merge runs only when (a) `force=True` or
     (b) the on-disk stamp is older than `installed_version`.
 
+    `stamp_path` and `opt_out_path` resolve from the module-level
+    `STAMP_PATH` / `OPT_OUT_PATH` constants when omitted. The default
+    is `None` rather than the constant itself so that tests
+    monkeypatching `auto_install.STAMP_PATH` propagate (#839 — bound
+    defaults captured the original module attribute at function-def
+    time, leaking real-merge writes to `~/.aelfrice/` during contributor
+    testing). Mirrors the existing `settings_path` pattern above.
+
     Returns an AutoInstallResult describing what (if anything) was done.
     Never raises for missing files; the caller's CLI is unaffected by a
     failed auto-install (the stamp stays at its prior value and the
     next invocation retries).
     """
+    if stamp_path is None:
+        stamp_path = STAMP_PATH
+    if opt_out_path is None:
+        opt_out_path = OPT_OUT_PATH
     prev = read_stamp(stamp_path)
     if not force and prev == installed_version:
         return AutoInstallResult(

--- a/tests/test_auto_install.py
+++ b/tests/test_auto_install.py
@@ -386,11 +386,8 @@ def test_auto_install_at_cli_entry_runs_when_uv_tool(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Sanity: when the gate reports uv-tool, `maybe_install_manifest`
-    is invoked. We do not exercise the merge end-to-end here — its
-    happy path is covered by the dedicated `_do_merge` tests above.
-    Note: the real-merge path uses bound default `stamp_path` /
-    `opt_out_path` arguments which would leak to the user's actual
-    `~/.aelfrice/` if not stubbed."""
+    is invoked. Stubbed for test isolation — happy-path behaviour of
+    `_do_merge` is covered by the dedicated `_do_merge` tests above."""
     monkeypatch.delenv("AELFRICE_NO_AUTO_INSTALL", raising=False)
     monkeypatch.setattr(
         auto_install, "is_running_from_uv_tool_install", lambda: True
@@ -406,6 +403,39 @@ def test_auto_install_at_cli_entry_runs_when_uv_tool(
     monkeypatch.setattr(auto_install, "maybe_install_manifest", stub)
     auto_install.auto_install_at_cli_entry(installed_version="2.2.0")
     assert calls == ["2.2.0"]
+
+
+def test_module_attr_monkeypatch_propagates_to_default_args(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Regression for #839: when the caller omits `stamp_path` /
+    `opt_out_path`, `maybe_install_manifest` MUST resolve them via
+    `auto_install.STAMP_PATH` / `OPT_OUT_PATH` looked up at *call*
+    time, not the value bound at function-definition time. Pre-fix
+    the defaults captured the original module attributes, so module
+    attribute monkeypatches were silently ignored and the merge ran
+    against the user's real `~/.aelfrice/`. Post-fix the defaults are
+    `None` and resolved inside the function from the module globals,
+    so monkeypatches propagate (mirroring the existing `settings_path`
+    pattern at the top of the function).
+
+    Direct positive assertion: if the fix is in place, the tmp stamp
+    file gets written to the new version. If the fix breaks, the tmp
+    stamp file stays at its pre-merge value (the merge wrote to the
+    real `~/.aelfrice/installed-manifest-version` instead) and the
+    assertion fails — which also surfaces the regression early enough
+    that the test author can investigate before the broken code lands."""
+    settings, stamp, opt_out = _settings_setup(tmp_path)
+    monkeypatch.setattr(auto_install, "STAMP_PATH", stamp)
+    monkeypatch.setattr(auto_install, "OPT_OUT_PATH", opt_out)
+    write_stamp(stamp, "1.0.0")  # establish a known pre-merge value
+    # Call maybe_install_manifest directly with no stamp_path / opt_out_path
+    # — the property under test is exactly the default-arg resolution.
+    maybe_install_manifest(
+        installed_version="2.2.0",
+        settings_path=settings,
+    )
+    assert read_stamp(stamp) == "2.2.0"
 
 
 # --- failure semantics ---------------------------------------------------


### PR DESCRIPTION
Closes #839.

## Bug

`maybe_install_manifest` in `src/aelfrice/auto_install.py` bound `stamp_path` and `opt_out_path` to the module-level `STAMP_PATH` / `OPT_OUT_PATH` constants **at function-definition time**:

```python
def maybe_install_manifest(
    *,
    installed_version: str,
    scope: SettingsScope = "user",
    settings_path: Path | None = None,
    stamp_path: Path = STAMP_PATH,        # bound at def time
    opt_out_path: Path = OPT_OUT_PATH,    # bound at def time
    ...
)
```

Tests that `monkeypatch.setattr(auto_install, "STAMP_PATH", tmp_path/...)` and then call `auto_install_at_cli_entry(...)` were silently ignored — the merge ran against the user's real `~/.aelfrice/installed-manifest-version` and `~/.aelfrice/opt-out-hooks.json`. I tripped this myself when writing tests for #834 / PR #836.

## Fix

Two-line signature change + four-line body addition. Defaults are `None`; resolution happens inside the function from the module globals (mirrors the existing `settings_path` pattern at the top of the same function).

```python
def maybe_install_manifest(
    *,
    installed_version: str,
    scope: SettingsScope = "user",
    settings_path: Path | None = None,
    stamp_path: Path | None = None,
    opt_out_path: Path | None = None,
    force: bool = False,
    timeout: int | None = None,
) -> AutoInstallResult:
    ...
    if stamp_path is None:
        stamp_path = STAMP_PATH
    if opt_out_path is None:
        opt_out_path = OPT_OUT_PATH
    ...
```

Existing call sites that pass paths explicitly are unaffected. The `cli.py` call path (`auto_install_at_cli_entry → maybe_install_manifest(installed_version=...)`) takes the `None`-default branch and resolves to the real `STAMP_PATH` / `OPT_OUT_PATH`, byte-identical behaviour for production.

## Test

`test_module_attr_monkeypatch_propagates_to_default_args` — monkeypatches `auto_install.STAMP_PATH` to a tmp file, calls `maybe_install_manifest(installed_version="2.2.0", settings_path=...)` with no explicit `stamp_path`, asserts the tmp stamp file got the new version. If the bound-default regression ever comes back the assertion fails (because the real `~/.aelfrice/installed-manifest-version` would have been written instead).

The pre-existing `test_auto_install_at_cli_entry_runs_when_uv_tool` docstring was tightened — it called out the bound-default leak as the rationale for stubbing `maybe_install_manifest`. With this PR the leak is fixed; the stub now stands on test-isolation grounds alone.

Full suite: 4276 passed, 62 skipped, 75 xfailed.

## Out of scope

- Same audit for `read_stamp` / `write_stamp` / `read_opt_outs` / `add_opt_out` / `remove_opt_out`. They all default to `STAMP_PATH` / `OPT_OUT_PATH` at function-def time too. They are not the load-bearing merge path that ends up writing user state during a CLI invocation, and refactoring them risks broader API churn for negligible gain. Worth filing as a separate cleanup if a test-side reason ever surfaces.
- Changing `cli.py:6472` to pass paths through explicitly. The `None`-default contract is the cleaner shape; the call site stays exactly as it is today.

## Tier

`rook` — single function, two-line signature change + four-line body addition + one test + one CHANGELOG entry. No production behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure configuration path defaults are resolved at call time instead of at definition time, fixing test-time overrides and improving reliability of path-based behavior.

* **Tests**
  * Added a regression test that verifies runtime overriding of module-level path values is respected by default parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/841)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->