### PR TITLE
docs(contributing): document gate:* / bench-gated / attn:decisions-needed triage labels (#843)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,40 @@ Body should include:
 
 Don't include `~/.aelfrice/memory.db` from a real project — it contains your private beliefs. Reproduce on a scratch DB (`AELFRICE_DB=/tmp/scratch.db`) and share that.
 
+## Triage labels
+
+The issue tracker uses a small label vocabulary that gh-driven tooling
+(`aelf-scan.sh`, `aelf-claim.sh`; see `src/aelfrice/cli.py` and
+`src/aelfrice/gate_list.py`) reads to decide whether an open issue is
+ready to be claimed or should be hidden from the active queue. Apply
+one or more of these at file-time when an issue isn't immediately
+actionable:
+
+- **`gate:operator`** — operator decision or operator-side data must
+  arrive before the issue can move. Example: a tracker that opens once
+  enough telemetry has accumulated to baseline against (#749, #488).
+- **`gate:prereq`** — blocked on another tracked work item (sub-task,
+  upstream dependency, framework landing first).
+- **`gate:lab-corpus`** — blocked on lab-side corpus delivery; the
+  public-tree work cannot exercise its acceptance criteria until the
+  corpus is committed.
+- **`gate:ratify`** — needs ratification of a design decision before
+  implementation should begin.
+- **`gate:umbrella`** — umbrella issue that coordinates sub-issues but
+  has no implementation surface of its own; closes when its children
+  close.
+- **`bench-gated`** — implementation has shipped; the only outstanding
+  work is a benchmark run whose result determines whether to flip a
+  default, ship a tuning change, or revert (#769, #697, #491).
+- **`attn:decisions-needed`** — operator must adjudicate something
+  before the issue can move. Sets it apart from `gate:operator`: the
+  operator has all the information, just hasn't picked.
+
+Issues carrying any of these labels surface in scanner inventory
+output but are excluded from the "next actionable" list. Adding the
+right label at file-time prevents the issue from being re-evaluated
+on every fresh scan.
+
 ## What's likely to land where
 
 The v1.x roadmap is bucketed. See [LIMITATIONS](docs/user/LIMITATIONS.md#known-issues-at-v10) for each issue's target version.


### PR DESCRIPTION
## Summary

Documents the `gate:*` / `bench-gated` / `attn:decisions-needed` triage
labels in `CONTRIBUTING.md`. The label vocabulary that gh-driven tooling
relies on to filter the active queue was previously undocumented on
`github/main`, so new issues kept being filed without the appropriate
label and resurfaced in every fresh scan.

Companion to label flips already applied server-side per #843 acceptance:

- #749 → `gate:operator` (operator-side data must accumulate before
  trigger criteria are met)
- #769 → `bench-gated` + `attn:decisions-needed` (bench result blocks
  the default-flip; deferral debate active in R7-R13 thread)

Re-running the scanner after the label flips moved both items out of
the §6 NEXT list and into §8 INVENTORY (#769 is also escalated to §4
DECISION via the `attn:decisions-needed` route, which is the more
specific path).

## Why this is small

Docs-only addition to `CONTRIBUTING.md`. No code, no test, no behavior
change. The documentation matches the labels already in use in the
tracker; it does not introduce new label vocabulary.

## Test plan

- [x] `grep -n "Triage labels" CONTRIBUTING.md` shows the new section.
- [x] `git diff github/main...HEAD` is docs-only; discretion grep clean.
- [x] Re-scan after label flips: #749 in §8 under `gate:operator`; #769
      in §4 (escalated by `attn:decisions-needed`) and §8 under
      `bench-gated`. §6 reduced to claimable items only.

Closes #843


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced CONTRIBUTING.md with a new "Triage labels" section explaining how issue labels affect scanner tooling output and the importance of proper label application during issue triage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/845)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->