### PR TITLE
feat(bench): A4 runner exact-method scorer path (#844)

### DIFF
--- a/benchmarks/context_rebuilder/score.py
+++ b/benchmarks/context_rebuilder/score.py
@@ -241,6 +241,47 @@ def _fixture_assistant_texts_after_clear(
     return out
 
 
+def score_text_pairs_exact(
+    truth_texts: list[str],
+    agent_texts: list[str],
+) -> FidelityScore:
+    """Exact-method scoring of aligned (truth, agent) text pairs.
+
+    The shared core between ``score_continuation_fidelity`` (which
+    builds the pairs from a ``ReplayResult``) and harness drivers that
+    already hold the pairs without going through ``replay.run``
+    (compression A4 runner under #844).
+
+    Raises ``ValueError`` on length mismatch — a misaligned caller is
+    a programming error and silent shift would mis-score every turn.
+    """
+    n = len(truth_texts)
+    if len(agent_texts) != n:
+        raise ValueError(
+            f"agent_texts length {len(agent_texts)} does not match "
+            f"truth_texts length {n}"
+        )
+    if n == 0:
+        return FidelityScore(
+            score=1.0,
+            method="exact",
+            n_post_clear_assistant_turns=0,
+            per_turn=[],
+        )
+    per_turn: list[int] = []
+    for truth, agent in zip(truth_texts, agent_texts):
+        if _normalize_for_exact(truth) == _normalize_for_exact(agent):
+            per_turn.append(1)
+        else:
+            per_turn.append(0)
+    return FidelityScore(
+        score=sum(per_turn) / float(n),
+        method="exact",
+        n_post_clear_assistant_turns=n,
+        per_turn=per_turn,
+    )
+
+
 def score_continuation_fidelity(
     replay_result: ReplayResult,
     *,
@@ -329,6 +370,9 @@ def score_continuation_fidelity(
         agent_texts = list(truth_texts)
     else:
         if len(post_clear_answers) != n:
+            # Preserve the replay-result-flavored error message rather
+            # than delegating to score_text_pairs_exact's generic one —
+            # callers grep for "post-clear assistant turn(s)" in tests.
             raise ValueError(
                 f"post_clear_answers length {len(post_clear_answers)} "
                 f"does not match the {n} post-clear assistant turn(s) "
@@ -336,29 +380,4 @@ def score_continuation_fidelity(
             )
         agent_texts = list(post_clear_answers)
 
-    # Vacuous case: no scoreable turns. By documented convention,
-    # this is 1.0 (vacuously perfect), with `n=0` recorded so
-    # callers can detect it.
-    if n == 0:
-        return FidelityScore(
-            score=1.0,
-            method="exact",
-            n_post_clear_assistant_turns=0,
-            per_turn=[],
-        )
-
-    # `exact` per-turn comparison.
-    per_turn: list[int] = []
-    for truth, agent in zip(truth_texts, agent_texts):
-        if _normalize_for_exact(truth) == _normalize_for_exact(agent):
-            per_turn.append(1)
-        else:
-            per_turn.append(0)
-
-    aggregate = sum(per_turn) / float(n)
-    return FidelityScore(
-        score=aggregate,
-        method="exact",
-        n_post_clear_assistant_turns=n,
-        per_turn=per_turn,
-    )
+    return score_text_pairs_exact(truth_texts, agent_texts)

--- a/tests/retrieve_uplift_runner.py
+++ b/tests/retrieve_uplift_runner.py
@@ -62,6 +62,7 @@ from aelfrice.retrieval import (
     retrieve_with_tiers,
 )
 from aelfrice.store import MemoryStore
+from benchmarks.context_rebuilder.score import score_text_pairs_exact
 
 _TS = "2026-05-05T00:00:00+00:00"
 
@@ -884,18 +885,29 @@ def run_compression_a2_uplift(
 # the ON arm must be at least the OFF arm minus a 0.005 noise band
 # (mirroring the BM25F gate-band model at #154).
 #
-# Fidelity-as-token-coverage proxy. The v1.4 exact-method scorer
-# (#138) compares an agent's post-clear answer to ground truth.
-# Capturing real agent answers under both arms requires a live model;
-# instead the runner uses a deterministic proxy: for each
-# expected_post_clear_answer, score the fraction of normalized answer
-# tokens that appear in the normalized rebuild block. Better
-# compression preserves more load-bearing tokens per token of budget,
-# so a passing A4 gate says "compression does not strip the
-# information that post-clear answers depended on, within the 0.005
-# tolerance band." The proxy is documented inline so a later swap to
-# captured-answer scoring (when the lab corpus carries
-# `captured_post_clear_answers_{off,on}` arrays) is a drop-in.
+# Fidelity scoring has two paths, picked per row:
+#
+# 1. Exact-method (#138 / #844). When a row carries
+#    `captured_post_clear_answers_off` and
+#    `captured_post_clear_answers_on` arrays — the agent's actual
+#    post-clear answer recorded under each arm — score each arm by
+#    `score_text_pairs_exact(expected_post_clear_answers,
+#    captured_post_clear_answers_<arm>)`. Same exact-match semantics
+#    `score_continuation_fidelity` uses. Lengths must align across
+#    the three arrays per row; mismatch raises `ValueError`.
+#
+# 2. Token-coverage proxy (legacy default). When the captured arrays
+#    are absent on a row, fall back to: for each
+#    expected_post_clear_answer, score the fraction of normalized
+#    answer tokens that appear in the normalized rebuild block.
+#    Better compression preserves more load-bearing tokens per token
+#    of budget, so a passing A4 gate under the proxy says
+#    "compression does not strip the information post-clear answers
+#    depended on, within the 0.005 tolerance band." The R7-R18
+#    campaign on #769 found the proxy is mathematically ceiling-bound
+#    at production budget; #844 wires the exact-method path so a
+#    corpus rewrite can escape the ceiling without changing this
+#    harness's contract.
 # ---------------------------------------------------------------------
 
 
@@ -999,14 +1011,27 @@ def run_compression_a4_fidelity(
     rebuilder's ``recent_turns`` list from ``transcript_pre_clear``.
     Call ``rebuild_v14`` twice — once with
     ``AELFRICE_TYPE_AWARE_COMPRESSION=0``, once ``=1`` — at the row's
-    ``rebuilder_token_budget`` (or the rebuilder's default). Score
-    each arm by the token-coverage proxy described in the module-level
-    block comment.
+    ``rebuilder_token_budget`` (or the rebuilder's default).
+
+    Per-arm scoring follows the two-path rule in the module-level
+    block comment: when a row carries
+    ``captured_post_clear_answers_off`` / ``...on`` arrays the arm
+    routes to the #138 exact-method scorer via
+    ``score_text_pairs_exact``; otherwise the legacy token-coverage
+    proxy runs against ``rebuild_block``.
 
     Empty rows produce ``CompressionA4Fidelity(0, 0.0, 0.0)``. Rows
     whose expected_post_clear_answers list is empty contribute a
     per-arm score of 1.0 (vacuously perfect, matching the #138
     scorer's empty-case convention).
+
+    Raises
+    ------
+    ValueError
+        If a row carries a ``captured_post_clear_answers_<arm>``
+        array whose length does not match
+        ``expected_post_clear_answers``. The row id is included in
+        the message so corpus-authoring drift is locatable.
     """
     from aelfrice.context_rebuilder import (
         DEFAULT_REBUILDER_TOKEN_BUDGET,
@@ -1053,8 +1078,26 @@ def run_compression_a4_fidelity(
                 finally:
                     store.close()
 
+                arm_key = (
+                    "captured_post_clear_answers_on"
+                    if compress_on
+                    else "captured_post_clear_answers_off"
+                )
+                captured = row.get(arm_key)
                 if not expected_answers:
                     score = 1.0
+                elif captured is not None:
+                    captured_list = [str(a) for a in captured]
+                    if len(captured_list) != len(expected_answers):
+                        raise ValueError(
+                            f"row {row['id']}: {arm_key} length "
+                            f"{len(captured_list)} does not match "
+                            f"expected_post_clear_answers length "
+                            f"{len(expected_answers)}"
+                        )
+                    score = score_text_pairs_exact(
+                        expected_answers, captured_list
+                    ).score
                 else:
                     per_answer = [
                         _coverage_score(a, rebuild_block)

--- a/tests/test_retrieve_uplift_runner.py
+++ b/tests/test_retrieve_uplift_runner.py
@@ -389,6 +389,102 @@ def test_compression_a2_uplift_fact_only_row_ties() -> None:
     )
 
 
+def test_compression_a4_fidelity_empty_input() -> None:
+    """Empty corpus: zero rows, both arms zero, no exceptions."""
+    from tests.retrieve_uplift_runner import (
+        CompressionA4Fidelity,
+        run_compression_a4_fidelity,
+    )
+    r = run_compression_a4_fidelity([])
+    assert isinstance(r, CompressionA4Fidelity)
+    assert r.n_rows == 0
+    assert r.mean_fidelity_off == 0.0
+    assert r.mean_fidelity_on == 0.0
+    assert r.uplift == 0.0
+
+
+def test_compression_a4_fidelity_shape_contract() -> None:
+    """Bench-gate reads .uplift / .mean_fidelity_off / .mean_fidelity_on
+    / .n_rows — verify the names haven't drifted."""
+    from tests.retrieve_uplift_runner import CompressionA4Fidelity
+    r = CompressionA4Fidelity(
+        n_rows=3,
+        mean_fidelity_off=0.6,
+        mean_fidelity_on=0.8,
+    )
+    assert abs(r.uplift - 0.2) < 1e-9
+
+
+def _a4_proxy_row() -> dict:  # type: ignore[type-arg]
+    """Minimal A4 row without captured-answer arrays — triggers the
+    legacy token-coverage proxy path."""
+    return {
+        "id": "a4-test-proxy",
+        "transcript_pre_clear": [
+            {"role": "user", "text": "tell me about beliefs"},
+            {"role": "assistant", "text": "beliefs are stored in sqlite"},
+        ],
+        "beliefs": [
+            {"id": "b1",
+             "content": "the memory store persists beliefs across sessions",
+             "retention_class": "fact", "lock_level": "none"},
+            {"id": "b2",
+             "content": "sqlite is the on-disk backend for beliefs",
+             "retention_class": "snapshot", "lock_level": "none"},
+        ],
+        "expected_post_clear_answers": ["beliefs are stored in sqlite"],
+        "rebuilder_token_budget": 1000,
+    }
+
+
+def test_compression_a4_fidelity_proxy_fallback() -> None:
+    """Row without captured_post_clear_answers_* falls back to the
+    token-coverage proxy. Shape contract + score-in-[0,1] is the
+    contract under test; sign of uplift is corpus-dependent and not
+    asserted here."""
+    from tests.retrieve_uplift_runner import run_compression_a4_fidelity
+    r = run_compression_a4_fidelity([_a4_proxy_row()])
+    assert r.n_rows == 1
+    assert 0.0 <= r.mean_fidelity_off <= 1.0
+    assert 0.0 <= r.mean_fidelity_on <= 1.0
+
+
+def test_compression_a4_fidelity_exact_method_path() -> None:
+    """Row with captured_post_clear_answers_{off,on} arrays routes to
+    the exact-method scorer. Construct a row whose OFF captured answer
+    matches expected and ON captured answer does not — exact-method
+    must produce OFF=1.0, ON=0.0 regardless of the rebuild block
+    contents or proxy ceiling.
+
+    Falsifiable: if the runner forgets to route captured arrays and
+    silently re-runs the proxy, both arms saturate near 1.0 and the
+    asserted spread (≥ 0.9) collapses."""
+    from tests.retrieve_uplift_runner import run_compression_a4_fidelity
+    row = _a4_proxy_row()
+    row["id"] = "a4-test-exact"
+    row["captured_post_clear_answers_off"] = ["beliefs are stored in sqlite"]
+    row["captured_post_clear_answers_on"] = ["something unrelated"]
+    r = run_compression_a4_fidelity([row])
+    assert r.n_rows == 1
+    assert r.mean_fidelity_off == 1.0
+    assert r.mean_fidelity_on == 0.0
+    assert r.uplift == -1.0
+
+
+def test_compression_a4_fidelity_captured_length_mismatch_raises() -> None:
+    """Captured array shorter / longer than expected is a corpus-
+    authoring error; the runner must surface it with row id rather
+    than silently scoring against a shifted index."""
+    import pytest
+    from tests.retrieve_uplift_runner import run_compression_a4_fidelity
+    row = _a4_proxy_row()
+    row["id"] = "a4-test-mismatch"
+    row["captured_post_clear_answers_off"] = []  # zero vs expected len=1
+    row["captured_post_clear_answers_on"] = ["x"]
+    with pytest.raises(ValueError, match=r"a4-test-mismatch"):
+        run_compression_a4_fidelity([row])
+
+
 def test_p99_ns_small_samples() -> None:
     """`_p99_ns` uses the k-th largest convention deterministically.
 


### PR DESCRIPTION
## Summary

Items 2 + 3 of #844: wire `tests/retrieve_uplift_runner.py` to route
A4 fidelity scoring to the exact-method scorer
(`benchmarks/context_rebuilder/score.py:244`,
`score_continuation_fidelity`) when a row carries captured-answer
arrays under both arms, falling back to the existing token-coverage
proxy when absent.

Item 1 of #844 (corpus rewrite, lab-side, operator-time) is out of
scope for this PR — that's the v0_2 corpus authoring against the
post-rewrite shape (`transcript_pre_clear` cannot pre-answer the
continuation question; questions must be content-bound to beliefs;
`expected_post_clear_answers` are full sentences).

Closes #844 partially. Issue stays open until the lab-side v0_2
corpus lands and the bench run artifact under
`benchmarks/results/<run-id>/compression_a4_exact_method.json` is
committed. Closes downstream blocker for #769 Path 2 (per the
verdict comment on #769).

## Two atomic commits

1. **`refactor(bench): extract score_text_pairs_exact helper`** —
   pulls the per-pair exact-match logic out of
   `score_continuation_fidelity` into a standalone function so harness
   drivers that hold (truth, agent) pairs directly (without going
   through `replay.run`) can score the same way. Behavior preserved
   — the replay-flavored ValueError message is kept on
   `score_continuation_fidelity`. All 20 existing scorer tests pass.

2. **`feat(bench): A4 runner uses exact-method scorer when captured
   answers present`** — adds the conditional path in
   `run_compression_a4_fidelity`:

   ```python
   arm_key = "captured_post_clear_answers_on" if compress_on else "captured_post_clear_answers_off"
   captured = row.get(arm_key)
   if not expected_answers:
       score = 1.0
   elif captured is not None:
       if len(captured) != len(expected_answers):
           raise ValueError(f"row {row['id']}: {arm_key} length ... ")
       score = score_text_pairs_exact(expected_answers, captured).score
   else:
       # proxy fallback (existing behavior)
       per_answer = [_coverage_score(a, rebuild_block) for a in expected_answers]
       score = sum(per_answer) / len(per_answer)
   ```

## Why

R7-R18 on #769 settled that the existing token-coverage proxy is
*mathematically* ceiling-bound at production budget on tested
corpus shapes: OFF saturates at fidelity=1.0 on every row, so
`max possible Δ_row = 1.0 − fidelity_off = 0`. R18 verified this
empirically: R14 had 8/15 OFF rows at ceiling; R16 had 20/20.

The exact-method scorer (`score_continuation_fidelity(method="exact")`)
has no construction ceiling — it scores exact-match between expected
and captured answers, normalize-then-equality. The runner branch
makes it the per-arm score when captured arrays are present, so the
v0_2 corpus rewrite (Item 1 of #844, operator-time) has a wired
landing pad.

## Tests

Five new unit tests in `tests/test_retrieve_uplift_runner.py`:

- `test_compression_a4_fidelity_empty_input` — empty corpus returns
  `(0, 0.0, 0.0)`.
- `test_compression_a4_fidelity_shape_contract` — `.uplift /
  .mean_fidelity_off / .mean_fidelity_on / .n_rows` field names
  haven't drifted (bench-gate test reads them).
- `test_compression_a4_fidelity_proxy_fallback` — row without
  captured arrays still runs the proxy; shape + `[0, 1]` bounds.
- `test_compression_a4_fidelity_exact_method_path` — row with
  captured arrays where OFF matches expected and ON does not
  produces `OFF=1.0, ON=0.0, uplift=-1.0`. This falsifies the case
  where the runner forgets to route and silently re-runs the proxy
  (both arms would saturate near 1.0).
- `test_compression_a4_fidelity_captured_length_mismatch_raises` —
  mismatch surfaces with the row id in the message.

Existing tests unchanged: 20 in `test_continuation_fidelity_scorer.py`
+ 24 in `test_retrieve_uplift_runner.py` continue to pass. Wider
compression + bench-gate suite (84 tests) green; the 3 skipped are
`bench_gated` tests skipping on absent `AELFRICE_CORPUS_ROOT`,
which is the expected public-CI behavior.

## Out of scope (deferred to follow-up work)

- Corpus rewrite — Item 1 of #844, operator-time hand-authoring on
  the rewritten shape. Lab-side under
  `tests/corpus/v2_0/compression_a4_fidelity/v0_2/`.
- Bench run artifact — once the v0_2 corpus lands, the run output
  goes under `benchmarks/results/<run-id>/compression_a4_exact_method.json`.
- Per-row diagnostic (#844 acceptance: "remove `<retrieved-beliefs>`
  → answer wrong" check + arm-divergence flag). The runner currently
  emits aggregate scores only; per-row diagnostics fit into a
  separate commit once the rewritten corpus exists to validate
  them against.
- A2 axis re-scoping. Separate ceiling problem (R7 cliff at budget
  ≥ 400 small pools, R12 K-bounded extras on large pools), out of
  scope here.

## References

- #844 — issue scoping the three-piece Path 2 work.
- #769 — type-aware compression flip-default umbrella.
- #138 — original exact-method scorer issue (closed; `score.py:244`
  shipped).
- #815 — post-#798 rebuilder honours `use_type_aware_compression`;
  precondition for the cost-side coupling R16 measured.
