### PR TITLE
docs(hot-path): flip remaining R7c gating language to deferred-with-evidence (#848)

### DIFF
--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -958,8 +958,9 @@ def user_prompt_submit(
             # #816 hot-path: record belief_touches alongside the ring
             # append, sharing the ring's fire_idx so JSON ring + sidecar
             # table track the same monotonic counter. v1 is write-only;
-            # the rerank consumer is gated on R7c (DESIGN.md v1 ship
-            # list item 7). Fail-soft: never breaks the hook.
+            # the originally-modelled rerank consumer is
+            # deferred-with-evidence post-R7c (see #848). Fail-soft:
+            # never breaks the hook.
             if _next_fire >= 1 and injected_ids:
                 _record_touches(
                     session_id=session_id,
@@ -1191,8 +1192,10 @@ def _record_touches(
 
     v1 ships INJECTION-only events (DESIGN.md v1 §"Event kinds — H4
     FAIL → INJECTION-only"); only bit 0 of ``event_kinds_bitmask`` is
-    set. v1 writes but does not read this state — the rerank consumer
-    is gated on the H3 fidelity test post-R7c.
+    set. v1 writes but does not read this state — the
+    originally-modelled posterior-rerank touch-temperature multiplier
+    consumer is deferred-with-evidence post-R7c and is not scheduled
+    (see #848).
 
     Fail-soft: path-resolution, store-open, or insert failure prints
     one line to stderr and never propagates. Touch state is

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -488,8 +488,11 @@ _SCHEMA: tuple[str, ...] = (
     # the per-session reset semantic from locked federation decision
     # #661 — touch state is local to the owning project DB; foreign
     # federated beliefs come in cold every read. Rerank consumer is
-    # NOT wired in v1 (DESIGN.md v1 ship list item 7); writes
-    # accumulate against the eventual H3 fidelity test, gated on R7c.
+    # NOT wired in v1 (DESIGN.md v1 ship list item 7); the
+    # originally-modelled posterior-rerank touch-temperature multiplier
+    # is deferred-with-evidence post-R7c and is not scheduled (#848).
+    # Writes are retained as substrate for any future H3 mechanism
+    # that pre-registers different falsification criteria.
     """
     CREATE TABLE IF NOT EXISTS belief_touches (
         belief_id           TEXT    NOT NULL,


### PR DESCRIPTION
## Summary

Reconciles three sister inline references that were missed when PR #821
/ PR #852 flipped the R7c gating language to **deferred-with-evidence**
in `docs/feature-hot-path.md` and `src/aelfrice/hot_path.py`.

`src/aelfrice/hot_path.py:22-28` already reads as of #852:

> R7c (2026-05-15) found production posterior-touch correlation above
> the 0.60 crossover R7b pre-committed (rho_mixed = +0.87 on the
> aelfrice corpus, +0.72 on an independent corpus); the
> originally-modelled posterior-rerank touch-temperature multiplier is
> deferred-with-evidence and is not scheduled. … See #848 for the tracker.

These three sister sites still read as "gated on R7c (pending fidelity
test)" on `github/main`:

- `src/aelfrice/hook.py:961-963` — touch-record block, comment above
  `_record_touches` call site
- `src/aelfrice/hook.py:1195` — `_record_touches` function docstring
- `src/aelfrice/store.py:490-492` — `belief_touches` CREATE-table
  comment

This patch flips all three to match the shipped outcome with #848 as
the tracker.

## Scope

Pure comment / docstring change. No behavior change.

`#848` lists three explicit acceptance items (docs/feature-hot-path.md
amend, hot_path.py docstring amend, scripts/probe_posterior_touch_correlation.py
add). All three shipped under PR #852 and PR #853. This PR addresses
**adjacent in-tree stale references** that the explicit acceptance
items did not enumerate, but which are now factually wrong against the
shipped outcome. Operator confirmed scope expansion before this branch
opened.

## Verification

- `grep -rnE 'gated on .*R7c|gated on the H3' src/ docs/` → no hits
  after the patch
- `tests/test_hot_path_touch_state.py` → 22/22 pass (one scipy cold-
  import flake on first run; passed clean on retry)
- Discretion grep on diff against `github/main` → clean
- Commit signed (G)

## Out of scope

- Ticking the three explicit acceptance boxes on #848 itself — handled
  by a separate status comment + body edit on the issue, citing the
  shipping PRs (#852, #853) and this PR.
- Closing #848 — left **open** per design ("tracker stays open as
  living gate" — body, "Tier" section). Re-opening conditions
  (R7c-extended sweep ρ_mixed < 0.60 on a meaningful fraction of cells,
  or a different H3 mechanism pre-registered with falsification
  criteria) remain the gate for any future consumer wire-up.

## Summary by Sourcery

Documentation:
- Clarify that the posterior-rerank touch-temperature multiplier consumer is deferred-with-evidence post-R7c and not scheduled, updating hook and store comments/docstrings accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to reflect current system state and defer certain behaviors post-release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->