### PR TITLE
feat(cli): aelf label — interactive corpus-row labelling subcommand (#859)

### DIFF
--- a/docs/feature-rerank-relevance-corpus.md
+++ b/docs/feature-rerank-relevance-corpus.md
@@ -133,6 +133,17 @@ Subsequent batches may be agent-assisted (machine pre-labelling, operator
 audits the rows in bulk). v0_2 may add inter-judge κ verification once
 two labellers exist.
 
+### Tooling: `aelf label` (#859)
+
+`aelf label rerank_relevance --input <stubs.jsonl> --output <v0_1.jsonl>`
+walks the labeller through steps 3–5 interactively. Input is a stub
+JSONL with `{id, query, beliefs[]}` (steps 1–2; produced upstream).
+The CLI prompts for `gold_top_k` indices, optional `gold_ordering`,
+and `labeller_note`, validates structure, and appends a schema-shaped
+row to the output. `--resume` skips ids already in output. The
+labelling *decision* stays with the operator; only the JSONL-typing
+friction moves to tooling.
+
 ---
 
 ## Discretion / directory-of-origin checklist

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2593,6 +2593,12 @@ def _cmd_eval(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _cmd_label(args: argparse.Namespace, out: object) -> int:
+    """Thin shim: dispatch to label_cli.cmd_label (#859)."""
+    from aelfrice.label_cli import cmd_label
+    return cmd_label(args, out)
+
+
 def _effective_scope(args: argparse.Namespace) -> SettingsScope:
     """Return the explicit `--scope` if given, else auto-detect."""
     scope = getattr(args, "scope", None)
@@ -6520,6 +6526,38 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help="emit machine-readable JSON instead of text block.",
     )
     p_eval.set_defaults(func=_cmd_eval)
+
+    # Hidden: `aelf label` — interactive corpus-row labelling driver
+    # (#859, enabler for #819's operator-time hand-labelling). Consumes
+    # a stub-row JSONL (id, query, beliefs[]) and emits schema-valid
+    # output rows with gold_top_k + labeller_note. Hidden because it's
+    # an operator/dev tooling surface, not a workflow verb.
+    p_label = sub.add_parser("label", help=argparse.SUPPRESS)
+    p_label.add_argument(
+        "module",
+        help="corpus module name (e.g. rerank_relevance). Recorded on the row only.",
+    )
+    p_label.add_argument(
+        "--input", dest="input", required=True,
+        help="stub-row JSONL with id, query, beliefs[]",
+    )
+    p_label.add_argument(
+        "--output", dest="output", required=True,
+        help="destination JSONL; append-only, created if missing",
+    )
+    p_label.add_argument(
+        "--resume", dest="resume", action="store_true",
+        help="skip stub ids already present in --output",
+    )
+    p_label.add_argument(
+        "--k", dest="k", type=int, default=10,
+        help="default k for rows that omit it (default 10)",
+    )
+    p_label.add_argument(
+        "--no-ordering", dest="no_ordering", action="store_true",
+        help="never prompt for gold_ordering",
+    )
+    p_label.set_defaults(func=_cmd_label)
 
     # Hidden: invoked by the CwdChanged hook (HOME repo). Pre-loads the
     # active project's SQLite + OS page caches so the next aelf call

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -6535,7 +6535,7 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
     p_label = sub.add_parser("label", help=argparse.SUPPRESS)
     p_label.add_argument(
         "module",
-        help="corpus module name (e.g. rerank_relevance). Recorded on the row only.",
+        help="corpus module name (e.g. rerank_relevance). Used in the startup log line; not written into output rows (module grouping is by output path).",
     )
     p_label.add_argument(
         "--input", dest="input", required=True,

--- a/src/aelfrice/label_cli.py
+++ b/src/aelfrice/label_cli.py
@@ -22,7 +22,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any, Iterable, TextIO
+from typing import Any, TextIO
 
 
 def _read_stub_rows(path: Path) -> list[dict[str, Any]]:

--- a/src/aelfrice/label_cli.py
+++ b/src/aelfrice/label_cli.py
@@ -1,0 +1,276 @@
+"""Interactive corpus-row labelling CLI (#859, enabler for #819).
+
+`aelf label <module>` walks the operator through stub-row JSONL input
+(`{id, query, beliefs}`) and produces a schema-valid output JSONL with
+`gold_top_k`, `gold_ordering` (optional), `labeller_note`, `k`, plus the
+common envelope (`provenance`, `label`).
+
+The stub input is produced upstream — either by `retrieve_v2(query, k=200)`
+over a real store (lab-side / private corpora) or by hand-authoring
+synthetic queries (public tree). This module does NOT generate stubs;
+it removes the JSONL-typing friction from the labelling-decision loop.
+
+Validation here is structural (indices in pool, non-empty strings, k≥1) —
+the full corpus contract is enforced by `tests/test_corpus_schema.py`
+once rows land in `tests/corpus/v2_0/<module>/`. Keeping the heavy
+validator in `tests/` (not shipped in wheel) and the lightweight
+typo-catcher here is intentional.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Iterable, TextIO
+
+
+def _read_stub_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise SystemExit(
+                    f"{path}:{lineno}: invalid JSON ({exc.msg})"
+                ) from None
+            if not isinstance(row, dict):
+                raise SystemExit(
+                    f"{path}:{lineno}: row must be an object, got {type(row).__name__}"
+                )
+            for field in ("id", "query", "beliefs"):
+                if field not in row:
+                    raise SystemExit(
+                        f"{path}:{lineno}: stub row missing required field {field!r}"
+                    )
+            if not isinstance(row["beliefs"], list) or not row["beliefs"]:
+                raise SystemExit(
+                    f"{path}:{lineno}: 'beliefs' must be a non-empty list"
+                )
+            rows.append(row)
+    return rows
+
+
+def _existing_ids(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    ids: set[str] = set()
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            rid = row.get("id")
+            if isinstance(rid, str) and rid:
+                ids.add(rid)
+    return ids
+
+
+def _parse_indices(raw: str, pool_size: int) -> list[int]:
+    """Parse '1,3,7' → [0,2,6]. '0' alone returns []. Raises ValueError on bad input."""
+    raw = raw.strip()
+    if raw == "0":
+        return []
+    if not raw:
+        raise ValueError("empty selection")
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    if not parts:
+        raise ValueError("empty selection")
+    out: list[int] = []
+    seen: set[int] = set()
+    for p in parts:
+        try:
+            idx = int(p)
+        except ValueError:
+            raise ValueError(f"not an integer: {p!r}") from None
+        if idx < 1 or idx > pool_size:
+            raise ValueError(f"index {idx} out of range 1..{pool_size}")
+        zero_idx = idx - 1
+        if zero_idx in seen:
+            raise ValueError(f"duplicate index: {idx}")
+        seen.add(zero_idx)
+        out.append(zero_idx)
+    return out
+
+
+def _prompt(stdin: TextIO, out: TextIO, msg: str) -> str:
+    print(msg, end="", file=out, flush=True)
+    line = stdin.readline()
+    if line == "":
+        raise EOFError
+    return line.rstrip("\n")
+
+
+def _show_row(out: TextIO, idx: int, total: int, row: dict[str, Any]) -> None:
+    print(f"\n[{idx}/{total}] id={row['id']}", file=out)
+    print(f"  query: {row['query']}", file=out)
+    print(f"  beliefs ({len(row['beliefs'])}):", file=out)
+    for i, b in enumerate(row["beliefs"], 1):
+        text = b.get("text", "")
+        if len(text) > 120:
+            text = text[:117] + "..."
+        print(f"    {i:>3}. [{b.get('id', '?')}] {text}", file=out)
+
+
+def _label_one(
+    stub: dict[str, Any],
+    *,
+    stdin: TextIO,
+    out: TextIO,
+    default_k: int,
+    no_ordering: bool,
+) -> dict[str, Any] | None:
+    """Return labelled row, or None if operator chose to skip."""
+    pool = stub["beliefs"]
+    pool_size = len(pool)
+
+    while True:
+        try:
+            raw = _prompt(stdin, out, "  gold_top_k indices (comma-separated, 0=skip row): ")
+        except EOFError:
+            return None
+        try:
+            zero_idx = _parse_indices(raw, pool_size)
+        except ValueError as exc:
+            print(f"  invalid: {exc}; retry.", file=out)
+            continue
+        if not zero_idx:
+            return None
+        gold_top_k = [pool[i]["id"] for i in zero_idx]
+        break
+
+    gold_ordering: list[str] | None = None
+    if not no_ordering:
+        while True:
+            try:
+                raw = _prompt(
+                    stdin, out,
+                    "  gold_ordering indices (comma-separated, blank to omit): ",
+                )
+            except EOFError:
+                return None
+            if not raw.strip():
+                break
+            try:
+                ord_idx = _parse_indices(raw, pool_size)
+            except ValueError as exc:
+                print(f"  invalid: {exc}; retry.", file=out)
+                continue
+            ord_ids = [pool[i]["id"] for i in ord_idx]
+            missing = [bid for bid in gold_top_k if bid not in ord_ids]
+            if missing:
+                print(
+                    f"  invalid: gold_ordering must contain every gold_top_k id; "
+                    f"missing {missing}; retry.",
+                    file=out,
+                )
+                continue
+            gold_ordering = ord_ids
+            break
+
+    while True:
+        try:
+            note = _prompt(stdin, out, "  labeller_note (one line, required): ")
+        except EOFError:
+            return None
+        if note.strip():
+            break
+        print("  invalid: labeller_note must be non-empty; retry.", file=out)
+
+    k_val = stub.get("k", default_k)
+    if not isinstance(k_val, int) or isinstance(k_val, bool) or k_val < 1:
+        k_val = default_k
+
+    provenance = stub.get("provenance") or "synthetic-v0.1"
+
+    row: dict[str, Any] = {
+        "id": stub["id"],
+        "provenance": provenance,
+        "labeller_note": note.strip(),
+        "label": "graded",
+        "query": stub["query"],
+        "beliefs": pool,
+        "gold_top_k": gold_top_k,
+        "k": k_val,
+    }
+    if gold_ordering is not None:
+        row["gold_ordering"] = gold_ordering
+    return row
+
+
+def _append_jsonl(path: Path, row: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row, ensure_ascii=False, sort_keys=True))
+        fh.write("\n")
+
+
+def cmd_label(args: argparse.Namespace, out: object) -> int:
+    """Entry point for `aelf label <module>`."""
+    stream: TextIO = out if hasattr(out, "write") else sys.stdout  # type: ignore[assignment]
+    stdin: TextIO = getattr(args, "stdin", None) or sys.stdin
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    if not input_path.exists():
+        print(f"error: --input {input_path} does not exist", file=stream)
+        return 2
+
+    stubs = _read_stub_rows(input_path)
+    if not stubs:
+        print(f"error: --input {input_path} contained no rows", file=stream)
+        return 2
+
+    skip_ids = _existing_ids(output_path) if args.resume else set()
+    pending = [s for s in stubs if s["id"] not in skip_ids]
+    total = len(pending)
+    print(
+        f"labelling module={args.module} input={input_path} "
+        f"output={output_path} pending={total} "
+        f"({len(stubs) - total} already in output, skipped)",
+        file=stream,
+    )
+
+    labelled = 0
+    skipped = 0
+    try:
+        for i, stub in enumerate(pending, 1):
+            _show_row(stream, i, total, stub)
+            row = _label_one(
+                stub,
+                stdin=stdin,
+                out=stream,
+                default_k=int(args.k),
+                no_ordering=bool(args.no_ordering),
+            )
+            if row is None:
+                skipped += 1
+                print(f"  -> skipped ({i}/{total})", file=stream)
+                continue
+            _append_jsonl(output_path, row)
+            labelled += 1
+            print(f"  -> wrote ({i}/{total}, {labelled} labelled total)", file=stream)
+    except KeyboardInterrupt:
+        print(
+            f"\ninterrupted: {labelled} labelled, {skipped} skipped, "
+            f"{total - labelled - skipped} remaining. Re-run with --resume.",
+            file=stream,
+        )
+        return 130
+
+    print(
+        f"done: {labelled} labelled, {skipped} skipped, output={output_path}",
+        file=stream,
+    )
+    return 0
+
+
+__all__ = ["cmd_label"]

--- a/src/aelfrice/label_cli.py
+++ b/src/aelfrice/label_cli.py
@@ -51,6 +51,17 @@ def _read_stub_rows(path: Path) -> list[dict[str, Any]]:
                 raise SystemExit(
                     f"{path}:{lineno}: 'beliefs' must be a non-empty list"
                 )
+            for bidx, belief in enumerate(row["beliefs"], 1):
+                if not isinstance(belief, dict):
+                    raise SystemExit(
+                        f"{path}:{lineno}: beliefs[{bidx}] must be an object, "
+                        f"got {type(belief).__name__}"
+                    )
+                bid = belief.get("id")
+                if not isinstance(bid, str) or not bid:
+                    raise SystemExit(
+                        f"{path}:{lineno}: beliefs[{bidx}] missing non-empty string 'id'"
+                    )
             rows.append(row)
     return rows
 

--- a/src/aelfrice/label_cli.py
+++ b/src/aelfrice/label_cli.py
@@ -229,6 +229,11 @@ def cmd_label(args: argparse.Namespace, out: object) -> int:
     stream: TextIO = out if hasattr(out, "write") else sys.stdout  # type: ignore[assignment]
     stdin: TextIO = getattr(args, "stdin", None) or sys.stdin
 
+    default_k = int(args.k)
+    if default_k < 1:
+        print(f"error: --k must be >= 1, got {default_k}", file=stream)
+        return 2
+
     input_path = Path(args.input)
     output_path = Path(args.output)
     if not input_path.exists():
@@ -259,7 +264,7 @@ def cmd_label(args: argparse.Namespace, out: object) -> int:
                 stub,
                 stdin=stdin,
                 out=stream,
-                default_k=int(args.k),
+                default_k=default_k,
                 no_ordering=bool(args.no_ordering),
             )
             if row is None:

--- a/tests/test_label_cli.py
+++ b/tests/test_label_cli.py
@@ -1,0 +1,368 @@
+"""Tests for `aelf label` (#859) — interactive corpus-row labelling.
+
+Covers happy-path one row, --resume skips, invalid-input re-prompt,
+`0`-skip behaviour, EOF-mid-prompt clean shutdown, and Ctrl-C between
+rows. All in-process via `aelfrice.cli.main(argv=...)` with a stdin
+StringIO injected through args, so no subprocess.
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aelfrice import cli as cli_mod
+from aelfrice.label_cli import _parse_indices, cmd_label
+
+
+def _stub_rows(tmp_path: Path, *rows: dict[str, Any]) -> Path:
+    p = tmp_path / "stubs.jsonl"
+    with p.open("w", encoding="utf-8") as fh:
+        for r in rows:
+            fh.write(json.dumps(r) + "\n")
+    return p
+
+
+def _row(rid: str, *bids: str) -> dict[str, Any]:
+    return {
+        "id": rid,
+        "query": f"q for {rid}",
+        "beliefs": [{"id": b, "text": f"belief text {b}"} for b in bids],
+    }
+
+
+def _read_jsonl(p: Path) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    with p.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+class _Args:
+    def __init__(self, **kw: Any) -> None:
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+# ---------- _parse_indices unit ----------
+
+def test_parse_indices_basic() -> None:
+    assert _parse_indices("1,3,7", 10) == [0, 2, 6]
+
+
+def test_parse_indices_zero_means_skip() -> None:
+    assert _parse_indices("0", 10) == []
+
+
+def test_parse_indices_rejects_out_of_range() -> None:
+    with pytest.raises(ValueError):
+        _parse_indices("11", 10)
+
+
+def test_parse_indices_rejects_duplicates() -> None:
+    with pytest.raises(ValueError):
+        _parse_indices("2,2", 10)
+
+
+def test_parse_indices_rejects_garbage() -> None:
+    with pytest.raises(ValueError):
+        _parse_indices("foo", 10)
+
+
+def test_parse_indices_rejects_empty() -> None:
+    with pytest.raises(ValueError):
+        _parse_indices("", 10)
+
+
+# ---------- cmd_label integration ----------
+
+def test_happy_path_one_row(tmp_path: Path) -> None:
+    stubs = _stub_rows(tmp_path, _row("rr-001", "b-a", "b-b", "b-c"))
+    out_path = tmp_path / "out.jsonl"
+    stdin = io.StringIO("1,3\n\nthis is the labeller note\n")
+    out_stream = io.StringIO()
+    args = _Args(
+        module="rerank_relevance",
+        input=str(stubs),
+        output=str(out_path),
+        resume=False,
+        k=10,
+        no_ordering=False,
+        stdin=stdin,
+    )
+    rc = cmd_label(args, out_stream)
+    assert rc == 0, out_stream.getvalue()
+    rows = _read_jsonl(out_path)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["id"] == "rr-001"
+    assert row["label"] == "graded"
+    assert row["provenance"] == "synthetic-v0.1"
+    assert row["gold_top_k"] == ["b-a", "b-c"]
+    assert "gold_ordering" not in row
+    assert row["k"] == 10
+    assert row["labeller_note"] == "this is the labeller note"
+
+
+def test_gold_ordering_captured(tmp_path: Path) -> None:
+    stubs = _stub_rows(tmp_path, _row("rr-002", "b-a", "b-b", "b-c"))
+    out_path = tmp_path / "out.jsonl"
+    stdin = io.StringIO("1,3\n1,3,2\nnote\n")
+    args = _Args(
+        module="rerank_relevance",
+        input=str(stubs),
+        output=str(out_path),
+        resume=False,
+        k=10,
+        no_ordering=False,
+        stdin=stdin,
+    )
+    rc = cmd_label(args, io.StringIO())
+    assert rc == 0
+    rows = _read_jsonl(out_path)
+    assert rows[0]["gold_ordering"] == ["b-a", "b-c", "b-b"]
+
+
+def test_gold_ordering_must_contain_top_k(tmp_path: Path) -> None:
+    stubs = _stub_rows(tmp_path, _row("rr-003", "b-a", "b-b", "b-c"))
+    out_path = tmp_path / "out.jsonl"
+    # First ordering omits b-c (id 3); re-prompt; second is valid.
+    stdin = io.StringIO("1,3\n1,2\n1,3,2\nnote\n")
+    out_stream = io.StringIO()
+    args = _Args(
+        module="rerank_relevance",
+        input=str(stubs),
+        output=str(out_path),
+        resume=False,
+        k=10,
+        no_ordering=False,
+        stdin=stdin,
+    )
+    rc = cmd_label(args, out_stream)
+    assert rc == 0
+    assert "must contain every gold_top_k id" in out_stream.getvalue()
+    rows = _read_jsonl(out_path)
+    assert rows[0]["gold_ordering"] == ["b-a", "b-c", "b-b"]
+
+
+def test_zero_skips_row(tmp_path: Path) -> None:
+    stubs = _stub_rows(tmp_path, _row("rr-004", "b-a", "b-b"))
+    out_path = tmp_path / "out.jsonl"
+    stdin = io.StringIO("0\n")
+    args = _Args(
+        module="rerank_relevance",
+        input=str(stubs),
+        output=str(out_path),
+        resume=False,
+        k=10,
+        no_ordering=False,
+        stdin=stdin,
+    )
+    rc = cmd_label(args, io.StringIO())
+    assert rc == 0
+    assert not out_path.exists() or _read_jsonl(out_path) == []
+
+
+def test_invalid_top_k_reprompts(tmp_path: Path) -> None:
+    stubs = _stub_rows(tmp_path, _row("rr-005", "b-a", "b-b"))
+    out_path = tmp_path / "out.jsonl"
+    # "9" out of range → re-prompt; "1" valid; no-ordering blank; note.
+    stdin = io.StringIO("9\n1\n\nfine\n")
+    out_stream = io.StringIO()
+    args = _Args(
+        module="rerank_relevance",
+        input=str(stubs),
+        output=str(out_path),
+        resume=False,
+        k=10,
+        no_ordering=False,
+        stdin=stdin,
+    )
+    rc = cmd_label(args, out_stream)
+    assert rc == 0
+    assert "out of range" in out_stream.getvalue()
+    rows = _read_jsonl(out_path)
+    assert rows[0]["gold_top_k"] == ["b-a"]
+
+
+def test_no_ordering_flag_skips_ordering_prompt(tmp_path: Path) -> None:
+    stubs = _stub_rows(tmp_path, _row("rr-006", "b-a", "b-b"))
+    out_path = tmp_path / "out.jsonl"
+    stdin = io.StringIO("1\nfine\n")
+    args = _Args(
+        module="rerank_relevance",
+        input=str(stubs),
+        output=str(out_path),
+        resume=False,
+        k=10,
+        no_ordering=True,
+        stdin=stdin,
+    )
+    rc = cmd_label(args, io.StringIO())
+    assert rc == 0
+    rows = _read_jsonl(out_path)
+    assert "gold_ordering" not in rows[0]
+
+
+def test_resume_skips_existing_ids(tmp_path: Path) -> None:
+    stubs = _stub_rows(
+        tmp_path,
+        _row("rr-007", "b-a", "b-b"),
+        _row("rr-008", "b-a", "b-b"),
+    )
+    out_path = tmp_path / "out.jsonl"
+    # Pre-populate output with rr-007.
+    out_path.write_text(
+        json.dumps({"id": "rr-007", "label": "graded"}) + "\n",
+        encoding="utf-8",
+    )
+    stdin = io.StringIO("1\n\nnote-for-rr-008\n")
+    args = _Args(
+        module="rerank_relevance",
+        input=str(stubs),
+        output=str(out_path),
+        resume=True,
+        k=10,
+        no_ordering=False,
+        stdin=stdin,
+    )
+    rc = cmd_label(args, io.StringIO())
+    assert rc == 0
+    rows = _read_jsonl(out_path)
+    assert [r["id"] for r in rows] == ["rr-007", "rr-008"]
+
+
+def test_empty_note_reprompts(tmp_path: Path) -> None:
+    stubs = _stub_rows(tmp_path, _row("rr-009", "b-a"))
+    out_path = tmp_path / "out.jsonl"
+    stdin = io.StringIO("1\n\n   \nfinal note\n")
+    out_stream = io.StringIO()
+    args = _Args(
+        module="rerank_relevance",
+        input=str(stubs),
+        output=str(out_path),
+        resume=False,
+        k=10,
+        no_ordering=False,
+        stdin=stdin,
+    )
+    rc = cmd_label(args, out_stream)
+    assert rc == 0
+    assert "labeller_note must be non-empty" in out_stream.getvalue()
+    rows = _read_jsonl(out_path)
+    assert rows[0]["labeller_note"] == "final note"
+
+
+def test_eof_mid_prompt_returns_cleanly(tmp_path: Path) -> None:
+    stubs = _stub_rows(
+        tmp_path,
+        _row("rr-010", "b-a"),
+        _row("rr-011", "b-a"),
+    )
+    out_path = tmp_path / "out.jsonl"
+    # First row labelled successfully; second row EOF at top-k prompt.
+    stdin = io.StringIO("1\n\nnote-10\n")
+    args = _Args(
+        module="rerank_relevance",
+        input=str(stubs),
+        output=str(out_path),
+        resume=False,
+        k=10,
+        no_ordering=False,
+        stdin=stdin,
+    )
+    # EOFError on second row's top-k prompt propagates as a SKIP, not crash.
+    rc = cmd_label(args, io.StringIO())
+    assert rc == 0
+    rows = _read_jsonl(out_path)
+    assert [r["id"] for r in rows] == ["rr-010"]
+
+
+def test_keyboard_interrupt_flushes_progress(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stubs = _stub_rows(
+        tmp_path,
+        _row("rr-012", "b-a"),
+        _row("rr-013", "b-a"),
+    )
+    out_path = tmp_path / "out.jsonl"
+    # First row labelled; second row raises KeyboardInterrupt at top-k.
+    call_count = {"n": 0}
+    real_readline = io.StringIO("1\n\nnote-12\n").readline
+    pre_stdin = io.StringIO("1\n\nnote-12\n")
+
+    class IntStdin:
+        def readline(self) -> str:
+            call_count["n"] += 1
+            if call_count["n"] <= 3:
+                return pre_stdin.readline()
+            raise KeyboardInterrupt
+
+    args = _Args(
+        module="rerank_relevance",
+        input=str(stubs),
+        output=str(out_path),
+        resume=False,
+        k=10,
+        no_ordering=False,
+        stdin=IntStdin(),
+    )
+    out_stream = io.StringIO()
+    rc = cmd_label(args, out_stream)
+    assert rc == 130
+    rows = _read_jsonl(out_path)
+    assert [r["id"] for r in rows] == ["rr-012"]
+    assert "interrupted" in out_stream.getvalue()
+
+
+def test_missing_input_returns_error(tmp_path: Path) -> None:
+    out_path = tmp_path / "out.jsonl"
+    args = _Args(
+        module="rerank_relevance",
+        input=str(tmp_path / "nope.jsonl"),
+        output=str(out_path),
+        resume=False,
+        k=10,
+        no_ordering=False,
+        stdin=io.StringIO(""),
+    )
+    rc = cmd_label(args, io.StringIO())
+    assert rc == 2
+
+
+def test_malformed_stub_row_raises(tmp_path: Path) -> None:
+    p = tmp_path / "bad.jsonl"
+    p.write_text("not json\n", encoding="utf-8")
+    args = _Args(
+        module="rerank_relevance",
+        input=str(p),
+        output=str(tmp_path / "out.jsonl"),
+        resume=False,
+        k=10,
+        no_ordering=False,
+        stdin=io.StringIO(""),
+    )
+    with pytest.raises(SystemExit):
+        cmd_label(args, io.StringIO())
+
+
+def test_cli_main_dispatches_to_label(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stubs = _stub_rows(tmp_path, _row("rr-014", "b-a"))
+    out_path = tmp_path / "out.jsonl"
+    monkeypatch.setattr("sys.stdin", io.StringIO("1\n\nvia-main\n"))
+    rc = cli_mod.main(
+        [
+            "label", "rerank_relevance",
+            "--input", str(stubs),
+            "--output", str(out_path),
+        ],
+        out=io.StringIO(),
+    )
+    assert rc == 0
+    rows = _read_jsonl(out_path)
+    assert rows[0]["labeller_note"] == "via-main"

--- a/tests/test_label_cli.py
+++ b/tests/test_label_cli.py
@@ -350,6 +350,45 @@ def test_malformed_stub_row_raises(tmp_path: Path) -> None:
         cmd_label(args, io.StringIO())
 
 
+def test_malformed_belief_item_raises(tmp_path: Path) -> None:
+    p = tmp_path / "bad.jsonl"
+    # belief is a bare string instead of {id, text}
+    p.write_text(
+        json.dumps({"id": "rr-x", "query": "q", "beliefs": ["just-a-string"]}) + "\n",
+        encoding="utf-8",
+    )
+    args = _Args(
+        module="rerank_relevance",
+        input=str(p),
+        output=str(tmp_path / "out.jsonl"),
+        resume=False,
+        k=10,
+        no_ordering=False,
+        stdin=io.StringIO(""),
+    )
+    with pytest.raises(SystemExit, match="must be an object"):
+        cmd_label(args, io.StringIO())
+
+
+def test_belief_missing_id_raises(tmp_path: Path) -> None:
+    p = tmp_path / "bad.jsonl"
+    p.write_text(
+        json.dumps({"id": "rr-y", "query": "q", "beliefs": [{"text": "no id here"}]}) + "\n",
+        encoding="utf-8",
+    )
+    args = _Args(
+        module="rerank_relevance",
+        input=str(p),
+        output=str(tmp_path / "out.jsonl"),
+        resume=False,
+        k=10,
+        no_ordering=False,
+        stdin=io.StringIO(""),
+    )
+    with pytest.raises(SystemExit, match="missing non-empty string 'id'"):
+        cmd_label(args, io.StringIO())
+
+
 def test_cli_main_dispatches_to_label(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     stubs = _stub_rows(tmp_path, _row("rr-014", "b-a"))
     out_path = tmp_path / "out.jsonl"

--- a/tests/test_label_cli.py
+++ b/tests/test_label_cli.py
@@ -293,7 +293,6 @@ def test_keyboard_interrupt_flushes_progress(tmp_path: Path, monkeypatch: pytest
     out_path = tmp_path / "out.jsonl"
     # First row labelled; second row raises KeyboardInterrupt at top-k.
     call_count = {"n": 0}
-    real_readline = io.StringIO("1\n\nnote-12\n").readline
     pre_stdin = io.StringIO("1\n\nnote-12\n")
 
     class IntStdin:

--- a/tests/test_label_cli.py
+++ b/tests/test_label_cli.py
@@ -350,6 +350,25 @@ def test_malformed_stub_row_raises(tmp_path: Path) -> None:
         cmd_label(args, io.StringIO())
 
 
+def test_nonpositive_k_rejected(tmp_path: Path) -> None:
+    stubs = _stub_rows(tmp_path, _row("rr-zk", "b-a"))
+    out_path = tmp_path / "out.jsonl"
+    args = _Args(
+        module="rerank_relevance",
+        input=str(stubs),
+        output=str(out_path),
+        resume=False,
+        k=0,
+        no_ordering=False,
+        stdin=io.StringIO(""),
+    )
+    buf = io.StringIO()
+    rc = cmd_label(args, buf)
+    assert rc == 2
+    assert "--k must be >= 1" in buf.getvalue()
+    assert not out_path.exists()
+
+
 def test_malformed_belief_item_raises(tmp_path: Path) -> None:
     p = tmp_path / "bad.jsonl"
     # belief is a bare string instead of {id, text}

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -232,6 +232,11 @@ HIDDEN_SUBCOMMANDS = frozenset({
     # edge-type) live in --help and the end-of-run NOTE lines so users
     # see them either way.
     "export-obsidian",
+    # `label` is the interactive corpus-row labelling driver (#859,
+    # enabler for #819). No slash command — it's a dev/operator
+    # tooling surface for building bench-gate corpora, not a workflow
+    # verb.
+    "label",
 })
 
 


### PR DESCRIPTION
## Summary

Adds `aelf label` — an interactive corpus-row labelling CLI that
walks the operator through stub-row JSONL input (`{id, query,
beliefs[]}`) and emits schema-shaped output rows with `gold_top_k`,
optional `gold_ordering`, and `labeller_note`. Closes #859.

Enabler for #819 (`gate:operator-labeling`): removes JSONL-typing
friction from the ~5 min/row × 50 rows = ~4–8h operator-time budget
without crossing the v0_2 line on agent-pre-labelling. The labelling
*decision* stays with the operator.

## What's in here

Three atomic commits:

1. `feat(label): add label_cli module + tests` — self-contained
   `src/aelfrice/label_cli.py` with stub reader, indices parser,
   interactive prompt loop, JSONL appender, `--resume` re-entry,
   and EOF/Ctrl-C clean shutdown. Comprehensive
   `tests/test_label_cli.py` (16 tests) covers happy path, all
   re-prompt branches, skip, resume, EOF, KeyboardInterrupt, and
   main() dispatch.
2. `feat(cli): wire 'aelf label' subparser` — hidden subcommand
   (same posture as `gate` / `scan-derivation` / `clamp-ghosts`),
   added to `HIDDEN_SUBCOMMANDS` in `test_slash_commands.py`.
3. `docs(rerank): point labeling protocol at 'aelf label' tooling`
   — one-paragraph pointer under § Labeling protocol in
   `docs/feature-rerank-relevance-corpus.md`.

## Out of scope (deferred per #859 body)

- Stub-row generation (upstream concern: `retrieve_v2(query, k=200)`
  for real stores, hand-authoring for synthetic).
- TUI / curses surface — plain line-prompt only.
- Pre-labelling via sub-agent (v0_2 per #819).
- Multi-rater inter-judge κ harness.

## Verification

- `uv run pytest tests/test_label_cli.py tests/test_slash_commands.py`
  → 142 passed, 1 skipped, 7.68s.
- `aelf --help` still hides `label` (HIDDEN_SUBCOMMANDS posture
  preserved); `aelf --advanced` lists it.
- Discretion grep on `git diff github/main...HEAD`: clean.

## Refs

- Closes #859.
- Enables operator-time work on #819 (corpus rows).
- Does not modify the schema validator (`tests/test_corpus_schema.py`)
  — rows produced here are validated by that suite once they land
  in `tests/corpus/v2_0/rerank_relevance/`.

## Summary by Sourcery

Add a hidden `aelf label` subcommand that provides an interactive CLI for labelling corpus stub rows into schema-shaped JSONL output, along with tests and documentation updates.

New Features:
- Introduce the `aelf label` CLI entrypoint for interactive labelling of corpus stub rows into schema-valid output with gold_top_k, optional gold_ordering, and labeller_note.

Enhancements:
- Wire the new label subcommand into the main CLI as a hidden operator/dev tool rather than a user-facing workflow verb.

Documentation:
- Document the `aelf label` workflow in the rerank relevance corpus feature guide, including usage and behaviour details.

Tests:
- Add a dedicated test suite for the label CLI covering index parsing, interactive flows, resume behavior, error handling, and main-dispatch integration.
- Register the `label` subcommand in slash-command tests to ensure it remains hidden from the primary help surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `aelf label` command for interactive labeling of corpus data with built-in validation, resume support for continued sessions, and structured output.

* **Documentation**
  * Documented the new labeling command with usage instructions and configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->