### PR TITLE
docs(hook): drop scope='user' from _filter_by_project_context docstring (#865)

### DIFF
--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -1451,9 +1451,10 @@ def _filter_by_project_context(hits: list[Belief]) -> list[Belief]:
     * Active context = `active_project_context()`. Empty string ('') is
       the no-filter marker (`AELFRICE_PROJECT_CONTEXT` unset or blank)
       — return hits unchanged.
-    * `scope != 'project'` (federation 'global' / 'shared:*' or
-      user-promoted 'user') bypasses the filter. A federation-shared or
-      user-promoted belief is cross-context by definition.
+    * `scope != 'project'` (federation 'global' / 'shared:*')
+      bypasses the filter. A federation-shared belief is cross-context
+      by definition. (`scope='user'` does not exist; user-promotion is
+      tracked via `lock_level == LOCK_USER`, orthogonal to scope.)
     * For scope='project' rows: keep iff `project_context == '' OR
       project_context == active`. Drop otherwise.
 


### PR DESCRIPTION
Closes #865.

One-line docstring correction in `_filter_by_project_context`. The bypass parenthetical claimed `scope='user'` is a valid value; it is not. `BELIEF_SCOPE_RE` (`src/aelfrice/models.py:260`) admits only `project` / `global` / `shared:<name>`, and `validate_belief_scope` raises on anything else. User-promotion is tracked via `lock_level == LOCK_USER`, orthogonal to scope.

Runtime predicate (`b.scope != BELIEF_SCOPE_PROJECT`) is unchanged; the parenthetical is the only edit.

## Test plan

- [x] No code path changes; existing tests cover the filter contract (`test_hook_project_context_filter.py`).
- [x] Discretion grep clean.
- [x] Commit signed.

## Summary by Sourcery

Documentation:
- Correct the _filter_by_project_context docstring to remove the invalid 'user' scope and explain that user promotion is handled via lock level, not scope.