### PR TITLE
feat(cadence): P3 enum constants + TOML/env resolvers + predicates (#876 PR 1/5)

### DIFF
--- a/src/aelfrice/cadence.py
+++ b/src/aelfrice/cadence.py
@@ -63,6 +63,9 @@ CTX_THRESHOLD_KEY: Final[str] = "ctx_threshold"
 CTX_BYTE_WINDOW_KEY: Final[str] = "ctx_byte_window"
 SHADOW_MODE_ENABLED_KEY: Final[str] = "shadow_mode_enabled"
 CADENCE_SHADOW_DIRNAME: Final[str] = "cadence_shadow"
+P3_VELOCITY_THRESHOLD_KEY: Final[str] = "p3_velocity_threshold"
+P3_SUBSTANTIVE_WINDOW_KEY: Final[str] = "p3_substantive_window"
+P3_SUBSTANTIVE_THRESHOLD_KEY: Final[str] = "p3_substantive_threshold"
 
 ENV_CADENCE_ENABLED: Final[str] = "AELFRICE_CADENCE_ENABLED"
 ENV_CADENCE_POLICY: Final[str] = "AELFRICE_CADENCE_POLICY"
@@ -70,15 +73,28 @@ ENV_CADENCE_K: Final[str] = "AELFRICE_CADENCE_K"
 ENV_CADENCE_CTX_THRESHOLD: Final[str] = "AELFRICE_CADENCE_CTX_THRESHOLD"
 ENV_CADENCE_CTX_BYTE_WINDOW: Final[str] = "AELFRICE_CADENCE_CTX_BYTE_WINDOW"
 ENV_CADENCE_SHADOW_MODE_ENABLED: Final[str] = "AELFRICE_CADENCE_SHADOW_MODE_ENABLED"
+ENV_CADENCE_P3_VELOCITY_THRESHOLD: Final[str] = (
+    "AELFRICE_CADENCE_P3_VELOCITY_THRESHOLD"
+)
+ENV_CADENCE_P3_SUBSTANTIVE_WINDOW: Final[str] = (
+    "AELFRICE_CADENCE_P3_SUBSTANTIVE_WINDOW"
+)
+ENV_CADENCE_P3_SUBSTANTIVE_THRESHOLD: Final[str] = (
+    "AELFRICE_CADENCE_P3_SUBSTANTIVE_THRESHOLD"
+)
 
 POLICY_OFF: Final[str] = "off"
 POLICY_P1_EVERY_K_TURNS: Final[str] = "p1_every_k_turns"
 POLICY_P2_CTX_THRESHOLD: Final[str] = "p2_ctx_threshold"
+POLICY_P3_VELOCITY: Final[str] = "p3_velocity"
+POLICY_P3_SUBSTANTIVE: Final[str] = "p3_substantive"
 
 _VALID_POLICIES: Final[frozenset[str]] = frozenset({
     POLICY_OFF,
     POLICY_P1_EVERY_K_TURNS,
     POLICY_P2_CTX_THRESHOLD,
+    POLICY_P3_VELOCITY,
+    POLICY_P3_SUBSTANTIVE,
 })
 
 DEFAULT_ENABLED: Final[bool] = False
@@ -107,6 +123,26 @@ non-selected policy decisions on identical workload. Ships default-
 OFF: most operators do not need the comparison data, and the per-
 tick predicate evaluations + JSONL write are a non-trivial extra
 I/O cost."""
+
+DEFAULT_P3_VELOCITY_THRESHOLD: Final[int] = 3000
+"""Bytes-per-turn floor that triggers p3_velocity (#876 axis 1).
+3000 bytes/turn ≈ ~1000 tokens/turn (English) or ~750 tokens/turn
+(code-heavy) — the rough boundary between exploratory back-and-forth
+and dense working session. Placeholder per the issue body; the
+operator tunes via `[cadence] p3_velocity_threshold = N` after
+empirical use, same posture as K=15 for P1."""
+
+DEFAULT_P3_SUBSTANTIVE_WINDOW: Final[int] = 10
+"""Number of last-N turns over which p3_substantive counts
+substantive turns. 10-turn window mirrors P1's K=15 starting point
+at a tighter horizon — the substantive predicate is denser than
+P1's pure counter so a smaller window is more sensitive."""
+
+DEFAULT_P3_SUBSTANTIVE_THRESHOLD: Final[float] = 0.6
+"""Substantive-ratio floor (0.0-1.0). p3_substantive fires when
+substantive_count / p3_substantive_window >= threshold. 0.6 ≈
+6-of-10 turns must be substantive (non-boundary). Same placeholder
+posture as p3_velocity_threshold."""
 
 _ENV_TRUTHY: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
 _ENV_FALSY: Final[frozenset[str]] = frozenset({"0", "false", "no", "off"})
@@ -196,6 +232,9 @@ class CadenceConfig:
     ctx_threshold: float = DEFAULT_CTX_THRESHOLD
     ctx_byte_window: int = DEFAULT_CTX_BYTE_WINDOW
     shadow_mode_enabled: bool = DEFAULT_SHADOW_MODE_ENABLED
+    p3_velocity_threshold: int = DEFAULT_P3_VELOCITY_THRESHOLD
+    p3_substantive_window: int = DEFAULT_P3_SUBSTANTIVE_WINDOW
+    p3_substantive_threshold: float = DEFAULT_P3_SUBSTANTIVE_THRESHOLD
 
 
 def _env_bool(name: str) -> bool | None:
@@ -315,6 +354,18 @@ def load_cadence_config(start: Path | None = None) -> CadenceConfig:
                 section, SHADOW_MODE_ENABLED_KEY,
                 DEFAULT_SHADOW_MODE_ENABLED, candidate, serr,
             )
+            p3_velocity_threshold = _read_positive_int(
+                section, P3_VELOCITY_THRESHOLD_KEY,
+                DEFAULT_P3_VELOCITY_THRESHOLD, candidate, serr,
+            )
+            p3_substantive_window = _read_positive_int(
+                section, P3_SUBSTANTIVE_WINDOW_KEY,
+                DEFAULT_P3_SUBSTANTIVE_WINDOW, candidate, serr,
+            )
+            p3_substantive_threshold = _read_unit_float(
+                section, P3_SUBSTANTIVE_THRESHOLD_KEY,
+                DEFAULT_P3_SUBSTANTIVE_THRESHOLD, candidate, serr,
+            )
             return CadenceConfig(
                 enabled=enabled,
                 policy=policy,
@@ -322,6 +373,9 @@ def load_cadence_config(start: Path | None = None) -> CadenceConfig:
                 ctx_threshold=ctx_threshold,
                 ctx_byte_window=ctx_byte_window,
                 shadow_mode_enabled=shadow_mode_enabled,
+                p3_velocity_threshold=p3_velocity_threshold,
+                p3_substantive_window=p3_substantive_window,
+                p3_substantive_threshold=p3_substantive_threshold,
             )
         if current.parent == current:
             break
@@ -573,6 +627,85 @@ def resolve_cadence_shadow_mode_enabled(
         return explicit
     return load_cadence_config(start).shadow_mode_enabled
 
+
+def resolve_cadence_p3_velocity_threshold(
+    explicit: int | None = None,
+    *,
+    start: Path | None = None,
+) -> int:
+    """Resolve the P3 velocity threshold (bytes/turn) — #876 axis 1.
+
+    Precedence (first decisive wins):
+      1. ``AELFRICE_CADENCE_P3_VELOCITY_THRESHOLD`` env var (positive int).
+      2. Explicit ``explicit`` kwarg from the caller.
+      3. ``[cadence] p3_velocity_threshold`` in ``.aelfrice.toml``.
+      4. Default: ``3000`` bytes/turn.
+    """
+    env = _env_positive_int(ENV_CADENCE_P3_VELOCITY_THRESHOLD)
+    if env is not None:
+        return env
+    if explicit is not None and explicit > 0:
+        return explicit
+    return load_cadence_config(start).p3_velocity_threshold
+
+
+def resolve_cadence_p3_substantive_window(
+    explicit: int | None = None,
+    *,
+    start: Path | None = None,
+) -> int:
+    """Resolve the P3 substantive-turn window (turns) — #876 axis 1.
+
+    Precedence (first decisive wins):
+      1. ``AELFRICE_CADENCE_P3_SUBSTANTIVE_WINDOW`` env var (positive int).
+      2. Explicit ``explicit`` kwarg from the caller.
+      3. ``[cadence] p3_substantive_window`` in ``.aelfrice.toml``.
+      4. Default: ``10`` turns.
+    """
+    env = _env_positive_int(ENV_CADENCE_P3_SUBSTANTIVE_WINDOW)
+    if env is not None:
+        return env
+    if explicit is not None and explicit > 0:
+        return explicit
+    return load_cadence_config(start).p3_substantive_window
+
+
+def resolve_cadence_p3_substantive_threshold(
+    explicit: float | None = None,
+    *,
+    start: Path | None = None,
+) -> float:
+    """Resolve the P3 substantive-ratio threshold (0.0-1.0) — #876 axis 1.
+
+    Precedence (first decisive wins):
+      1. ``AELFRICE_CADENCE_P3_SUBSTANTIVE_THRESHOLD`` env var (unit float).
+      2. Explicit ``explicit`` kwarg from the caller.
+      3. ``[cadence] p3_substantive_threshold`` in ``.aelfrice.toml``.
+      4. Default: ``0.6``.
+    """
+    env = _env_unit_float(ENV_CADENCE_P3_SUBSTANTIVE_THRESHOLD)
+    if env is not None:
+        return env
+    if explicit is not None and 0.0 <= explicit <= 1.0:
+        return explicit
+    return load_cadence_config(start).p3_substantive_threshold
+
+
+def is_substantive_turn(prompt: str | None) -> bool:
+    """Classify a user prompt as substantive (vs phase-boundary).
+
+    Pure function, inverse of :func:`is_phase_boundary_signal`. A turn
+    is "substantive" when the user prompt does NOT match the closed
+    phase-boundary allowlist used by P2. Empty or None prompts return
+    False (no signal to count).
+
+    Used by P3 substantive-window counting (#876 axis 1, option C).
+    The classifier reuses P2's allowlist by inversion so the same
+    closed-set maintenance burden covers both predicates.
+    """
+    if not prompt or not prompt.strip():
+        return False
+    return not is_phase_boundary_signal(prompt)
 
 
 def would_fire_p1(
@@ -873,6 +1006,167 @@ def should_fire_p2(
     fired, _ = would_fire_p2(
         transcript_path=transcript_path,
         last_user_prompt=last_user_prompt,
+        config=config,
+    )
+    return fired
+
+
+def would_fire_p3_velocity(
+    *,
+    bytes_at_last_fire: int,
+    transcript_bytes: int,
+    turns_since_last_fire: int,
+    config: CadenceConfig,
+) -> tuple[bool, str]:
+    """P3-velocity policy-agnostic predicate — bytes/turn density.
+
+    Pure function over the four inputs. Determinism (#605): same
+    inputs reproduce same ``(bool, reason)``. No wall-clock, no I/O.
+
+    Density = ``(transcript_bytes - bytes_at_last_fire) / turns_since_last_fire``.
+    Fires when density exceeds ``config.p3_velocity_threshold``.
+
+    Unlike :func:`should_fire_p3_velocity`, this does NOT check
+    ``config.policy``. Answers "would p3_velocity fire here" — the
+    predicate the shadow-evaluation log (#875) writes for non-selected
+    policy decisions.
+
+    Conditions for True:
+      * ``config.enabled`` is True.
+      * ``turns_since_last_fire`` is positive (no division-by-zero).
+      * ``transcript_bytes >= bytes_at_last_fire`` (monotonic transcript).
+      * ``config.p3_velocity_threshold`` is positive.
+      * computed density >= threshold.
+    """
+    if not config.enabled:
+        return (False, "cadence disabled")
+    if turns_since_last_fire <= 0:
+        return (False, f"turns_since_last_fire={turns_since_last_fire} not positive")
+    if transcript_bytes < bytes_at_last_fire:
+        return (
+            False,
+            f"transcript_bytes={transcript_bytes} below "
+            f"bytes_at_last_fire={bytes_at_last_fire}",
+        )
+    threshold = config.p3_velocity_threshold
+    if threshold <= 0:
+        return (False, f"p3_velocity_threshold={threshold} not positive")
+    delta_bytes = transcript_bytes - bytes_at_last_fire
+    velocity = delta_bytes / turns_since_last_fire
+    if velocity < threshold:
+        return (
+            False,
+            f"velocity={velocity:.1f} bytes/turn below threshold={threshold}",
+        )
+    return (
+        True,
+        f"velocity={velocity:.1f} bytes/turn >= threshold={threshold}",
+    )
+
+
+def should_fire_p3_velocity(
+    *,
+    bytes_at_last_fire: int,
+    transcript_bytes: int,
+    turns_since_last_fire: int,
+    config: CadenceConfig,
+) -> bool:
+    """P3-velocity firing predicate — policy-gated.
+
+    Pure function. Determinism (#605): same inputs → same decision.
+
+    Conditions:
+      * ``config.policy`` is ``p3_velocity``.
+      * :func:`would_fire_p3_velocity` returns True.
+
+    Never raises. For shadow-evaluation, see :func:`would_fire_p3_velocity`.
+    """
+    if config.policy != POLICY_P3_VELOCITY:
+        return False
+    fired, _ = would_fire_p3_velocity(
+        bytes_at_last_fire=bytes_at_last_fire,
+        transcript_bytes=transcript_bytes,
+        turns_since_last_fire=turns_since_last_fire,
+        config=config,
+    )
+    return fired
+
+
+def would_fire_p3_substantive(
+    *,
+    substantive_count: int,
+    config: CadenceConfig,
+) -> tuple[bool, str]:
+    """P3-substantive policy-agnostic predicate — substantive-ratio.
+
+    Pure function over ``(substantive_count, config)``. Determinism
+    (#605): same inputs reproduce same decision.
+
+    Predicate: ``substantive_count / config.p3_substantive_window >=
+    config.p3_substantive_threshold``. The caller computes
+    ``substantive_count`` by classifying the last N prompts via
+    :func:`is_substantive_turn` and summing the True count; the
+    session-ring maintenance of that rolling window is separate
+    (lands in the next PR of the #876 stack).
+
+    Conditions for True:
+      * ``config.enabled`` is True.
+      * ``config.p3_substantive_window`` is positive.
+      * ``0.0 <= substantive_count <= window`` (sanity).
+      * ratio >= ``config.p3_substantive_threshold``.
+
+    Threshold is treated as a unit-float; values outside [0, 1] are
+    rejected as misconfigured (return False with a reason).
+    """
+    if not config.enabled:
+        return (False, "cadence disabled")
+    window = config.p3_substantive_window
+    if window <= 0:
+        return (False, f"p3_substantive_window={window} not positive")
+    if substantive_count < 0 or substantive_count > window:
+        return (
+            False,
+            f"substantive_count={substantive_count} outside [0, {window}]",
+        )
+    threshold = config.p3_substantive_threshold
+    if not 0.0 <= threshold <= 1.0:
+        return (
+            False,
+            f"p3_substantive_threshold={threshold} outside [0.0, 1.0]",
+        )
+    ratio = substantive_count / window
+    if ratio < threshold:
+        return (
+            False,
+            f"ratio={ratio:.3f} below threshold={threshold:.3f}",
+        )
+    return (
+        True,
+        f"ratio={ratio:.3f} >= threshold={threshold:.3f} "
+        f"({substantive_count}/{window})",
+    )
+
+
+def should_fire_p3_substantive(
+    *,
+    substantive_count: int,
+    config: CadenceConfig,
+) -> bool:
+    """P3-substantive firing predicate — policy-gated.
+
+    Pure function. Determinism (#605): same inputs → same decision.
+
+    Conditions:
+      * ``config.policy`` is ``p3_substantive``.
+      * :func:`would_fire_p3_substantive` returns True.
+
+    Never raises. For shadow-evaluation, see
+    :func:`would_fire_p3_substantive`.
+    """
+    if config.policy != POLICY_P3_SUBSTANTIVE:
+        return False
+    fired, _ = would_fire_p3_substantive(
+        substantive_count=substantive_count,
         config=config,
     )
     return fired

--- a/tests/test_cadence_p3.py
+++ b/tests/test_cadence_p3.py
@@ -1,0 +1,308 @@
+"""Unit tests for #876 P3 cadence policies — enum + resolvers + predicates.
+
+This PR is surface-only — no Stop/UPS dispatcher wiring, no session-ring
+state additions. Those land in subsequent PRs of the #876 stack.
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from aelfrice.cadence import (
+    CONFIG_FILENAME,
+    CadenceConfig,
+    DEFAULT_P3_SUBSTANTIVE_THRESHOLD,
+    DEFAULT_P3_SUBSTANTIVE_WINDOW,
+    DEFAULT_P3_VELOCITY_THRESHOLD,
+    ENV_CADENCE_P3_SUBSTANTIVE_THRESHOLD,
+    ENV_CADENCE_P3_SUBSTANTIVE_WINDOW,
+    ENV_CADENCE_P3_VELOCITY_THRESHOLD,
+    POLICY_OFF,
+    POLICY_P1_EVERY_K_TURNS,
+    POLICY_P3_SUBSTANTIVE,
+    POLICY_P3_VELOCITY,
+    _VALID_POLICIES,
+    is_substantive_turn,
+    resolve_cadence_p3_substantive_threshold,
+    resolve_cadence_p3_substantive_window,
+    resolve_cadence_p3_velocity_threshold,
+    should_fire_p3_substantive,
+    should_fire_p3_velocity,
+    would_fire_p3_substantive,
+    would_fire_p3_velocity,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        ENV_CADENCE_P3_VELOCITY_THRESHOLD,
+        ENV_CADENCE_P3_SUBSTANTIVE_WINDOW,
+        ENV_CADENCE_P3_SUBSTANTIVE_THRESHOLD,
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _write_toml(repo: Path, body: str) -> None:
+    (repo / CONFIG_FILENAME).write_text(textwrap.dedent(body))
+
+
+# --- Policy enum -----------------------------------------------------
+
+
+def test_p3_policies_in_valid_set() -> None:
+    assert POLICY_P3_VELOCITY in _VALID_POLICIES
+    assert POLICY_P3_SUBSTANTIVE in _VALID_POLICIES
+    assert POLICY_P3_VELOCITY == "p3_velocity"
+    assert POLICY_P3_SUBSTANTIVE == "p3_substantive"
+
+
+# --- Resolvers --------------------------------------------------------
+
+
+def test_velocity_threshold_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert resolve_cadence_p3_velocity_threshold() == DEFAULT_P3_VELOCITY_THRESHOLD
+
+
+def test_velocity_threshold_env_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_toml(tmp_path, "[cadence]\np3_velocity_threshold = 5000\n")
+    monkeypatch.setenv(ENV_CADENCE_P3_VELOCITY_THRESHOLD, "7000")
+    assert resolve_cadence_p3_velocity_threshold(explicit=4000) == 7000
+
+
+def test_velocity_threshold_kwarg_over_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_toml(tmp_path, "[cadence]\np3_velocity_threshold = 5000\n")
+    assert resolve_cadence_p3_velocity_threshold(explicit=4000) == 4000
+
+
+def test_velocity_threshold_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_toml(tmp_path, "[cadence]\np3_velocity_threshold = 5000\n")
+    assert resolve_cadence_p3_velocity_threshold() == 5000
+
+
+def test_substantive_window_resolver_chain(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert resolve_cadence_p3_substantive_window() == DEFAULT_P3_SUBSTANTIVE_WINDOW
+    _write_toml(tmp_path, "[cadence]\np3_substantive_window = 20\n")
+    assert resolve_cadence_p3_substantive_window() == 20
+    assert resolve_cadence_p3_substantive_window(explicit=15) == 15
+    monkeypatch.setenv(ENV_CADENCE_P3_SUBSTANTIVE_WINDOW, "25")
+    assert resolve_cadence_p3_substantive_window(explicit=15) == 25
+
+
+def test_substantive_threshold_resolver_chain(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert resolve_cadence_p3_substantive_threshold() == DEFAULT_P3_SUBSTANTIVE_THRESHOLD
+    _write_toml(tmp_path, "[cadence]\np3_substantive_threshold = 0.75\n")
+    assert resolve_cadence_p3_substantive_threshold() == pytest.approx(0.75)
+    assert resolve_cadence_p3_substantive_threshold(explicit=0.5) == 0.5
+    monkeypatch.setenv(ENV_CADENCE_P3_SUBSTANTIVE_THRESHOLD, "0.9")
+    assert resolve_cadence_p3_substantive_threshold(explicit=0.5) == pytest.approx(0.9)
+
+
+def test_substantive_threshold_out_of_range_kwarg_falls_through(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_toml(tmp_path, "[cadence]\np3_substantive_threshold = 0.5\n")
+    assert resolve_cadence_p3_substantive_threshold(explicit=1.5) == pytest.approx(0.5)
+    assert resolve_cadence_p3_substantive_threshold(explicit=-0.1) == pytest.approx(0.5)
+
+
+# --- is_substantive_turn ---------------------------------------------
+
+
+def test_is_substantive_turn_inverts_phase_boundary() -> None:
+    assert is_substantive_turn("how does the rebuilder budget work")
+    assert not is_substantive_turn("ok thanks")
+    assert not is_substantive_turn("next task")
+    assert not is_substantive_turn("ship it")
+
+
+def test_is_substantive_turn_empty_or_none() -> None:
+    assert not is_substantive_turn(None)
+    assert not is_substantive_turn("")
+    assert not is_substantive_turn("   ")
+
+
+# --- would_fire_p3_velocity ------------------------------------------
+
+
+def _cfg_velocity(enabled: bool = True, threshold: int = 3000) -> CadenceConfig:
+    return CadenceConfig(
+        enabled=enabled, policy=POLICY_P3_VELOCITY, p3_velocity_threshold=threshold,
+    )
+
+
+def test_velocity_disabled_no_fire() -> None:
+    cfg = _cfg_velocity(enabled=False)
+    fired, reason = would_fire_p3_velocity(
+        bytes_at_last_fire=0, transcript_bytes=10_000,
+        turns_since_last_fire=2, config=cfg,
+    )
+    assert not fired
+    assert "disabled" in reason
+
+
+def test_velocity_fires_when_density_at_threshold() -> None:
+    cfg = _cfg_velocity(threshold=3000)
+    fired, reason = would_fire_p3_velocity(
+        bytes_at_last_fire=10_000, transcript_bytes=16_000,
+        turns_since_last_fire=2, config=cfg,
+    )
+    assert fired, reason
+    assert "bytes/turn" in reason
+
+
+def test_velocity_no_fire_below_threshold() -> None:
+    cfg = _cfg_velocity(threshold=3000)
+    fired, reason = would_fire_p3_velocity(
+        bytes_at_last_fire=10_000, transcript_bytes=15_000,
+        turns_since_last_fire=2, config=cfg,
+    )
+    assert not fired
+    assert "below threshold" in reason
+
+
+def test_velocity_zero_turns_no_fire() -> None:
+    cfg = _cfg_velocity()
+    fired, reason = would_fire_p3_velocity(
+        bytes_at_last_fire=0, transcript_bytes=10_000,
+        turns_since_last_fire=0, config=cfg,
+    )
+    assert not fired
+    assert "turns_since_last_fire=0" in reason
+
+
+def test_velocity_transcript_shrunk_no_fire() -> None:
+    cfg = _cfg_velocity()
+    fired, reason = would_fire_p3_velocity(
+        bytes_at_last_fire=10_000, transcript_bytes=5_000,
+        turns_since_last_fire=1, config=cfg,
+    )
+    assert not fired
+    assert "below" in reason
+
+
+def test_velocity_threshold_must_be_positive() -> None:
+    cfg = _cfg_velocity(threshold=0)
+    fired, reason = would_fire_p3_velocity(
+        bytes_at_last_fire=0, transcript_bytes=10_000,
+        turns_since_last_fire=1, config=cfg,
+    )
+    assert not fired
+    assert "p3_velocity_threshold=0" in reason
+
+
+def test_should_fire_velocity_policy_gated() -> None:
+    cfg_velocity = _cfg_velocity(threshold=1000)
+    assert should_fire_p3_velocity(
+        bytes_at_last_fire=0, transcript_bytes=2000,
+        turns_since_last_fire=1, config=cfg_velocity,
+    )
+    cfg_other = CadenceConfig(
+        enabled=True, policy=POLICY_P1_EVERY_K_TURNS, p3_velocity_threshold=1000,
+    )
+    assert not should_fire_p3_velocity(
+        bytes_at_last_fire=0, transcript_bytes=2000,
+        turns_since_last_fire=1, config=cfg_other,
+    )
+
+
+# --- would_fire_p3_substantive ---------------------------------------
+
+
+def _cfg_substantive(
+    enabled: bool = True, window: int = 10, threshold: float = 0.6,
+) -> CadenceConfig:
+    return CadenceConfig(
+        enabled=enabled, policy=POLICY_P3_SUBSTANTIVE,
+        p3_substantive_window=window, p3_substantive_threshold=threshold,
+    )
+
+
+def test_substantive_disabled_no_fire() -> None:
+    fired, reason = would_fire_p3_substantive(
+        substantive_count=8, config=_cfg_substantive(enabled=False),
+    )
+    assert not fired
+    assert "disabled" in reason
+
+
+def test_substantive_fires_at_threshold() -> None:
+    cfg = _cfg_substantive(window=10, threshold=0.6)
+    fired, reason = would_fire_p3_substantive(substantive_count=6, config=cfg)
+    assert fired, reason
+    assert "6/10" in reason
+
+
+def test_substantive_below_threshold_no_fire() -> None:
+    cfg = _cfg_substantive(window=10, threshold=0.6)
+    fired, reason = would_fire_p3_substantive(substantive_count=5, config=cfg)
+    assert not fired
+    assert "below" in reason
+
+
+def test_substantive_count_exceeds_window_no_fire() -> None:
+    cfg = _cfg_substantive(window=10)
+    fired, reason = would_fire_p3_substantive(substantive_count=15, config=cfg)
+    assert not fired
+    assert "outside" in reason
+
+
+def test_substantive_negative_count_no_fire() -> None:
+    cfg = _cfg_substantive(window=10)
+    fired, reason = would_fire_p3_substantive(substantive_count=-1, config=cfg)
+    assert not fired
+    assert "outside" in reason
+
+
+def test_substantive_threshold_out_of_range_no_fire() -> None:
+    cfg = _cfg_substantive(threshold=1.5)
+    fired, reason = would_fire_p3_substantive(substantive_count=6, config=cfg)
+    assert not fired
+    assert "outside" in reason
+
+
+def test_substantive_zero_window_no_fire() -> None:
+    cfg = _cfg_substantive(window=0)
+    fired, reason = would_fire_p3_substantive(substantive_count=0, config=cfg)
+    assert not fired
+    assert "p3_substantive_window=0" in reason
+
+
+def test_should_fire_substantive_policy_gated() -> None:
+    cfg_sub = _cfg_substantive(window=10, threshold=0.6)
+    assert should_fire_p3_substantive(substantive_count=7, config=cfg_sub)
+    cfg_other = CadenceConfig(
+        enabled=True, policy=POLICY_OFF,
+        p3_substantive_window=10, p3_substantive_threshold=0.6,
+    )
+    assert not should_fire_p3_substantive(substantive_count=7, config=cfg_other)
+
+
+# --- Determinism -----------------------------------------------------
+
+
+def test_velocity_predicate_is_pure() -> None:
+    cfg = _cfg_velocity(threshold=2000)
+    inputs = dict(
+        bytes_at_last_fire=5000, transcript_bytes=15_000,
+        turns_since_last_fire=4, config=cfg,
+    )
+    r1 = would_fire_p3_velocity(**inputs)
+    r2 = would_fire_p3_velocity(**inputs)
+    assert r1 == r2
+
+
+def test_substantive_predicate_is_pure() -> None:
+    cfg = _cfg_substantive(window=8, threshold=0.5)
+    r1 = would_fire_p3_substantive(substantive_count=4, config=cfg)
+    r2 = would_fire_p3_substantive(substantive_count=4, config=cfg)
+    assert r1 == r2


### PR DESCRIPTION
Part of #876. **PR 1 of 5 in the stack — surface only.**

## Summary

Lands the policy enum entries, TOML/env resolvers, and pure firing predicates for the two P3 sub-policies operator-ratified on #876 (2026-05-21):

- `p3_velocity` — bytes/turn density predicate
- `p3_substantive` — substantive-turn-ratio predicate (inverse of P2's phase-boundary allowlist)

No dispatcher wiring, no session-ring state, no shadow-mode integration in this PR. Those land separately. Existing P1 / P2 paths are byte-identical before/after this commit; default behavior unchanged.

## Mechanism

### Enum

```python
POLICY_P3_VELOCITY: Final[str] = "p3_velocity"
POLICY_P3_SUBSTANTIVE: Final[str] = "p3_substantive"
```

Added to `_VALID_POLICIES` frozenset.

### TOML / env / dataclass

| field | default | env var |
|---|---|---|
| `p3_velocity_threshold` | 3000 bytes/turn | `AELFRICE_CADENCE_P3_VELOCITY_THRESHOLD` |
| `p3_substantive_window` | 10 turns | `AELFRICE_CADENCE_P3_SUBSTANTIVE_WINDOW` |
| `p3_substantive_threshold` | 0.6 (ratio) | `AELFRICE_CADENCE_P3_SUBSTANTIVE_THRESHOLD` |

All defaults are operator-tunable placeholders per #876's framing. `load_cadence_config` reads them via the existing `_read_positive_int` / `_read_unit_float` helpers.

### Predicates

- `would_fire_p3_velocity(*, bytes_at_last_fire, transcript_bytes, turns_since_last_fire, config) -> (bool, reason)` — pure function, returns `(True, reason)` when `(transcript_bytes - bytes_at_last_fire) / turns_since_last_fire >= config.p3_velocity_threshold`.
- `would_fire_p3_substantive(*, substantive_count, config) -> (bool, reason)` — pure function, returns `(True, reason)` when `substantive_count / config.p3_substantive_window >= config.p3_substantive_threshold`.
- `should_fire_p3_velocity` / `should_fire_p3_substantive` — policy-gated wrappers in the existing `should_fire_*` pattern.
- `is_substantive_turn(prompt)` — inverse of `is_phase_boundary_signal`; reuses P2's allowlist by inversion so the same closed-set maintenance burden covers both predicates. Whitespace-only and None inputs classify as non-substantive.

## Determinism (#605)

Every new predicate is a pure function over its inputs. No wall-clock, no I/O, no random sampling. Same inputs reproduce the same `(bool, reason)` tuple. Resolver-precedence is env > kwarg > TOML > default, matching every other knob.

## Tests

27 new unit tests in `tests/test_cadence_p3.py`:

- enum membership + string values
- resolver precedence chain for all three new fields, including out-of-range kwarg fall-through
- `is_substantive_turn` boundary cases (None, empty, whitespace-only, phase-boundary, substantive)
- `would_fire_p3_velocity` cross-product (disabled, density-at-threshold = fire, below-threshold = no-fire, zero turns, shrunk transcript, non-positive threshold)
- `would_fire_p3_substantive` cross-product (disabled, at-threshold = fire, below = no-fire, count-out-of-bounds, negative count, threshold-out-of-range, zero window)
- policy-gating (right policy fires; wrong policy no-op even with predicate-yes inputs)
- determinism: same inputs → same output

178 total cadence tests pass (151 prior + 27 new). Full suite pass also pending in this PR's CI.

## Discretion (`ab96e9d3501b1c14`)

Diff against `main` is clean against the pre-push deny-list. No `~/.claude/`-derived content; no model role tokens; no coordination markers.

## What lands next in the #876 stack

2. `feat(session_ring): bytes_at_last_fire + recent_classifications state slots` — backward-compat migration for the new state.
3. `feat(cadence): wire p3_velocity into Stop + UPS dispatchers`
4. `feat(cadence): wire p3_substantive into Stop + UPS + #881 shadow-mode companions`
5. `docs(cadence): CHANGELOG + CONFIG.md + design doc updates`

Each stacks on the previous; merge-train serializes.
