### PR TITLE
feat(session_ring): P3 state slots — bytes_at_last_fire + classifications (#876 PR 2/5)

### DIFF
--- a/src/aelfrice/session_ring.py
+++ b/src/aelfrice/session_ring.py
@@ -435,11 +435,13 @@ def update_bytes_at_last_fire(
             try:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
             except OSError:
+                # Best-effort cleanup; lock_fd may already be closed.
                 pass
     finally:
         try:
             os.close(lock_fd)
         except OSError:
+            # Best-effort cleanup; fd may already be closed.
             pass
 
 
@@ -509,11 +511,13 @@ def push_classification(
             try:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
             except OSError:
+                # Best-effort cleanup; lock_fd may already be closed.
                 pass
     finally:
         try:
             os.close(lock_fd)
         except OSError:
+            # Best-effort cleanup; fd may already be closed.
             pass
 
 

--- a/src/aelfrice/session_ring.py
+++ b/src/aelfrice/session_ring.py
@@ -155,6 +155,12 @@ def _normalize_for_session(
     If the stored ``session_id`` differs (or is missing), start a fresh
     ring. Otherwise normalize the existing ring shape (clamp ring_max,
     coerce missing fields, trim oversize).
+
+    P3 cadence state (#876): ``bytes_at_last_fire`` and
+    ``classifications`` are optional slots used by p3_velocity and
+    p3_substantive respectively. Pre-#876 ring files lack these fields;
+    we default them on read so backward-compat is automatic — no
+    schema migration needed.
     """
     stored_sid = data.get("session_id") if isinstance(data, dict) else None
     if not isinstance(stored_sid, str) or stored_sid != session_id:
@@ -164,6 +170,8 @@ def _normalize_for_session(
             "ring_max": ring_max,
             "next_fire_idx": 0,
             "evicted_total": 0,
+            "bytes_at_last_fire": 0,
+            "classifications": [],
         }
     ring = data.get("ring")
     if not isinstance(ring, list):
@@ -174,12 +182,28 @@ def _normalize_for_session(
     evicted = data.get("evicted_total")
     if not isinstance(evicted, int) or evicted < 0:
         evicted = 0
+    # P3-velocity state — non-negative int; default 0 for pre-#876 rings
+    bytes_at_last_fire = data.get("bytes_at_last_fire")
+    if (
+        not isinstance(bytes_at_last_fire, int)
+        or isinstance(bytes_at_last_fire, bool)
+        or bytes_at_last_fire < 0
+    ):
+        bytes_at_last_fire = 0
+    # P3-substantive state — list of bools; default [] for pre-#876 rings
+    classifications_raw = data.get("classifications")
+    if isinstance(classifications_raw, list):
+        classifications = [bool(c) for c in classifications_raw if isinstance(c, bool)]
+    else:
+        classifications = []
     return {
         "session_id": session_id,
         "ring": [e for e in ring if isinstance(e, dict) and isinstance(e.get("id"), str)],
         "ring_max": ring_max,
         "next_fire_idx": next_idx,
         "evicted_total": evicted,
+        "bytes_at_last_fire": bytes_at_last_fire,
+        "classifications": classifications,
     }
 
 
@@ -336,6 +360,8 @@ def append_ids(
             data["next_fire_idx"] = next_fire_idx
             data["evicted_total"] = int(data.get("evicted_total", 0)) + evicted
             data["ring_max"] = ring_max
+            # P3 state slots (#876) are preserved through normalize_for_session
+            # at read time and round-trip unchanged through this append path.
             _atomic_write(ring_path, json.dumps(data))
             return next_fire_idx
         except Exception as exc:
@@ -346,6 +372,143 @@ def append_ids(
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
             except OSError:
                 # Best-effort cleanup; lock_fd may already be closed.
+                pass
+    finally:
+        try:
+            os.close(lock_fd)
+        except OSError:
+            pass
+
+
+def update_bytes_at_last_fire(
+    session_id: str | None,
+    transcript_bytes: int,
+    *,
+    stderr: IO[str] | None = None,
+) -> bool:
+    """Update the p3_velocity ``bytes_at_last_fire`` slot (#876).
+
+    Called by the cadence dispatcher after a p3_velocity fire — the
+    predicate's next evaluation reads this value to compute density
+    ``(transcript_bytes - bytes_at_last_fire) / turns_since_last_fire``.
+
+    Takes the same advisory lock as :func:`append_ids` so concurrent
+    UPS + Stop hooks can't clobber each other's writes. Fail-soft:
+    returns False on any error (file missing, lock failure, malformed
+    JSON, etc.); the caller continues without raising.
+
+    Returns True on successful write, False on no-op or error.
+    """
+    if not session_id:
+        return False
+    if not isinstance(transcript_bytes, int) or transcript_bytes < 0:
+        return False
+    ring_path = _session_ring_path()
+    if ring_path is None:
+        return False
+    ring_max = _resolve_ring_max()
+    lock_path = _session_ring_lock_path(ring_path)
+    try:
+        lock_fd = _open_lock(lock_path)
+    except OSError as exc:
+        _warn(stderr, f"session_ring: lock open failed (non-fatal): {exc}")
+        return False
+    try:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        except OSError as exc:
+            _warn(stderr, f"session_ring: flock failed (non-fatal): {exc}")
+            return False
+        try:
+            data = _read_ring_unlocked(ring_path)
+            data = _normalize_for_session(data, session_id, ring_max)
+            data["bytes_at_last_fire"] = transcript_bytes
+            _atomic_write(ring_path, json.dumps(data))
+            return True
+        except Exception as exc:
+            _warn(
+                stderr,
+                f"session_ring: update_bytes_at_last_fire failed (non-fatal): {exc}",
+            )
+            return False
+        finally:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+    finally:
+        try:
+            os.close(lock_fd)
+        except OSError:
+            pass
+
+
+def push_classification(
+    session_id: str | None,
+    is_substantive: bool,
+    *,
+    window_cap: int,
+    stderr: IO[str] | None = None,
+) -> bool:
+    """Push one classification onto the p3_substantive rolling window (#876).
+
+    Called by the cadence dispatcher per turn (Stop or UPS) regardless
+    of whether cadence fires — the window is a running classification
+    history independent of fire decisions. The predicate sums True
+    values across the window to compute the substantive-ratio.
+
+    ``window_cap`` caps the list length: oldest classifications are
+    evicted FIFO once the cap is exceeded. The cap typically equals
+    ``CadenceConfig.p3_substantive_window`` but the ring module stays
+    cadence-config-agnostic — caller passes the cap explicitly.
+
+    Takes the same advisory lock as :func:`append_ids`. Fail-soft:
+    returns False on any error.
+
+    Returns True on successful write, False on no-op or error.
+    """
+    if not session_id:
+        return False
+    if not isinstance(is_substantive, bool):
+        return False
+    if not isinstance(window_cap, int) or window_cap < 1:
+        return False
+    ring_path = _session_ring_path()
+    if ring_path is None:
+        return False
+    ring_max = _resolve_ring_max()
+    lock_path = _session_ring_lock_path(ring_path)
+    try:
+        lock_fd = _open_lock(lock_path)
+    except OSError as exc:
+        _warn(stderr, f"session_ring: lock open failed (non-fatal): {exc}")
+        return False
+    try:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        except OSError as exc:
+            _warn(stderr, f"session_ring: flock failed (non-fatal): {exc}")
+            return False
+        try:
+            data = _read_ring_unlocked(ring_path)
+            data = _normalize_for_session(data, session_id, ring_max)
+            classifications: list[bool] = data["classifications"]
+            classifications.append(is_substantive)
+            if len(classifications) > window_cap:
+                classifications[:] = classifications[-window_cap:]
+            data["classifications"] = classifications
+            _atomic_write(ring_path, json.dumps(data))
+            return True
+        except Exception as exc:
+            _warn(
+                stderr,
+                f"session_ring: push_classification failed (non-fatal): {exc}",
+            )
+            return False
+        finally:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except OSError:
                 pass
     finally:
         try:

--- a/tests/test_session_ring_p3.py
+++ b/tests/test_session_ring_p3.py
@@ -1,0 +1,224 @@
+"""Unit tests for #876 P3 session-ring state slots — PR 2 of 5."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aelfrice.session_ring import (
+    _normalize_for_session,
+    append_ids,
+    push_classification,
+    read_ring_file,
+    read_ring_state,
+    update_bytes_at_last_fire,
+)
+
+
+@pytest.fixture
+def db_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    aelf_dir = tmp_path / ".git" / "aelfrice"
+    aelf_dir.mkdir(parents=True)
+    db = aelf_dir / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    from aelfrice.store import MemoryStore
+    MemoryStore(str(db)).close()
+    return aelf_dir
+
+
+# --- backward compat: pre-#876 ring files ---------------------------
+
+
+def test_normalize_defaults_missing_p3_fields() -> None:
+    old = {
+        "session_id": "s1", "ring": [], "ring_max": 200,
+        "next_fire_idx": 5, "evicted_total": 0,
+    }
+    n = _normalize_for_session(old, "s1", 200)
+    assert n["bytes_at_last_fire"] == 0
+    assert n["classifications"] == []
+
+
+def test_normalize_preserves_p3_fields_when_present() -> None:
+    new = {
+        "session_id": "s1", "ring": [], "ring_max": 200,
+        "next_fire_idx": 5, "evicted_total": 0,
+        "bytes_at_last_fire": 12_345,
+        "classifications": [True, False, True],
+    }
+    n = _normalize_for_session(new, "s1", 200)
+    assert n["bytes_at_last_fire"] == 12_345
+    assert n["classifications"] == [True, False, True]
+
+
+def test_normalize_rejects_negative_bytes_at_last_fire() -> None:
+    bad = {
+        "session_id": "s1", "ring": [], "ring_max": 200,
+        "next_fire_idx": 0, "evicted_total": 0,
+        "bytes_at_last_fire": -10, "classifications": [],
+    }
+    n = _normalize_for_session(bad, "s1", 200)
+    assert n["bytes_at_last_fire"] == 0
+
+
+def test_normalize_rejects_bool_bytes_at_last_fire() -> None:
+    bad = {
+        "session_id": "s1", "ring": [], "ring_max": 200,
+        "next_fire_idx": 0, "evicted_total": 0,
+        "bytes_at_last_fire": True, "classifications": [],
+    }
+    n = _normalize_for_session(bad, "s1", 200)
+    assert n["bytes_at_last_fire"] == 0
+
+
+def test_normalize_filters_non_bool_classifications() -> None:
+    bad = {
+        "session_id": "s1", "ring": [], "ring_max": 200,
+        "next_fire_idx": 0, "evicted_total": 0,
+        "bytes_at_last_fire": 0,
+        "classifications": [True, "false", None, False, 1],
+    }
+    n = _normalize_for_session(bad, "s1", 200)
+    assert n["classifications"] == [True, False]
+
+
+def test_normalize_classifications_not_a_list_resets_to_empty() -> None:
+    bad = {
+        "session_id": "s1", "ring": [], "ring_max": 200,
+        "next_fire_idx": 0, "evicted_total": 0,
+        "bytes_at_last_fire": 0, "classifications": "not a list",
+    }
+    n = _normalize_for_session(bad, "s1", 200)
+    assert n["classifications"] == []
+
+
+# --- update_bytes_at_last_fire ---------------------------------------
+
+
+def test_update_bytes_at_last_fire_persists(db_root: Path) -> None:
+    append_ids("s1", ["b1", "b2"])
+    assert update_bytes_at_last_fire("s1", 50_000)
+    state = read_ring_state("s1")
+    assert state["bytes_at_last_fire"] == 50_000
+
+
+def test_update_bytes_at_last_fire_overwrites(db_root: Path) -> None:
+    append_ids("s1", ["b1"])
+    update_bytes_at_last_fire("s1", 10_000)
+    update_bytes_at_last_fire("s1", 25_000)
+    state = read_ring_state("s1")
+    assert state["bytes_at_last_fire"] == 25_000
+
+
+def test_update_bytes_at_last_fire_creates_ring_for_new_session(db_root: Path) -> None:
+    assert update_bytes_at_last_fire("s-fresh", 12_345)
+    state = read_ring_state("s-fresh")
+    assert state["session_id"] == "s-fresh"
+    assert state["bytes_at_last_fire"] == 12_345
+
+
+def test_update_bytes_at_last_fire_rejects_empty_session_id(db_root: Path) -> None:
+    assert not update_bytes_at_last_fire("", 100)
+    assert not update_bytes_at_last_fire(None, 100)
+
+
+def test_update_bytes_at_last_fire_rejects_negative(db_root: Path) -> None:
+    append_ids("s1", ["b1"])
+    assert not update_bytes_at_last_fire("s1", -1)
+    state = read_ring_state("s1")
+    assert state["bytes_at_last_fire"] == 0
+
+
+def test_update_bytes_at_last_fire_preserves_ring(db_root: Path) -> None:
+    append_ids("s1", ["b1", "b2", "b3"])
+    state_before = read_ring_state("s1")
+    update_bytes_at_last_fire("s1", 8000)
+    state_after = read_ring_state("s1")
+    assert [e["id"] for e in state_after["ring"]] == ["b1", "b2", "b3"]
+    assert state_after["next_fire_idx"] == state_before["next_fire_idx"]
+
+
+# --- push_classification ---------------------------------------------
+
+
+def test_push_classification_appends(db_root: Path) -> None:
+    append_ids("s1", ["b1"])
+    push_classification("s1", True, window_cap=10)
+    push_classification("s1", False, window_cap=10)
+    push_classification("s1", True, window_cap=10)
+    state = read_ring_state("s1")
+    assert state["classifications"] == [True, False, True]
+
+
+def test_push_classification_fifo_evicts_at_cap(db_root: Path) -> None:
+    append_ids("s1", ["b1"])
+    for i in range(12):
+        push_classification("s1", i % 2 == 0, window_cap=5)
+    state = read_ring_state("s1")
+    assert len(state["classifications"]) == 5
+    # i = 7..11: F,T,F,T,F (7=odd=F, 8=even=T, 9=F, 10=T, 11=F)
+    assert state["classifications"] == [False, True, False, True, False]
+
+
+def test_push_classification_rejects_empty_session_id(db_root: Path) -> None:
+    assert not push_classification("", True, window_cap=10)
+    assert not push_classification(None, True, window_cap=10)
+
+
+def test_push_classification_rejects_non_positive_cap(db_root: Path) -> None:
+    append_ids("s1", ["b1"])
+    assert not push_classification("s1", True, window_cap=0)
+    assert not push_classification("s1", True, window_cap=-5)
+
+
+def test_push_classification_creates_ring_for_new_session(db_root: Path) -> None:
+    assert push_classification("s-fresh", True, window_cap=10)
+    state = read_ring_state("s-fresh")
+    assert state["classifications"] == [True]
+
+
+def test_push_classification_preserves_ring(db_root: Path) -> None:
+    append_ids("s1", ["b1", "b2"])
+    state_before = read_ring_state("s1")
+    push_classification("s1", True, window_cap=10)
+    state_after = read_ring_state("s1")
+    assert [e["id"] for e in state_after["ring"]] == ["b1", "b2"]
+    assert state_after["next_fire_idx"] == state_before["next_fire_idx"]
+
+
+# --- Cross-session safety --------------------------------------------
+
+
+def test_new_session_resets_p3_state(db_root: Path) -> None:
+    push_classification("s1", True, window_cap=10)
+    update_bytes_at_last_fire("s1", 99_999)
+    append_ids("s2", ["b1"])
+    state = read_ring_state("s2")
+    assert state["classifications"] == []
+    assert state["bytes_at_last_fire"] == 0
+
+
+# --- append_ids round-trips P3 state ---------------------------------
+
+
+def test_append_ids_preserves_p3_state(db_root: Path) -> None:
+    append_ids("s1", ["b1"])
+    update_bytes_at_last_fire("s1", 5000)
+    push_classification("s1", True, window_cap=10)
+    push_classification("s1", False, window_cap=10)
+    append_ids("s1", ["b2", "b3"])
+    state = read_ring_state("s1")
+    assert state["bytes_at_last_fire"] == 5000
+    assert state["classifications"] == [True, False]
+
+
+# --- read_ring_file (no session match) returns full shape ------------
+
+
+def test_read_ring_file_includes_p3_fields(db_root: Path) -> None:
+    push_classification("s1", True, window_cap=10)
+    update_bytes_at_last_fire("s1", 42_000)
+    raw = read_ring_file()
+    assert raw["session_id"] == "s1"
+    assert raw["bytes_at_last_fire"] == 42_000
+    assert raw["classifications"] == [True]


### PR DESCRIPTION
Part of #876. **PR 2 of 5 in the stack — session-ring state surface.**

Builds on PR 1 (#884, merged at 647953bb). The P3 predicates from PR 1 consume the state slots this PR adds. The Stop + UPS dispatcher wiring + #881 shadow-mode companions land in PRs 3 + 4.

## Summary

Two new persistent state slots in the per-session ring JSON file:

| field | type | semantics |
|---|---|---|
| `bytes_at_last_fire` | int | transcript byte count at last `p3_velocity` fire; predicate reads to compute `delta_bytes / turns_since_last_fire` |
| `classifications` | `list[bool]` | rolling window of last-N substantive-vs-boundary classifications; predicate sums True values for the substantive-ratio |

Plus two new writer helpers exposed in `aelfrice.session_ring`:

```python
update_bytes_at_last_fire(session_id, transcript_bytes) -> bool
push_classification(session_id, is_substantive, *, window_cap) -> bool
```

Both fail-soft (returns False on any error; no raise out of the hook).

## Backward compat

Pre-#876 ring files lack these fields. `_normalize_for_session` defaults them to `0 / []` on read. No schema-version bump, no migration step, no behavioral change for existing flows. The `append_ids` path round-trips both new fields unchanged via the existing read-then-write cycle.

Validated by `test_normalize_defaults_missing_p3_fields` and `test_append_ids_preserves_p3_state`.

## Concurrency

Both writer helpers acquire the same `fcntl.LOCK_EX` advisory lock as `append_ids`. Concurrent UPS + Stop hooks updating the ring simultaneously serialize cleanly.

## Determinism (#605)

`bytes_at_last_fire` and `classifications` are pure functions of inputs already observable from the hook (transcript size, prompt text). No wall-clock, no random sampling, no new I/O surfaces beyond the ring file the module already owned.

## Tests

21 new tests in `tests/test_session_ring_p3.py`:

- **normalize backward-compat** — missing fields default; preserved when present; non-int / bool / non-list values rejected and reset.
- **`update_bytes_at_last_fire`** — persist, overwrite, create-on-empty, reject empty session_id, reject negative, preserve ring.
- **`push_classification`** — append, FIFO-evict at cap, reject empty session_id, reject non-positive cap, create-on-empty, preserve ring.
- **cross-session** — new session_id resets P3 state alongside the dedup ring.
- **`append_ids` interaction** — both directions; the dedup-path append and the P3-state writes don't clobber each other.
- **`read_ring_file`** — doctor-surface read includes the new fields.

38 session_ring tests pass (17 prior + 21 new). Full suite pass also pending in this PR's CI.

## Discretion

Diff against `main` is clean against the pre-push deny-list. No `~/.claude/`-derived content, no model role tokens, no coordination markers.

## What lands next in the #876 stack

3. `feat(cadence): wire p3_velocity into Stop + UPS dispatchers` — uses `update_bytes_at_last_fire` post-fire.
4. `feat(cadence): wire p3_substantive into Stop + UPS + #881 shadow-mode companions` — uses `push_classification` per turn.
5. `docs(cadence): CHANGELOG + CONFIG.md + design doc updates`
