### PR TITLE
feat(cadence): wire p3_velocity into Stop + UPS dispatchers (#876 PR 3/5)

### DIFF
--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -2741,6 +2741,7 @@ def _maybe_fire_cadence_checkpoint(
         POLICY_OFF,
         POLICY_P1_EVERY_K_TURNS,
         POLICY_P2_CTX_THRESHOLD,
+        POLICY_P3_VELOCITY,
         append_shadow_row,
         estimate_transcript_bytes,
         format_shadow_row,
@@ -2749,15 +2750,20 @@ def _maybe_fire_cadence_checkpoint(
         resolve_cadence_ctx_threshold,
         resolve_cadence_enabled,
         resolve_cadence_k,
+        resolve_cadence_p3_velocity_threshold,
         resolve_cadence_policy,
         resolve_cadence_shadow_mode_enabled,
         shadow_log_path,
         should_fire,
         should_fire_p2,
+        should_fire_p3_velocity,
         would_fire_p1,
         would_fire_p2,
     )
-    from aelfrice.session_ring import read_ring_state  # noqa: PLC0415
+    from aelfrice.session_ring import (  # noqa: PLC0415
+        read_ring_state,
+        update_p3_velocity_state,
+    )
 
     cwd_obj = payload.get(_CWD_KEY)
     cwd = (
@@ -2845,6 +2851,66 @@ def _maybe_fire_cadence_checkpoint(
         )
         return
 
+    if policy == POLICY_P3_VELOCITY:
+        threshold = resolve_cadence_p3_velocity_threshold(start=cwd)
+        cfg = CadenceConfig(
+            enabled=True, policy=policy, p3_velocity_threshold=threshold,
+        )
+        state = read_ring_state(session_id)
+        if not isinstance(state, dict):
+            return
+        raw_next: Any = state.get("next_fire_idx")
+        raw_bytes_last: Any = state.get("bytes_at_last_fire", 0)
+        raw_fire_last: Any = state.get("fire_idx_at_last_fire", 0)
+        if (
+            isinstance(raw_next, bool) or not isinstance(raw_next, int)
+            or isinstance(raw_bytes_last, bool) or not isinstance(raw_bytes_last, int)
+            or isinstance(raw_fire_last, bool) or not isinstance(raw_fire_last, int)
+        ):
+            return
+        next_fire_idx = raw_next
+        bytes_at_last_fire = raw_bytes_last
+        fire_idx_at_last_fire = raw_fire_last
+        turns_since_last_fire = next_fire_idx - fire_idx_at_last_fire
+        if turns_since_last_fire <= 0:
+            return
+        tp_obj = payload.get(_TRANSCRIPT_PATH_KEY)
+        tp: Path | None
+        if isinstance(tp_obj, str) and tp_obj:
+            tp = Path(tp_obj)
+        elif isinstance(tp_obj, os.PathLike):
+            tp = Path(tp_obj)
+        else:
+            tp = None
+        transcript_bytes = estimate_transcript_bytes(tp)
+        if not should_fire_p3_velocity(
+            bytes_at_last_fire=bytes_at_last_fire,
+            transcript_bytes=transcript_bytes,
+            turns_since_last_fire=turns_since_last_fire,
+            config=cfg,
+        ):
+            return
+        body = _run_cadence_rebuild(payload, cwd)
+        if body is None:
+            return
+        _write_cadence_resume_cache(body, session_id, policy, serr)
+        # Update both p3-velocity state slots atomically so the next fire's
+        # density calculation sees consistent (bytes, fire_idx) inputs.
+        update_p3_velocity_state(
+            session_id,
+            transcript_bytes=transcript_bytes,
+            fire_idx=next_fire_idx,
+            stderr=serr,
+        )
+        density = (transcript_bytes - bytes_at_last_fire) / turns_since_last_fire
+        print(
+            f"aelfrice: cadence checkpoint fired @ fire_idx={next_fire_idx} "
+            f"(policy={policy}, velocity={density:.1f} bytes/turn, "
+            f"threshold={threshold})",
+            file=serr,
+        )
+        return
+
     # Unknown policy / POLICY_OFF — no-op.
 
 
@@ -2881,16 +2947,23 @@ def _maybe_run_ups_cadence_checkpoint(
         CadenceConfig,
         POLICY_P1_EVERY_K_TURNS,
         POLICY_P2_CTX_THRESHOLD,
+        POLICY_P3_VELOCITY,
+        estimate_transcript_bytes,
         read_last_user_prompt,
         resolve_cadence_ctx_byte_window,
         resolve_cadence_ctx_threshold,
         resolve_cadence_enabled,
         resolve_cadence_k,
+        resolve_cadence_p3_velocity_threshold,
         resolve_cadence_policy,
         should_fire,
         should_fire_p2,
+        should_fire_p3_velocity,
     )
-    from aelfrice.session_ring import read_ring_state  # noqa: PLC0415
+    from aelfrice.session_ring import (  # noqa: PLC0415
+        read_ring_state,
+        update_p3_velocity_state,
+    )
 
     cwd_obj = payload.get(_CWD_KEY)
     cwd = (
@@ -2950,6 +3023,67 @@ def _maybe_run_ups_cadence_checkpoint(
             return None
         print(
             f"aelfrice: ups cadence checkpoint fired (policy={policy})",
+            file=serr,
+        )
+        return body
+
+    if policy == POLICY_P3_VELOCITY:
+        threshold = resolve_cadence_p3_velocity_threshold(start=cwd)
+        cfg = CadenceConfig(
+            enabled=True, policy=policy, p3_velocity_threshold=threshold,
+        )
+        state = read_ring_state(session_id)
+        if not isinstance(state, dict):
+            return None
+        raw_next: Any = state.get("next_fire_idx")
+        raw_bytes_last: Any = state.get("bytes_at_last_fire", 0)
+        raw_fire_last: Any = state.get("fire_idx_at_last_fire", 0)
+        if (
+            isinstance(raw_next, bool) or not isinstance(raw_next, int)
+            or isinstance(raw_bytes_last, bool) or not isinstance(raw_bytes_last, int)
+            or isinstance(raw_fire_last, bool) or not isinstance(raw_fire_last, int)
+        ):
+            return None
+        next_fire_idx = raw_next
+        bytes_at_last_fire = raw_bytes_last
+        fire_idx_at_last_fire = raw_fire_last
+        turns_since_last_fire = next_fire_idx - fire_idx_at_last_fire
+        if turns_since_last_fire <= 0:
+            return None
+        tp_obj = payload.get(_TRANSCRIPT_PATH_KEY)
+        tp: Path | None
+        if isinstance(tp_obj, str) and tp_obj:
+            tp = Path(tp_obj)
+        elif isinstance(tp_obj, os.PathLike):
+            tp = Path(tp_obj)
+        else:
+            tp = None
+        transcript_bytes = estimate_transcript_bytes(tp)
+        if not should_fire_p3_velocity(
+            bytes_at_last_fire=bytes_at_last_fire,
+            transcript_bytes=transcript_bytes,
+            turns_since_last_fire=turns_since_last_fire,
+            config=cfg,
+        ):
+            return None
+        body = _run_cadence_rebuild(payload, cwd)
+        if body is None:
+            return None
+        # Update both p3-velocity state slots atomically — mirrors Stop-side.
+        # When Stop and UPS both fire on the same boundary (the post-#874
+        # counter-sharing pattern), the second writer just overwrites with
+        # identical values, so the race is benign.
+        update_p3_velocity_state(
+            session_id,
+            transcript_bytes=transcript_bytes,
+            fire_idx=next_fire_idx,
+            stderr=serr,
+        )
+        density = (transcript_bytes - bytes_at_last_fire) / turns_since_last_fire
+        print(
+            f"aelfrice: ups cadence checkpoint fired @ fire_idx={next_fire_idx} "
+            f"(policy={policy}, velocity={density:.1f} bytes/turn, "
+            f"threshold={threshold})",
             file=serr,
         )
         return body

--- a/src/aelfrice/session_ring.py
+++ b/src/aelfrice/session_ring.py
@@ -171,6 +171,7 @@ def _normalize_for_session(
             "next_fire_idx": 0,
             "evicted_total": 0,
             "bytes_at_last_fire": 0,
+            "fire_idx_at_last_fire": 0,
             "classifications": [],
         }
     ring = data.get("ring")
@@ -182,7 +183,9 @@ def _normalize_for_session(
     evicted = data.get("evicted_total")
     if not isinstance(evicted, int) or evicted < 0:
         evicted = 0
-    # P3-velocity state — non-negative int; default 0 for pre-#876 rings
+    # P3-velocity state — non-negative ints; default 0 for pre-#876 rings.
+    # fire_idx_at_last_fire pairs with bytes_at_last_fire so the dispatcher
+    # can compute turns_since_last_fire = next_fire_idx - fire_idx_at_last_fire.
     bytes_at_last_fire = data.get("bytes_at_last_fire")
     if (
         not isinstance(bytes_at_last_fire, int)
@@ -190,6 +193,13 @@ def _normalize_for_session(
         or bytes_at_last_fire < 0
     ):
         bytes_at_last_fire = 0
+    fire_idx_at_last_fire = data.get("fire_idx_at_last_fire")
+    if (
+        not isinstance(fire_idx_at_last_fire, int)
+        or isinstance(fire_idx_at_last_fire, bool)
+        or fire_idx_at_last_fire < 0
+    ):
+        fire_idx_at_last_fire = 0
     # P3-substantive state — list of bools; default [] for pre-#876 rings
     classifications_raw = data.get("classifications")
     if isinstance(classifications_raw, list):
@@ -203,6 +213,7 @@ def _normalize_for_session(
         "next_fire_idx": next_idx,
         "evicted_total": evicted,
         "bytes_at_last_fire": bytes_at_last_fire,
+        "fire_idx_at_last_fire": fire_idx_at_last_fire,
         "classifications": classifications,
     }
 
@@ -388,20 +399,74 @@ def update_bytes_at_last_fire(
 ) -> bool:
     """Update the p3_velocity ``bytes_at_last_fire`` slot (#876).
 
+    Kept for backward-compat with the PR 2 surface; new callers should
+    prefer :func:`update_p3_velocity_state` which updates both
+    ``bytes_at_last_fire`` and ``fire_idx_at_last_fire`` atomically so
+    the velocity predicate's two state inputs stay in sync.
+
+    Takes the same advisory lock as :func:`append_ids`. Fail-soft.
+    """
+    return _update_p3_velocity_fields(
+        session_id, bytes_at_last_fire=transcript_bytes, fire_idx_at_last_fire=None,
+        stderr=stderr,
+    )
+
+
+def update_p3_velocity_state(
+    session_id: str | None,
+    *,
+    transcript_bytes: int,
+    fire_idx: int,
+    stderr: IO[str] | None = None,
+) -> bool:
+    """Update both p3_velocity state slots atomically (#876).
+
     Called by the cadence dispatcher after a p3_velocity fire — the
-    predicate's next evaluation reads this value to compute density
-    ``(transcript_bytes - bytes_at_last_fire) / turns_since_last_fire``.
+    next predicate evaluation reads both values to compute:
 
-    Takes the same advisory lock as :func:`append_ids` so concurrent
-    UPS + Stop hooks can't clobber each other's writes. Fail-soft:
-    returns False on any error (file missing, lock failure, malformed
-    JSON, etc.); the caller continues without raising.
+      density = (current_transcript_bytes - bytes_at_last_fire)
+              / (current_next_fire_idx - fire_idx_at_last_fire)
 
-    Returns True on successful write, False on no-op or error.
+    Keeping these two in lock-step under a single ring write avoids the
+    sub-window where one is updated and the other isn't (which would
+    distort the density calculation on the next fire).
+
+    Takes the same advisory lock as :func:`append_ids`. Fail-soft:
+    returns False on any error.
+    """
+    if not isinstance(transcript_bytes, int) or transcript_bytes < 0:
+        return False
+    if not isinstance(fire_idx, int) or fire_idx < 0:
+        return False
+    return _update_p3_velocity_fields(
+        session_id,
+        bytes_at_last_fire=transcript_bytes,
+        fire_idx_at_last_fire=fire_idx,
+        stderr=stderr,
+    )
+
+
+def _update_p3_velocity_fields(
+    session_id: str | None,
+    *,
+    bytes_at_last_fire: int | None,
+    fire_idx_at_last_fire: int | None,
+    stderr: IO[str] | None,
+) -> bool:
+    """Shared inner for ``update_bytes_at_last_fire`` + ``update_p3_velocity_state``.
+
+    Either field can be None to mean 'leave unchanged'. Validation of
+    non-None values happens at the public callers.
     """
     if not session_id:
         return False
-    if not isinstance(transcript_bytes, int) or transcript_bytes < 0:
+    if bytes_at_last_fire is not None and (
+        not isinstance(bytes_at_last_fire, int) or bytes_at_last_fire < 0
+    ):
+        return False
+    if fire_idx_at_last_fire is not None and (
+        not isinstance(fire_idx_at_last_fire, int) or fire_idx_at_last_fire < 0
+    ):
         return False
     ring_path = _session_ring_path()
     if ring_path is None:
@@ -422,13 +487,16 @@ def update_bytes_at_last_fire(
         try:
             data = _read_ring_unlocked(ring_path)
             data = _normalize_for_session(data, session_id, ring_max)
-            data["bytes_at_last_fire"] = transcript_bytes
+            if bytes_at_last_fire is not None:
+                data["bytes_at_last_fire"] = bytes_at_last_fire
+            if fire_idx_at_last_fire is not None:
+                data["fire_idx_at_last_fire"] = fire_idx_at_last_fire
             _atomic_write(ring_path, json.dumps(data))
             return True
         except Exception as exc:
             _warn(
                 stderr,
-                f"session_ring: update_bytes_at_last_fire failed (non-fatal): {exc}",
+                f"session_ring: update_p3_velocity_state failed (non-fatal): {exc}",
             )
             return False
         finally:

--- a/tests/test_hook_stop_cadence_p3_velocity.py
+++ b/tests/test_hook_stop_cadence_p3_velocity.py
@@ -1,0 +1,282 @@
+"""Integration tests for #876 p3_velocity dispatcher wiring — Stop side.
+
+PR 3 of 5 in the #876 stack. Covers the new POLICY_P3_VELOCITY branch
+in _maybe_fire_cadence_checkpoint: predicate evaluation, ring state
+read, on-fire updates to both p3_velocity state slots, fail-soft
+behaviour.
+"""
+from __future__ import annotations
+
+import io
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from aelfrice import hook
+from aelfrice.cadence import (
+    CONFIG_FILENAME,
+    ENV_CADENCE_P3_VELOCITY_THRESHOLD,
+    POLICY_P3_VELOCITY,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "AELFRICE_CADENCE_ENABLED",
+        "AELFRICE_CADENCE_POLICY",
+        ENV_CADENCE_P3_VELOCITY_THRESHOLD,
+        "AELF_AUTOLOCK_CORRECTIONS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _seed_db(db: Path) -> None:
+    from aelfrice.store import MemoryStore
+    MemoryStore(str(db)).close()
+
+
+def _write_toml(repo: Path, body: str) -> None:
+    (repo / CONFIG_FILENAME).write_text(textwrap.dedent(body))
+
+
+def _write_ring_state(
+    state_dir: Path,
+    session_id: str,
+    *,
+    next_fire_idx: int,
+    bytes_at_last_fire: int = 0,
+    fire_idx_at_last_fire: int = 0,
+) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "session_id": session_id,
+        "ring": [],
+        "ring_max": 200,
+        "next_fire_idx": next_fire_idx,
+        "evicted_total": 0,
+        "bytes_at_last_fire": bytes_at_last_fire,
+        "fire_idx_at_last_fire": fire_idx_at_last_fire,
+        "classifications": [],
+    }
+    (state_dir / "session_injected_ids.json").write_text(json.dumps(payload))
+
+
+def _write_transcript(path: Path, size_bytes: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    filler = json.dumps({
+        "message": {"role": "assistant", "content": "x" * 800},
+    }) + "\n"
+    n = max(1, size_bytes // len(filler))
+    with path.open("w", encoding="utf-8") as f:
+        for _ in range(n):
+            f.write(filler)
+
+
+def _stub_rebuild_and_format(
+    monkeypatch: pytest.MonkeyPatch,
+    body: str = "<rebuilder synthesis body>",
+) -> list[dict[str, object]]:
+    calls: list[dict[str, object]] = []
+
+    def _stub(recent, token_budget, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append({"n_recent": len(recent), "token_budget": token_budget})
+        return body
+
+    monkeypatch.setattr(hook, "_rebuild_and_format", _stub)
+    return calls
+
+
+def _stub_read_recent(monkeypatch: pytest.MonkeyPatch, n_turns: int = 1) -> None:
+    from aelfrice.context_rebuilder import RecentTurn
+    canned = [RecentTurn(role="user", text=f"turn-{i}") for i in range(n_turns)]
+    monkeypatch.setattr(
+        hook, "_read_recent_for_pre_compact", lambda _payload, _n: canned,
+    )
+
+
+def _stop_payload(session_id: str, cwd: Path, transcript_path: Path) -> str:
+    return json.dumps({
+        "session_id": session_id,
+        "cwd": str(cwd),
+        "transcript_path": str(transcript_path),
+    })
+
+
+def _setup_test(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    next_fire_idx: int,
+    bytes_at_last_fire: int,
+    fire_idx_at_last_fire: int,
+    transcript_bytes: int,
+    threshold: int = 3000,
+) -> tuple[io.StringIO, list, Path]:
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    _seed_db(db)
+    _write_ring_state(
+        db.parent, "sess-V",
+        next_fire_idx=next_fire_idx,
+        bytes_at_last_fire=bytes_at_last_fire,
+        fire_idx_at_last_fire=fire_idx_at_last_fire,
+    )
+    _write_toml(tmp_path, f"""
+        [cadence]
+        enabled = true
+        policy = "p3_velocity"
+        p3_velocity_threshold = {threshold}
+    """)
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(transcript, transcript_bytes)
+    calls = _stub_rebuild_and_format(monkeypatch)
+    _stub_read_recent(monkeypatch)
+    serr = io.StringIO()
+    rc = hook.stop(
+        stdin=io.StringIO(_stop_payload("sess-V", tmp_path, transcript)),
+        stderr=serr,
+    )
+    assert rc == 0
+    return serr, calls, db.parent
+
+
+# --- Tests ----------------------------------------------------------------
+
+
+def test_velocity_above_threshold_fires(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """At density >= threshold the dispatch fires and updates state."""
+    serr, calls, state_dir = _setup_test(
+        tmp_path, monkeypatch,
+        next_fire_idx=10, bytes_at_last_fire=0, fire_idx_at_last_fire=0,
+        transcript_bytes=50_000, threshold=3000,
+    )
+    # 50k bytes / 10 turns = 5000 bytes/turn >= 3000 threshold
+    assert len(calls) == 1, "rebuilder should fire"
+    assert "cadence checkpoint fired" in serr.getvalue()
+    assert "p3_velocity" in serr.getvalue()
+    # State slots updated atomically
+    persisted = json.loads(
+        (state_dir / "session_injected_ids.json").read_text()
+    )
+    assert persisted["fire_idx_at_last_fire"] == 10
+    assert persisted["bytes_at_last_fire"] >= 40_000  # actual transcript size
+
+
+def test_velocity_below_threshold_does_not_fire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    serr, calls, state_dir = _setup_test(
+        tmp_path, monkeypatch,
+        next_fire_idx=10, bytes_at_last_fire=0, fire_idx_at_last_fire=0,
+        transcript_bytes=10_000, threshold=3000,
+    )
+    # 10k / 10 turns = 1000 bytes/turn < 3000
+    assert calls == []
+    assert "cadence checkpoint" not in serr.getvalue()
+    persisted = json.loads(
+        (state_dir / "session_injected_ids.json").read_text()
+    )
+    # Unchanged
+    assert persisted["bytes_at_last_fire"] == 0
+    assert persisted["fire_idx_at_last_fire"] == 0
+
+
+def test_velocity_zero_turns_since_last_fire_skips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Immediately after a fire (turns_since_last_fire == 0), no new fire."""
+    serr, calls, _ = _setup_test(
+        tmp_path, monkeypatch,
+        next_fire_idx=10, bytes_at_last_fire=20_000, fire_idx_at_last_fire=10,
+        transcript_bytes=50_000, threshold=3000,
+    )
+    assert calls == []
+
+
+def test_velocity_disabled_no_fire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    _seed_db(db)
+    _write_ring_state(
+        db.parent, "sess-V", next_fire_idx=10,
+        bytes_at_last_fire=0, fire_idx_at_last_fire=0,
+    )
+    # cadence section absent: enabled defaults False
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(transcript, 100_000)
+    calls = _stub_rebuild_and_format(monkeypatch)
+    _stub_read_recent(monkeypatch)
+    serr = io.StringIO()
+    rc = hook.stop(
+        stdin=io.StringIO(_stop_payload("sess-V", tmp_path, transcript)),
+        stderr=serr,
+    )
+    assert rc == 0
+    assert calls == []
+
+
+def test_velocity_env_threshold_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env override pushes the threshold above the actual velocity → no fire."""
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    _seed_db(db)
+    _write_ring_state(
+        db.parent, "sess-V", next_fire_idx=10,
+        bytes_at_last_fire=0, fire_idx_at_last_fire=0,
+    )
+    _write_toml(tmp_path, """
+        [cadence]
+        enabled = true
+        policy = "p3_velocity"
+        p3_velocity_threshold = 1000
+    """)
+    monkeypatch.setenv(ENV_CADENCE_P3_VELOCITY_THRESHOLD, "10000")
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(transcript, 50_000)
+    calls = _stub_rebuild_and_format(monkeypatch)
+    _stub_read_recent(monkeypatch)
+    serr = io.StringIO()
+    rc = hook.stop(
+        stdin=io.StringIO(_stop_payload("sess-V", tmp_path, transcript)),
+        stderr=serr,
+    )
+    assert rc == 0
+    # 50k/10 = 5000 bytes/turn; env threshold 10000 ⇒ no fire
+    assert calls == []
+
+
+def test_velocity_missing_session_state_skips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ring file at all — predicate cannot read state, skips cleanly."""
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    _seed_db(db)
+    # NO _write_ring_state call
+    _write_toml(tmp_path, """
+        [cadence]
+        enabled = true
+        policy = "p3_velocity"
+        p3_velocity_threshold = 1000
+    """)
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(transcript, 50_000)
+    calls = _stub_rebuild_and_format(monkeypatch)
+    _stub_read_recent(monkeypatch)
+    serr = io.StringIO()
+    rc = hook.stop(
+        stdin=io.StringIO(_stop_payload("sess-V", tmp_path, transcript)),
+        stderr=serr,
+    )
+    assert rc == 0
+    # next_fire_idx unset → turns_since_last_fire = 0 - 0 = 0 → no fire
+    assert calls == []

--- a/tests/test_hook_stop_cadence_p3_velocity.py
+++ b/tests/test_hook_stop_cadence_p3_velocity.py
@@ -18,7 +18,6 @@ from aelfrice import hook
 from aelfrice.cadence import (
     CONFIG_FILENAME,
     ENV_CADENCE_P3_VELOCITY_THRESHOLD,
-    POLICY_P3_VELOCITY,
 )
 
 

--- a/tests/test_hook_ups_cadence_p3_velocity.py
+++ b/tests/test_hook_ups_cadence_p3_velocity.py
@@ -1,0 +1,190 @@
+"""Integration tests for #876 p3_velocity dispatcher wiring — UPS side."""
+from __future__ import annotations
+
+import io
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from aelfrice import hook
+from aelfrice.cadence import (
+    CONFIG_FILENAME,
+    ENV_CADENCE_P3_VELOCITY_THRESHOLD,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "AELFRICE_CADENCE_ENABLED",
+        "AELFRICE_CADENCE_POLICY",
+        ENV_CADENCE_P3_VELOCITY_THRESHOLD,
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _seed_db(db: Path) -> None:
+    from aelfrice.store import MemoryStore
+    MemoryStore(str(db)).close()
+
+
+def _write_toml(repo: Path, body: str) -> None:
+    (repo / CONFIG_FILENAME).write_text(textwrap.dedent(body))
+
+
+def _write_ring_state(
+    state_dir: Path,
+    session_id: str,
+    *,
+    next_fire_idx: int,
+    bytes_at_last_fire: int = 0,
+    fire_idx_at_last_fire: int = 0,
+) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "session_id": session_id, "ring": [], "ring_max": 200,
+        "next_fire_idx": next_fire_idx, "evicted_total": 0,
+        "bytes_at_last_fire": bytes_at_last_fire,
+        "fire_idx_at_last_fire": fire_idx_at_last_fire,
+        "classifications": [],
+    }
+    (state_dir / "session_injected_ids.json").write_text(json.dumps(payload))
+
+
+def _write_transcript(path: Path, size_bytes: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    filler = json.dumps({
+        "message": {"role": "assistant", "content": "x" * 800},
+    }) + "\n"
+    n = max(1, size_bytes // len(filler))
+    with path.open("w", encoding="utf-8") as f:
+        for _ in range(n):
+            f.write(filler)
+
+
+def _stub_rebuild_and_format(monkeypatch: pytest.MonkeyPatch) -> list:
+    calls: list = []
+
+    def _stub(recent, token_budget, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(1)
+        return "<body>"
+
+    monkeypatch.setattr(hook, "_rebuild_and_format", _stub)
+    return calls
+
+
+def _stub_read_recent(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aelfrice.context_rebuilder import RecentTurn
+    monkeypatch.setattr(
+        hook, "_read_recent_for_pre_compact",
+        lambda _payload, _n: [RecentTurn(role="user", text="t")],
+    )
+
+
+def test_ups_velocity_fires_returns_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    _seed_db(db)
+    _write_ring_state(
+        db.parent, "sess-U", next_fire_idx=10,
+        bytes_at_last_fire=0, fire_idx_at_last_fire=0,
+    )
+    _write_toml(tmp_path, """
+        [cadence]
+        enabled = true
+        policy = "p3_velocity"
+        p3_velocity_threshold = 3000
+    """)
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(transcript, 50_000)
+    calls = _stub_rebuild_and_format(monkeypatch)
+    _stub_read_recent(monkeypatch)
+    payload = {
+        "session_id": "sess-U",
+        "cwd": str(tmp_path),
+        "transcript_path": str(transcript),
+    }
+    serr = io.StringIO()
+    body = hook._maybe_run_ups_cadence_checkpoint(payload, "sess-U", serr)
+    assert body == "<body>"
+    assert len(calls) == 1
+    assert "ups cadence checkpoint fired" in serr.getvalue()
+    assert "p3_velocity" in serr.getvalue()
+
+
+def test_ups_velocity_below_threshold_returns_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    _seed_db(db)
+    _write_ring_state(
+        db.parent, "sess-U", next_fire_idx=10,
+        bytes_at_last_fire=0, fire_idx_at_last_fire=0,
+    )
+    _write_toml(tmp_path, """
+        [cadence]
+        enabled = true
+        policy = "p3_velocity"
+        p3_velocity_threshold = 3000
+    """)
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(transcript, 10_000)
+    calls = _stub_rebuild_and_format(monkeypatch)
+    _stub_read_recent(monkeypatch)
+    payload = {
+        "session_id": "sess-U",
+        "cwd": str(tmp_path),
+        "transcript_path": str(transcript),
+    }
+    serr = io.StringIO()
+    body = hook._maybe_run_ups_cadence_checkpoint(payload, "sess-U", serr)
+    assert body is None
+    assert calls == []
+
+
+def test_ups_velocity_state_update_on_fire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    _seed_db(db)
+    _write_ring_state(
+        db.parent, "sess-U", next_fire_idx=15,
+        bytes_at_last_fire=5_000, fire_idx_at_last_fire=5,
+    )
+    _write_toml(tmp_path, """
+        [cadence]
+        enabled = true
+        policy = "p3_velocity"
+        p3_velocity_threshold = 1000
+    """)
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(transcript, 50_000)
+    _stub_rebuild_and_format(monkeypatch)
+    _stub_read_recent(monkeypatch)
+    payload = {
+        "session_id": "sess-U",
+        "cwd": str(tmp_path),
+        "transcript_path": str(transcript),
+    }
+    hook._maybe_run_ups_cadence_checkpoint(payload, "sess-U", io.StringIO())
+    persisted = json.loads(
+        (db.parent / "session_injected_ids.json").read_text()
+    )
+    assert persisted["fire_idx_at_last_fire"] == 15
+    assert persisted["bytes_at_last_fire"] > 5_000
+
+
+def test_ups_velocity_empty_session_id_skips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    serr = io.StringIO()
+    body = hook._maybe_run_ups_cadence_checkpoint(
+        {"cwd": str(tmp_path)}, "", serr,
+    )
+    assert body is None


### PR DESCRIPTION
Part of #876. **PR 3 of 5 in the stack.** Builds on #884 (PR 1) + #885 (PR 2).

## Summary

Wires `p3_velocity` into both Stop and UPS cadence dispatchers. After this PR, an operator can opt into bytes-per-turn-density cadence by setting `[cadence] enabled = true` + `[cadence] policy = "p3_velocity"` in `.aelfrice.toml`.

## New in this PR

### Session-ring slot

Added `fire_idx_at_last_fire` to the ring schema. The velocity predicate needs both `bytes_at_last_fire` AND a fire_idx anchor to compute `turns_since_last_fire = next_fire_idx - fire_idx_at_last_fire`. Backward-compat handled in `_normalize_for_session` — pre-PR-3 rings default the field to 0.

### Atomic combined updater

`update_p3_velocity_state(session_id, *, transcript_bytes, fire_idx)` writes both p3_velocity state slots atomically under the existing advisory lock. Keeps the two inputs in sync so the next predicate evaluation sees a consistent `(bytes, fire_idx)` snapshot. `update_bytes_at_last_fire` is kept as a thin wrapper for backward-compat with PR 2 callers.

### Dispatch wiring

`POLICY_P3_VELOCITY` branch in `_maybe_fire_cadence_checkpoint` (Stop) and `_maybe_run_ups_cadence_checkpoint` (UPS). Both branches:

1. Read ring state — extract `next_fire_idx`, `bytes_at_last_fire`, `fire_idx_at_last_fire`.
2. Resolve `p3_velocity_threshold` + estimate transcript bytes via the existing P2 helper.
3. Compute `turns_since_last_fire`; bail if non-positive.
4. Call `should_fire_p3_velocity` with the three state inputs.
5. On fire: run the rebuilder, write resume cache (Stop only), call `update_p3_velocity_state` to advance both state slots atomically.
6. Emit stderr observability line with computed density + threshold.

Counter-sharing post-#874 pattern preserved: UPS reads ring state before this turn's `_ring_append_ids`, sees same `next_fire_idx` Stop saw at end of prior turn. Both fire on the same boundary; second updater is a benign overwrite.

## Determinism (#605)

Predicate inputs are filesystem state + config. Same inputs reproduce same fire decisions across replays.

## Tests

10 new wiring tests across two files:

**`tests/test_hook_stop_cadence_p3_velocity.py`** — 6 tests: above-threshold fires, below skips, `turns_since_last_fire == 0` short-circuit, default-OFF respected, env override, missing session state skips cleanly.

**`tests/test_hook_ups_cadence_p3_velocity.py`** — 4 tests: UPS fires returns body, UPS below skips, atomic state update on UPS fire, empty session_id short-circuit.

All 277 cadence + session_ring tests pass locally. Full suite pass pending in CI.

## Discretion

Diff clean against the pre-push deny-list.

## What's left in the stack

- **PR 4**: wire `p3_substantive` into Stop + UPS + #881 shadow-mode companions.
- **PR 5**: CHANGELOG + CONFIG.md + design-doc updates.
