### PR TITLE
ci(bench-canonical): install --extra benchmarks so adapters can load

### DIFF
--- a/.github/workflows/bench-canonical.yml
+++ b/.github/workflows/bench-canonical.yml
@@ -57,7 +57,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dev group
-        run: uv sync --frozen --group dev --extra archive
+        run: uv sync --frozen --group dev --extra archive --extra benchmarks
 
       - name: Bootstrap bench-canonical-results worktree
         run: |


### PR DESCRIPTION
## Summary

Closes #889 acceptance item 1. One-line fix: `.github/workflows/bench-canonical.yml` now installs `--extra benchmarks` alongside `--extra archive`, so `nltk` / `tiktoken` / `datasets` / `huggingface_hub` are present in the runner.

## Why

`benchmarks/mab_adapter.py`, `benchmarks/locomo_adapter.py`, and `benchmarks/amabench_adapter.py` all import these packages at module top level. Without the extra, every adapter subprocess of `aelf bench all` raises `ModuleNotFoundError` immediately. Today's cron entry (`v2.0.0-cron-2026-05-21.json` on `bench-canonical-results`, commit `8f61eda6`) shows the failure mode unchanged across 13+ consecutive days.

The pinned `v3.0.1.json` numbers (2026-05-13) remain the last actually-real bench evidence on record.

## Diff

```diff
-        run: uv sync --frozen --group dev --extra archive
+        run: uv sync --frozen --group dev --extra archive --extra benchmarks
```

## Verification (AC #2)

Cannot be done in-PR — needs an actual workflow run after merge. Two options:

1. **Wait for the 05:00 UTC cron** the day after merge. The next cron commit on `bench-canonical-results` either lands ≥7 `_status: "ok"` rows (success) or the issue stays open.
2. **Trigger `workflow_dispatch` manually** post-merge: `gh workflow run bench-canonical.yml --ref main`.

Either way I'll re-check the resulting JSON and post follow-up on #889.

## Deferred to operator decision

The original issue lists three more items I'm explicitly **not** rolling into this PR:

- **AC #3 / scope 2 — StructMemEval fixture fetch path.** Three options in the issue body (commit 14-case fixture / download step / document operator-only). No prior locked decision in memory. Needs operator pick.
- **AC #4 / scope 3 — AMA-Bench in pinned `v3.0.1.json` headline_cut.** Note: today's cron JSON `headline_cut` already includes `amabench`, so the dispatcher is invoking it; only the pinned `v3.0.1.json` reference is missing the key. Question is whether to regenerate `v3.0.1.json` from a fresh real run after this fix lands, or amend it manually.

Recommend handling each as a follow-up PR after this lands and we have at least one clean cron entry to compare against.

## Test plan

- [ ] PR merges to main.
- [ ] Next cron (05:00 UTC) or manual `workflow_dispatch` produces a `v2.0.0-cron-YYYY-MM-DD.json` with ≥7 `_status: "ok"` rows.
- [ ] Follow-up issue/PR opened (or existing #889 re-scoped) for StructMemEval fixture + AMA-Bench pinning decisions.

## Summary by Sourcery

CI:
- Install the benchmarks extra alongside archive in the bench-canonical workflow so benchmark adapters’ Python dependencies are available during CI runs.