### PR TITLE
exp(bench): MAB LRU back-fill — n=171 3-run SEM=24.2% F1=37.2% (#899)

### DIFF
--- a/benchmarks/results/v3.0.1-mab-lru-backfill.json
+++ b/benchmarks/results/v3.0.1-mab-lru-backfill.json
@@ -1,5 +1,5 @@
 {
-  "_calibration_notes": "Back-fill measurement of MAB Long_Range_Understanding (171q) — one of the TBDs noted in v3.0.1.json _calibration_notes. Measured 2026-05-21 against current main HEAD (e5e5c20c, post-PR #887/#888/#893/#896, none of which changed retrieve_v2 ranking behaviour vs v3.0.1 tag commit 0e91fd1d). Methodology: full retrieve-then-reader pipeline. Step 1 — `uv run python benchmarks/mab_adapter.py --split Long_Range_Understanding --retrieve-only` produced 171 (question, context) pairs across 110 source rows; budget=2000 per retrieve call, retrieve_v2 via the v1.0.x lab-compat shim with use_bfs=True. Step 2 — six in-process LLM helpers dispatched in parallel (one per chunk_<N>.json slice of ~29 questions), each writing predictions_<N>.json. Locked rule honored: bench LLM calls go through in-process helpers, never via a direct SDK / API-key path. Step 3 — score via mab_adapter.score_multi_answer (substring_exact_match + token-level F1) joined on (row_idx, id). All 171 items had non-empty retrieval context (median 7930 chars, max 7997). Source mix: infbench_sum_eng_shots2 (summary task, ~13 books) plus detective_qa (multiple-choice mystery comprehension across 7 stories). Single-run capture; no variance band. Bench fixtures downloaded fresh per run. Not pinned by checksum.",
+  "_calibration_notes": "Back-fill measurement of MAB Long_Range_Understanding (171q) — one of the TBDs noted in v3.0.1.json _calibration_notes. Measured 2026-05-21 against current main HEAD (e5e5c20c, post-PR #887/#888/#893/#896, none of which changed retrieve_v2 ranking behaviour vs v3.0.1 tag commit 0e91fd1d). Methodology: full retrieve-then-reader pipeline. Step 1 — `uv run python benchmarks/mab_adapter.py --split Long_Range_Understanding --retrieve-only` produced 171 (question, context) pairs across 110 source rows; budget=2000 per retrieve call, retrieve_v2 via the v1.0.x lab-compat shim with use_bfs=True. Step 2 — six in-process LLM helpers dispatched in parallel (one per chunk_<N>.json slice of ~29 questions), each writing predictions_<N>.json. Locked rule honored: bench LLM calls go through in-process helpers, never via a direct SDK / API-key path. Step 3 — score via mab_adapter.score_multi_answer (substring_exact_match + token-level F1) joined on (row_idx, id). All 171 items had non-empty retrieval context (median 7930 chars, max 7997). Source mix: infbench_sum_eng_shots2 (summary task, ~13 books) plus detective_qa (multiple-choice mystery comprehension across 7 stories). n=3 multi-run variance probed; retrieval is deterministic per #605 (same retrieval.json across runs), so variance lives entirely in the reader pass. SEM band is tight (22.2-26.9%, stdev 2.43); EM and F1 have wider spread (EM 11.7-26.9%, F1 31.4-48.2%) driven by detective_qa being more sensitive to reader phrasing on MCQ items. Headline numbers below are the 3-run mean. Bench fixtures downloaded fresh per run. Not pinned by checksum.",
   "aelfrice_version": "3.0.1",
   "captured_at_utc": "2026-05-21T20:31:00Z",
   "git_commit": "e5e5c20cbc8e66caf4a269778c2ebf8925be1e03",
@@ -21,28 +21,36 @@
         "_status": "ok",
         "output": {
           "metric": "substring_exact_match",
-          "score_pct": 23.4,
-          "correct": 40,
+          "score_pct": 24.2,
           "total": 171,
-          "f1_pct": 32.0,
-          "exact_match_pct": 16.4,
-          "n_runs": 1,
-          "variance_probed": false,
-          "by_source": {
-            "detective_qa": {
-              "n": 71,
-              "exact_match_pct": 39.4,
-              "substring_exact_match_pct": 56.3,
-              "f1_pct": 43.1
-            },
-            "infbench_sum_eng_shots2": {
-              "n": 100,
-              "exact_match_pct": 0.0,
-              "substring_exact_match_pct": 0.0,
-              "f1_pct": 24.1
-            }
+          "f1_pct": 37.2,
+          "exact_match_pct": 18.3,
+          "n_runs": 3,
+          "variance_probed": true,
+          "variance_probed_3run_distribution": {
+            "exact_match_pct": [16.4, 11.7, 26.9],
+            "substring_exact_match_pct": [23.4, 22.2, 26.9],
+            "f1_pct": [32.0, 31.4, 48.2]
           },
-          "source_breakdown_note": "Mixed-source split. detective_qa (71 items) is multiple-choice mystery-novel reading comprehension; short letter+option answers favour SEM when the correct option text matches retrieval. infbench_sum_eng_shots2 (100 items) is multi-paragraph book-summary generation; long-form prose answers never match SEM substring rules but contribute to F1 via token overlap. The aggregate 23.4% SEM is dominated by detective_qa (56.3% SEM × 71/171 = 23.4 pp). The 32.0% F1 is closer to the summary task's contribution (24.1% × 100/171 + 43.1% × 71/171 ≈ 32.0)."
+          "variance_probed_stdev": {
+            "exact_match_pct": 7.79,
+            "substring_exact_match_pct": 2.43,
+            "f1_pct": 9.57
+          },
+          "variance_probed_note": "3 reader-pass runs over the same deterministic retrieval.json (retrieval is byte-identical across runs per #605). SEM stays inside a 5pp band (22.2-26.9%), F1 has a 17pp spread (31.4-48.2%) driven by reader sensitivity on detective_qa MCQ items — run 3 chose more verbatim option-text matches; runs 1+2 paraphrased more. Treat the SEM mean (24.2%) as the headline; treat EM and F1 means as having one-stdev uncertainty bands of roughly +/- 8 and +/- 10 pp respectively.",
+          "by_source_run1": {
+            "detective_qa": {"n": 71, "exact_match_pct": 39.4, "substring_exact_match_pct": 56.3, "f1_pct": 43.1},
+            "infbench_sum_eng_shots2": {"n": 100, "exact_match_pct": 0.0, "substring_exact_match_pct": 0.0, "f1_pct": 24.1}
+          },
+          "by_source_run2": {
+            "detective_qa": {"n": 71, "exact_match_pct": 28.2, "substring_exact_match_pct": 53.5, "f1_pct": 39.4},
+            "infbench_sum_eng_shots2": {"n": 100, "exact_match_pct": 0.0, "substring_exact_match_pct": 0.0, "f1_pct": 25.6}
+          },
+          "by_source_run3": {
+            "detective_qa": {"n": 71, "exact_match_pct": 64.8, "substring_exact_match_pct": 64.8, "f1_pct": 68.5},
+            "infbench_sum_eng_shots2": {"n": 100, "exact_match_pct": 0.0, "substring_exact_match_pct": 0.0, "f1_pct": 33.8}
+          },
+          "source_breakdown_note": "Mixed-source split. detective_qa (71 items) is multiple-choice mystery-novel reading comprehension; short letter+option answers favour SEM when the correct option text matches retrieval. infbench_sum_eng_shots2 (100 items) is multi-paragraph book-summary generation; long-form prose answers never match SEM substring rules but contribute to F1 via token overlap. SEM across the 3 runs is essentially the detective_qa contribution (each run's detective_qa SEM × 71/171 reconstructs the aggregate to within 1pp); summary items contribute 0 to SEM but lift F1 by token overlap."
         }
       }
     }

--- a/benchmarks/results/v3.0.1-mab-lru-backfill.json
+++ b/benchmarks/results/v3.0.1-mab-lru-backfill.json
@@ -1,0 +1,51 @@
+{
+  "_calibration_notes": "Back-fill measurement of MAB Long_Range_Understanding (171q) — one of the TBDs noted in v3.0.1.json _calibration_notes. Measured 2026-05-21 against current main HEAD (e5e5c20c, post-PR #887/#888/#893/#896, none of which changed retrieve_v2 ranking behaviour vs v3.0.1 tag commit 0e91fd1d). Methodology: full retrieve-then-reader pipeline. Step 1 — `uv run python benchmarks/mab_adapter.py --split Long_Range_Understanding --retrieve-only` produced 171 (question, context) pairs across 110 source rows; budget=2000 per retrieve call, retrieve_v2 via the v1.0.x lab-compat shim with use_bfs=True. Step 2 — six in-process LLM helpers dispatched in parallel (one per chunk_<N>.json slice of ~29 questions), each writing predictions_<N>.json. Locked rule honored: bench LLM calls go through in-process helpers, never via a direct SDK / API-key path. Step 3 — score via mab_adapter.score_multi_answer (substring_exact_match + token-level F1) joined on (row_idx, id). All 171 items had non-empty retrieval context (median 7930 chars, max 7997). Source mix: infbench_sum_eng_shots2 (summary task, ~13 books) plus detective_qa (multiple-choice mystery comprehension across 7 stories). Single-run capture; no variance band. Bench fixtures downloaded fresh per run. Not pinned by checksum.",
+  "aelfrice_version": "3.0.1",
+  "captured_at_utc": "2026-05-21T20:31:00Z",
+  "git_commit": "e5e5c20cbc8e66caf4a269778c2ebf8925be1e03",
+  "harness_version": "1",
+  "headline_cut": {
+    "mab": [
+      {
+        "args": ["--split", "Long_Range_Understanding"],
+        "sub_key": "long_range_understanding"
+      }
+    ]
+  },
+  "label": "v3.0.1 MAB LRU back-fill",
+  "metric_overrides": {},
+  "results": {
+    "mab": {
+      "long_range_understanding": {
+        "_elapsed_sec": null,
+        "_status": "ok",
+        "output": {
+          "metric": "substring_exact_match",
+          "score_pct": 23.4,
+          "correct": 40,
+          "total": 171,
+          "f1_pct": 32.0,
+          "exact_match_pct": 16.4,
+          "n_runs": 1,
+          "variance_probed": false,
+          "by_source": {
+            "detective_qa": {
+              "n": 71,
+              "exact_match_pct": 39.4,
+              "substring_exact_match_pct": 56.3,
+              "f1_pct": 43.1
+            },
+            "infbench_sum_eng_shots2": {
+              "n": 100,
+              "exact_match_pct": 0.0,
+              "substring_exact_match_pct": 0.0,
+              "f1_pct": 24.1
+            }
+          },
+          "source_breakdown_note": "Mixed-source split. detective_qa (71 items) is multiple-choice mystery-novel reading comprehension; short letter+option answers favour SEM when the correct option text matches retrieval. infbench_sum_eng_shots2 (100 items) is multi-paragraph book-summary generation; long-form prose answers never match SEM substring rules but contribute to F1 via token overlap. The aggregate 23.4% SEM is dominated by detective_qa (56.3% SEM × 71/171 = 23.4 pp). The 32.0% F1 is closer to the summary task's contribution (24.1% × 100/171 + 43.1% × 71/171 ≈ 32.0)."
+        }
+      }
+    }
+  },
+  "schema_version": "1.0"
+}


### PR DESCRIPTION
Refs #899.

## Summary

Back-fills the **MAB Long_Range_Understanding** TBD from v3.0.1.json's `_calibration_notes`. Single new pinned capture file: `benchmarks/results/v3.0.1-mab-lru-backfill.json`.

| Metric | 3-run mean | Notes |
|---|---|---|
| exact_match | 18.3% | stdev 7.79 (range 11.7–26.9) |
| substring_exact_match | **24.2%** | stdev 2.43 (range 22.2–26.9) |
| f1 | **37.2%** | stdev 9.57 (range 31.4–48.2) |

> Reviewer note: title/headline corrected to the committed 3-run-mean values. The original 16.4/23.4/32.0 figures were the run-1 single-pass values from an earlier draft; the file at HEAD is an n=3 variance-probed capture (`n_runs: 3`).

Per-source decomposition (LRU is a mixed-task split):

| Source | n | EM | SEM | F1 |
|---|---:|---:|---:|---:|
| detective_qa | 71 | 39.4% | 56.3% | 43.1% |
| infbench_sum_eng_shots2 | 100 | 0.0% | 0.0% | 24.1% |

## How this compares to v2.0.0

`benchmarks/results/v2.0.0.json` `results.mab.Long_Range_Understanding`:

| Metric | v2.0.0 (retrieval-only as prediction) | this PR (retrieve-then-reader) | Δ |
|---|---|---|---|
| exact_match | 0.0% | 18.3% | +18.3 pp |
| substring_exact_match | 2.34% | 24.2% | +21.9 pp |
| f1 | 18.11% | 37.2% | +19.1 pp |

Same 171 questions, same retrieval substrate, same adapter scorer. The delta is **the reader pass that v2.0.0 / v3.0.1 captures never ran**. This is the methodology gap referenced in PR #896's calibration recalibration.

## Methodology (3-step, all building blocks already in public)

1. **Retrieve-only**:
   ```
   uv run python benchmarks/mab_adapter.py \
     --split Long_Range_Understanding \
     --retrieve-only /tmp/mab-lru-run/retrieval.json
   ```
   Produces 171 `{question, context}` pairs + companion `_gt.json` (ISOLATION guarantee per the adapter's retrieve-only block: retrieval file contains no answers).

2. **Reader pass**: six in-process LLM helpers dispatched in parallel, each handling ~29 questions from a `chunk_<N>.json` slice, writing `predictions_<N>.json`. Honors the locked rule that bench LLM calls go through in-process helpers, never a direct SDK / API-key path.

3. **Score**: `mab_adapter.score_multi_answer` (substring_exact_match + token-level F1) joined on `(row_idx, id)` composite key.

n=3 variance-probed capture (SEM stdev 2.43; EM/F1 wider, see file `variance_probed_*` fields). Captured at HEAD = `e5e5c20c` (current main, post-PR #887/#888/#893/#896); none of those PRs touched `retrieve_v2` ranking behaviour vs the v3.0.1 tag (`0e91fd1d`), so this is effectively a v3.0.1-substrate measurement back-fill.

## Why a separate pinned file vs editing v3.0.1.json

`v3.0.1.json`'s `git_commit` field is `0e91fd1d` (the v3.0.1 tag). Adding a measurement taken at a later commit would misrepresent the pinned-baseline schema. The separate file follows the `v1.2.0-pre.json` precedent: distinct pinned capture, own `git_commit` and `captured_at_utc`, own `_calibration_notes` explaining the gap-fill nature of the measurement.

## What this PR is NOT

- Not a code change. Zero substrate impact.
- An n=3 multi-run variance probe (not a single capture). Wider multi-run / cross-model variance still trackable on #899 if desired.
- Not the three remaining MAB TBDs (Conflict_Resolution, Test_Time_Learning, Accurate_Retrieval) or the StructMemEval per-sub-task back-fill. Those are itemized on #899 as separate back-fill PRs.

## Test plan

- [ ] CI green (JSON-only addition; no test surface).
- [ ] No bench-canonical schema regressions — schema matches existing v1.2.0-pre.json / v3.0.1.json shape (`_calibration_notes`, `aelfrice_version`, `captured_at_utc`, `git_commit`, `harness_version`, `headline_cut`, `label`, `metric_overrides`, `results`, `schema_version`).

## Summary by Sourcery

New Features:
- Record a new v3.0.1 MAB Long_Range_Understanding benchmark run in a dedicated JSON results file with its own metadata and calibration notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added performance benchmark results for "v3.0.1 MAB LRU back-fill" (Long Range Understanding) with headline metrics: substring exact match 24.2%, exact match 18.3%, token-level F1 37.2% over 171 items.
  * Includes variance probing across 3 reader-pass runs, per-run metric distributions and per-source breakdowns, plus calibration notes and run metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
