### PR TITLE
test(promotion): refresh stale #616-merge skip-reason text

### DIFF
--- a/tests/test_promotion_adversarial.py
+++ b/tests/test_promotion_adversarial.py
@@ -92,7 +92,8 @@ def _build_param_list(category: str) -> list:
 
 @pytest.mark.skipif(
     not _surface_b_available(),
-    reason="Surface B (find_phantom_lock_matches) not yet on main — gated on #616 merge",
+    reason="Surface B (find_phantom_lock_matches) not importable — shipped via #616 "
+           "but the predicate stays defensive for back-revision benches against pre-#616 trees",
 )
 class TestPromotionAdversarial:
     """Adversarial bench fixture for Surface B."""


### PR DESCRIPTION
## Summary

Refreshes a stale skip-reason in `tests/test_promotion_adversarial.py` after #616 (Surface B / phantom promotion) shipped. The `skipif` predicate's runtime check still works correctly — `_surface_b_available()` returns True on current main, so the test class executes (27 passed + 75 xfailed against the documented edge-case fixture). Only the reason text was misleading.

## What changed

Reason string:

```diff
- reason="Surface B (find_phantom_lock_matches) not yet on main — gated on #616 merge",
+ reason="Surface B (find_phantom_lock_matches) not importable — shipped via #616 "
+        "but the predicate stays defensive for back-revision benches against pre-#616 trees",
```

The framing flips from "gated on a future merge" (false at v3.3.0) to "kept as defensive scaffolding for back-revision benches" (true — runtime detection of Surface B's importability is useful when someone bisects across the #616 boundary or runs the suite against a pre-#616 checkout).

## Verification

```
$ uv run pytest tests/test_promotion_adversarial.py
======================== 27 passed, 75 xfailed in 0.36s ========================
```

Byte-identical pass/xfail counts to pre-edit.

## Context

Surfaced by the v3.3.0 release-cycle docs/code drift audit. Living TODO at `~/.claude/handoffs/audit-2026-05-21-aelfrice-v3.3.0.md` row [MED-2].

## Summary by Sourcery

Tests:
- Refresh the pytest skip reason string for Surface B adversarial promotion tests to accurately describe its defensive use for pre-#616 trees.