### PR TITLE
docs(readme): bump 'Latest stable' from v3.0.1 to v3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Running in the background. No action required after `aelf setup`.
 
 ## Status
 
-Latest stable: **v3.0.1** (2026-05-13). Per-entry detail in [CHANGELOG § 3.0.1](CHANGELOG.md). Per-version history: [docs/concepts/ROADMAP.md](docs/concepts/ROADMAP.md). Known limits: [docs/user/LIMITATIONS.md](docs/user/LIMITATIONS.md).
+Latest stable: **v3.3.0** (2026-05-21). Per-entry detail in [CHANGELOG § 3.3.0](CHANGELOG.md). Per-version history: [docs/concepts/ROADMAP.md](docs/concepts/ROADMAP.md). Known limits: [docs/user/LIMITATIONS.md](docs/user/LIMITATIONS.md).
 
 ---
 


### PR DESCRIPTION
Courtesy version-pin bump in README.md line 185. The pinned line stayed at v3.0.1 across the v3.1.0 / v3.2.0 / v3.3.0 cuts. Now that v3.3.0 is tagged and publishing to PyPI, the line tracks current state.

The CHANGELOG compare-link half of audit row [LOW-2] shipped as part of release PR #898 (release-docs-check required it before merge); this closes the remaining README half.

Audit row: [LOW-2] in `~/.claude/handoffs/audit-2026-05-21-aelfrice-v3.3.0.md`.