### PR TITLE
fix(bench): task-aware StructMemEval prediction scorers

### DIFF
--- a/benchmarks/structmemeval_adapter.py
+++ b/benchmarks/structmemeval_adapter.py
@@ -312,6 +312,136 @@ def check_state_correctness(retrieved: str, reference: ReferenceAnswer) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Task-aware prediction scoring (#899)
+#
+# `check_state_correctness` above is a single word-overlap heuristic over
+# the *whole* reference text. It is invalid for scoring a reader's
+# prediction for three independent reasons, one per task:
+#
+#   * location: the reference embeds an exclusion note ("should NOT
+#     mention <previous cities>"). Those distractor tokens land in the
+#     word-set, so raw retrieval (which contains every stale city)
+#     matches them and scores high, while a concise *correct* answer
+#     that omits them falls below the 0.5 threshold and scores 0.
+#   * tree: the answer is binary (Yes/No) wrapped in boilerplate
+#     ("...indirect colleagues according to their graph relations"). A
+#     correct "No" prediction shares almost none of the boilerplate
+#     word-set, so polarity is never actually tested.
+#   * accounting: the reference is a set of settlement tuples
+#     ("Charlie -> Bob : 218.33 EUR | ..."); word overlap on names and
+#     bare numbers does not check that the amounts and directions match.
+#
+# The functions below score a *prediction* (not raw retrieval) with
+# task-appropriate logic. `score_prediction` dispatches by task name.
+# ---------------------------------------------------------------------------
+
+_LOC_EXCLUSION_MARKERS: Final[tuple[str, ...]] = (
+    "should not mention",
+    "not mention",
+    "do not mention",
+)
+_STOPWORDS: Final[frozenset[str]] = frozenset({
+    "the", "that", "this", "with", "from", "should", "their", "about",
+    "your", "since", "currently", "live", "answer", "previous", "cities",
+    "city", "activities", "activity", "neighbor", "neighbors", "mention",
+    "based", "where", "now", "and", "for", "you",
+})
+
+
+def _significant_words(text: str) -> list[str]:
+    return [
+        w.strip(".,()") for w in text.lower().split()
+        if len(w.strip(".,()")) > 3 and w.strip(".,()") not in _STOPWORDS
+    ]
+
+
+def _split_location_reference(reference_text: str) -> tuple[str, str]:
+    """Split a location reference into (expected_portion, exclusion_portion).
+
+    The exclusion portion is everything from the first exclusion marker
+    onward; the expected portion is the text before it. When no marker
+    is present the whole reference is the expected portion and the
+    exclusion portion is empty.
+    """
+    low: str = reference_text.lower()
+    for marker in _LOC_EXCLUSION_MARKERS:
+        idx: int = low.find(marker)
+        if idx != -1:
+            return reference_text[:idx], reference_text[idx:]
+    return reference_text, ""
+
+
+def score_location_prediction(
+    prediction: str, reference_text: str, present_threshold: float = 0.5,
+) -> bool:
+    """Correct iff the prediction reflects the current state AND omits
+    the excluded (stale) distractors.
+
+    * expected_present: at least `present_threshold` of the significant
+      words in the expected portion appear in the prediction.
+    * exclusion_clean: no significant word that appears ONLY in the
+      exclusion portion (i.e. a distractor not also part of the current
+      answer) appears in the prediction.
+
+    Both conditions must hold. The exclusion-clean check is the fix that
+    `check_state_correctness` lacked.
+    """
+    expected_text, exclusion_text = _split_location_reference(reference_text)
+    pred_lower: str = prediction.lower()
+    expected_words: list[str] = _significant_words(expected_text)
+    if not expected_words:
+        return False
+    present: int = sum(1 for w in expected_words if w in pred_lower)
+    expected_present: bool = (present / len(expected_words)) >= present_threshold
+    expected_set: set[str] = set(expected_words)
+    exclusion_only: set[str] = {
+        w for w in _significant_words(exclusion_text) if w not in expected_set
+    }
+    leaked: bool = any(w in pred_lower for w in exclusion_only)
+    return expected_present and not leaked
+
+
+def _polarity(text: str) -> str | None:
+    """Return 'yes' / 'no' from the first polarity token, else None."""
+    for tok in text.lower().replace(",", " ").replace(".", " ").split():
+        if tok == "yes":
+            return "yes"
+        if tok == "no":
+            return "no"
+    return None
+
+
+def score_tree_prediction(prediction: str, reference_text: str) -> bool:
+    """Correct iff the prediction's Yes/No polarity matches the reference.
+
+    Tree answers are binary connectivity verdicts wrapped in boilerplate;
+    only the polarity is load-bearing.
+    """
+    ref_pol: str | None = _polarity(reference_text)
+    pred_pol: str | None = _polarity(prediction)
+    return ref_pol is not None and ref_pol == pred_pol
+
+
+def score_prediction(
+    prediction: str, reference_text: str, task: str,
+) -> bool:
+    """Dispatch prediction scoring by task.
+
+    `location` and `tree` have dedicated scorers; `accounting` and any
+    other task fall back to the legacy word-overlap heuristic (which is
+    a recall proxy, not a correctness check — accounting needs a
+    settlement-tuple comparison, tracked separately).
+    """
+    if task == "location":
+        return score_location_prediction(prediction, reference_text)
+    if task == "tree":
+        return score_tree_prediction(prediction, reference_text)
+    return check_state_correctness(
+        prediction, ReferenceAnswer(text=reference_text),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 

--- a/tests/test_structmemeval_subtask_scorer.py
+++ b/tests/test_structmemeval_subtask_scorer.py
@@ -1,0 +1,99 @@
+"""#899 StructMemEval per-sub-task scorer fix.
+
+`check_state_correctness` is a single word-overlap heuristic over the
+whole reference and is invalid for scoring reader predictions: for
+location it counts the "should NOT mention <distractors>" exclusion
+words (so raw retrieval containing every stale city scores high while a
+concise correct answer scores 0); for tree the binary Yes/No polarity is
+drowned by boilerplate. These tests lock the task-aware replacements.
+"""
+from __future__ import annotations
+
+from benchmarks.structmemeval_adapter import (
+    _polarity,
+    _split_location_reference,
+    score_location_prediction,
+    score_prediction,
+    score_tree_prediction,
+)
+
+_LOC_REF = (
+    "Since you currently live in Sydney (Bondi), your Saturday activity "
+    "is sunrise yoga on Bondi Beach followed by brunch at Bills. The "
+    "answer should NOT mention activities from your previous cities "
+    "(Lisbon Feira da Ladra, Tokyo Tsukiji Market, London Columbia Road, "
+    "or Barcelona La Boqueria)."
+)
+
+
+# --- location ------------------------------------------------------------
+
+
+def test_location_split_separates_expected_from_exclusion() -> None:
+    expected, exclusion = _split_location_reference(_LOC_REF)
+    assert "Sydney" in expected and "Bondi Beach" in expected
+    assert "should not mention" in exclusion.lower()
+    assert "Lisbon" in exclusion and "Tokyo" in exclusion
+
+
+def test_location_correct_current_state_passes() -> None:
+    pred = "You currently live in Sydney (Bondi); Saturday is sunrise yoga on Bondi Beach then brunch at Bills."
+    assert score_location_prediction(pred, _LOC_REF) is True
+
+
+def test_location_stale_state_fails() -> None:
+    # Names a previous city (Lisbon / Feira da Ladra) — the #909 reader's
+    # original error. Must score False.
+    pred = "Visit Feira da Ladra flea market; you live in Alfama, Lisbon."
+    assert score_location_prediction(pred, _LOC_REF) is False
+
+
+def test_location_raw_retrieval_containing_all_cities_fails() -> None:
+    # The old metric scored this HIGH (it matches the exclusion words).
+    # The fix must reject it: it leaks excluded distractors.
+    raw = (
+        "Life in Sydney Bondi sunrise yoga Bills. Life in Lisbon Feira "
+        "da Ladra. Life in Tokyo Tsukiji. Life in London Columbia Road. "
+        "Life in Barcelona La Boqueria."
+    )
+    assert score_location_prediction(raw, _LOC_REF) is False
+
+
+def test_location_correct_state_but_leaks_one_distractor_fails() -> None:
+    pred = "You live in Sydney (Bondi), sunrise yoga at Bondi Beach and Bills — unlike Tokyo Tsukiji."
+    assert score_location_prediction(pred, _LOC_REF) is False
+
+
+# --- tree ----------------------------------------------------------------
+
+
+def test_polarity_extraction() -> None:
+    assert _polarity("Yes, they are indirect colleagues.") == "yes"
+    assert _polarity("No, there is no path between them.") == "no"
+    assert _polarity("They might be related somehow.") is None
+
+
+def test_tree_matching_polarity_passes() -> None:
+    ref = "Yes, they are indirect colleagues according to their graph relations."
+    assert score_tree_prediction("Yes, a path connects them.", ref) is True
+
+
+def test_tree_opposite_polarity_fails() -> None:
+    ref = "Yes, they are indirect colleagues according to their graph relations."
+    assert score_tree_prediction("No, they are in disconnected components.", ref) is False
+
+
+def test_tree_missing_polarity_fails() -> None:
+    ref = "Yes, they are indirect colleagues according to their graph relations."
+    assert score_tree_prediction("They share a manager.", ref) is False
+
+
+# --- dispatch ------------------------------------------------------------
+
+
+def test_score_prediction_dispatches_by_task() -> None:
+    good_loc = "Sydney Bondi sunrise yoga Bondi Beach Bills."
+    assert score_prediction(good_loc, _LOC_REF, "location") is True
+    tree_ref = "Yes, they are indirect colleagues according to their graph relations."
+    assert score_prediction("Yes, connected.", tree_ref, "tree") is True
+    assert score_prediction("No, disconnected.", tree_ref, "tree") is False


### PR DESCRIPTION
## What

Adds **task-aware prediction scorers** for StructMemEval. The shipped `check_state_correctness` is a single word-overlap heuristic over the whole reference and is invalid for scoring answers, in a different way per task. Part of #899.

## Why the current scorer is invalid

`check_state_correctness(text, reference)` builds a significant-word set from the **entire** reference and returns `(matches / |ref_words|) >= 0.5`. Per task:

- **location** — the reference embeds an exclusion note: *"…should NOT mention activities from your previous cities (Lisbon …, Tokyo …, London …, Barcelona …)."* Those distractor tokens enter the word-set, so text that contains **every stale city** matches them and scores high, while a concise **correct** answer that omits them falls below 0.5 and scores 0. Measured: raw retrieval (which carries all stale states) scored **92.9%**; a correct reader answer scored **0%** — the metric is inverted.
- **tree** — the answer is a binary *Yes/No* wrapped in boilerplate (*"…indirect colleagues according to their graph relations"*). A correct *"No"* shares almost none of the boilerplate word-set, so polarity is never actually tested.

## Fix

New functions in `structmemeval_adapter.py`:
- `score_location_prediction` — correct iff the expected-state terms are present **AND** no excluded-distractor term leaks in.
- `score_tree_prediction` — Yes/No **polarity** match.
- `score_prediction(prediction, reference, task)` — dispatches by task; `accounting` / other fall back to the legacy heuristic (accounting needs a settlement-tuple scorer, tracked separately).

The legacy `check_state_correctness` and the default raw-retrieval scoring path (adapter line ~404) are **left unchanged** — properly fixing the default path requires wiring an in-process reader (the #891 no-reader-in-dispatcher issue), out of scope here.

**Validation:** under the fixed scorers the raw-retrieval baseline correctly drops to **0%** on both location and tree (vs the old 92.9% location recall). 10 unit tests in `tests/test_structmemeval_subtask_scorer.py`.

## Relationship to the merged StructMemEval back-fill (`61219415`)

The recently-merged `v3.0.1-structmemeval-backfill.json` (location 90.5% / accounting 0% / recommendations 15.4% / tree 0%) was produced by the **default raw-retrieval path** scored with the broken `check_state_correctness`. Those numbers are therefore raw-retrieval *recall* artifacts, not answer correctness — the location 90.5% is inflated by the exclusion-distractor matching described above, and the tree 0% reflects polarity never being tested. With the reader pipeline + these fixed scorers, location measures **~57%** and tree **~7%** (the latter dominated by retrieval trimming the connecting edges — all references are "Yes"). A correction note is posted on #899; re-measuring the merged capture with the fixed scorers is recommended as follow-up.

Refs #899.
