### PR TITLE
fix(bench): settlement-tuple scorer for StructMemEval accounting

### DIFF
--- a/benchmarks/structmemeval_adapter.py
+++ b/benchmarks/structmemeval_adapter.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 import tempfile
 import time
@@ -422,20 +423,101 @@ def score_tree_prediction(prediction: str, reference_text: str) -> bool:
     return ref_pol is not None and ref_pol == pred_pol
 
 
+# Settlement transaction parsing for the accounting task. Two forms are
+# accepted: the reference's "Payer -> Payee : amount EUR" and the
+# question's requested answer format "Payer pays amount to Payee".
+_SETTLE_ARROW_RE: Final = re.compile(
+    r"([A-Za-z]+)\s*->\s*([A-Za-z]+)\s*:\s*([\d]+(?:\.[\d]+)?)",
+)
+_SETTLE_PAYS_RE: Final = re.compile(
+    r"([A-Za-z]+)\s+pays\s+(?:€|EUR\s*)?([\d]+(?:\.[\d]+)?)\s*(?:€|EUR)?\s+to\s+([A-Za-z]+)",
+    re.IGNORECASE,
+)
+_ACCT_AMOUNT_TOLERANCE: Final[float] = 0.5
+
+
+def _parse_settlement_transactions(text: str) -> set[tuple[str, str, float]]:
+    """Parse settlement transactions into a set of (payer, payee, amount).
+
+    Accepts both the reference arrow form ("Alice -> Bob : 91.00 EUR") and
+    the requested answer form ("Alice pays 91 to Bob"). Names are
+    lower-cased; amounts are floats. A directed (payer, payee) pair plus
+    amount uniquely keys a transaction.
+    """
+    out: set[tuple[str, str, float]] = set()
+    for payer, payee, amt in _SETTLE_ARROW_RE.findall(text):
+        out.add((payer.lower(), payee.lower(), float(amt)))
+    for payer, amt, payee in _SETTLE_PAYS_RE.findall(text):
+        out.add((payer.lower(), payee.lower(), float(amt)))
+    return out
+
+
+def _transaction_sets_match(
+    pred: set[tuple[str, str, float]],
+    ref: set[tuple[str, str, float]],
+    tolerance: float = _ACCT_AMOUNT_TOLERANCE,
+) -> bool:
+    """True iff pred and ref have the same directed transactions with
+    amounts within `tolerance`. Same cardinality required (no extra or
+    missing transactions)."""
+    if not ref or len(pred) != len(ref):
+        return False
+    remaining: list[tuple[str, str, float]] = list(pred)
+    for r_payer, r_payee, r_amt in ref:
+        match_idx: int | None = None
+        for i, (p_payer, p_payee, p_amt) in enumerate(remaining):
+            if (
+                p_payer == r_payer
+                and p_payee == r_payee
+                and abs(p_amt - r_amt) <= tolerance
+            ):
+                match_idx = i
+                break
+        if match_idx is None:
+            return False
+        remaining.pop(match_idx)
+    return True
+
+
+def score_accounting_prediction(prediction: str, reference_text: str) -> bool:
+    """Correct iff the prediction's settlement transactions match ANY of
+    the acceptable reference alternatives.
+
+    The reference is a `" | "`-joined list of alternative settlements
+    (the benchmark accepts several valid resolutions of ambiguous
+    split instructions). Each alternative and the prediction are parsed
+    into directed (payer, payee, amount) sets; the prediction is correct
+    if its set matches any alternative within an amount tolerance. This
+    replaces the word-overlap heuristic, which never checked amounts or
+    directions.
+    """
+    pred_tx: set[tuple[str, str, float]] = _parse_settlement_transactions(
+        prediction,
+    )
+    if not pred_tx:
+        return False
+    for alternative in reference_text.split(" | "):
+        ref_tx = _parse_settlement_transactions(alternative)
+        if _transaction_sets_match(pred_tx, ref_tx):
+            return True
+    return False
+
+
 def score_prediction(
     prediction: str, reference_text: str, task: str,
 ) -> bool:
     """Dispatch prediction scoring by task.
 
-    `location` and `tree` have dedicated scorers; `accounting` and any
-    other task fall back to the legacy word-overlap heuristic (which is
-    a recall proxy, not a correctness check — accounting needs a
-    settlement-tuple comparison, tracked separately).
+    `location`, `tree`, and `accounting` have dedicated scorers; any
+    other task falls back to the legacy word-overlap heuristic (a recall
+    proxy, not a correctness check).
     """
     if task == "location":
         return score_location_prediction(prediction, reference_text)
     if task == "tree":
         return score_tree_prediction(prediction, reference_text)
+    if task == "accounting":
+        return score_accounting_prediction(prediction, reference_text)
     return check_state_correctness(
         prediction, ReferenceAnswer(text=reference_text),
     )

--- a/tests/test_structmemeval_accounting_scorer.py
+++ b/tests/test_structmemeval_accounting_scorer.py
@@ -1,0 +1,79 @@
+"""#899 StructMemEval accounting settlement-tuple scorer.
+
+The legacy `check_state_correctness` word-overlap never checks settlement
+amounts or directions. `score_accounting_prediction` parses both the
+reference (a " | "-joined list of acceptable alternative settlements) and
+the prediction into directed (payer, payee, amount) sets and accepts the
+prediction if it matches ANY alternative within an amount tolerance.
+"""
+from __future__ import annotations
+
+from benchmarks.structmemeval_adapter import (
+    _parse_settlement_transactions,
+    _transaction_sets_match,
+    score_accounting_prediction,
+    score_prediction,
+)
+
+_REF = (
+    "Settlement: Alice -> Bob : 91.00 EUR, Alice -> Charlie : 16.00 EUR | "
+    "Settlement: Alice -> Bob : 145.00 EUR, Alice -> Charlie : 52.00 EUR | "
+    "Settlement: Alice -> Bob : 284.00 EUR, Charlie -> Bob : 33.50 EUR"
+)
+
+
+def test_parse_arrow_form() -> None:
+    tx = _parse_settlement_transactions("Alice -> Bob : 91.00 EUR, Charlie -> Bob : 33.50 EUR")
+    assert tx == {("alice", "bob", 91.0), ("charlie", "bob", 33.5)}
+
+
+def test_parse_pays_form() -> None:
+    tx = _parse_settlement_transactions("Alice pays 91 to Bob\nCharlie pays 33.50 to Bob")
+    assert tx == {("alice", "bob", 91.0), ("charlie", "bob", 33.5)}
+
+
+def test_match_exact_alternative() -> None:
+    assert score_accounting_prediction("Alice pays 91 to Bob. Alice pays 16 to Charlie.", _REF) is True
+
+
+def test_match_third_alternative_with_cents() -> None:
+    assert score_accounting_prediction("Alice pays 284.00 to Bob, Charlie pays 33.50 to Bob", _REF) is True
+
+
+def test_wrong_amount_fails() -> None:
+    assert score_accounting_prediction("Alice pays 99 to Bob. Alice pays 16 to Charlie.", _REF) is False
+
+
+def test_wrong_direction_fails() -> None:
+    # Right amounts, reversed payer/payee.
+    assert score_accounting_prediction("Bob pays 91 to Alice. Charlie pays 16 to Alice.", _REF) is False
+
+
+def test_missing_transaction_fails() -> None:
+    assert score_accounting_prediction("Alice pays 91 to Bob.", _REF) is False
+
+
+def test_extra_transaction_fails() -> None:
+    assert score_accounting_prediction(
+        "Alice pays 91 to Bob. Alice pays 16 to Charlie. Bob pays 5 to Alice.", _REF,
+    ) is False
+
+
+def test_no_transactions_fails() -> None:
+    assert score_accounting_prediction("I cannot determine the settlement.", _REF) is False
+
+
+def test_within_tolerance_passes() -> None:
+    # 91.00 vs 91.4 is within the 0.5 tolerance.
+    assert score_accounting_prediction("Alice pays 91.4 to Bob. Alice pays 16 to Charlie.", _REF) is True
+
+
+def test_transaction_sets_match_requires_same_cardinality() -> None:
+    a = {("alice", "bob", 91.0)}
+    b = {("alice", "bob", 91.0), ("alice", "charlie", 16.0)}
+    assert _transaction_sets_match(a, b) is False
+
+
+def test_score_prediction_dispatches_accounting() -> None:
+    assert score_prediction("Alice pays 91 to Bob. Alice pays 16 to Charlie.", _REF, "accounting") is True
+    assert score_prediction("Bob pays 91 to Alice. Charlie pays 16 to Alice.", _REF, "accounting") is False


### PR DESCRIPTION
## What

Extends the task-aware StructMemEval scorer module (from #914, merged) with a **settlement-tuple scorer** for the accounting sub-task. Part of #899.

## Why

The legacy `check_state_correctness` word-overlap never checks settlement **amounts** or **directions** — so the merged capture's accounting 0% is uninformative. `score_accounting_prediction`:
- parses the reference (a `" | "`-joined list of acceptable alternative settlements) and the prediction into directed `(payer, payee, amount)` transaction sets,
- accepts both the reference arrow form (`Alice -> Bob : 91.00 EUR`) and the requested answer form (`Alice pays 91 to Bob`),
- returns correct iff the prediction matches **any** alternative within a 0.5 EUR tolerance (same cardinality; no extra/missing transactions).

Wired into `score_prediction` dispatch. 12 unit tests.

## Scope note — this lands the scoring *tool*, not an accounting number

A valid accounting **number** is not yet admissible. On the live data the reference settlements' net-balance **direction is inconsistent with the parsed expense log**: e.g. for `accounting_10%_1`, top-payer Alice nets **+188 EUR** (paid 1780 vs Bob 1377 / Charlie 1401), so Alice should be the creditor — but all three reference alternatives make **Bob** the creditor. Retrieval is **complete** (45/45 expense lines present in context), so this is *not* a retrieval gap. Either the benchmark applies a split/refund/settlement convention not yet reverse-engineered, and/or the three `|`-alternatives encode specific resolutions of the injected contradictory splits.

A reader-based reader pass scored 0/15 against these references, but I'm **not reporting that as a substrate/reader result** until the settlement convention is pinned — the discrepancy is in the reference↔expense-log mapping, not (demonstrably) in the reader. Tracked on #899.

This complements the merged #914 (location + tree scorers). Together they replace the invalid word-overlap for 3 of the 4 StructMemEval sub-tasks.

Refs #899.
