### PR TITLE
feat(bench): reader-prediction scoring seam for StructMemEval

### DIFF
--- a/benchmarks/structmemeval_adapter.py
+++ b/benchmarks/structmemeval_adapter.py
@@ -523,6 +523,71 @@ def score_prediction(
     )
 
 
+def score_predictions(
+    predictions: list[dict[str, object]],
+    ground_truth: list[dict[str, object]],
+    default_task: str | None = None,
+) -> dict[str, object]:
+    """Score reader predictions against ground truth with `score_prediction`.
+
+    This is the reader seam that completes the `--retrieve-only` workflow
+    (#915): `--retrieve-only` writes context (NO answers) for an external
+    reader (a sub-agent — bench LLM calls do not run in this adapter), and
+    this function grades the reader's predictions with the task-aware
+    scorer instead of the raw-retrieval `check_state_correctness` path.
+
+    `predictions` items must carry `case_id`, `question`, and `prediction`;
+    `task` is read per-item when present, else `default_task`. `ground_truth`
+    items carry `case_id`, `question`, and `reference_answer` (the GT file
+    written alongside the retrieval file). Predictions are matched to GT on
+    the `(case_id, question)` key.
+
+    Returns an aggregate dict mirroring the `--output` schema: `task`,
+    `total`, `correct`, `score_pct`, `unmatched` (predictions with no GT
+    row), and `per_query` rows.
+    """
+    gt_index: dict[tuple[str, str], str] = {}
+    for row in ground_truth:
+        key = (str(row.get("case_id", "")), str(row.get("question", "")))
+        gt_index[key] = str(row.get("reference_answer", ""))
+
+    per_query: list[dict[str, object]] = []
+    correct: int = 0
+    unmatched: int = 0
+    for pred in predictions:
+        case_id: str = str(pred.get("case_id", ""))
+        question: str = str(pred.get("question", ""))
+        prediction: str = str(pred.get("prediction", ""))
+        task: str = str(pred.get("task") or default_task or "")
+        key = (case_id, question)
+        if key not in gt_index:
+            unmatched += 1
+            continue
+        reference: str = gt_index[key]
+        is_correct: bool = score_prediction(prediction, reference, task)
+        if is_correct:
+            correct += 1
+        per_query.append({
+            "case_id": case_id,
+            "question": question,
+            "task": task,
+            "prediction": prediction,
+            "reference_answer": reference,
+            "correct": is_correct,
+        })
+
+    total: int = len(per_query)
+    score_pct: float = round(correct / total * 100, 1) if total else 0.0
+    return {
+        "task": default_task,
+        "total": total,
+        "correct": correct,
+        "score_pct": score_pct,
+        "unmatched": unmatched,
+        "per_query": per_query,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
@@ -709,7 +774,58 @@ def main() -> None:
         "--retrieve-only", default=None, metavar="PATH",
         help="Run retrieval only, write question+context+reference for LLM judge scoring",
     )
+    parser.add_argument(
+        "--score-predictions", default=None, metavar="PATH",
+        help=(
+            "Score reader predictions JSON against ground truth with the "
+            "task-aware scorer (#915 reader seam). Pairs with --ground-truth; "
+            "skips retrieval/ingest. No reader runs here — predictions come "
+            "from an external sub-agent."
+        ),
+    )
+    parser.add_argument(
+        "--ground-truth", default=None, metavar="PATH",
+        help=(
+            "Ground-truth JSON for --score-predictions (the *_gt file written "
+            "by --retrieve-only). Defaults to the predictions path's _gt sibling."
+        ),
+    )
     args: argparse.Namespace = parser.parse_args()
+
+    # #915 reader seam: score externally-produced reader predictions with
+    # the task-aware scorer. No retrieval/ingest — predictions come from a
+    # sub-agent reader fed by an earlier --retrieve-only run.
+    if args.score_predictions:
+        preds_path: Path = Path(args.score_predictions)
+        gt_path: Path = (
+            Path(args.ground_truth)
+            if args.ground_truth
+            else preds_path.with_name(preds_path.stem + "_gt" + preds_path.suffix)
+        )
+        if not preds_path.exists() or not gt_path.exists():
+            print(
+                f"score-predictions: missing input "
+                f"(predictions={preds_path}, ground_truth={gt_path})",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        with preds_path.open(encoding="utf-8") as f:
+            predictions: list[dict[str, object]] = json.load(f)
+        with gt_path.open(encoding="utf-8") as f:
+            ground_truth: list[dict[str, object]] = json.load(f)
+        scored: dict[str, object] = score_predictions(
+            predictions, ground_truth, default_task=args.task,
+        )
+        print(
+            f"Scored {scored['total']} predictions "
+            f"({scored['correct']} correct = {scored['score_pct']}%); "
+            f"{scored['unmatched']} unmatched",
+        )
+        if args.output:
+            with Path(args.output).open("w", encoding="utf-8") as f:
+                json.dump(scored, f, indent=2)
+            print(f"Detailed scoring written to {args.output}")
+        return
 
     print(f"Loading StructMemEval cases: task={args.task}, bench={args.bench}")
     cases: list[Case] = discover_cases(args.data, args.task, args.bench)

--- a/tests/test_structmemeval_reader_scoring.py
+++ b/tests/test_structmemeval_reader_scoring.py
@@ -1,0 +1,103 @@
+"""#915 StructMemEval reader-prediction scoring seam.
+
+`score_predictions` completes the `--retrieve-only` workflow: an external
+reader (a sub-agent) produces predictions from the dumped context, and this
+function grades them with the task-aware `score_prediction` instead of the
+raw-retrieval `check_state_correctness`. These tests lock the seam —
+matching on (case_id, question), per-item task dispatch, unmatched
+accounting, and (the load-bearing one) that a raw-retrieval-style answer is
+now scored WRONG because it routes through the task-aware scorer.
+"""
+from __future__ import annotations
+
+from benchmarks.structmemeval_adapter import score_predictions
+
+_LOC_REF = (
+    "Since you currently live in Sydney (Bondi), your Saturday activity "
+    "is sunrise yoga on Bondi Beach. The answer should NOT mention "
+    "activities from your previous cities (Lisbon, Tokyo, London)."
+)
+_TREE_REF = "Yes, they are indirect colleagues according to their graph relations."
+
+
+def _gt(rows: list[tuple[str, str, str]]) -> list[dict[str, object]]:
+    return [
+        {"case_id": c, "question": q, "reference_answer": r} for c, q, r in rows
+    ]
+
+
+def test_correct_location_prediction_scores_correct() -> None:
+    gt = _gt([("loc_1", "Where do you live and what is Saturday?", _LOC_REF)])
+    preds = [{
+        "case_id": "loc_1",
+        "question": "Where do you live and what is Saturday?",
+        "prediction": "You live in Sydney (Bondi); Saturday is sunrise yoga on Bondi Beach.",
+        "task": "location",
+    }]
+    out = score_predictions(preds, gt, default_task="location")
+    assert out["total"] == 1
+    assert out["correct"] == 1
+    assert out["score_pct"] == 100.0
+    assert out["unmatched"] == 0
+
+
+def test_raw_retrieval_style_answer_scores_wrong() -> None:
+    # The whole point of #914/#915: an answer that names every stale city
+    # (what raw retrieval surfaces) scored HIGH under check_state_correctness.
+    # Routed through score_prediction it must be WRONG (leaks distractors).
+    gt = _gt([("loc_1", "Where do you live?", _LOC_REF)])
+    preds = [{
+        "case_id": "loc_1",
+        "question": "Where do you live?",
+        "prediction": "Sydney Bondi yoga, and previously Lisbon, Tokyo, London.",
+        "task": "location",
+    }]
+    out = score_predictions(preds, gt, default_task="location")
+    assert out["correct"] == 0
+    assert out["score_pct"] == 0.0
+
+
+def test_per_item_task_dispatch() -> None:
+    gt = _gt([
+        ("loc_1", "loc?", _LOC_REF),
+        ("tree_1", "connected?", _TREE_REF),
+    ])
+    preds = [
+        {"case_id": "loc_1", "question": "loc?",
+         "prediction": "Sydney Bondi sunrise yoga Bondi Beach.", "task": "location"},
+        {"case_id": "tree_1", "question": "connected?",
+         "prediction": "Yes, a path connects them.", "task": "tree"},
+    ]
+    out = score_predictions(preds, gt)
+    assert out["correct"] == 2
+    assert out["total"] == 2
+
+
+def test_default_task_used_when_item_omits_task() -> None:
+    gt = _gt([("tree_1", "connected?", _TREE_REF)])
+    preds = [{"case_id": "tree_1", "question": "connected?",
+              "prediction": "No, disconnected components."}]
+    out = score_predictions(preds, gt, default_task="tree")
+    # Opposite polarity ⇒ wrong, but it must have dispatched to the tree scorer.
+    assert out["correct"] == 0
+    assert out["total"] == 1
+
+
+def test_unmatched_prediction_counted_not_scored() -> None:
+    gt = _gt([("loc_1", "q1", _LOC_REF)])
+    preds = [
+        {"case_id": "loc_1", "question": "q1",
+         "prediction": "Sydney Bondi sunrise yoga Bondi Beach.", "task": "location"},
+        {"case_id": "ghost", "question": "no-such-q",
+         "prediction": "whatever", "task": "location"},
+    ]
+    out = score_predictions(preds, gt, default_task="location")
+    assert out["total"] == 1  # only the matched one is scored
+    assert out["correct"] == 1
+    assert out["unmatched"] == 1
+
+
+def test_empty_predictions_yields_zero_not_crash() -> None:
+    out = score_predictions([], _gt([("c", "q", _LOC_REF)]), default_task="location")
+    assert out["total"] == 0
+    assert out["score_pct"] == 0.0


### PR DESCRIPTION
## What

Adds the reader-prediction scoring seam for StructMemEval — the entry point that lets the task-aware scorers (#914 location/tree, #917 accounting) grade an actual reader's answers instead of raw retrieval.

- `score_predictions(predictions, ground_truth, default_task)` — matches reader predictions to the `--retrieve-only` ground-truth file on `(case_id, question)` and grades each with `score_prediction`. Returns an aggregate (`total` / `correct` / `score_pct` / `unmatched` / `per_query`).
- `--score-predictions PATH` CLI mode (pairs with `--ground-truth`, defaults to the `_gt` sibling). Skips retrieval/ingest.

## Why

The adapter scored raw retrieval with `check_state_correctness` (the invalid heuristic — see the #912 correction banner). The new scorers existed but had no way to consume reader output. This completes the existing `--retrieve-only` isolation workflow: retrieve context (no answers) → external reader → score predictions with the task-aware scorer.

**No reader runs in the adapter.** Predictions come from a sub-agent fed by an earlier `--retrieve-only` run, preserving the deterministic, no-API-key contract for bench adapters.

## Test plan

- 6 unit tests in `tests/test_structmemeval_reader_scoring.py`, incl. the load-bearing one: a raw-retrieval-style answer (names every stale city) now scores **wrong** because it routes through `score_location_prediction`, not `check_state_correctness`.
- CLI smoke verified locally (`--score-predictions` + `_gt` sibling inference).

## Scope — what this does NOT do (tracked on #915)

- Does **not** run the full multi-query re-measure (15–1104 queries/task via sub-agent reader) — that's a separate execution.
- Does **not** admit an accounting number — the settlement-convention discrepancy from #917 (reference net-balance vs expense log) is still unresolved.

Refs #915.
