### PR TITLE
feat(cadence): p3_substantive dispatch + shadow capture + 4-policy scorer + offline replay (#876)

### DIFF
--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policy pair, so p1 / p2 / p3_velocity / p3_substantive can be
   compared head-to-head. The legacy 2x2 P1-vs-P2 matrix is retained for
   backward compatibility.
+- **Offline cadence replay bench (`benchmarks/cadence_replay.py`, #876).**
+  Produces the same four-policy comparison `aelf cadence-score` emits
+  from a live shadow bake, but from a self-contained synthetic fixture
+  — no operator-week of real shadow data required. Each fixture tick is
+  fed through every `would_fire` predicate; the rows aggregate through
+  the same `compute_summary`. Deterministic (#605), no live state, no
+  `~/.claude/` content. A sample fixture ships at
+  `benchmarks/fixtures/cadence_replay_sample.json`.
 
 ### Fixed
 

--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`p3_substantive` cadence policy is now wired live (#876).** The
+  substantive-turn density policy (axis-1 option C) joins `p3_velocity`
+  in the Stop and UPS dispatchers. Each turn the policy is active, the
+  Stop hook classifies the user prompt via `is_substantive_turn` and
+  pushes it onto a rolling window in the session ring; the firing
+  predicate fires when the substantive ratio over the last
+  `p3_substantive_window` turns meets `p3_substantive_threshold`. Stop
+  owns the per-turn push; UPS reads the window only (a one-turn read
+  lag, matching the existing `p3_velocity` counter-sharing semantics),
+  so the window advances exactly once per turn. Deterministic (#605),
+  no embeddings. Shadow-mode P3 capture + 4-policy scoring land in the
+  next PR of the stack.
+
 ### Fixed
 
 - **UserPromptSubmit retrieval is now conversation-aware (#909).** The

--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -20,8 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   owns the per-turn push; UPS reads the window only (a one-turn read
   lag, matching the existing `p3_velocity` counter-sharing semantics),
   so the window advances exactly once per turn. Deterministic (#605),
-  no embeddings. Shadow-mode P3 capture + 4-policy scoring land in the
-  next PR of the stack.
+  no embeddings.
+- **Shadow-evaluation mode now captures all four cadence policies
+  (#876).** `_maybe_log_cadence_shadow_tick` previously logged only
+  `would_fire` for p1 and p2; it now also evaluates `p3_velocity` and
+  `p3_substantive` against the same tick inputs, so the shadow log
+  carries every implemented policy's decision. This is the data source
+  `aelf cadence-score` reads to compare policies head-to-head on
+  identical workload.
 
 ### Fixed
 

--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carries every implemented policy's decision. This is the data source
   `aelf cadence-score` reads to compare policies head-to-head on
   identical workload.
+- **`aelf cadence-score` now reports a four-policy comparison (#876).**
+  Per-policy fire rates already spanned every policy in the log; the
+  scorer adds a generalised `pairwise_agreement` table (both / a-only /
+  b-only / neither, plus a divergence rate) across every unordered
+  policy pair, so p1 / p2 / p3_velocity / p3_substantive can be
+  compared head-to-head. The legacy 2x2 P1-vs-P2 matrix is retained for
+  backward compatibility.
 
 ### Fixed
 

--- a/benchmarks/cadence_replay.py
+++ b/benchmarks/cadence_replay.py
@@ -1,0 +1,254 @@
+"""Offline deterministic replay bench for cadence policies (#876).
+
+The cadence-policy bake (#749 / #875 shadow mode) normally needs an
+operator-week of live shadow data before ``aelf cadence-score`` can
+compare policies. This harness produces the *same* comparison from a
+self-contained synthetic fixture instead — feeding per-tick inputs
+through every implemented ``would_fire`` predicate (p1, p2,
+p3_velocity, p3_substantive) and emitting shadow-log-shaped rows that
+:func:`aelfrice.cadence_score.compute_summary` aggregates exactly as it
+would a live bake.
+
+Determinism (#605): same fixture → same report. No wall-clock, no
+random sampling, no network. Discretion (``ab96e9d3501b1c14``): the
+fixture is synthetic input authored alongside the bench; the harness
+reads no ``~/.claude/``-derived state and writes only the capture the
+caller names.
+
+Fixture schema (JSON)::
+
+    {
+      "config": {
+        "k": 15,
+        "ctx_threshold": 0.8,
+        "ctx_byte_window": 100000,
+        "p3_velocity_threshold": 3000,
+        "p3_substantive_window": 5,
+        "p3_substantive_threshold": 0.6
+      },
+      "selected": "p1_every_k_turns",   # optional; default "off"
+      "ticks": [
+        {
+          "fire_idx": 7,
+          "bytes_at_last_fire": 0,
+          "fire_idx_at_last_fire": 0,
+          "transcript_bytes": 70000,
+          "last_prompt": "ok next",
+          "classifications": [true, true, true, true, true]
+        },
+        ...
+      ]
+    }
+
+Each tick yields one shadow row. The optional ``selected`` policy (also
+overridable per-tick) drives the ``fired`` field so the selected-policy
+live-fire rate is meaningful; the four ``would_fire`` decisions are
+policy-agnostic and always recorded.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from aelfrice.cadence import (
+    CadenceConfig,
+    POLICY_OFF,
+    POLICY_P1_EVERY_K_TURNS,
+    POLICY_P2_CTX_THRESHOLD,
+    POLICY_P3_SUBSTANTIVE,
+    POLICY_P3_VELOCITY,
+    estimate_transcript_bytes,
+    would_fire_p1,
+    would_fire_p2,
+    would_fire_p3_substantive,
+    would_fire_p3_velocity,
+)
+from aelfrice.cadence_score import compute_summary, format_report
+
+
+def _config_from_fixture(raw: dict[str, Any]) -> CadenceConfig:
+    """Build a CadenceConfig from the fixture ``config`` block.
+
+    Missing knobs fall back to CadenceConfig defaults. ``enabled`` and
+    ``policy`` are forced (enabled=True, policy=OFF) — the replay
+    evaluates policy-agnostic would_fire predicates, so the selected
+    policy on the config object is irrelevant to the comparison.
+    """
+    cfg = raw.get("config")
+    cfg = cfg if isinstance(cfg, dict) else {}
+    defaults = CadenceConfig()
+    return CadenceConfig(
+        enabled=True,
+        policy=POLICY_OFF,
+        k=int(cfg.get("k", defaults.k)),
+        ctx_threshold=float(cfg.get("ctx_threshold", defaults.ctx_threshold)),
+        ctx_byte_window=int(cfg.get("ctx_byte_window", defaults.ctx_byte_window)),
+        p3_velocity_threshold=int(
+            cfg.get("p3_velocity_threshold", defaults.p3_velocity_threshold)
+        ),
+        p3_substantive_window=int(
+            cfg.get("p3_substantive_window", defaults.p3_substantive_window)
+        ),
+        p3_substantive_threshold=float(
+            cfg.get("p3_substantive_threshold", defaults.p3_substantive_threshold)
+        ),
+    )
+
+
+def _write_transcript(path: Path, target_bytes: int, last_prompt: str) -> None:
+    """Write a synthetic transcript of ~``target_bytes`` ending in a user line.
+
+    The final line is the user prompt (so ``read_last_user_prompt`` and the
+    P2 phase-boundary check see it); preceding filler assistant lines pad
+    the file toward ``target_bytes``. The exact size need not be byte-perfect
+    — fixtures pick byte counts comfortably above/below the watermark.
+    """
+    user_line = json.dumps({"message": {"role": "user", "content": last_prompt}})
+    filler = json.dumps({"message": {"role": "assistant", "content": "x" * 800}})
+    user_size = len(user_line.encode("utf-8")) + 1
+    filler_size = len(filler.encode("utf-8")) + 1
+    pad = max(0, target_bytes - user_size)
+    n_filler = pad // filler_size
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for _ in range(n_filler):
+            f.write(filler + "\n")
+        f.write(user_line + "\n")
+
+
+def replay_fixture(fixture: dict[str, Any]) -> list[dict[str, Any]]:
+    """Replay every tick in ``fixture`` into shadow-log-shaped rows.
+
+    Returns a list of rows with the same shape the Stop-hook shadow
+    logger writes, so :func:`compute_summary` aggregates them directly.
+    Deterministic and pure aside from the per-tick temp transcript file
+    (written inside a TemporaryDirectory and discarded).
+    """
+    cfg = _config_from_fixture(fixture)
+    default_selected = str(fixture.get("selected", POLICY_OFF))
+    ticks = fixture.get("ticks")
+    ticks = ticks if isinstance(ticks, list) else []
+
+    rows: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="cadence_replay_") as tmpdir:
+        tmp = Path(tmpdir)
+        for idx, tick in enumerate(ticks):
+            if not isinstance(tick, dict):
+                continue
+            fire_idx = int(tick.get("fire_idx", 0))
+            bytes_at_last_fire = int(tick.get("bytes_at_last_fire", 0))
+            fire_idx_at_last_fire = int(tick.get("fire_idx_at_last_fire", 0))
+            target_bytes = int(tick.get("transcript_bytes", 0))
+            last_prompt = str(tick.get("last_prompt", ""))
+            raw_classes = tick.get("classifications")
+            classifications = (
+                [bool(c) for c in raw_classes] if isinstance(raw_classes, list) else []
+            )
+            selected = str(tick.get("selected", default_selected))
+
+            transcript = tmp / f"tick-{idx}.jsonl"
+            _write_transcript(transcript, target_bytes, last_prompt)
+            # Use the actual written file size for both P2 (reads the file)
+            # and p3_velocity (takes the int), so the two predicates see a
+            # consistent transcript-byte figure.
+            actual_bytes = estimate_transcript_bytes(transcript)
+            turns_since = fire_idx - fire_idx_at_last_fire
+            window = cfg.p3_substantive_window
+            substantive_count = sum(
+                1 for c in classifications[-window:] if c is True
+            )
+
+            p1_fire, p1_reason = would_fire_p1(fire_idx=fire_idx, config=cfg)
+            p2_fire, p2_reason = would_fire_p2(
+                transcript_path=transcript,
+                last_user_prompt=last_prompt,
+                config=cfg,
+            )
+            p3v_fire, p3v_reason = would_fire_p3_velocity(
+                bytes_at_last_fire=bytes_at_last_fire,
+                transcript_bytes=actual_bytes,
+                turns_since_last_fire=turns_since,
+                config=cfg,
+            )
+            p3s_fire, p3s_reason = would_fire_p3_substantive(
+                substantive_count=substantive_count,
+                config=cfg,
+            )
+
+            fired_by_selected = {
+                POLICY_P1_EVERY_K_TURNS: p1_fire,
+                POLICY_P2_CTX_THRESHOLD: p2_fire,
+                POLICY_P3_VELOCITY: p3v_fire,
+                POLICY_P3_SUBSTANTIVE: p3s_fire,
+            }.get(selected, False)
+
+            rows.append({
+                "ts": f"replay-{idx:06d}",
+                "session_id": "replay",
+                "selected": selected,
+                "fired": fired_by_selected,
+                "shadow": {
+                    POLICY_P1_EVERY_K_TURNS: {
+                        "would_fire": p1_fire, "reason": p1_reason,
+                    },
+                    POLICY_P2_CTX_THRESHOLD: {
+                        "would_fire": p2_fire, "reason": p2_reason,
+                    },
+                    POLICY_P3_VELOCITY: {
+                        "would_fire": p3v_fire, "reason": p3v_reason,
+                    },
+                    POLICY_P3_SUBSTANTIVE: {
+                        "would_fire": p3s_fire, "reason": p3s_reason,
+                    },
+                },
+            })
+    return rows
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Offline deterministic replay bench for cadence policies (#876)",
+    )
+    parser.add_argument(
+        "--fixture", required=True, metavar="PATH",
+        help="Path to the JSON replay fixture.",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit the ShadowSummary as JSON instead of the text report.",
+    )
+    parser.add_argument(
+        "--output", default=None, metavar="PATH",
+        help="Write the JSON summary to PATH (in addition to stdout).",
+    )
+    args = parser.parse_args(argv)
+
+    fixture_path = Path(args.fixture)
+    if not fixture_path.is_file():
+        print(f"cadence-replay: fixture not found: {fixture_path}", file=sys.stderr)
+        return 2
+    try:
+        fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"cadence-replay: cannot read fixture: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(fixture, dict):
+        print("cadence-replay: fixture must be a JSON object", file=sys.stderr)
+        return 2
+
+    rows = replay_fixture(fixture)
+    summary = compute_summary(rows)
+    print(format_report(summary, as_json=args.json), end="")
+    if args.output:
+        Path(args.output).write_text(
+            format_report(summary, as_json=True), encoding="utf-8",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/fixtures/cadence_replay_sample.json
+++ b/benchmarks/fixtures/cadence_replay_sample.json
@@ -1,0 +1,37 @@
+{
+  "config": {
+    "k": 15,
+    "ctx_threshold": 0.8,
+    "ctx_byte_window": 100000,
+    "p3_velocity_threshold": 3000,
+    "p3_substantive_window": 5,
+    "p3_substantive_threshold": 0.6
+  },
+  "selected": "p1_every_k_turns",
+  "ticks": [
+    {
+      "fire_idx": 15,
+      "bytes_at_last_fire": 0,
+      "fire_idx_at_last_fire": 0,
+      "transcript_bytes": 10000,
+      "last_prompt": "implement the parser module",
+      "classifications": [true, true, true, true, true]
+    },
+    {
+      "fire_idx": 7,
+      "bytes_at_last_fire": 0,
+      "fire_idx_at_last_fire": 0,
+      "transcript_bytes": 120000,
+      "last_prompt": "next task",
+      "classifications": [false, false, false, false, false]
+    },
+    {
+      "fire_idx": 3,
+      "bytes_at_last_fire": 0,
+      "fire_idx_at_last_fire": 0,
+      "transcript_bytes": 5000,
+      "last_prompt": "thinking about the design",
+      "classifications": [true, false, false, false, false]
+    }
+  ]
+}

--- a/src/aelfrice/cadence_score.py
+++ b/src/aelfrice/cadence_score.py
@@ -32,9 +32,17 @@ class ShadowSummary:
     """Aggregate statistics over a set of shadow-log rows.
 
     ``per_policy_fire_count`` and ``per_policy_total`` are keyed by
-    policy name. ``selected_fire_count`` counts rows where the
-    selected policy fired live. ``agreement_matrix`` is a 2x2
-    ``{(p1_fire, p2_fire): count}`` dict — keys are bool pairs.
+    policy name — these already span every policy present in the rows
+    (p1, p2, p3_velocity, p3_substantive). ``selected_fire_count``
+    counts rows where the selected policy fired live.
+
+    ``agreement_matrix`` is the legacy 2x2 ``{(p1_fire, p2_fire):
+    count}`` dict, retained for backward compatibility.
+    ``pairwise_agreement`` generalises it to every unordered policy
+    pair present in the rows (#876 four-policy bake): keyed by a
+    lexicographically-ordered ``(policy_a, policy_b)`` tuple, the value
+    is a count dict with ``both`` / ``a_only`` / ``b_only`` / ``neither``
+    — the head-to-head divergence the bake reads to pick a winner.
     """
     total_rows: int
     sessions: int
@@ -45,6 +53,9 @@ class ShadowSummary:
     selected_fire_count: dict[str, int] = field(default_factory=dict)
     selected_total: dict[str, int] = field(default_factory=dict)
     agreement_matrix: dict[tuple[bool, bool], int] = field(default_factory=dict)
+    pairwise_agreement: dict[tuple[str, str], dict[str, int]] = field(
+        default_factory=dict
+    )
 
 
 def iter_shadow_rows(shadow_dir: Path) -> Iterator[dict[str, Any]]:
@@ -85,8 +96,9 @@ def compute_summary(
     ``session_id`` field does not exactly match. Used by the CLI
     ``--session`` flag.
 
-    Returns a frozen summary with totals, per-policy counts, and the
-    2x2 P1/P2 agreement matrix. Empty input -> all zeros.
+    Returns a frozen summary with totals, per-policy counts, the legacy
+    2x2 P1/P2 agreement matrix, and the generalised pairwise-agreement
+    table across every policy pair present. Empty input -> all zeros.
     """
     total = 0
     sessions: set[str] = set()
@@ -102,6 +114,7 @@ def compute_summary(
         (False, True): 0,
         (False, False): 0,
     }
+    pairwise: dict[tuple[str, str], dict[str, int]] = {}
 
     for row in rows:
         sid = row.get("session_id")
@@ -130,6 +143,7 @@ def compute_summary(
 
         p1_fire = False
         p2_fire = False
+        row_fire: dict[str, bool] = {}
         for policy, decision in shadow.items():
             if not isinstance(decision, dict):
                 continue
@@ -139,11 +153,33 @@ def compute_summary(
             per_policy_total[policy] = per_policy_total.get(policy, 0) + 1
             if would:
                 per_policy_fire[policy] = per_policy_fire.get(policy, 0) + 1
+            row_fire[policy] = would
             if policy == POLICY_P1_EVERY_K_TURNS:
                 p1_fire = would
             elif policy == POLICY_P2_CTX_THRESHOLD:
                 p2_fire = would
         agreement[(p1_fire, p2_fire)] += 1
+
+        # Generalised pairwise agreement over every unordered policy pair
+        # whose decision was logged on this row. The pair key is ordered
+        # lexicographically (a < b); ``a_only``/``b_only`` follow that order.
+        policies = sorted(row_fire)
+        for i in range(len(policies)):
+            for j in range(i + 1, len(policies)):
+                a, b = policies[i], policies[j]
+                cell = pairwise.setdefault(
+                    (a, b),
+                    {"both": 0, "a_only": 0, "b_only": 0, "neither": 0},
+                )
+                fa, fb = row_fire[a], row_fire[b]
+                if fa and fb:
+                    cell["both"] += 1
+                elif fa:
+                    cell["a_only"] += 1
+                elif fb:
+                    cell["b_only"] += 1
+                else:
+                    cell["neither"] += 1
 
     return ShadowSummary(
         total_rows=total,
@@ -155,6 +191,7 @@ def compute_summary(
         selected_fire_count=selected_fire,
         selected_total=selected_total,
         agreement_matrix=agreement,
+        pairwise_agreement=pairwise,
     )
 
 
@@ -184,6 +221,10 @@ def format_report(summary: ShadowSummary, *, as_json: bool = False) -> str:
             "agreement_matrix": {
                 f"p1={int(k[0])},p2={int(k[1])}": v
                 for k, v in summary.agreement_matrix.items()
+            },
+            "pairwise_agreement": {
+                f"{a}|{b}": cell
+                for (a, b), cell in summary.pairwise_agreement.items()
             },
         }
         return json.dumps(payload, indent=2, sort_keys=True)
@@ -219,6 +260,23 @@ def format_report(summary: ShadowSummary, *, as_json: bool = False) -> str:
         f"{summary.agreement_matrix.get((False, True), 0):>9}"
         f"{summary.agreement_matrix.get((False, False), 0):>9}"
     )
+    if summary.pairwise_agreement:
+        lines.append("")
+        lines.append("pairwise policy agreement (both / a-only / b-only / neither):")
+        for (a, b) in sorted(summary.pairwise_agreement):
+            cell = summary.pairwise_agreement[(a, b)]
+            both = cell.get("both", 0)
+            a_only = cell.get("a_only", 0)
+            b_only = cell.get("b_only", 0)
+            neither = cell.get("neither", 0)
+            n = both + a_only + b_only + neither
+            diverge = a_only + b_only
+            div_pct = (diverge / n * 100) if n else 0.0
+            lines.append(
+                f"  {a} vs {b}: "
+                f"{both}/{a_only}/{b_only}/{neither} "
+                f"(diverge {diverge}/{n} = {div_pct:.1f}%)"
+            )
     return "\n".join(lines) + "\n"
 
 

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -3109,26 +3109,32 @@ def _maybe_fire_cadence_checkpoint(
         POLICY_OFF,
         POLICY_P1_EVERY_K_TURNS,
         POLICY_P2_CTX_THRESHOLD,
+        POLICY_P3_SUBSTANTIVE,
         POLICY_P3_VELOCITY,
         append_shadow_row,
         estimate_transcript_bytes,
         format_shadow_row,
+        is_substantive_turn,
         read_last_user_prompt,
         resolve_cadence_ctx_byte_window,
         resolve_cadence_ctx_threshold,
         resolve_cadence_enabled,
         resolve_cadence_k,
+        resolve_cadence_p3_substantive_threshold,
+        resolve_cadence_p3_substantive_window,
         resolve_cadence_p3_velocity_threshold,
         resolve_cadence_policy,
         resolve_cadence_shadow_mode_enabled,
         shadow_log_path,
         should_fire,
         should_fire_p2,
+        should_fire_p3_substantive,
         should_fire_p3_velocity,
         would_fire_p1,
         would_fire_p2,
     )
     from aelfrice.session_ring import (  # noqa: PLC0415
+        push_classification,
         read_ring_state,
         update_p3_velocity_state,
     )
@@ -3279,6 +3285,58 @@ def _maybe_fire_cadence_checkpoint(
         )
         return
 
+    if policy == POLICY_P3_SUBSTANTIVE:
+        window = resolve_cadence_p3_substantive_window(start=cwd)
+        threshold = resolve_cadence_p3_substantive_threshold(start=cwd)
+        cfg = CadenceConfig(
+            enabled=True,
+            policy=policy,
+            p3_substantive_window=window,
+            p3_substantive_threshold=threshold,
+        )
+        tp_obj = payload.get(_TRANSCRIPT_PATH_KEY)
+        tp: Path | None
+        if isinstance(tp_obj, str) and tp_obj:
+            tp = Path(tp_obj)
+        elif isinstance(tp_obj, os.PathLike):
+            tp = Path(tp_obj)
+        else:
+            tp = None
+        last_prompt = read_last_user_prompt(tp)
+        # Stop owns the per-turn classification push; UPS reads the window
+        # without pushing so the rolling history advances exactly once per
+        # turn — a double-push would distort the substantive ratio. The push
+        # happens every turn the policy is active, regardless of fire.
+        push_classification(
+            session_id,
+            is_substantive_turn(last_prompt),
+            window_cap=window,
+            stderr=serr,
+        )
+        state = read_ring_state(session_id)
+        if not isinstance(state, dict):
+            return
+        classifications = state.get("classifications")
+        if not isinstance(classifications, list):
+            return
+        substantive_count = sum(1 for c in classifications[-window:] if c is True)
+        if not should_fire_p3_substantive(
+            substantive_count=substantive_count,
+            config=cfg,
+        ):
+            return
+        body = _run_cadence_rebuild(payload, cwd)
+        if body is None:
+            return
+        _write_cadence_resume_cache(body, session_id, policy, serr)
+        print(
+            f"aelfrice: cadence checkpoint fired "
+            f"(policy={policy}, substantive={substantive_count}/{window}, "
+            f"threshold={threshold})",
+            file=serr,
+        )
+        return
+
     # Unknown policy / POLICY_OFF — no-op.
 
 
@@ -3315,6 +3373,7 @@ def _maybe_run_ups_cadence_checkpoint(
         CadenceConfig,
         POLICY_P1_EVERY_K_TURNS,
         POLICY_P2_CTX_THRESHOLD,
+        POLICY_P3_SUBSTANTIVE,
         POLICY_P3_VELOCITY,
         estimate_transcript_bytes,
         read_last_user_prompt,
@@ -3322,10 +3381,13 @@ def _maybe_run_ups_cadence_checkpoint(
         resolve_cadence_ctx_threshold,
         resolve_cadence_enabled,
         resolve_cadence_k,
+        resolve_cadence_p3_substantive_threshold,
+        resolve_cadence_p3_substantive_window,
         resolve_cadence_p3_velocity_threshold,
         resolve_cadence_policy,
         should_fire,
         should_fire_p2,
+        should_fire_p3_substantive,
         should_fire_p3_velocity,
     )
     from aelfrice.session_ring import (  # noqa: PLC0415
@@ -3451,6 +3513,43 @@ def _maybe_run_ups_cadence_checkpoint(
         print(
             f"aelfrice: ups cadence checkpoint fired @ fire_idx={next_fire_idx} "
             f"(policy={policy}, velocity={density:.1f} bytes/turn, "
+            f"threshold={threshold})",
+            file=serr,
+        )
+        return body
+
+    if policy == POLICY_P3_SUBSTANTIVE:
+        window = resolve_cadence_p3_substantive_window(start=cwd)
+        threshold = resolve_cadence_p3_substantive_threshold(start=cwd)
+        cfg = CadenceConfig(
+            enabled=True,
+            policy=policy,
+            p3_substantive_window=window,
+            p3_substantive_threshold=threshold,
+        )
+        # Stop owns the per-turn classification push (see Stop-side note);
+        # UPS reads the window only. The window therefore reflects
+        # classifications through the prior turn's Stop tick — a one-turn
+        # read lag, consistent with the p3_velocity counter-sharing
+        # semantics above.
+        state = read_ring_state(session_id)
+        if not isinstance(state, dict):
+            return None
+        classifications = state.get("classifications")
+        if not isinstance(classifications, list):
+            return None
+        substantive_count = sum(1 for c in classifications[-window:] if c is True)
+        if not should_fire_p3_substantive(
+            substantive_count=substantive_count,
+            config=cfg,
+        ):
+            return None
+        body = _run_cadence_rebuild(payload, cwd)
+        if body is None:
+            return None
+        print(
+            f"aelfrice: ups cadence checkpoint fired "
+            f"(policy={policy}, substantive={substantive_count}/{window}, "
             f"threshold={threshold})",
             file=serr,
         )

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -3571,16 +3571,20 @@ def _maybe_log_cadence_shadow_tick(
     """Write one shadow-evaluation row for this Stop-hook tick (#875).
 
     No-op when ``[cadence] shadow_mode_enabled`` is false (default).
-    When true, evaluates would_fire_p1 and would_fire_p2 against the
-    same inputs the live dispatch would use, derives ``fired`` from
-    the selected policy's decision, and appends one JSONL row to
-    ``<aelfrice-dir>/cadence_shadow/<session_id>.jsonl``.
+    When true, evaluates every implemented policy's would_fire
+    predicate (p1, p2, p3_velocity, p3_substantive) against the same
+    inputs the live dispatch would use, derives ``fired`` from the
+    selected policy's decision, and appends one JSONL row to
+    ``<aelfrice-dir>/cadence_shadow/<session_id>.jsonl``. The four
+    decisions let ``aelf cadence-score`` compare policies head-to-head
+    on identical workload (#876 axis-3 bake).
 
     The function intentionally re-resolves the same knobs the live
-    dispatch reads (k, ctx_threshold, ctx_byte_window, transcript
-    path, last user prompt). The duplicate work is bounded by
-    shadow_mode_enabled defaulting to false — when off, this
-    function returns on the first line at no measurable cost.
+    dispatch reads (k, ctx_threshold, ctx_byte_window, p3_velocity_
+    threshold, p3_substantive_window/threshold, transcript path, last
+    user prompt, ring fire/byte/classification state). The duplicate
+    work is bounded by shadow_mode_enabled defaulting to false — when
+    off, this function returns on the first line at no measurable cost.
 
     Fail-soft: any exception traces a stderr line and returns. The
     log is diagnostic; a missing row is recoverable.
@@ -3591,16 +3595,24 @@ def _maybe_log_cadence_shadow_tick(
         POLICY_OFF,
         POLICY_P1_EVERY_K_TURNS,
         POLICY_P2_CTX_THRESHOLD,
+        POLICY_P3_SUBSTANTIVE,
+        POLICY_P3_VELOCITY,
         append_shadow_row,
+        estimate_transcript_bytes,
         format_shadow_row,
         read_last_user_prompt,
         resolve_cadence_ctx_byte_window,
         resolve_cadence_ctx_threshold,
         resolve_cadence_k,
+        resolve_cadence_p3_substantive_threshold,
+        resolve_cadence_p3_substantive_window,
+        resolve_cadence_p3_velocity_threshold,
         resolve_cadence_shadow_mode_enabled,
         shadow_log_path,
         would_fire_p1,
         would_fire_p2,
+        would_fire_p3_substantive,
+        would_fire_p3_velocity,
     )
     from aelfrice.context_rebuilder import _rebuild_log_dir_for_db  # noqa: PLC0415
     from aelfrice.session_ring import read_ring_state  # noqa: PLC0415
@@ -3615,12 +3627,18 @@ def _maybe_log_cadence_shadow_tick(
         k = resolve_cadence_k(start=cwd)
         ctx_threshold = resolve_cadence_ctx_threshold(start=cwd)
         ctx_byte_window = resolve_cadence_ctx_byte_window(start=cwd)
+        p3_velocity_threshold = resolve_cadence_p3_velocity_threshold(start=cwd)
+        p3_substantive_window = resolve_cadence_p3_substantive_window(start=cwd)
+        p3_substantive_threshold = resolve_cadence_p3_substantive_threshold(start=cwd)
         cfg = CadenceConfig(
             enabled=True,
             policy=policy,
             k=k,
             ctx_threshold=ctx_threshold,
             ctx_byte_window=ctx_byte_window,
+            p3_velocity_threshold=p3_velocity_threshold,
+            p3_substantive_window=p3_substantive_window,
+            p3_substantive_threshold=p3_substantive_threshold,
         )
 
         # P1 input: fire_idx from session ring state. Tolerate missing /
@@ -3642,10 +3660,51 @@ def _maybe_log_cadence_shadow_tick(
             tp = None
         last_prompt = read_last_user_prompt(tp)
 
+        # P3-velocity inputs: byte delta since last fire / turns since.
+        # Tolerate missing / malformed slots by defaulting to 0 (the
+        # predicate rejects non-positive turns and non-monotonic bytes).
+        raw_bytes_last: Any = (
+            state.get("bytes_at_last_fire", 0) if isinstance(state, dict) else 0
+        )
+        raw_fire_last: Any = (
+            state.get("fire_idx_at_last_fire", 0) if isinstance(state, dict) else 0
+        )
+        bytes_at_last_fire = (
+            raw_bytes_last
+            if isinstance(raw_bytes_last, int) and not isinstance(raw_bytes_last, bool)
+            else 0
+        )
+        fire_idx_at_last_fire = (
+            raw_fire_last
+            if isinstance(raw_fire_last, int) and not isinstance(raw_fire_last, bool)
+            else 0
+        )
+        transcript_bytes = estimate_transcript_bytes(tp)
+        turns_since_last_fire = fire_idx - fire_idx_at_last_fire
+
+        # P3-substantive input: substantive ratio over the rolling window.
+        raw_classes: Any = (
+            state.get("classifications") if isinstance(state, dict) else None
+        )
+        classifications = raw_classes if isinstance(raw_classes, list) else []
+        substantive_count = sum(
+            1 for c in classifications[-p3_substantive_window:] if c is True
+        )
+
         p1_fires, p1_reason = would_fire_p1(fire_idx=fire_idx, config=cfg)
         p2_fires, p2_reason = would_fire_p2(
             transcript_path=tp,
             last_user_prompt=last_prompt,
+            config=cfg,
+        )
+        p3v_fires, p3v_reason = would_fire_p3_velocity(
+            bytes_at_last_fire=bytes_at_last_fire,
+            transcript_bytes=transcript_bytes,
+            turns_since_last_fire=turns_since_last_fire,
+            config=cfg,
+        )
+        p3s_fires, p3s_reason = would_fire_p3_substantive(
+            substantive_count=substantive_count,
             config=cfg,
         )
 
@@ -3653,6 +3712,10 @@ def _maybe_log_cadence_shadow_tick(
             fired = p1_fires
         elif policy == POLICY_P2_CTX_THRESHOLD:
             fired = p2_fires
+        elif policy == POLICY_P3_VELOCITY:
+            fired = p3v_fires
+        elif policy == POLICY_P3_SUBSTANTIVE:
+            fired = p3s_fires
         else:
             # POLICY_OFF or unknown — selected policy never fires.
             fired = False
@@ -3678,6 +3741,14 @@ def _maybe_log_cadence_shadow_tick(
                 POLICY_P2_CTX_THRESHOLD: {
                     "would_fire": p2_fires,
                     "reason": p2_reason,
+                },
+                POLICY_P3_VELOCITY: {
+                    "would_fire": p3v_fires,
+                    "reason": p3v_reason,
+                },
+                POLICY_P3_SUBSTANTIVE: {
+                    "would_fire": p3s_fires,
+                    "reason": p3s_reason,
                 },
             },
             now=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/tests/test_cadence_replay.py
+++ b/tests/test_cadence_replay.py
@@ -1,0 +1,154 @@
+"""Tests for the offline cadence replay bench (#876).
+
+The harness replays a synthetic fixture through all four would_fire
+predicates and aggregates via cadence_score, producing the same
+comparison a live shadow bake would — deterministically, no live data.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aelfrice.cadence import (
+    POLICY_P1_EVERY_K_TURNS,
+    POLICY_P2_CTX_THRESHOLD,
+    POLICY_P3_SUBSTANTIVE,
+    POLICY_P3_VELOCITY,
+)
+from aelfrice.cadence_score import compute_summary
+from benchmarks.cadence_replay import main, replay_fixture
+
+_FIXTURE = {
+    "config": {
+        "k": 15,
+        "ctx_threshold": 0.8,
+        "ctx_byte_window": 100000,
+        "p3_velocity_threshold": 3000,
+        "p3_substantive_window": 5,
+        "p3_substantive_threshold": 0.6,
+    },
+    "selected": "p1_every_k_turns",
+    "ticks": [
+        # p1 fires (15 % 15 == 0); p3_substantive fires (5/5 >= 0.6).
+        {
+            "fire_idx": 15,
+            "bytes_at_last_fire": 0,
+            "fire_idx_at_last_fire": 0,
+            "transcript_bytes": 10000,
+            "last_prompt": "implement the parser module",
+            "classifications": [True, True, True, True, True],
+        },
+        # p2 fires (>= watermark + "next task" boundary); p3_velocity fires.
+        {
+            "fire_idx": 7,
+            "bytes_at_last_fire": 0,
+            "fire_idx_at_last_fire": 0,
+            "transcript_bytes": 120000,
+            "last_prompt": "next task",
+            "classifications": [False, False, False, False, False],
+        },
+        # nothing fires.
+        {
+            "fire_idx": 3,
+            "bytes_at_last_fire": 0,
+            "fire_idx_at_last_fire": 0,
+            "transcript_bytes": 5000,
+            "last_prompt": "thinking about the design",
+            "classifications": [True, False, False, False, False],
+        },
+    ],
+}
+
+
+def test_replay_fixture_row_count_and_shape() -> None:
+    rows = replay_fixture(_FIXTURE)
+    assert len(rows) == 3
+    for row in rows:
+        assert set(row["shadow"]) == {
+            POLICY_P1_EVERY_K_TURNS,
+            POLICY_P2_CTX_THRESHOLD,
+            POLICY_P3_VELOCITY,
+            POLICY_P3_SUBSTANTIVE,
+        }
+
+
+def test_replay_per_tick_decisions() -> None:
+    rows = replay_fixture(_FIXTURE)
+    t0, t1, t2 = rows
+
+    # tick 0: p1 + p3_substantive
+    assert t0["shadow"][POLICY_P1_EVERY_K_TURNS]["would_fire"] is True
+    assert t0["shadow"][POLICY_P2_CTX_THRESHOLD]["would_fire"] is False
+    assert t0["shadow"][POLICY_P3_VELOCITY]["would_fire"] is False
+    assert t0["shadow"][POLICY_P3_SUBSTANTIVE]["would_fire"] is True
+
+    # tick 1: p2 + p3_velocity
+    assert t1["shadow"][POLICY_P1_EVERY_K_TURNS]["would_fire"] is False
+    assert t1["shadow"][POLICY_P2_CTX_THRESHOLD]["would_fire"] is True
+    assert t1["shadow"][POLICY_P3_VELOCITY]["would_fire"] is True
+    assert t1["shadow"][POLICY_P3_SUBSTANTIVE]["would_fire"] is False
+
+    # tick 2: nothing
+    assert all(
+        t2["shadow"][p]["would_fire"] is False
+        for p in t2["shadow"]
+    )
+
+
+def test_replay_selected_fired_tracks_selected_policy() -> None:
+    rows = replay_fixture(_FIXTURE)
+    # selected = p1; only tick 0 fires for p1
+    fired = [r["fired"] for r in rows]
+    assert fired == [True, False, False]
+
+
+def test_replay_summary_per_policy_rates() -> None:
+    summary = compute_summary(replay_fixture(_FIXTURE))
+    # each policy fires on exactly one of the 3 ticks
+    for policy in (
+        POLICY_P1_EVERY_K_TURNS,
+        POLICY_P2_CTX_THRESHOLD,
+        POLICY_P3_VELOCITY,
+        POLICY_P3_SUBSTANTIVE,
+    ):
+        assert summary.per_policy_total[policy] == 3
+        assert summary.per_policy_fire_count[policy] == 1
+    # 6 unordered pairs across 4 policies
+    assert len(summary.pairwise_agreement) == 6
+
+
+def test_replay_is_deterministic() -> None:
+    """Same fixture → byte-identical rows (#605)."""
+    a = replay_fixture(_FIXTURE)
+    b = replay_fixture(_FIXTURE)
+    # strip the would_fire/reason — reasons embed byte counts which are
+    # stable across runs too, so the whole structure should match.
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+
+def test_replay_cli_reads_sample_fixture(capsys) -> None:  # type: ignore[no-untyped-def]
+    fixture = (
+        Path(__file__).resolve().parents[1]
+        / "benchmarks" / "fixtures" / "cadence_replay_sample.json"
+    )
+    rc = main(["--fixture", str(fixture)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "per-policy would_fire rate:" in out
+    assert "pairwise policy agreement" in out
+
+
+def test_replay_cli_json_output(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    fixture = tmp_path / "fx.json"
+    fixture.write_text(json.dumps(_FIXTURE))
+    out_path = tmp_path / "summary.json"
+    rc = main(["--fixture", str(fixture), "--json", "--output", str(out_path)])
+    assert rc == 0
+    parsed = json.loads(out_path.read_text())
+    assert parsed["per_policy_fire_count"][POLICY_P3_VELOCITY] == 1
+    assert "pairwise_agreement" in parsed
+
+
+def test_replay_cli_missing_fixture_returns_2(tmp_path: Path) -> None:
+    rc = main(["--fixture", str(tmp_path / "nope.json")])
+    assert rc == 2

--- a/tests/test_cadence_score.py
+++ b/tests/test_cadence_score.py
@@ -11,6 +11,8 @@ from aelfrice.cadence import (
     POLICY_OFF,
     POLICY_P1_EVERY_K_TURNS,
     POLICY_P2_CTX_THRESHOLD,
+    POLICY_P3_SUBSTANTIVE,
+    POLICY_P3_VELOCITY,
 )
 from aelfrice.cadence_score import (
     compute_summary,
@@ -114,6 +116,78 @@ def test_compute_summary_agreement_matrix() -> None:
     assert summ.agreement_matrix[(True, False)] == 1
     assert summ.agreement_matrix[(False, True)] == 1
     assert summ.agreement_matrix[(False, False)] == 3
+
+
+def _row4(
+    *,
+    sid: str = "s1",
+    selected: str = POLICY_P1_EVERY_K_TURNS,
+    fired: bool = False,
+    p1: bool = False,
+    p2: bool = False,
+    p3v: bool = False,
+    p3s: bool = False,
+) -> dict:
+    """A shadow row carrying all four implemented policies (#876)."""
+    return {
+        "ts": "2026-05-26T00:00:00Z",
+        "session_id": sid,
+        "selected": selected,
+        "fired": fired,
+        "shadow": {
+            POLICY_P1_EVERY_K_TURNS: {"would_fire": p1, "reason": "r"},
+            POLICY_P2_CTX_THRESHOLD: {"would_fire": p2, "reason": "r"},
+            POLICY_P3_VELOCITY: {"would_fire": p3v, "reason": "r"},
+            POLICY_P3_SUBSTANTIVE: {"would_fire": p3s, "reason": "r"},
+        },
+    }
+
+
+def test_compute_summary_four_policy_per_policy_rates() -> None:
+    """Per-policy counts span all four policies once the rows carry them."""
+    rows = [
+        _row4(p1=True, p2=False, p3v=True, p3s=True),
+        _row4(p1=False, p2=False, p3v=True, p3s=False),
+    ]
+    summ = compute_summary(rows)
+    assert summ.per_policy_total[POLICY_P3_VELOCITY] == 2
+    assert summ.per_policy_fire_count[POLICY_P3_VELOCITY] == 2
+    assert summ.per_policy_total[POLICY_P3_SUBSTANTIVE] == 2
+    assert summ.per_policy_fire_count[POLICY_P3_SUBSTANTIVE] == 1
+
+
+def test_compute_summary_pairwise_agreement_all_pairs() -> None:
+    """Pairwise table covers every unordered pair with a/b ordered lexically."""
+    # one row: p1 fires, p3_velocity fires; p2 and p3_substantive skip
+    summ = compute_summary([_row4(p1=True, p2=False, p3v=True, p3s=False)])
+    # 4 policies → C(4,2) = 6 pairs
+    assert len(summ.pairwise_agreement) == 6
+    # lexical order: p1_every_k_turns < p2_ctx_threshold < p3_substantive < p3_velocity
+    p1, p2 = POLICY_P1_EVERY_K_TURNS, POLICY_P2_CTX_THRESHOLD
+    p3v, p3s = POLICY_P3_VELOCITY, POLICY_P3_SUBSTANTIVE
+    # p1 (fire) vs p2 (skip): a_only since p1 < p2
+    assert summ.pairwise_agreement[(p1, p2)] == {
+        "both": 0, "a_only": 1, "b_only": 0, "neither": 0,
+    }
+    # p1 (fire) vs p3_velocity (fire): both. p1 < p3_velocity
+    assert summ.pairwise_agreement[(p1, p3v)] == {
+        "both": 1, "a_only": 0, "b_only": 0, "neither": 0,
+    }
+    # p3_substantive (skip) vs p3_velocity (fire): p3_substantive < p3_velocity
+    # → b_only
+    assert summ.pairwise_agreement[(p3s, p3v)] == {
+        "both": 0, "a_only": 0, "b_only": 1, "neither": 0,
+    }
+
+
+def test_format_report_renders_pairwise_section() -> None:
+    summ = compute_summary([_row4(p1=True, p3v=True)])
+    text = format_report(summ)
+    assert "pairwise policy agreement" in text
+    parsed = json.loads(format_report(summ, as_json=True))
+    assert "pairwise_agreement" in parsed
+    key = f"{POLICY_P1_EVERY_K_TURNS}|{POLICY_P3_VELOCITY}"
+    assert parsed["pairwise_agreement"][key]["both"] == 1
 
 
 def test_compute_summary_session_filter() -> None:

--- a/tests/test_hook_stop_cadence_p3_substantive.py
+++ b/tests/test_hook_stop_cadence_p3_substantive.py
@@ -1,0 +1,261 @@
+"""Integration tests for #876 p3_substantive dispatcher wiring — Stop side.
+
+PR 4 of 5 in the #876 stack. Covers the new POLICY_P3_SUBSTANTIVE branch
+in _maybe_fire_cadence_checkpoint: per-turn classification push, rolling
+substantive-window read, firing predicate, fail-soft behaviour.
+
+The Stop side owns the per-turn classification push (UPS reads only), so
+these tests also assert the ``classifications`` ring slot advances exactly
+once per tick regardless of whether cadence fires.
+"""
+from __future__ import annotations
+
+import io
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from aelfrice import hook
+from aelfrice.cadence import (
+    CONFIG_FILENAME,
+    is_substantive_turn,
+)
+
+# A clearly substantive prompt (not in P2's phase-boundary allowlist) and a
+# clearly filler one. Asserted below so the fixtures stay self-validating if
+# the allowlist shifts.
+_SUBSTANTIVE_PROMPT = "implement the substantive-window predicate for cadence"
+_FILLER_PROMPT = "ok thanks"
+
+
+def test_fixture_prompts_classify_as_expected() -> None:
+    assert is_substantive_turn(_SUBSTANTIVE_PROMPT) is True
+    assert is_substantive_turn(_FILLER_PROMPT) is False
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "AELFRICE_CADENCE_ENABLED",
+        "AELFRICE_CADENCE_POLICY",
+        "AELFRICE_CADENCE_P3_SUBSTANTIVE_WINDOW",
+        "AELFRICE_CADENCE_P3_SUBSTANTIVE_THRESHOLD",
+        "AELF_AUTOLOCK_CORRECTIONS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _seed_db(db: Path) -> None:
+    from aelfrice.store import MemoryStore
+    MemoryStore(str(db)).close()
+
+
+def _write_toml(repo: Path, body: str) -> None:
+    (repo / CONFIG_FILENAME).write_text(textwrap.dedent(body))
+
+
+def _write_ring_state(
+    state_dir: Path,
+    session_id: str,
+    *,
+    next_fire_idx: int = 10,
+    classifications: list[bool] | None = None,
+) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "session_id": session_id,
+        "ring": [],
+        "ring_max": 200,
+        "next_fire_idx": next_fire_idx,
+        "evicted_total": 0,
+        "bytes_at_last_fire": 0,
+        "fire_idx_at_last_fire": 0,
+        "classifications": classifications if classifications is not None else [],
+    }
+    (state_dir / "session_injected_ids.json").write_text(json.dumps(payload))
+
+
+def _read_classifications(state_dir: Path) -> list[bool]:
+    data = json.loads((state_dir / "session_injected_ids.json").read_text())
+    return data["classifications"]
+
+
+def _write_transcript_with_prompt(path: Path, prompt: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps({"message": {"role": "assistant", "content": "earlier"}}),
+        json.dumps({"message": {"role": "user", "content": prompt}}),
+    ]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _stub_rebuild_and_format(
+    monkeypatch: pytest.MonkeyPatch,
+    body: str = "<rebuilder synthesis body>",
+) -> list[dict[str, object]]:
+    calls: list[dict[str, object]] = []
+
+    def _stub(recent, token_budget, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append({"n_recent": len(recent), "token_budget": token_budget})
+        return body
+
+    monkeypatch.setattr(hook, "_rebuild_and_format", _stub)
+    return calls
+
+
+def _stub_read_recent(monkeypatch: pytest.MonkeyPatch, n_turns: int = 1) -> None:
+    from aelfrice.context_rebuilder import RecentTurn
+    canned = [RecentTurn(role="user", text=f"turn-{i}") for i in range(n_turns)]
+    monkeypatch.setattr(
+        hook, "_read_recent_for_pre_compact", lambda _payload, _n: canned,
+    )
+
+
+def _stop_payload(session_id: str, cwd: Path, transcript_path: Path) -> str:
+    return json.dumps({
+        "session_id": session_id,
+        "cwd": str(cwd),
+        "transcript_path": str(transcript_path),
+    })
+
+
+def _run_stop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    prompt: str,
+    classifications: list[bool],
+    window: int = 5,
+    threshold: float = 0.6,
+) -> tuple[io.StringIO, list, Path]:
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    _seed_db(db)
+    _write_ring_state(db.parent, "sess-S", classifications=list(classifications))
+    _write_toml(tmp_path, f"""
+        [cadence]
+        enabled = true
+        policy = "p3_substantive"
+        p3_substantive_window = {window}
+        p3_substantive_threshold = {threshold}
+    """)
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript_with_prompt(transcript, prompt)
+    calls = _stub_rebuild_and_format(monkeypatch)
+    _stub_read_recent(monkeypatch)
+    serr = io.StringIO()
+    rc = hook.stop(
+        stdin=io.StringIO(_stop_payload("sess-S", tmp_path, transcript)),
+        stderr=serr,
+    )
+    assert rc == 0
+    return serr, calls, db.parent
+
+
+# --- Tests ----------------------------------------------------------------
+
+
+def test_substantive_above_threshold_fires(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Window of mostly-substantive turns + a substantive push fires."""
+    # seed 3 trues; substantive push → [T,T,T,T] over window 5 = 4/5 = 0.8
+    serr, calls, state_dir = _run_stop(
+        tmp_path, monkeypatch,
+        prompt=_SUBSTANTIVE_PROMPT,
+        classifications=[True, True, True],
+        window=5, threshold=0.6,
+    )
+    assert len(calls) == 1, "rebuilder should fire"
+    out = serr.getvalue()
+    assert "cadence checkpoint fired" in out
+    assert "p3_substantive" in out
+    # push landed: classifications now ends with the substantive True
+    classes = _read_classifications(state_dir)
+    assert classes[-1] is True
+    assert classes.count(True) == 4
+
+
+def test_substantive_below_threshold_does_not_fire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sparse substantive history stays below threshold — no fire."""
+    # seed 4 falses; substantive push → 1/5 = 0.2 < 0.6
+    serr, calls, state_dir = _run_stop(
+        tmp_path, monkeypatch,
+        prompt=_SUBSTANTIVE_PROMPT,
+        classifications=[False, False, False, False],
+        window=5, threshold=0.6,
+    )
+    assert calls == []
+    assert "cadence checkpoint" not in serr.getvalue()
+    # push still happened (window advances regardless of fire)
+    classes = _read_classifications(state_dir)
+    assert classes[-1] is True
+    assert classes.count(True) == 1
+
+
+def test_filler_classification_keeps_below_threshold(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A filler prompt is classified False — isolates the classifier effect.
+
+    Same seeded window as ``test_substantive_above_threshold_fires`` minus
+    one true: with a substantive push the ratio would clear 0.8 threshold,
+    but a filler push leaves it just under.
+    """
+    serr, calls, state_dir = _run_stop(
+        tmp_path, monkeypatch,
+        prompt=_FILLER_PROMPT,
+        classifications=[True, True, True, False],
+        window=5, threshold=0.8,
+    )
+    # [T,T,T,F,F] → 3/5 = 0.6 < 0.8 → no fire
+    assert calls == []
+    classes = _read_classifications(state_dir)
+    assert classes[-1] is False
+    assert classes.count(True) == 3
+
+
+def test_substantive_disabled_no_fire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    _seed_db(db)
+    _write_ring_state(db.parent, "sess-S", classifications=[True, True, True, True])
+    # cadence section absent: enabled defaults False
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript_with_prompt(transcript, _SUBSTANTIVE_PROMPT)
+    calls = _stub_rebuild_and_format(monkeypatch)
+    _stub_read_recent(monkeypatch)
+    serr = io.StringIO()
+    rc = hook.stop(
+        stdin=io.StringIO(_stop_payload("sess-S", tmp_path, transcript)),
+        stderr=serr,
+    )
+    assert rc == 0
+    assert calls == []
+
+
+def test_substantive_window_cap_evicts_oldest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """push_classification caps the window at p3_substantive_window.
+
+    Seeding a window already at cap (one filler at the front) and pushing a
+    substantive turn evicts the oldest entry FIFO, leaving length == window.
+    """
+    serr, calls, state_dir = _run_stop(
+        tmp_path, monkeypatch,
+        prompt=_SUBSTANTIVE_PROMPT,
+        classifications=[False, True, True, True, True],
+        window=5, threshold=0.6,
+    )
+    classes = _read_classifications(state_dir)
+    assert len(classes) == 5, "window length stays capped after push"
+    # oldest (the leading False) evicted; window is now all True → fires
+    assert classes == [True, True, True, True, True]
+    assert len(calls) == 1

--- a/tests/test_hook_stop_cadence_shadow.py
+++ b/tests/test_hook_stop_cadence_shadow.py
@@ -15,6 +15,8 @@ from aelfrice.cadence import (
     POLICY_OFF,
     POLICY_P1_EVERY_K_TURNS,
     POLICY_P2_CTX_THRESHOLD,
+    POLICY_P3_SUBSTANTIVE,
+    POLICY_P3_VELOCITY,
 )
 
 
@@ -297,3 +299,96 @@ def test_shadow_env_override(
         stderr=io.StringIO(),
     )
     assert _shadow_log(db, "sess-G").exists()
+
+
+def _write_ring_state_p3(
+    state_dir: Path,
+    session_id: str,
+    *,
+    next_fire_idx: int,
+    bytes_at_last_fire: int,
+    fire_idx_at_last_fire: int,
+    classifications: list[bool],
+) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "session_id": session_id,
+        "ring": [],
+        "ring_max": 200,
+        "next_fire_idx": next_fire_idx,
+        "evicted_total": 0,
+        "bytes_at_last_fire": bytes_at_last_fire,
+        "fire_idx_at_last_fire": fire_idx_at_last_fire,
+        "classifications": classifications,
+    }
+    (state_dir / "session_injected_ids.json").write_text(json.dumps(payload))
+
+
+def _write_transcript(path: Path, size_bytes: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    filler = json.dumps({
+        "message": {"role": "assistant", "content": "x" * 800},
+    }) + "\n"
+    n = max(1, size_bytes // len(filler))
+    path.write_text(filler * n)
+
+
+def test_shadow_row_captures_all_four_policies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#876: the shadow row now carries p3_velocity + p3_substantive too.
+
+    Selected policy is p1 (not firing), but the row records would_fire
+    for all four implemented policies. p3_velocity is rigged to fire
+    (high byte velocity) and p3_substantive to fire (all-substantive
+    window), so the row proves both P3 predicates are evaluated and
+    logged independently of the selected policy.
+    """
+    db = tmp_path / "memory.db"
+    _set_db(monkeypatch, db)
+    _seed_db(db)
+    _write_toml(tmp_path, """\
+        [cadence]
+        enabled = true
+        policy = "p1_every_k_turns"
+        k = 15
+        shadow_mode_enabled = true
+        p3_velocity_threshold = 3000
+        p3_substantive_window = 5
+        p3_substantive_threshold = 0.6
+    """)
+    # next_fire_idx=7 (p1 no-fire @ k=15); 70k bytes over 7 turns since last
+    # fire = 10k bytes/turn >= 3000 → p3_velocity fires. classifications all
+    # True over window 5 → 1.0 >= 0.6 → p3_substantive fires.
+    _write_ring_state_p3(
+        db.parent, "sess-P3",
+        next_fire_idx=7,
+        bytes_at_last_fire=0,
+        fire_idx_at_last_fire=0,
+        classifications=[True, True, True, True, True],
+    )
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(transcript, 70_000)
+    _stub_rebuild_no_op(monkeypatch)
+
+    rc = hook.stop(
+        stdin=io.StringIO(_stop_payload("sess-P3", tmp_path, transcript)),
+        stderr=io.StringIO(),
+    )
+    assert rc == 0
+    log = _shadow_log(db, "sess-P3")
+    rows = [json.loads(line) for line in log.read_text().splitlines() if line]
+    assert len(rows) == 1
+    shadow = rows[0]["shadow"]
+    # All four policies present
+    assert set(shadow) >= {
+        POLICY_P1_EVERY_K_TURNS,
+        POLICY_P2_CTX_THRESHOLD,
+        POLICY_P3_VELOCITY,
+        POLICY_P3_SUBSTANTIVE,
+    }
+    # Selected p1 did not fire; both P3 predicates did (independently logged)
+    assert rows[0]["selected"] == POLICY_P1_EVERY_K_TURNS
+    assert rows[0]["fired"] is False
+    assert shadow[POLICY_P3_VELOCITY]["would_fire"] is True
+    assert shadow[POLICY_P3_SUBSTANTIVE]["would_fire"] is True

--- a/tests/test_hook_ups_cadence_p3_substantive.py
+++ b/tests/test_hook_ups_cadence_p3_substantive.py
@@ -1,0 +1,164 @@
+"""Integration tests for #876 p3_substantive dispatcher wiring — UPS side.
+
+PR 4 of 5 in the #876 stack. Covers the new POLICY_P3_SUBSTANTIVE branch
+in _maybe_run_ups_cadence_checkpoint.
+
+UPS reads the substantive-window from the ring but does NOT push — Stop
+owns the per-turn classification push. These tests assert the read-only
+contract: firing on a warm window, and the ``classifications`` slot being
+left untouched by the UPS path.
+"""
+from __future__ import annotations
+
+import io
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from aelfrice import hook
+from aelfrice.cadence import CONFIG_FILENAME
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "AELFRICE_CADENCE_ENABLED",
+        "AELFRICE_CADENCE_POLICY",
+        "AELFRICE_CADENCE_P3_SUBSTANTIVE_WINDOW",
+        "AELFRICE_CADENCE_P3_SUBSTANTIVE_THRESHOLD",
+        "AELF_AUTOLOCK_CORRECTIONS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _seed_db(db: Path) -> None:
+    from aelfrice.store import MemoryStore
+    MemoryStore(str(db)).close()
+
+
+def _write_toml(repo: Path, body: str) -> None:
+    (repo / CONFIG_FILENAME).write_text(textwrap.dedent(body))
+
+
+def _write_ring_state(
+    state_dir: Path,
+    session_id: str,
+    *,
+    classifications: list[bool],
+) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "session_id": session_id,
+        "ring": [],
+        "ring_max": 200,
+        "next_fire_idx": 10,
+        "evicted_total": 0,
+        "bytes_at_last_fire": 0,
+        "fire_idx_at_last_fire": 0,
+        "classifications": list(classifications),
+    }
+    (state_dir / "session_injected_ids.json").write_text(json.dumps(payload))
+
+
+def _read_classifications(state_dir: Path) -> list[bool]:
+    data = json.loads((state_dir / "session_injected_ids.json").read_text())
+    return data["classifications"]
+
+
+def _stub_rebuild_and_format(
+    monkeypatch: pytest.MonkeyPatch, body: str = "<body>",
+) -> list[dict[str, object]]:
+    calls: list[dict[str, object]] = []
+
+    def _stub(recent, token_budget, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append({"n_recent": len(recent), "token_budget": token_budget})
+        return body
+
+    monkeypatch.setattr(hook, "_rebuild_and_format", _stub)
+    return calls
+
+
+def _stub_read_recent(monkeypatch: pytest.MonkeyPatch, n_turns: int = 1) -> None:
+    from aelfrice.context_rebuilder import RecentTurn
+    canned = [RecentTurn(role="user", text=f"turn-{i}") for i in range(n_turns)]
+    monkeypatch.setattr(
+        hook, "_read_recent_for_pre_compact", lambda _payload, _n: canned,
+    )
+
+
+def _run_ups(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    classifications: list[bool],
+    window: int = 5,
+    threshold: float = 0.6,
+) -> tuple[str | None, list, Path]:
+    db = tmp_path / "memory.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    _seed_db(db)
+    _write_ring_state(db.parent, "sess-U", classifications=classifications)
+    _write_toml(tmp_path, f"""
+        [cadence]
+        enabled = true
+        policy = "p3_substantive"
+        p3_substantive_window = {window}
+        p3_substantive_threshold = {threshold}
+    """)
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps({"message": {"role": "user", "content": "anything"}}) + "\n"
+    )
+    calls = _stub_rebuild_and_format(monkeypatch)
+    _stub_read_recent(monkeypatch)
+    payload = {
+        "session_id": "sess-U",
+        "cwd": str(tmp_path),
+        "transcript_path": str(transcript),
+    }
+    serr = io.StringIO()
+    body = hook._maybe_run_ups_cadence_checkpoint(payload, "sess-U", serr)
+    return body, calls, db.parent
+
+
+def test_ups_substantive_above_threshold_returns_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body, calls, _ = _run_ups(
+        tmp_path, monkeypatch,
+        classifications=[True, True, True, True],  # 4/5 = 0.8 >= 0.6
+        window=5, threshold=0.6,
+    )
+    assert body == "<body>"
+    assert len(calls) == 1
+
+
+def test_ups_substantive_below_threshold_returns_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body, calls, _ = _run_ups(
+        tmp_path, monkeypatch,
+        classifications=[True, False, False, False],  # 1/5 = 0.2 < 0.6
+        window=5, threshold=0.6,
+    )
+    assert body is None
+    assert calls == []
+
+
+def test_ups_does_not_push_classification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """UPS reads the window read-only — Stop owns the push.
+
+    The classifications slot must be byte-identical after the UPS pass.
+    """
+    seed = [True, True, True, True]
+    body, _calls, state_dir = _run_ups(
+        tmp_path, monkeypatch,
+        classifications=seed,
+        window=5, threshold=0.6,
+    )
+    assert body == "<body>"  # fired, so the read path ran
+    assert _read_classifications(state_dir) == seed, "UPS must not mutate window"


### PR DESCRIPTION
## Summary

Completes the #876 P3 cadence work and makes the bench gate runnable.
The prior series (#884/#885/#886, PRs 1–3 of 5) shipped the enum
constants, session-ring slots, and the `p3_velocity` live dispatch, but
stopped there: `p3_substantive` was never dispatched (selecting it was a
silent no-op), the shadow logger captured only P1/P2, and `aelf
cadence-score` could only report a 2×2 P1-vs-P2 matrix. So the
`bench-gated` comparison the triage (axis-3 bake) depends on had no P3
data and no way to produce it offline.

This PR closes that gap in four atomic commits.

## Commits

1. **`feat(cadence): dispatch p3_substantive live in Stop + UPS`** — adds
   the `POLICY_P3_SUBSTANTIVE` branch to both dispatchers. Stop owns the
   per-turn classification push (`is_substantive_turn` →
   `push_classification` onto the session-ring rolling window) and reads
   the window to fire; UPS reads the window read-only (no push) to keep
   it advancing exactly once per turn — a one-turn read lag matching the
   established `p3_velocity` counter-sharing semantics.

2. **`feat(cadence): capture both P3 policies in shadow log`** —
   `_maybe_log_cadence_shadow_tick` now evaluates `would_fire_p3_velocity`
   and `would_fire_p3_substantive` against the same tick inputs and
   records all four policies in the shadow row. This is the bake data
   source.

3. **`feat(cadence-score): four-policy pairwise comparison`** — per-policy
   fire rates already spanned every logged policy; adds a generalised
   `pairwise_agreement` table (both / a-only / b-only / neither + a
   divergence rate) across every policy pair, so all four compare
   head-to-head. The legacy 2×2 P1-vs-P2 matrix is retained unchanged.

4. **`feat(bench): offline cadence-policy replay harness`** — the
   "replay" half: `benchmarks/cadence_replay.py` produces the same
   four-policy comparison from a self-contained synthetic fixture, with
   no operator-week of live shadow data. Each tick is fed through every
   `would_fire` predicate and aggregated by `compute_summary`.
   Deterministic (#605); sample fixture included.

## Determinism / discretion

All predicates are pure functions (#605); the replay is byte-identical
across runs. No `~/.claude/`-derived content — the fixture is synthetic
input authored alongside the bench.

## Testing

- New: `test_hook_stop_cadence_p3_substantive`,
  `test_hook_ups_cadence_p3_substantive`, the P3-capture test in
  `test_hook_stop_cadence_shadow`, four-policy/pairwise tests in
  `test_cadence_score`, and `test_cadence_replay` (8 tests incl. CLI +
  determinism).
- Sample replay output (3-tick fixture) shows the head-to-head spread:
  `p1 ↔ p3_substantive` co-fire on the dense-substantive tick, `p2 ↔
  p3_velocity` co-fire on the high-byte boundary tick.
- 795 passed / 3 skipped across the cadence/hook/shadow subset.

Closes #876.

Refs #749, #875, #884, #885, #886.

## Summary by Sourcery

Wire the P3 substantive cadence policy through live dispatch, shadow logging, scoring, and benchmarking to complete four-policy cadence evaluation and offline replay.

New Features:
- Enable the P3 substantive cadence policy in both Stop and UPS dispatchers, using rolling substantive-turn classification to decide when to fire.
- Extend cadence shadow logging to record would_fire decisions for all four policies, including P3 velocity and P3 substantive, per tick.
- Augment the cadence-score reporting to include a general pairwise policy agreement table across all policies alongside existing per-policy and P1/P2 metrics.
- Introduce an offline deterministic cadence replay benchmark that replays synthetic fixtures through all four policies and summarizes them via the existing scoring pipeline.

Documentation:
- Document the new P3 substantive policy wiring, four-policy shadow capture, extended scorer output, and offline replay bench in the v3 changelog.

Tests:
- Add Stop- and UPS-side integration tests for P3 substantive dispatch, including window maintenance and non-mutation guarantees for UPS.
- Add tests ensuring the shadow log captures all four policies’ decisions, and that cadence-score correctly computes four-policy per-policy rates and pairwise agreement.
- Add tests for the cadence replay harness and CLI covering determinism, fixture handling, and JSON/text output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * P3 substantive-window cadence policy now integrated into Stop/UPS dispatchers for conversation quality-based trigger decisions
  * Multi-policy pairwise agreement comparison in cadence scoring reports
  * Offline cadence replay tool for deterministic scenario testing

* **Tests**
  * Extended integration test coverage for substantive-window behavior with various thresholds and configurations
  * New shadow log evaluation tests verifying all four policies are independently evaluated and logged
  * Comprehensive CLI tests for the cadence replay tool with JSON output support

* **Documentation**
  * Updated changelog documenting cadence policy additions and enhanced tooling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robotrocketscience/aelfrice/pull/920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->