### PR TITLE
chore: gitignore hook_audit.jsonl to prevent accidental commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ build/
 !tests/e2e/fixtures/*.db
 telemetry/
 .agents/
+
+# aelfrice hook audit log (per-turn UserPromptSubmit retrieval records).
+# Canonical home is <git-common-dir>/aelfrice/ (inside .git, never tracked),
+# but it can land at a working-tree root; it may contain prompt content, so
+# never commit it. Covers the single-slot rotation sibling (.1) too.
+hook_audit.jsonl
+hook_audit.jsonl.*


### PR DESCRIPTION
## What

Adds `hook_audit.jsonl` and `hook_audit.jsonl.*` to `.gitignore`.

## Why

The per-turn hook audit log (`src/aelfrice/hook.py` `AUDIT_FILENAME`) is canonically written under `<git-common-dir>/aelfrice/` — inside `.git/`, so never tracked. But a stray copy also lands at the **root of git worktrees**, where it is an untracked file at risk of being swept into a commit by `git add -A`. The audit log records per-turn retrieval data and can contain prompt content from the running session, so committing it would breach the discretion boundary.

This ignores the bare filename (matches at any depth) and the single-slot rotation sibling (`.1`), so no session can commit the audit log via a stray working-tree copy.

## Scope

Defense-in-depth only. This does **not** fix the separate path-resolution behavior that causes the log to be written to worktree roots in the first place (observed across multiple worktrees) — that is a distinct bug worth its own issue.

## Test plan

- `git check-ignore -v hook_audit.jsonl hook_audit.jsonl.1` → both match the new rules.
- The previously-untracked worktree-root copy no longer appears in `git status`.

## Summary by Sourcery

Chores:
- Add hook_audit.jsonl and its rotated variants to .gitignore to avoid tracking per-turn hook audit logs.