### PR TITLE
fix(hook): skip audit write for :memory: DB to stop CWD pollution

### DIFF
--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -759,6 +759,8 @@ def _write_hook_audit_record(
         return
     try:
         p = db_path()
+        if str(p) == ":memory:":
+            return
         audit_path = _audit_path_for_db(p)
     except Exception:
         return
@@ -2008,6 +2010,8 @@ def _write_sentiment_feedback_audit(
         return
     try:
         p = db_path()
+        if str(p) == ":memory:":
+            return
         audit_path = _audit_path_for_db(p)
     except Exception:
         return

--- a/tests/test_hook_audit.py
+++ b/tests/test_hook_audit.py
@@ -448,3 +448,29 @@ def test_audit_write_failsoft_on_unwriteable_path(
     # Hook still produced its output block; only the audit failed.
     assert sout.getvalue().startswith("<aelfrice-memory>")
     assert "hook audit write failed" in serr.getvalue()
+
+
+def test_write_audit_record_memory_db_no_cwd_pollution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """:memory: DB has no real parent directory, so the audit write must be
+    a clean no-op — NOT a stray ``hook_audit.jsonl`` in the process CWD.
+
+    Regression: ``Path(":memory:").parent`` is ``.``, so the audit log was
+    being written relative to the working directory. Any session running
+    against an in-memory DB (tests, ``--bench``) scattered the log to the
+    git-worktree root, where it sat untracked and at risk of being committed.
+    """
+    monkeypatch.setenv("AELFRICE_DB", ":memory:")
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    _write_hook_audit_record(
+        hook=AUDIT_HOOK_USER_PROMPT_SUBMIT,
+        prompt="how many bananas",
+        rendered_block='<belief id="F1">the kitchen is full of bananas</belief>',
+        n_beliefs=1,
+        n_locked=0,
+        session_id="mem-sess",
+    )
+    assert not (tmp_path / AUDIT_FILENAME).exists()
+    assert list(tmp_path.glob("**/" + AUDIT_FILENAME)) == []


### PR DESCRIPTION
## Problem

The per-turn hook audit log was being written to the process **current working directory** whenever a session ran against an in-memory DB. Observed concretely: a stray `hook_audit.jsonl` at the root of every git worktree, untracked and at risk of being committed — and the audit log can contain prompt content.

## Root cause

`_write_hook_audit_record` and `_write_sentiment_feedback_audit` both derive the path as:

```python
p = db_path()
audit_path = _audit_path_for_db(p)   # = p.parent / "hook_audit.jsonl"
```

For `AELFRICE_DB=:memory:`, `Path(":memory:").parent` is `.`, so `audit_path` becomes the **relative** `hook_audit.jsonl` — written wherever the process happens to be. The test suite and `--bench` both use `:memory:`, so any worktree where they ran accumulated a stray log at its root. (The canonical home is `<git-common-dir>/aelfrice/hook_audit.jsonl`, inside `.git`, which is correct and safe.)

## Fix

Both writers now apply the same `if str(p) == ":memory:": return` guard the audit **reader** (`read_recent_audit_for_session`) already uses — an in-memory DB has no real parent directory, so the write is a clean no-op, symmetric with the reader returning `[]` for `:memory:`. Matches the `:memory:` idiom used in ~15 other places in `hook.py`.

## Test

Adds `test_write_audit_record_memory_db_no_cwd_pollution`: asserts no `hook_audit.jsonl` appears under CWD after a `:memory:` audit write. Verified it **fails on the prior code** (the file lands in the test's tmp CWD) and passes with the guard. Full hook test modules green (51 passed): `test_hook_audit.py`, `test_hook_ups_cadence_resume.py`, `test_hook_sentiment_feedback.py`.

## Relationship to #921

#921 (gitignore `hook_audit.jsonl`) is the defense-in-depth net; this PR removes the source. Complementary — keep both.

## Summary by Sourcery

Prevent hook audit logs from being written when using an in-memory database to avoid polluting the current working directory with stray files.

Bug Fixes:
- Skip writing hook audit records for :memory: databases to avoid creating hook_audit.jsonl in the process working directory.
- Skip writing sentiment feedback audit records for :memory: databases to avoid creating hook_audit.jsonl in the process working directory.

Tests:
- Add a regression test ensuring no hook_audit.jsonl is created in the current working directory when auditing against a :memory: database.