### PR TITLE
release: v3.4.0

### DIFF
--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-05-26
+
 ### Added
 
 - **`p3_substantive` cadence policy is now wired live (#876).** The
@@ -56,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the current prompt weighted to stay dominant. Default-on, opt-out via
   `[user_prompt_submit_hook] conversation_aware_query_enabled`; window
   and weight are tunable. Deterministic, no embeddings.
+- **Audit writes are skipped for in-memory (`:memory:`) databases.**
+  Test and ephemeral in-memory sessions no longer drop a stray
+  `hook_audit.jsonl` into the process working directory.
 
 ## [3.3.0] - 2026-05-21
 
@@ -342,7 +347,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`urllib3` 2.6.3 → 2.7.0 for CVE patches** ([#640](https://github.com/robotrocketscience/aelfrice/issues/640)). Lockfile-only dependency bump pulled in via `uv lock` to clear two CVEs flagged by GitHub's dependency scanner. `urllib3` is a transitive dep (via `requests` in the publish workflow and the `gh` CLI's Python shim); aelfrice itself does not import it. No source change.
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v3.3.0...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v3.4.0...HEAD
+[3.4.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.0.1...v3.1.0

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Running in the background. No action required after `aelf setup`.
 
 ## Status
 
-Latest stable: **v3.3.0** (2026-05-21). Per-entry detail in [CHANGELOG § 3.3.0](CHANGELOG.md). Per-version history: [docs/concepts/ROADMAP.md](docs/concepts/ROADMAP.md). Known limits: [docs/user/LIMITATIONS.md](docs/user/LIMITATIONS.md).
+Latest stable: **v3.4.0** (2026-05-26). Per-entry detail in [CHANGELOG § 3.4.0](CHANGELOG.md). Per-version history: [docs/concepts/ROADMAP.md](docs/concepts/ROADMAP.md). Known limits: [docs/user/LIMITATIONS.md](docs/user/LIMITATIONS.md).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "3.3.0"
+version = "3.4.0"
 description = "Persistent memory for AI agents. Set up once. Stays out of your way. Local SQLite, auditable, no GPU, no network."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "3.3.0"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
<!-- no-issue -->

Cuts **v3.4.0** from the changelog `[Unreleased]` backlog accumulated since v3.3.0.

## What ships (runtime)

- **Conversation-aware UserPromptSubmit retrieval** (#909) — recent turns folded into the BM25 query; default-on, opt-out via `[user_prompt_submit_hook] conversation_aware_query_enabled`. Deterministic, no embeddings.
- **`p3_substantive` cadence policy wired live** in Stop + UPS dispatchers, with shadow-log capture of all four policies (#876). Default-OFF.
- **`aelf cadence-score` four-policy pairwise comparison** + **offline cadence replay bench** (#876).
- **Fix:** audit writes skipped for `:memory:` DBs (no more stray `hook_audit.jsonl` in CWD).

## Release mechanics

- `pyproject.toml` 3.3.0 → 3.4.0, `uv.lock` re-resolved.
- `CHANGELOG/v3.md`: `[Unreleased]` dated as `## [3.4.0] - 2026-05-26`, compare-link footnote added, fresh empty `[Unreleased]` opened.
- README "Latest stable" pointer bumped to v3.4.0.

Tag `v3.4.0` (→ publish.yml → PyPI) is applied **after** this merges and staging-gate is green, per the release process.

## Summary by Sourcery

Cut the v3.4.0 release from the existing unreleased changes and update project metadata accordingly.

New Features:
- Document the new p3_substantive cadence policy, aelf cadence-score comparison tooling, and conversation-aware UserPromptSubmit retrieval in the v3.4.0 changelog.

Bug Fixes:
- Document that audit writes are now skipped for in-memory (:memory:) databases in the v3.4.0 changelog.

Build:
- Bump the project version from 3.3.0 to 3.4.0 in pyproject.toml and refresh the uv.lock for the release.

Documentation:
- Add a v3.4.0 section to the changelog with a compare link and update the README to mark v3.4.0 as the latest stable release.