### PR TITLE
fix(setup): refuse worktree-pathed venv in hook resolvers (#928)

### DIFF
--- a/src/aelfrice/setup.py
+++ b/src/aelfrice/setup.py
@@ -454,17 +454,7 @@ def resolve_transcript_logger_command(scope: SettingsScope) -> str:
     pins to the venv next to sys.executable; user scope prefers
     $PATH (typically a pipx install).
     """
-    venv_bin = _venv_bin_dir()
-    venv_hook = _executable_in_dir(venv_bin, TRANSCRIPT_LOGGER_SCRIPT_NAME)
-    path_hook_str = shutil.which(TRANSCRIPT_LOGGER_SCRIPT_NAME)
-    path_hook = Path(path_hook_str) if path_hook_str else None
-    if scope == "project":
-        chosen = venv_hook or path_hook
-    else:
-        chosen = path_hook or venv_hook
-    if chosen is None:
-        return TRANSCRIPT_LOGGER_SCRIPT_NAME
-    return str(chosen)
+    return _resolve_script(TRANSCRIPT_LOGGER_SCRIPT_NAME, scope)
 
 
 @dataclass(frozen=True)
@@ -579,17 +569,7 @@ def resolve_commit_ingest_command(scope: SettingsScope) -> str:
     pins to the venv next to sys.executable; user scope prefers
     $PATH (typically a pipx install).
     """
-    venv_bin = _venv_bin_dir()
-    venv_hook = _executable_in_dir(venv_bin, COMMIT_INGEST_SCRIPT_NAME)
-    path_hook_str = shutil.which(COMMIT_INGEST_SCRIPT_NAME)
-    path_hook = Path(path_hook_str) if path_hook_str else None
-    if scope == "project":
-        chosen = venv_hook or path_hook
-    else:
-        chosen = path_hook or venv_hook
-    if chosen is None:
-        return COMMIT_INGEST_SCRIPT_NAME
-    return str(chosen)
+    return _resolve_script(COMMIT_INGEST_SCRIPT_NAME, scope)
 
 
 def install_commit_ingest_hook(
@@ -676,17 +656,7 @@ def resolve_search_tool_command(scope: SettingsScope) -> str:
     scope pins to the venv next to sys.executable; user scope prefers
     $PATH (typically a pipx install).
     """
-    venv_bin = _venv_bin_dir()
-    venv_hook = _executable_in_dir(venv_bin, SEARCH_TOOL_SCRIPT_NAME)
-    path_hook_str = shutil.which(SEARCH_TOOL_SCRIPT_NAME)
-    path_hook = Path(path_hook_str) if path_hook_str else None
-    if scope == "project":
-        chosen = venv_hook or path_hook
-    else:
-        chosen = path_hook or venv_hook
-    if chosen is None:
-        return SEARCH_TOOL_SCRIPT_NAME
-    return str(chosen)
+    return _resolve_script(SEARCH_TOOL_SCRIPT_NAME, scope)
 
 
 def install_search_tool_hook(
@@ -859,17 +829,7 @@ def resolve_session_start_hook_command(scope: SettingsScope) -> str:
     resolve_transcript_logger_command: project scope pins to the venv
     next to sys.executable; user scope prefers $PATH.
     """
-    venv_bin = _venv_bin_dir()
-    venv_hook = _executable_in_dir(venv_bin, SESSION_START_HOOK_SCRIPT_NAME)
-    path_hook_str = shutil.which(SESSION_START_HOOK_SCRIPT_NAME)
-    path_hook = Path(path_hook_str) if path_hook_str else None
-    if scope == "project":
-        chosen = venv_hook or path_hook
-    else:
-        chosen = path_hook or venv_hook
-    if chosen is None:
-        return SESSION_START_HOOK_SCRIPT_NAME
-    return str(chosen)
+    return _resolve_script(SESSION_START_HOOK_SCRIPT_NAME, scope)
 
 
 def install_session_start_hook(
@@ -961,17 +921,7 @@ def resolve_stop_hook_command(scope: SettingsScope) -> str:
     scope pins to the venv next to sys.executable; user scope prefers
     $PATH.
     """
-    venv_bin = _venv_bin_dir()
-    venv_hook = _executable_in_dir(venv_bin, STOP_HOOK_SCRIPT_NAME)
-    path_hook_str = shutil.which(STOP_HOOK_SCRIPT_NAME)
-    path_hook = Path(path_hook_str) if path_hook_str else None
-    if scope == "project":
-        chosen = venv_hook or path_hook
-    else:
-        chosen = path_hook or venv_hook
-    if chosen is None:
-        return STOP_HOOK_SCRIPT_NAME
-    return str(chosen)
+    return _resolve_script(STOP_HOOK_SCRIPT_NAME, scope)
 
 
 def install_stop_hook(

--- a/src/aelfrice/setup.py
+++ b/src/aelfrice/setup.py
@@ -150,6 +150,24 @@ def _executable_in_dir(directory: Path, name: str) -> Path | None:
     return None
 
 
+def _is_worktree_path(path: Path) -> bool:
+    """True if `path` lives under a `.claude/worktrees/<id>/` directory.
+
+    Worktrees there are ephemeral — the surrounding agent harness
+    creates and removes them around individual sessions. Pinning a
+    hook into a worktree's `.venv/bin/` produces a settings.json
+    entry that survives the worktree's deletion, causing non-blocking
+    "No such file or directory" errors on every subsequent session.
+    Detect this structural pattern so resolvers can skip the worktree
+    binary in favor of a stable `$PATH` entry.
+    """
+    parts = path.parts
+    for i, part in enumerate(parts[:-1]):
+        if part == ".claude" and i + 1 < len(parts) and parts[i + 1] == "worktrees":
+            return True
+    return False
+
+
 def resolve_hook_command(scope: SettingsScope) -> str:
     """Pick the absolute `aelf-hook` path appropriate for `scope`.
 
@@ -182,6 +200,10 @@ def resolve_pre_compact_hook_command(scope: SettingsScope) -> str:
 def _resolve_script(script_name: str, scope: SettingsScope) -> str:
     venv_bin = _venv_bin_dir()
     venv_hook = _executable_in_dir(venv_bin, script_name)
+    # #928: a venv under .claude/worktrees/<id>/ is ephemeral; refuse to
+    # write its absolute path into settings.json regardless of scope.
+    if venv_hook is not None and _is_worktree_path(venv_hook):
+        venv_hook = None
     path_hook_str = shutil.which(script_name)
     path_hook = Path(path_hook_str) if path_hook_str else None
     if scope == "project":

--- a/tests/test_setup_resolution.py
+++ b/tests/test_setup_resolution.py
@@ -84,6 +84,61 @@ def test_resolve_hook_command_last_resort_is_bare_name(
     assert resolve_hook_command("user") == "aelf-hook"
 
 
+# --- #928: refuse worktree-pathed venv hooks ---------------------------
+
+
+def test_resolve_hook_command_project_skips_worktree_venv_falls_back_to_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Simulate a harness-worktree shell: sys.prefix is a venv inside
+    # <repo>/.claude/worktrees/<id>/.venv. Even at project scope, we must
+    # NOT pin that ephemeral path into settings.json.
+    worktree_venv = tmp_path / "repo" / ".claude" / "worktrees" / "095830" / ".venv"
+    worktree_bin = worktree_venv / "bin"
+    worktree_hook = worktree_bin / "aelf-hook"
+    _make_executable(worktree_hook)
+    stable_dir = tmp_path / "stable" / "bin"
+    stable_hook = stable_dir / "aelf-hook"
+    _make_executable(stable_hook)
+    monkeypatch.setattr(sys, "prefix", str(worktree_venv))
+    monkeypatch.setenv("PATH", str(stable_dir))
+
+    assert resolve_hook_command("project") == str(stable_hook)
+    assert resolve_hook_command("user") == str(stable_hook)
+
+
+def test_resolve_hook_command_skips_worktree_venv_no_path_returns_bare(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Worktree venv is the only thing available, $PATH is empty: the
+    # resolver must refuse the worktree path and fall through to the
+    # bare name, so doctor can flag it instead of writing a stale path.
+    worktree_venv = tmp_path / "repo" / ".claude" / "worktrees" / "abc" / ".venv"
+    worktree_bin = worktree_venv / "bin"
+    worktree_hook = worktree_bin / "aelf-hook"
+    _make_executable(worktree_hook)
+    monkeypatch.setattr(sys, "prefix", str(worktree_venv))
+    monkeypatch.setenv("PATH", "/nonexistent")
+
+    assert resolve_hook_command("project") == "aelf-hook"
+    assert resolve_hook_command("user") == "aelf-hook"
+
+
+def test_resolve_hook_command_non_worktree_venv_unaffected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression guard: a normal project venv (no .claude/worktrees/
+    # segment in the path) must still be selected at project scope.
+    project_venv = tmp_path / "myrepo" / ".venv"
+    venv_bin = project_venv / "bin"
+    venv_hook = venv_bin / "aelf-hook"
+    _make_executable(venv_hook)
+    monkeypatch.setattr(sys, "prefix", str(project_venv))
+    monkeypatch.setenv("PATH", "/nonexistent")
+
+    assert resolve_hook_command("project") == str(venv_hook)
+
+
 # --- detect_default_scope -----------------------------------------------
 
 


### PR DESCRIPTION
Fixes #928.

## Problem

When `aelf setup` (or any re-install path) runs from inside a harness-managed worktree shell, the resolvers write absolute paths under `<repo>/.claude/worktrees/<id>/.venv/bin/aelf-*-hook` into `~/.claude/settings.json`. When the harness later cleans up the worktree, the path evaporates but the settings entry remains, producing non-blocking but noisy "No such file or directory" errors on every subsequent session, tool-use, and prompt submit (one local install accumulated 27 stale entries across 4 removed worktrees).

## Approach

Two atomic commits:

1. **`refactor(setup): delegate per-event resolvers to _resolve_script`** — Five resolvers (transcript_logger, commit_ingest, search_tool, session_start_hook, stop_hook) each inlined the same 10-line venv / $PATH / bare-name fallback that already lived in `_resolve_script`. Collapse them so the fix lands in one place. No behavior change; existing 11 tests pass.

2. **`fix(setup): refuse worktree-pathed venv in hook resolvers (#928)`** — `_resolve_script` now treats a venv hook under a `.claude/worktrees/` path segment as if it were not found, so the fallback chain proceeds to `shutil.which()` and finally the bare basename. Detection is structural (adjacent `.claude` and `worktrees` parts) so it works regardless of repo location.

## Tests

`test_setup_resolution.py` adds three cases:

- project + user scope with worktree venv + stable `$PATH` → both pick the stable path
- worktree venv + empty `$PATH` → falls through to bare name (doctor can flag, per #929)
- regression guard: non-worktree venv still selected at project scope

All 58 tests in the four setup test files pass.

## Out of scope (already shipped under #781)

- **Detection** of stale entries already in users' settings.json: `aelf doctor` (verified live — flags all 27 stale entries from the originating bug report with "path does not exist").
- **Cleanup** of those existing entries: `aelf doctor --fix` (`prune_broken_aelf_hooks`, gates strictly on `aelf-*` basenames so custom hooks are safe; supports `--dry-run`).

I filed #929 and #930 in haste without first running `aelf doctor` against the dirty settings.json — both were duplicates of #781 and have been closed. This PR is the only real remaining work: stop the bleeding for fresh installs and re-runs from worktree shells. After it merges, the existing 27 stale entries can be pruned with `aelf doctor --fix`.
