### PR TITLE
feat(statusline): L0/L1/? count badges (#932)

### DIFF
--- a/src/aelfrice/statusline.py
+++ b/src/aelfrice/statusline.py
@@ -17,7 +17,9 @@ Design (mirrors GSD's gsd-statusline.js):
 from __future__ import annotations
 
 import os
-from typing import Final
+import sqlite3
+from pathlib import Path
+from typing import Callable, Final
 
 from aelfrice.lifecycle import (
     UpdateStatus,
@@ -93,9 +95,71 @@ def format_snippet(
     return f"{color_on}{body}{color_off}{SEPARATOR}"
 
 
+COUNTS_ENV: Final[str] = "AELF_STATUSLINE_COUNTS"
+"""Env var: set to '0' to suppress the L0/L1/? count badges. Statusline
+integration is itself opt-in (the user wires `aelf statusline` into
+their shell); the badges follow that opt-in, but this escape hatch
+lets a user keep the upgrade prefix only."""
+
+
+def _count_badges(
+    env: dict[str, str] | None = None,
+    db_path_fn: Callable[[], Path] | None = None,
+) -> str:
+    """Return the `aelf L0=N L1=N [?=M]` count snippet.
+
+    Empty string when: counts suppressed via env var; DB file does
+    not exist (no aelfrice setup in this repo); DB read raises (the
+    statusline must never break the user's shell prompt); or the
+    store is empty (no L0 and no L1).
+
+    The `?=M` badge is omitted when M==0 — a clean store should not
+    draw user attention to a non-existent problem.
+    """
+    src = os.environ if env is None else env
+    if src.get(COUNTS_ENV) == "0":
+        return ""
+    try:
+        if db_path_fn is None:
+            from aelfrice.db_paths import db_path as _db_path
+            p = _db_path()
+        else:
+            p = db_path_fn()
+        if not p.exists():
+            return ""
+        from aelfrice.models import EDGE_POTENTIALLY_STALE
+        conn = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
+        try:
+            l0 = conn.execute(
+                "SELECT COUNT(*) FROM beliefs WHERE lock_level != 'none'"
+            ).fetchone()[0]
+            l1 = conn.execute(
+                "SELECT COUNT(*) FROM beliefs WHERE lock_level = 'none'"
+            ).fetchone()[0]
+            stale = conn.execute(
+                "SELECT COUNT(DISTINCT dst) FROM edges WHERE type = ?",
+                (EDGE_POTENTIALLY_STALE,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+    except (sqlite3.Error, OSError, ImportError):
+        return ""
+    if l0 == 0 and l1 == 0:
+        return ""
+    parts = [f"L0={l0}", f"L1={l1}"]
+    if stale > 0:
+        parts.append(f"?={stale}")
+    return f"aelf {' '.join(parts)}"
+
+
 def render() -> str:
     """Read the cache and return the statusline snippet.
 
-    Convenience wrapper: this is what the CLI subcommand prints.
+    Composition: `[upgrade-snippet-with-separator][count-badges]`.
+    Either or both may be empty. When the upgrade snippet is present
+    it carries its own trailing ' │ '; when only counts are present
+    the output has no leading separator.
     """
-    return format_snippet(read_cache())
+    upgrade = format_snippet(read_cache())
+    counts = _count_badges()
+    return upgrade + counts

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -116,3 +116,152 @@ def test_render_reads_cache(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("COLORTERM", "truecolor")
     out = statusline.render()
     assert "1.5.0" in out
+
+
+# ---------------------------------------------------------------------------
+# #932 — L0 / L1 / ? count badges
+# ---------------------------------------------------------------------------
+
+
+def _seed_store(path, *, locked: int, speculative: int, stale_targets: int) -> None:
+    """Build a minimal aelfrice DB at `path` with the given row counts.
+
+    Schema is reproduced inline (rather than imported from store.py) so
+    the test exercises the exact column shape statusline._count_badges
+    reads — if a future migration renames `lock_level` or `dst`, this
+    test catches it independently of MemoryStore.
+    """
+    import sqlite3 as _sqlite3
+
+    conn = _sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE beliefs (
+            id          TEXT PRIMARY KEY,
+            lock_level  TEXT NOT NULL DEFAULT 'none'
+        );
+        CREATE TABLE edges (
+            src   TEXT NOT NULL,
+            dst   TEXT NOT NULL,
+            type  TEXT NOT NULL,
+            PRIMARY KEY (src, dst, type)
+        );
+        """
+    )
+    rows = []
+    for i in range(locked):
+        rows.append((f"L{i:04d}", "user"))
+    for i in range(speculative):
+        rows.append((f"S{i:04d}", "none"))
+    conn.executemany("INSERT INTO beliefs(id, lock_level) VALUES (?, ?)", rows)
+    edges = [(f"src{i}", f"L{i:04d}", "POTENTIALLY_STALE") for i in range(stale_targets)]
+    if edges:
+        conn.executemany("INSERT INTO edges(src, dst, type) VALUES (?, ?, ?)", edges)
+    conn.commit()
+    conn.close()
+
+
+def test_count_badges_empty_when_no_db(tmp_path) -> None:
+    missing = tmp_path / "does-not-exist.db"
+    assert statusline._count_badges(env={}, db_path_fn=lambda: missing) == ""
+
+
+def test_count_badges_empty_when_store_empty(tmp_path) -> None:
+    p = tmp_path / "memory.db"
+    _seed_store(p, locked=0, speculative=0, stale_targets=0)
+    assert statusline._count_badges(env={}, db_path_fn=lambda: p) == ""
+
+
+def test_count_badges_basic_l0_l1(tmp_path) -> None:
+    p = tmp_path / "memory.db"
+    _seed_store(p, locked=42, speculative=128, stale_targets=0)
+    out = statusline._count_badges(env={}, db_path_fn=lambda: p)
+    assert out == "aelf L0=42 L1=128"
+
+
+def test_count_badges_includes_stale_when_nonzero(tmp_path) -> None:
+    p = tmp_path / "memory.db"
+    _seed_store(p, locked=5, speculative=10, stale_targets=3)
+    out = statusline._count_badges(env={}, db_path_fn=lambda: p)
+    assert out == "aelf L0=5 L1=10 ?=3"
+
+
+def test_count_badges_omits_stale_when_zero(tmp_path) -> None:
+    p = tmp_path / "memory.db"
+    _seed_store(p, locked=1, speculative=1, stale_targets=0)
+    out = statusline._count_badges(env={}, db_path_fn=lambda: p)
+    assert "?=" not in out
+
+
+def test_count_badges_env_opt_out(tmp_path) -> None:
+    p = tmp_path / "memory.db"
+    _seed_store(p, locked=42, speculative=128, stale_targets=3)
+    out = statusline._count_badges(
+        env={"AELF_STATUSLINE_COUNTS": "0"},
+        db_path_fn=lambda: p,
+    )
+    assert out == ""
+
+
+def test_count_badges_stale_dedups_on_dst(tmp_path) -> None:
+    """Multiple stale edges to the same target count as one stale belief."""
+    import sqlite3 as _sqlite3
+
+    p = tmp_path / "memory.db"
+    _seed_store(p, locked=2, speculative=0, stale_targets=0)
+    conn = _sqlite3.connect(str(p))
+    conn.executemany(
+        "INSERT INTO edges(src, dst, type) VALUES (?, ?, ?)",
+        [
+            ("a", "L0000", "POTENTIALLY_STALE"),
+            ("b", "L0000", "POTENTIALLY_STALE"),
+            ("a", "L0001", "POTENTIALLY_STALE"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    out = statusline._count_badges(env={}, db_path_fn=lambda: p)
+    assert out == "aelf L0=2 L1=0 ?=2"
+
+
+def test_count_badges_swallows_db_errors(tmp_path) -> None:
+    """A garbage DB must not raise — statusline can't break the shell."""
+    p = tmp_path / "memory.db"
+    p.write_bytes(b"this is not sqlite")
+    assert statusline._count_badges(env={}, db_path_fn=lambda: p) == ""
+
+
+def test_render_composes_upgrade_and_counts(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "memory.db"
+    _seed_store(p, locked=3, speculative=7, stale_targets=0)
+    # Force the upgrade snippet to fire.
+    cache_path = tmp_path / "cache.json"
+    lifecycle._write_cache(_fresh("9.9.9"), cache_path)
+    monkeypatch.setattr(
+        statusline, "read_cache",
+        lambda: lifecycle.read_cache(cache_path),
+    )
+    # Patch db_path resolution so the real _count_badges hits the
+    # fixture DB rather than the user's actual store.
+    import aelfrice.db_paths as _db_paths_mod
+    monkeypatch.setattr(_db_paths_mod, "db_path", lambda: p)
+    out = statusline.render()
+    assert "9.9.9" in out
+    assert "aelf L0=3 L1=7" in out
+    # Upgrade snippet carries its own ' │ ' separator before the counts.
+    assert statusline.SEPARATOR in out
+
+
+def test_render_counts_only_when_no_upgrade(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "memory.db"
+    _seed_store(p, locked=3, speculative=7, stale_targets=0)
+    no_update = lifecycle.UpdateStatus(False, "1.0.0", "1.0.0", time.time(), None)
+    monkeypatch.setattr(statusline, "read_cache", lambda: no_update)
+    import aelfrice.db_paths as _db_paths_mod
+    monkeypatch.setattr(_db_paths_mod, "db_path", lambda: p)
+    out = statusline.render()
+    assert out == "aelf L0=3 L1=7"


### PR DESCRIPTION
Closes #932.

## Summary

- Extends `aelf statusline` with `aelf L0=N L1=N [?=M]` count badges appended after the existing upgrade-prefix snippet.
- Three indexed `COUNT` queries against `beliefs.lock_level` + `edges.type='POTENTIALLY_STALE'`.
- `?=M` badge omitted when M==0 (clean store shouldn't draw user attention to a non-existent problem).
- Read-only sqlite open, all errors swallowed — statusline can never break a user's shell prompt.
- `AELF_STATUSLINE_COUNTS=0` env var disables badges (keeps upgrade prefix only).
- Empty output when DB doesn't exist (no aelfrice setup in this repo).

## Latency

0.47ms mean per call over a 10k-belief fixture (5% locked, 200 stale edges) vs the ≤5ms p95 gate from the spec.

## Test plan

- [x] `tests/test_statusline.py` extended with 9 new tests (empty store, no DB, basic L0/L1, stale ≠0, stale =0, env opt-out, dedup on dst, swallows malformed DB, render-composes-both, render-counts-only).
- [x] `uv run pytest tests/test_statusline.py tests/test_setup_statusline.py` — 38 passed.
- [x] Latency micro-bench under spec gate.
- [x] Signed commit verified.

## #605 / #606 fit

Three COUNT queries — deterministic, zero inference. Statusline integration is itself opt-in via the user's shell config, so the badges follow that posture without introducing a new opt-in decision (resolves the broader default-on vs default-off question per the wonder-dispatch on 2026-06-04 — see #931 PR body for the longer write-up).

## Summary by Sourcery

Extend the statusline output with database-derived belief count badges and compose them with the existing upgrade snippet.

New Features:
- Add L0/L1/stale ('?') count badges to the statusline based on beliefs and edges stored in the aelfrice database.
- Introduce an environment-variable escape hatch to disable count badges while retaining the upgrade prefix.

Enhancements:
- Ensure statusline rendering gracefully handles missing or malformed databases and never breaks the shell prompt.
- Refine statusline composition so upgrade and count snippets are combined without redundant separators.

Tests:
- Add comprehensive tests covering count badge generation, environment opt-out behavior, stale deduplication, error swallowing, and integration with the upgrade snippet.