### PR TITLE
feat(observability): .aelfrice-feed.jsonl write-event log + aelf:feed reader (#931)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -204,6 +204,32 @@ _FEEDBACK_VALENCES: Final[dict[str, float]] = {"used": 1.0, "harmful": -1.0}
 _VALID_SCOPES: Final[tuple[SettingsScope, ...]] = ("user", "project")
 
 
+def _feed_log_event(
+    event: str,
+    belief_id: str | None,
+    args: argparse.Namespace | None = None,
+    **extra: object,
+) -> None:
+    """Append a row to the belief-write feed log (#931).
+
+    Pulls a snippet from the args namespace when present (covers
+    lock / wonder etc that have a `text` or `content` attribute).
+    All errors swallowed by `feed_log.append`; this wrapper exists
+    only to keep the call sites terse.
+    """
+    from aelfrice import feed_log
+    payload: dict[str, object] = dict(extra)
+    if belief_id is not None:
+        payload["id"] = belief_id
+    if args is not None and "snippet" not in payload:
+        for attr in ("statement", "text", "content", "message"):
+            val = getattr(args, attr, None)
+            if isinstance(val, str) and val:
+                payload["snippet"] = val[:120]
+                break
+    feed_log.append(event, **payload)
+
+
 def _git_first_commit_age_days() -> int | None:
     """Days since cwd's first git commit, or None when unknown.
 
@@ -460,6 +486,15 @@ def _cmd_onboard_accept_classifications(
         ),
         file=out,  # type: ignore[arg-type]
     )
+    if result.inserted:
+        _feed_log_event(
+            "belief.ingested",
+            None,
+            None,
+            source="onboard",
+            session_id=result.session_id,
+            count=result.inserted,
+        )
     return 0
 
 
@@ -1561,6 +1596,15 @@ def _cmd_wonder_persist_docs(args: argparse.Namespace, out: object) -> int:
         f"skipped={result.skipped} edges_created={result.edges_created}",
         file=out,  # type: ignore[arg-type]
     )
+    if result.inserted:
+        _feed_log_event(
+            "belief.ingested",
+            None,
+            None,
+            source="wonder.persist-docs",
+            count=result.inserted,
+            edges_created=result.edges_created,
+        )
     return 0
 
 
@@ -1856,12 +1900,15 @@ def _cmd_lock(args: argparse.Namespace, out: object) -> int:
                 existing.origin = ORIGIN_USER_STATED
                 store.update_belief(existing)
             print(f"upgraded existing belief to lock: {actual_id}", file=out)  # type: ignore[arg-type]
+            _feed_log_event("belief.locked", actual_id, args, kind="upgrade")
         elif actual_id in ids_before:
             # content_hash collision with a different-source belief —
             # worker corroborated; preserve the prior surface message.
             print(f"locked: {actual_id} (corroborated existing)", file=out)  # type: ignore[arg-type]
+            _feed_log_event("belief.locked", actual_id, args, kind="corroborated")
         else:
             print(f"locked: {actual_id}", file=out)  # type: ignore[arg-type]
+            _feed_log_event("belief.locked", actual_id, args, kind="new")
 
         # #435 doc-linker manual anchor. Idempotent on (belief_id,
         # doc_uri); subsequent lock --doc with the same URI is a no-op
@@ -2283,6 +2330,13 @@ def _cmd_validate(args: argparse.Namespace, out: object) -> int:
             f"(origin: {result.prior_origin} -> {result.new_origin})",
             file=out,  # type: ignore[arg-type]
         )
+        _feed_log_event(
+            "wonder.promoted",
+            args.belief_id,
+            None,
+            from_origin=result.prior_origin,
+            to_origin=result.new_origin,
+        )
     finally:
         store.close()
     return 0
@@ -2397,6 +2451,15 @@ def _cmd_confirm(args: argparse.Namespace, out: object) -> int:
     if result.get("note"):
         msg += f" [{result['note']}]"
     print(msg, file=out)  # type: ignore[arg-type]
+    _feed_log_event(
+        "feedback.applied",
+        args.belief_id,
+        None,
+        kind="confirm",
+        source=args.source,
+        prior_alpha=prior_alpha,
+        new_alpha=new_alpha,
+    )
     return 0
 
 
@@ -2576,6 +2639,16 @@ def _cmd_feedback(args: argparse.Namespace, out: object) -> int:
         f"alpha {result.prior_alpha:.3f}->{result.new_alpha:.3f}, "
         f"beta {result.prior_beta:.3f}->{result.new_beta:.3f}",
         file=out,  # type: ignore[arg-type]
+    )
+    _feed_log_event(
+        "feedback.applied",
+        args.belief_id,
+        None,
+        kind="feedback",
+        signal=args.signal,
+        source=args.source,
+        prior_alpha=result.prior_alpha,
+        new_alpha=result.new_alpha,
     )
     return 0
 

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2017,6 +2017,74 @@ def _cmd_stale(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _cmd_feed(args: argparse.Namespace, out: object) -> int:
+    """Read the belief-write event log (#931).
+
+    Mirrors `aelf tail`'s ergonomics: `--since 5m` / `--since 2h` /
+    `--since 1d` for relative-duration filtering, `--limit N` for the
+    last N rows, `--json` for passthrough.
+    """
+    from datetime import datetime, timezone as _tz
+
+    from aelfrice import feed_log
+    from aelfrice.hook_tail import parse_since
+
+    p = feed_log.feed_path()
+    rows = feed_log.read_rows(p)
+
+    if args.since:
+        try:
+            delta = parse_since(args.since)
+        except ValueError as e:
+            print(str(e), file=out)  # type: ignore[arg-type]
+            return 2
+        cutoff = datetime.now(_tz.utc) - delta
+        kept: list[dict[str, object]] = []
+        for row in rows:
+            ts = str(row.get("ts", ""))
+            normalised = ts.rstrip()
+            if normalised.endswith("Z"):
+                normalised = normalised[:-1] + "+00:00"
+            try:
+                dt = datetime.fromisoformat(normalised)
+            except ValueError:
+                continue
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=_tz.utc)
+            if dt >= cutoff:
+                kept.append(row)
+        rows = kept
+
+    if args.limit and args.limit > 0:
+        rows = rows[-args.limit:]
+
+    if args.json:
+        import json as _json
+        for row in rows:
+            print(_json.dumps(row, ensure_ascii=False), file=out)  # type: ignore[arg-type]
+        return 0
+
+    if not rows:
+        print("no feed entries", file=out)  # type: ignore[arg-type]
+        return 0
+    for row in rows:
+        ts = str(row.get("ts", ""))[:19]  # YYYY-MM-DDTHH:MM:SS
+        event = str(row.get("event", "?"))
+        bid = row.get("id") or row.get("belief_id") or ""
+        snippet = (str(row.get("snippet") or ""))[:60].replace("\n", " ")
+        extras: list[str] = []
+        for k, v in row.items():
+            if k in {"ts", "event", "id", "belief_id", "snippet"}:
+                continue
+            extras.append(f"{k}={v}")
+        extra = (" " + " ".join(extras)) if extras else ""
+        print(  # type: ignore[arg-type]
+            f"{ts}  {event:24}  {str(bid)[:12]:12}  {snippet}{extra}",
+            file=out,
+        )
+    return 0
+
+
 def _cmd_scope_out(args: argparse.Namespace, out: object) -> int:
     """Manage the active session's retrieval-exclusion list (#856).
 
@@ -5746,6 +5814,28 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help="cap rows (default 20)",
     )
     p_stale.set_defaults(func=_cmd_stale)
+
+    # v3.5 (#931) — per-project JSONL belief-write event log reader.
+    # Mirrors `aelf tail` ergonomics. Writer is in aelfrice.feed_log;
+    # 5 write paths emit one row each on lock/onboard/wonder-promote/
+    # feedback. AELFRICE_FEED_LOG=0 disables.
+    p_feed = sub.add_parser(
+        "feed",
+        help="read the belief-write event log (.aelfrice/feed.jsonl)",
+    )
+    p_feed.add_argument(
+        "--since", default=None,
+        help="filter to rows within the last duration (e.g. 5m / 2h / 1d)",
+    )
+    p_feed.add_argument(
+        "--limit", type=int, default=0,
+        help="show only the last N rows (0 = all; default 0)",
+    )
+    p_feed.add_argument(
+        "--json", action="store_true",
+        help="emit raw JSONL rows verbatim",
+    )
+    p_feed.set_defaults(func=_cmd_feed)
 
     # v3.x (#856) — session-scoped retrieval exclusion list. Reads/writes
     # session_exclusions.json keyed by the hook-written session_first_prompt.json;

--- a/src/aelfrice/feed_log.py
+++ b/src/aelfrice/feed_log.py
@@ -1,0 +1,136 @@
+"""Per-project JSONL event log for belief writes (#931).
+
+Writer module — appended to from every belief-write path so users can
+`tail -f` the file and see what aelfrice is doing. Sibling of
+`memory.db` under `<git-common-dir>/aelfrice/feed.jsonl`.
+
+Design constraints:
+
+* **Errors are swallowed.** A failed feed write must never break the
+  write-side CLI command that triggered it. The feed log is a
+  visibility surface; correctness of writes is not.
+* **Rotation, not bounded growth.** At 100 MB the active log is
+  renamed to `feed.<unix-ts>.jsonl.archive` and a fresh `feed.jsonl`
+  starts. Archives are not deleted automatically — users can sweep
+  them on their own schedule.
+* **No write announcement on stderr.** Stderr-bleed into Claude
+  Code's transcript ingestion is a self-feedback risk; the JSONL
+  file is the only channel.
+* **Default on.** `AELFRICE_FEED_LOG=0` disables. Statusline /
+  setup integration can layer richer opt-out in follow-up work.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Final
+
+ENV_FEED_LOG: Final[str] = "AELFRICE_FEED_LOG"
+"""Set to '0' to suppress all feed-log writes."""
+
+FEED_FILENAME: Final[str] = "feed.jsonl"
+
+ROTATE_BYTES: Final[int] = 100 * 1024 * 1024
+"""Rotate the active log when it exceeds 100 MB."""
+
+
+def is_enabled(env: dict[str, str] | None = None) -> bool:
+    """True unless `AELFRICE_FEED_LOG=0` is set."""
+    src = os.environ if env is None else env
+    return src.get(ENV_FEED_LOG) != "0"
+
+
+def feed_path(db_dir: Path | None = None) -> Path:
+    """Return the feed-log path. Sibling of `memory.db`.
+
+    `db_dir=None` resolves via `aelfrice.db_paths.db_path().parent`,
+    which honours `AELFRICE_DB` overrides.
+    """
+    if db_dir is None:
+        from aelfrice.db_paths import db_path as _db_path
+        db_dir = _db_path().parent
+    return db_dir / FEED_FILENAME
+
+
+def _utc_now_iso() -> str:
+    """Return current time as an ISO-Z-suffixed UTC string."""
+    return (
+        datetime.now(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rotate_if_needed(p: Path) -> None:
+    """Rename `p` to `feed.<ts>.jsonl.archive` if it exceeds ROTATE_BYTES.
+
+    Errors are swallowed — if rotation fails the log keeps growing
+    rather than the write path failing.
+    """
+    try:
+        size = p.stat().st_size
+    except OSError:
+        return
+    if size < ROTATE_BYTES:
+        return
+    archive_name = f"feed.{int(time.time())}.jsonl.archive"
+    try:
+        p.rename(p.with_name(archive_name))
+    except OSError:
+        return
+
+
+def append(event: str, **fields: Any) -> None:
+    """Append one JSONL row to the feed log.
+
+    `event` is the canonical event type (`belief.locked`,
+    `belief.ingested`, `wonder.promoted`, `feedback.applied`).
+    Additional structured fields are merged into the row.
+
+    Returns None unconditionally. All errors (env-disabled, missing
+    parent dir, json-serialisation, OS write failures) are swallowed
+    — the write path must not see them.
+    """
+    if not is_enabled():
+        return
+    row: dict[str, Any] = {"ts": _utc_now_iso(), "event": event, **fields}
+    try:
+        p = feed_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        _rotate_if_needed(p)
+        with p.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+    except (OSError, ValueError, TypeError):
+        return
+
+
+def read_rows(p: Path | None = None) -> list[dict[str, Any]]:
+    """Read the active feed log into a list of dicts.
+
+    For the reader CLI. Malformed JSON lines are skipped silently
+    (the writer's swallow-errors posture means we may occasionally
+    have partial lines from interrupted writes — a malformed row in
+    the middle of a file shouldn't prevent the reader from showing
+    the rest).
+    """
+    if p is None:
+        p = feed_path()
+    if not p.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    out.append(json.loads(line))
+                except ValueError:
+                    continue
+    except OSError:
+        return out
+    return out

--- a/src/aelfrice/slash_commands/feed.md
+++ b/src/aelfrice/slash_commands/feed.md
@@ -1,0 +1,16 @@
+---
+name: aelf:feed
+description: Read the belief-write event log — see what aelfrice has been recording.
+allowed-tools:
+  - Bash
+---
+<objective>
+Surface what aelfrice has been writing — one JSONL row per belief
+lock / onboard / wonder-promote / feedback event. The log lives at
+`<git-common-dir>/aelfrice/feed.jsonl` (sibling of memory.db).
+</objective>
+
+<process>
+Run: `uv run aelf feed "$@"`
+Display the output verbatim. Do not add commentary.
+</process>

--- a/tests/test_cli_feed.py
+++ b/tests/test_cli_feed.py
@@ -1,0 +1,121 @@
+"""Tests for `aelf feed` CLI subcommand (#931)."""
+from __future__ import annotations
+
+import io
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from aelfrice import feed_log
+from aelfrice.cli import main
+
+
+@pytest.fixture
+def isolated_feed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    p = tmp_path / "feed.jsonl"
+    monkeypatch.setattr(
+        feed_log, "feed_path",
+        lambda db_dir=None: p,
+    )
+    return p
+
+
+def _run(*argv: str) -> tuple[int, str]:
+    buf = io.StringIO()
+    code = main(argv=list(argv), out=buf)
+    return code, buf.getvalue()
+
+
+def _write_rows(p: Path, rows: list[dict]) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def _iso(seconds_ago: int) -> str:
+    return (
+        datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+    ).isoformat().replace("+00:00", "Z")
+
+
+def test_feed_empty_when_no_log(isolated_feed: Path) -> None:
+    code, out = _run("feed")
+    assert code == 0
+    assert "no feed entries" in out
+
+
+def test_feed_renders_human_rows(isolated_feed: Path) -> None:
+    _write_rows(isolated_feed, [
+        {"ts": _iso(60), "event": "belief.locked", "id": "abc123",
+         "snippet": "atomic commits beat batched"},
+        {"ts": _iso(30), "event": "wonder.promoted", "id": "def456",
+         "from_": "speculative", "to": "locked"},
+    ])
+    code, out = _run("feed")
+    assert code == 0
+    assert "belief.locked" in out
+    assert "abc123" in out
+    assert "wonder.promoted" in out
+    assert "from_=speculative" in out
+
+
+def test_feed_json_passthrough(isolated_feed: Path) -> None:
+    _write_rows(isolated_feed, [
+        {"ts": _iso(60), "event": "belief.ingested", "id": "a"},
+        {"ts": _iso(30), "event": "feedback.applied", "belief_id": "b"},
+    ])
+    code, out = _run("feed", "--json")
+    parsed = [json.loads(line) for line in out.splitlines() if line.strip()]
+    assert len(parsed) == 2
+    assert parsed[0]["event"] == "belief.ingested"
+    assert parsed[1]["belief_id"] == "b"
+
+
+def test_feed_since_filters_to_window(isolated_feed: Path) -> None:
+    _write_rows(isolated_feed, [
+        {"ts": _iso(3600), "event": "belief.locked", "id": "old"},
+        {"ts": _iso(60), "event": "belief.locked", "id": "recent"},
+    ])
+    code, out = _run("feed", "--since", "5m", "--json")
+    parsed = [json.loads(line) for line in out.splitlines() if line.strip()]
+    assert len(parsed) == 1
+    assert parsed[0]["id"] == "recent"
+
+
+def test_feed_since_rejects_bad_spec(isolated_feed: Path) -> None:
+    _write_rows(isolated_feed, [
+        {"ts": _iso(60), "event": "belief.locked", "id": "x"},
+    ])
+    code, out = _run("feed", "--since", "garbage")
+    assert code == 2
+    assert "--since" in out
+
+
+def test_feed_limit_caps_to_last_n(isolated_feed: Path) -> None:
+    _write_rows(isolated_feed, [
+        {"ts": _iso(300), "event": "belief.locked", "id": "a"},
+        {"ts": _iso(200), "event": "belief.locked", "id": "b"},
+        {"ts": _iso(100), "event": "belief.locked", "id": "c"},
+        {"ts": _iso(50), "event": "belief.locked", "id": "d"},
+    ])
+    code, out = _run("feed", "--limit", "2", "--json")
+    parsed = [json.loads(line) for line in out.splitlines() if line.strip()]
+    assert [r["id"] for r in parsed] == ["c", "d"]
+
+
+def test_feed_skips_malformed_lines(isolated_feed: Path) -> None:
+    """Partial / corrupt lines from interrupted writes must not crash."""
+    isolated_feed.parent.mkdir(parents=True, exist_ok=True)
+    isolated_feed.write_text(
+        json.dumps({"ts": _iso(60), "event": "belief.locked", "id": "ok"})
+        + "\n"
+        + "{this is not json\n"
+        + json.dumps({"ts": _iso(30), "event": "belief.ingested", "id": "ok2"})
+        + "\n"
+    )
+    code, out = _run("feed", "--json")
+    parsed = [json.loads(line) for line in out.splitlines() if line.strip()]
+    assert [r["id"] for r in parsed] == ["ok", "ok2"]

--- a/tests/test_feed_log.py
+++ b/tests/test_feed_log.py
@@ -1,0 +1,145 @@
+"""Tests for the feed_log writer module (#931)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice import feed_log
+
+
+@pytest.fixture
+def isolated_feed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect feed_path() to a writable temp dir."""
+    target = tmp_path / "feed.jsonl"
+    monkeypatch.setattr(
+        feed_log, "feed_path",
+        lambda db_dir=None: target,
+    )
+    return target
+
+
+def test_is_enabled_default_true() -> None:
+    assert feed_log.is_enabled(env={}) is True
+
+
+def test_is_enabled_false_when_env_zero() -> None:
+    assert feed_log.is_enabled(env={"AELFRICE_FEED_LOG": "0"}) is False
+
+
+def test_is_enabled_true_when_env_one() -> None:
+    assert feed_log.is_enabled(env={"AELFRICE_FEED_LOG": "1"}) is True
+
+
+def test_append_writes_jsonl_row(
+    isolated_feed: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AELFRICE_FEED_LOG", raising=False)
+    feed_log.append("belief.locked", id="abc123", snippet="hello world")
+    assert isolated_feed.exists()
+    rows = isolated_feed.read_text().splitlines()
+    assert len(rows) == 1
+    parsed = json.loads(rows[0])
+    assert parsed["event"] == "belief.locked"
+    assert parsed["id"] == "abc123"
+    assert parsed["snippet"] == "hello world"
+    assert parsed["ts"].endswith("Z")
+
+
+def test_append_appends_multiple_rows(
+    isolated_feed: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AELFRICE_FEED_LOG", raising=False)
+    feed_log.append("belief.locked", id="a")
+    feed_log.append("belief.ingested", id="b")
+    feed_log.append("wonder.promoted", id="c", from_="speculative", to="locked")
+    rows = isolated_feed.read_text().splitlines()
+    assert len(rows) == 3
+    events = [json.loads(r)["event"] for r in rows]
+    assert events == ["belief.locked", "belief.ingested", "wonder.promoted"]
+
+
+def test_append_swallows_disabled_env(
+    isolated_feed: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AELFRICE_FEED_LOG", "0")
+    feed_log.append("belief.locked", id="x")
+    assert not isolated_feed.exists()
+
+
+def test_append_swallows_unserialisable_field(
+    isolated_feed: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A field that json.dumps can't handle must not raise to the caller."""
+    monkeypatch.delenv("AELFRICE_FEED_LOG", raising=False)
+
+    class _NoSerialize:
+        pass
+
+    feed_log.append("belief.locked", id="x", weird=_NoSerialize())
+    # File may or may not exist (no row was written) — what matters
+    # is that the call returned None instead of raising.
+
+
+def test_append_swallows_missing_parent_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even if the parent dir resolves to something un-mkdir-able,
+    the writer must return cleanly."""
+    monkeypatch.delenv("AELFRICE_FEED_LOG", raising=False)
+    # Point feed_path at a path under a regular file (mkdir will fail).
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("blocker")
+    monkeypatch.setattr(
+        feed_log, "feed_path",
+        lambda db_dir=None: blocker / "feed.jsonl",
+    )
+    feed_log.append("belief.locked", id="x")
+    # No exception is the assertion.
+
+
+def test_rotation_renames_oversized_log(
+    isolated_feed: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A log exceeding ROTATE_BYTES is renamed before the next append."""
+    monkeypatch.delenv("AELFRICE_FEED_LOG", raising=False)
+    monkeypatch.setattr(feed_log, "ROTATE_BYTES", 100)
+    isolated_feed.parent.mkdir(parents=True, exist_ok=True)
+    isolated_feed.write_bytes(b"x" * 200)
+    feed_log.append("belief.locked", id="post-rotation")
+    archives = list(isolated_feed.parent.glob("feed.*.jsonl.archive"))
+    assert len(archives) == 1
+    # The fresh active log carries only the post-rotation row.
+    fresh_rows = isolated_feed.read_text().splitlines()
+    assert len(fresh_rows) == 1
+    assert json.loads(fresh_rows[0])["id"] == "post-rotation"
+
+
+def test_read_rows_returns_empty_when_no_file(tmp_path: Path) -> None:
+    p = tmp_path / "feed.jsonl"
+    assert feed_log.read_rows(p) == []
+
+
+def test_read_rows_skips_malformed_lines(tmp_path: Path) -> None:
+    p = tmp_path / "feed.jsonl"
+    p.write_text(
+        '{"ts":"2026-01-01T00:00:00Z","event":"belief.locked","id":"a"}\n'
+        "not json\n"
+        '{"ts":"2026-01-01T00:00:01Z","event":"belief.ingested","id":"b"}\n'
+    )
+    rows = feed_log.read_rows(p)
+    assert len(rows) == 2
+    assert [r["id"] for r in rows] == ["a", "b"]
+
+
+def test_feed_path_is_sibling_of_db(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """feed_path() with no arg should resolve next to the resolved DB."""
+    import aelfrice.db_paths as _db_paths_mod
+    monkeypatch.setattr(
+        _db_paths_mod, "db_path",
+        lambda: tmp_path / "memory.db",
+    )
+    assert feed_log.feed_path() == tmp_path / "feed.jsonl"

--- a/tests/test_feed_log_instrumentation.py
+++ b/tests/test_feed_log_instrumentation.py
@@ -1,0 +1,152 @@
+"""Integration: verify the 5 write-path CLI commands emit feed-log rows (#931)."""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice import feed_log
+from aelfrice.cli import main
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    LOCK_NONE,
+    ORIGIN_AGENT_INFERRED,
+    Belief,
+)
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture(autouse=True)
+def isolated_db_and_feed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Per-test DB + redirect feed_log.feed_path() to a tmp file."""
+    db = tmp_path / "aelf.db"
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    monkeypatch.delenv("AELFRICE_FEED_LOG", raising=False)
+    feed_file = tmp_path / "feed.jsonl"
+    monkeypatch.setattr(
+        feed_log, "feed_path",
+        lambda db_dir=None: feed_file,
+    )
+    return feed_file
+
+
+def _run(*argv: str) -> tuple[int, str]:
+    buf = io.StringIO()
+    code = main(argv=list(argv), out=buf)
+    return code, buf.getvalue()
+
+
+def _read_feed(p: Path) -> list[dict]:
+    if not p.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in p.read_text().splitlines()
+        if line.strip()
+    ]
+
+
+def _seed_unlocked(db: Path, bid: str = "deadbeef00000001") -> None:
+    s = MemoryStore(str(db))
+    try:
+        s.insert_belief(Belief(
+            id=bid, content="seed belief",
+            content_hash=f"hash-{bid}",
+            alpha=1.0, beta=1.0,
+            type=BELIEF_FACTUAL, lock_level=LOCK_NONE, locked_at=None,
+            created_at="2026-05-01T00:00:00Z",
+            last_retrieved_at=None,
+            origin=ORIGIN_AGENT_INFERRED,
+        ))
+    finally:
+        s.close()
+
+
+def test_lock_emits_belief_locked(
+    isolated_db_and_feed: Path, tmp_path: Path,
+) -> None:
+    code, _out = _run("lock", "atomic commits beat batched")
+    assert code == 0
+    rows = _read_feed(isolated_db_and_feed)
+    locked_rows = [r for r in rows if r["event"] == "belief.locked"]
+    assert len(locked_rows) == 1
+    assert "id" in locked_rows[0]
+    assert "snippet" in locked_rows[0]
+    assert "atomic commits" in locked_rows[0]["snippet"]
+
+
+def test_lock_respects_feed_log_disabled(
+    isolated_db_and_feed: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AELFRICE_FEED_LOG", "0")
+    code, _out = _run("lock", "this should not write a feed row")
+    assert code == 0
+    assert not isolated_db_and_feed.exists()
+
+
+def test_promote_emits_wonder_promoted(
+    isolated_db_and_feed: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import os
+    db = Path(os.environ["AELFRICE_DB"])
+    _seed_unlocked(db, bid="deadbeef00000001")
+    code, _out = _run("promote", "deadbeef00000001")
+    assert code == 0
+    rows = _read_feed(isolated_db_and_feed)
+    promoted = [r for r in rows if r["event"] == "wonder.promoted"]
+    assert len(promoted) == 1
+    assert promoted[0]["id"] == "deadbeef00000001"
+    assert "from_origin" in promoted[0]
+    assert "to_origin" in promoted[0]
+
+
+def test_confirm_emits_feedback_applied(
+    isolated_db_and_feed: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import os
+    db = Path(os.environ["AELFRICE_DB"])
+    _seed_unlocked(db, bid="deadbeef00000002")
+    code, _out = _run("confirm", "deadbeef00000002", "--source", "operator")
+    assert code == 0
+    rows = _read_feed(isolated_db_and_feed)
+    fb = [r for r in rows if r["event"] == "feedback.applied"]
+    assert len(fb) == 1
+    assert fb[0]["kind"] == "confirm"
+    assert fb[0]["new_alpha"] > fb[0]["prior_alpha"]
+
+
+def test_feedback_emits_feedback_applied(
+    isolated_db_and_feed: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import os
+    db = Path(os.environ["AELFRICE_DB"])
+    _seed_unlocked(db, bid="deadbeef00000003")
+    code, _out = _run(
+        "feedback", "deadbeef00000003",
+        "used", "--source", "operator",
+    )
+    assert code == 0
+    rows = _read_feed(isolated_db_and_feed)
+    fb = [r for r in rows if r["event"] == "feedback.applied"]
+    assert len(fb) == 1
+    assert fb[0]["kind"] == "feedback"
+    assert fb[0]["signal"] == "used"
+
+
+def test_lock_stdout_unchanged_by_feed_log(
+    isolated_db_and_feed: Path,
+) -> None:
+    """The existing CLI summary must be unchanged — adding feed-log
+    instrumentation does NOT alter stdout."""
+    code, out = _run("lock", "preserve stdout contract")
+    assert code == 0
+    # The lock CLI's signature line still leads with "locked:".
+    assert "locked:" in out

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -71,6 +71,10 @@ EXPECTED_COMMANDS = (
     # Deterministic threshold-based listing over existing
     # created_at + last_retrieved_at; no decay model.
     "stale",
+    # v3.5 (#931) — read the per-project belief-write event log.
+    # Writer is aelfrice.feed_log; 5 write paths emit one JSONL row
+    # each on lock/onboard/wonder-promote/feedback events.
+    "feed",
 )
 
 


### PR DESCRIPTION
Closes #931.

## Summary

Per-project JSONL belief-write event log + reader CLI. Three atomic commits:

- **A:** `src/aelfrice/feed_log.py` — writer module (append-only JSONL sibling of memory.db, rotates at 100MB, swallows all errors, env-gated by `AELFRICE_FEED_LOG=0`).
- **B:** `aelf feed` reader CLI + slash command `aelf:feed`. Mirrors `aelf tail`'s ergonomics (`--since 5m/2h/1d`, `--limit N`, `--json`).
- **C:** Instrument 5 user-explicit write paths to emit one row each: `_cmd_lock` → `belief.locked`; `_cmd_onboard_accept` → `belief.ingested`; `_cmd_wonder_persist_docs` → `belief.ingested`; `_cmd_validate` (aliased by `_cmd_promote`) → `wonder.promoted`; `_cmd_confirm` + `_cmd_feedback` → `feedback.applied`.

## Why a file log, not stderr

Resolved by the 2026-06-04 wonder dispatch (`coverage_extension` axis): stderr-bleed into Claude Code's transcript ingestion is a self-feedback risk — aelfrice's own announce would get re-ingested as user prose. JSONL file the user opts to `tail -f` cleanly separates the visibility channel from the conversation channel.

## Default-on per the broader hook precedent

Resolved by the same dispatch (`uncertainty_deep_dive` axis): all 7 shipped hooks in `data/hook_manifest.json` are `default_on: true` with `--no-X` opt-out. #606's default-off was narrow (sentiment-driven posterior mutation). Write-announce on user-explicit writes follows the broader default-on policy (#553/#738/#739/#769/#882 flip precedent). Opt-out: `AELFRICE_FEED_LOG=0`.

## Out of scope (deferred per spec)

- `--no-feed-log` flag at `aelf setup` — env var is sufficient for now; setup-config persistence can land in a follow-up if users want it.
- Hook-driven retrieval rows (`feedback_history` from the search hook) — only user-explicit feedback fires `feedback.applied` in this PR. Hook-side coverage is a derivative that can land separately.

## #605 fit

Append-only fixed-schema JSONL. No model inference, no decay/scoring, no embedding. Deterministic by construction.

## Test plan

- [x] `tests/test_feed_log.py` — 12 tests (env gating, rotation, error-swallow, JSONL write, malformed-line skip on read).
- [x] `tests/test_cli_feed.py` — 7 tests (empty log, human render, JSON passthrough, --since window, --since rejects bad spec, --limit cap, malformed-line skip).
- [x] `tests/test_feed_log_instrumentation.py` — 6 integration tests covering each of the 5 write paths + a stdout-contract test verifying existing summaries are unchanged + an `AELFRICE_FEED_LOG=0` opt-out test.
- [x] `tests/test_slash_commands.py` — `"feed"` added to `EXPECTED_COMMANDS` (per `feedback_subcommand_update_hidden_list` memory).
- [x] All 173 tests across feed_log + cli_feed + instrumentation + statusline + slash_commands pass.

Closes #931. Sibling PRs: #940 (#932 statusline badges), #942 (#933 stale subcommand).

## Summary by Sourcery

Add a per-project JSONL belief-write event log with a CLI and slash-command reader, and instrument key belief-related commands to emit structured events.

New Features:
- Introduce a feed_log module that records belief-write events to a rotating per-project JSONL log file, gated by an environment variable.
- Add an `aelf feed` CLI subcommand and `aelf:feed` slash command to read, filter, and format belief-write event log entries.

Enhancements:
- Instrument lock, onboarding accept, wonder persist-docs, promote/validate, confirm, and feedback CLI paths to emit structured belief-write and feedback events into the feed log.

Tests:
- Add unit and integration tests for the feed_log writer, the `aelf feed` CLI behavior, and CLI instrumentation to ensure correct event emission and opt-out behavior.
- Extend slash command tests to cover the new `feed` command.