### PR TITLE
feat(cli): aelf:speculative — list non-user-locked beliefs (#937)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2221,6 +2221,50 @@ def _cmd_review(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _cmd_speculative(args: argparse.Namespace, out: object) -> int:
+    """List non-user-locked (L1) beliefs, sorted by alpha descending.
+
+    Complementary read-only lens to `aelf locked`. Shows every active
+    belief that has not been user-asserted (lock_level = 'none'), grouped
+    by origin tag. Use ``--origin TAG`` to restrict to a single origin;
+    use ``--json`` for machine-readable JSONL output.
+    """
+    store = _open_store()
+    try:
+        origin_filter: str | None = getattr(args, "origin", None) or None
+        limit: int | None = getattr(args, "limit", None)
+        beliefs = store.list_speculative_beliefs(
+            origin_filter=origin_filter,
+            limit=limit,
+        )
+    finally:
+        store.close()
+
+    if not beliefs:
+        print("no speculative beliefs", file=out)  # type: ignore[arg-type]
+        return 0
+
+    if getattr(args, "json", False):
+        for b in beliefs:
+            row = {
+                "id": b.id,
+                "origin": b.origin,
+                "alpha": float(b.alpha),
+                "beta": float(b.beta),
+                "created_at": b.created_at,
+                "snippet": b.content[:120],
+            }
+            print(json.dumps(row), file=out)  # type: ignore[arg-type]
+        return 0
+
+    for b in beliefs:
+        print(
+            f"{b.id} [{b.origin}] α={b.alpha:.1f}/β={b.beta:.1f}: {b.content}",
+            file=out,  # type: ignore[arg-type]
+        )
+    return 0
+
+
 def _cmd_scope_out(args: argparse.Namespace, out: object) -> int:
     """Manage the active session's retrieval-exclusion list (#856).
 
@@ -6212,6 +6256,46 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help="--apply only: emit ApplyReport as JSON instead of human prose",
     )
     p_review.set_defaults(func=_cmd_review)
+
+    # (#937) — read-only L1 (non-user-locked) belief listing. Complementary
+    # to `locked`; shows agent-inferred / wonder-generated / ingested beliefs.
+    def _positive_int(s: str) -> int:
+        n = int(s)
+        if n <= 0:
+            raise argparse.ArgumentTypeError(
+                f"--limit must be a positive integer (got {n!r}); SQLite "
+                "treats negative LIMIT as uncapped, which would surface "
+                "the entire L1 tier."
+            )
+        return n
+
+    p_speculative = sub.add_parser(
+        "speculative",
+        help="list non-user-locked (L1) beliefs sorted by alpha descending",
+    )
+    p_speculative.add_argument(
+        "--origin",
+        default=None,
+        metavar="TAG",
+        help=(
+            "restrict to beliefs with this exact origin tag "
+            "(e.g. 'agent_inferred', 'speculative', 'unknown')"
+        ),
+    )
+    p_speculative.add_argument(
+        "--limit",
+        type=_positive_int,
+        default=20,
+        metavar="N",
+        help="maximum number of rows to return (default: 20)",
+    )
+    p_speculative.add_argument(
+        "--json",
+        action="store_true",
+        dest="json",
+        help="emit one JSON object per line (JSONL)",
+    )
+    p_speculative.set_defaults(func=_cmd_speculative)
 
     # v3.x (#856) — session-scoped retrieval exclusion list. Reads/writes
     # session_exclusions.json keyed by the hook-written session_first_prompt.json;

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -6282,6 +6282,16 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
             "(e.g. 'agent_inferred', 'speculative', 'unknown')"
         ),
     )
+    def _positive_int(s: str) -> int:
+        n = int(s)
+        if n <= 0:
+            raise argparse.ArgumentTypeError(
+                f"--limit must be a positive integer (got {n!r}); SQLite "
+                "treats negative LIMIT as uncapped, which would surface "
+                "the entire L1 tier."
+            )
+        return n
+
     p_speculative.add_argument(
         "--limit",
         type=_positive_int,

--- a/src/aelfrice/slash_commands/speculative.md
+++ b/src/aelfrice/slash_commands/speculative.md
@@ -1,0 +1,21 @@
+---
+name: aelf:speculative
+description: List non-user-locked (L1) beliefs sorted by alpha descending — the agent-inferred and ingested layer.
+allowed-tools:
+  - Bash
+---
+<objective>
+Inspect the L1 (non-user-locked) belief tier — beliefs that were ingested,
+inferred, or wonder-generated but not yet explicitly asserted by the user.
+</objective>
+
+<process>
+Run: `uv run aelf speculative`
+
+Optionally:
+- `uv run aelf speculative --origin <tag>` to restrict to a single origin tag.
+- `uv run aelf speculative --limit N` to cap the row count.
+- `uv run aelf speculative --json` for machine-readable JSONL output.
+
+Display the output verbatim. Do not add commentary.
+</process>

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -3546,29 +3546,26 @@ class MemoryStore:
                 are returned; callers can also slice afterwards but
                 passing it here lets the DB do the work.
         """
+        # Build the query from static fragments (no interpolation of caller
+        # input into the SQL text) so the static-analysis pass that flags
+        # f-string SQL doesn't fire. All caller-supplied values go through
+        # the parameterised ? placeholders.
         params: list[object] = []
-        origin_clause = ""
+        sql_parts: list[str] = [
+            "SELECT b.*, "
+            "(SELECT COUNT(*) FROM belief_corroborations bc "
+            "WHERE bc.belief_id = b.id) AS corroboration_count "
+            "FROM beliefs b "
+            "WHERE b.lock_level = 'none' AND b.valid_to IS NULL",
+        ]
         if origin_filter is not None:
-            origin_clause = "AND b.origin = ?"
+            sql_parts.append("AND b.origin = ?")
             params.append(origin_filter)
-        limit_clause = ""
+        sql_parts.append("ORDER BY b.alpha DESC, b.id ASC")
         if limit is not None:
-            limit_clause = "LIMIT ?"
+            sql_parts.append("LIMIT ?")
             params.append(limit)
-        cur = self._conn.execute(
-            f"""
-            SELECT b.*,
-                   (SELECT COUNT(*) FROM belief_corroborations bc
-                    WHERE bc.belief_id = b.id) AS corroboration_count
-            FROM beliefs b
-            WHERE b.lock_level = 'none'
-              AND b.valid_to IS NULL
-              {origin_clause}
-            ORDER BY b.alpha DESC, b.id ASC
-            {limit_clause}
-            """,
-            params,
-        )
+        cur = self._conn.execute(" ".join(sql_parts), params)
         return [_row_to_belief(r) for r in cur.fetchall()]
 
     def find_orphan_beliefs(self, *, max_n: int | None = None) -> list[Belief]:

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -3527,6 +3527,50 @@ class MemoryStore:
         )
         return [_row_to_belief(r) for r in cur.fetchall()]
 
+    def list_speculative_beliefs(
+        self,
+        *,
+        origin_filter: str | None = None,
+        limit: int | None = None,
+    ) -> list["Belief"]:
+        """Active beliefs with lock_level = 'none', sorted by alpha DESC.
+
+        These are the L1 (non-user-locked) beliefs: agent-inferred,
+        wonder-generated, document-ingested, etc. Complementary to
+        list_locked_beliefs(), which returns the L0 user-asserted tier.
+
+        Args:
+            origin_filter: if given, restrict to beliefs with this exact
+                origin tag (e.g. 'agent_inferred', 'speculative').
+            limit: cap the result count. When None all matching rows
+                are returned; callers can also slice afterwards but
+                passing it here lets the DB do the work.
+        """
+        params: list[object] = []
+        origin_clause = ""
+        if origin_filter is not None:
+            origin_clause = "AND b.origin = ?"
+            params.append(origin_filter)
+        limit_clause = ""
+        if limit is not None:
+            limit_clause = "LIMIT ?"
+            params.append(limit)
+        cur = self._conn.execute(
+            f"""
+            SELECT b.*,
+                   (SELECT COUNT(*) FROM belief_corroborations bc
+                    WHERE bc.belief_id = b.id) AS corroboration_count
+            FROM beliefs b
+            WHERE b.lock_level = 'none'
+              AND b.valid_to IS NULL
+              {origin_clause}
+            ORDER BY b.alpha DESC, b.id ASC
+            {limit_clause}
+            """,
+            params,
+        )
+        return [_row_to_belief(r) for r in cur.fetchall()]
+
     def find_orphan_beliefs(self, *, max_n: int | None = None) -> list[Belief]:
         """Return beliefs that have no classified type and no feedback signal.
 

--- a/tests/test_cli_speculative.py
+++ b/tests/test_cli_speculative.py
@@ -219,3 +219,23 @@ def test_speculative_json_sorted_alpha_descending(isolated_db: Path) -> None:
     rows = [json.loads(ln) for ln in out.splitlines() if ln.strip()]
     alphas = [r["alpha"] for r in rows]
     assert alphas == sorted(alphas, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# --limit validation (CodeRabbit #944 finding)
+# ---------------------------------------------------------------------------
+
+
+def test_speculative_negative_limit_rejected(isolated_db: Path) -> None:
+    """`--limit -1` must be rejected — SQLite treats negative LIMIT as uncapped."""
+    with pytest.raises(SystemExit) as exc:
+        _run("speculative", "--limit", "-1")
+    assert exc.value.code == 2
+
+
+def test_speculative_zero_limit_rejected(isolated_db: Path) -> None:
+    """`--limit 0` must be rejected — returning zero rows is silly, and the
+    type-check is structurally `n > 0`."""
+    with pytest.raises(SystemExit) as exc:
+        _run("speculative", "--limit", "0")
+    assert exc.value.code == 2

--- a/tests/test_cli_speculative.py
+++ b/tests/test_cli_speculative.py
@@ -1,0 +1,221 @@
+"""cli: aelf speculative subcommand tests (#937).
+
+Each test sets AELFRICE_DB to a tmp_path-scoped DB and calls main()
+in-process with an io.StringIO so output is capturable without subprocess
+overhead. Fixture pattern mirrors test_cli.py.
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from aelfrice.cli import main
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, LOCK_USER, Belief
+from aelfrice.store import MemoryStore
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Every test gets a fresh DB at <tmp>/aelf.db."""
+    p = tmp_path / "aelf.db"
+    monkeypatch.setenv("AELFRICE_DB", str(p))
+    return p
+
+
+def _run(*argv: str) -> tuple[int, str]:
+    buf = io.StringIO()
+    code = main(argv=list(argv), out=buf)
+    return code, buf.getvalue()
+
+
+def _seed_belief(
+    db: Path,
+    content: str,
+    *,
+    origin: str,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+    lock_level: str = LOCK_NONE,
+) -> str:
+    """Insert a belief directly via the store and return its id."""
+    bid = uuid.uuid4().hex
+    chash = hashlib.sha256(content.encode()).hexdigest()
+    b = Belief(
+        id=bid,
+        content=content,
+        content_hash=chash,
+        alpha=alpha,
+        beta=beta,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=None,
+        created_at="2026-01-01T00:00:00Z",
+        last_retrieved_at=None,
+        origin=origin,
+    )
+    s = MemoryStore(str(db))
+    try:
+        s.insert_belief(b)
+    finally:
+        s.close()
+    return bid
+
+
+# ---------------------------------------------------------------------------
+# Empty store
+# ---------------------------------------------------------------------------
+
+
+def test_speculative_empty_store_exits_zero(isolated_db: Path) -> None:
+    code, out = _run("speculative")
+    assert code == 0
+    assert "no speculative beliefs" in out
+
+
+def test_speculative_empty_json_exits_zero(isolated_db: Path) -> None:
+    """--json with no rows: exits 0 with the empty message (no JSONL)."""
+    code, out = _run("speculative", "--json")
+    assert code == 0
+    assert "no speculative beliefs" in out
+
+
+# ---------------------------------------------------------------------------
+# User-locked rows excluded
+# ---------------------------------------------------------------------------
+
+
+def test_speculative_excludes_user_locked_rows(isolated_db: Path) -> None:
+    """Rows with lock_level='user' must not appear in speculative output."""
+    _seed_belief(isolated_db, "user-locked belief", origin="user_stated",
+                 lock_level=LOCK_USER)
+    code, out = _run("speculative")
+    assert code == 0
+    assert "no speculative beliefs" in out
+
+
+def test_speculative_includes_non_locked_rows(isolated_db: Path) -> None:
+    """Non-locked rows appear in output."""
+    bid = _seed_belief(isolated_db, "agent inferred fact", origin="agent_inferred")
+    code, out = _run("speculative")
+    assert code == 0
+    assert bid in out
+    assert "agent inferred fact" in out
+
+
+def test_speculative_mixed_origins_excludes_locked(isolated_db: Path) -> None:
+    """Mixed DB: only non-locked rows surface."""
+    locked_bid = _seed_belief(isolated_db, "locked content", origin="user_stated",
+                               lock_level=LOCK_USER)
+    free_bid = _seed_belief(isolated_db, "free content", origin="agent_inferred")
+    code, out = _run("speculative")
+    assert code == 0
+    assert free_bid in out
+    assert locked_bid not in out
+
+
+# ---------------------------------------------------------------------------
+# --origin filter
+# ---------------------------------------------------------------------------
+
+
+def test_speculative_origin_filter(isolated_db: Path) -> None:
+    """--origin restricts output to that tag only."""
+    bid_a = _seed_belief(isolated_db, "agent fact", origin="agent_inferred")
+    bid_s = _seed_belief(isolated_db, "speculative fact", origin="speculative")
+    code, out = _run("speculative", "--origin", "agent_inferred")
+    assert code == 0
+    assert bid_a in out
+    assert bid_s not in out
+
+
+def test_speculative_origin_filter_no_match(isolated_db: Path) -> None:
+    """--origin with no matching rows: graceful empty output, exit 0."""
+    _seed_belief(isolated_db, "some fact", origin="agent_inferred")
+    code, out = _run("speculative", "--origin", "speculative")
+    assert code == 0
+    assert "no speculative beliefs" in out
+
+
+# ---------------------------------------------------------------------------
+# --limit
+# ---------------------------------------------------------------------------
+
+
+def test_speculative_limit_truncates(isolated_db: Path) -> None:
+    """--limit N returns at most N rows."""
+    for i in range(5):
+        _seed_belief(isolated_db, f"fact {i}", origin="agent_inferred",
+                     alpha=float(i + 1))
+    code, out = _run("speculative", "--limit", "2")
+    assert code == 0
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    assert len(lines) == 2
+
+
+# ---------------------------------------------------------------------------
+# --json output
+# ---------------------------------------------------------------------------
+
+
+def test_speculative_json_emits_valid_jsonl(isolated_db: Path) -> None:
+    """--json emits one valid JSON object per line."""
+    _seed_belief(isolated_db, "some fact", origin="agent_inferred",
+                 alpha=3.0, beta=1.0)
+    code, out = _run("speculative", "--json")
+    assert code == 0
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    assert len(lines) == 1
+    obj = json.loads(lines[0])
+    assert "id" in obj
+    assert "origin" in obj
+    assert "alpha" in obj
+    assert "beta" in obj
+    assert "created_at" in obj
+    assert "snippet" in obj
+    assert isinstance(obj["alpha"], float)
+    assert isinstance(obj["beta"], float)
+    assert obj["origin"] == "agent_inferred"
+
+
+def test_speculative_json_alpha_is_numeric(isolated_db: Path) -> None:
+    """JSONL alpha/beta fields are numeric, not strings."""
+    _seed_belief(isolated_db, "numeric check", origin="unknown",
+                 alpha=2.5, beta=1.5)
+    _, out = _run("speculative", "--json")
+    obj = json.loads(out.strip().splitlines()[0])
+    assert obj["alpha"] == pytest.approx(2.5)
+    assert obj["beta"] == pytest.approx(1.5)
+
+
+# ---------------------------------------------------------------------------
+# Sort order: alpha descending
+# ---------------------------------------------------------------------------
+
+
+def test_speculative_sorted_alpha_descending(isolated_db: Path) -> None:
+    """Rows are returned with highest alpha first."""
+    bid_low = _seed_belief(isolated_db, "low alpha", origin="agent_inferred",
+                           alpha=1.0, beta=1.0)
+    bid_high = _seed_belief(isolated_db, "high alpha", origin="agent_inferred",
+                            alpha=5.0, beta=1.0)
+    code, out = _run("speculative")
+    assert code == 0
+    pos_high = out.index(bid_high)
+    pos_low = out.index(bid_low)
+    assert pos_high < pos_low, "high-alpha row should appear before low-alpha row"
+
+
+def test_speculative_json_sorted_alpha_descending(isolated_db: Path) -> None:
+    """JSONL output preserves alpha-descending order."""
+    _seed_belief(isolated_db, "first", origin="agent_inferred", alpha=1.0)
+    _seed_belief(isolated_db, "second", origin="agent_inferred", alpha=4.0)
+    _seed_belief(isolated_db, "third", origin="agent_inferred", alpha=2.0)
+    _, out = _run("speculative", "--json")
+    rows = [json.loads(ln) for ln in out.splitlines() if ln.strip()]
+    alphas = [r["alpha"] for r in rows]
+    assert alphas == sorted(alphas, reverse=True)

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -82,6 +82,10 @@ EXPECTED_COMMANDS = (
     # (#935) — cross-store dedup audit between locked aelfrice beliefs and
     # the claude-memory MEMORY.md index. Pure read-only report.
     "audit-claude-memory",
+    # (#937) — read-only L1 (non-user-locked) belief listing. Complement
+    # of `locked`; shows agent-inferred / ingested / wonder-generated
+    # beliefs sorted by alpha descending.
+    "speculative",
 )
 
 


### PR DESCRIPTION
Closes #937.

## What

New `aelf speculative` read-only subcommand that lists active L1 (non-user-locked) beliefs, sorted by α descending. Complementary to `aelf locked`, which surfaces only the L0 user-asserted tier.

```
$ aelf speculative --help
usage: aelf speculative [-h] [--origin TAG] [--limit N] [--json]
```

- `--origin TAG` restricts to a single origin (e.g. `agent_inferred`, `speculative`, `unknown`).
- `--limit N` caps the row count (default 20).
- `--json` emits JSONL (`id`, `origin`, `alpha`, `beta`, `created_at`, `snippet`).

## Why

User-perception gap from #937: `aelf locked` exposes only user-asserted beliefs, leaving the agent-inferred / wonder-generated / document-ingested layer structurally invisible. `aelf speculative` is the read-only mirror — no promote / lock affordance in the output, no recommendation surface (#605 PHILOSOPHY: stay deterministic, narrow surface).

## Implementation notes

- Query lives in `MemoryStore.list_speculative_beliefs()`: `WHERE lock_level = 'none' AND valid_to IS NULL`, parameterized origin filter, `ORDER BY alpha DESC, id ASC`.
- The issue body's example origin tags (`hook`, `wonder`, `derivation`, `correction`, `agent_inferred`) did **not** match the actual constants in `models.py` / `store.py`. The real origin universe is `user_stated`, `user_corrected`, `user_validated`, `agent_inferred`, `agent_remembered`, `document_recent`, `unknown`, `speculative`. The `--origin` help text reflects the real values; the filter is unrestricted so users can pass any tag the store recognises.
- `_cmd_locked` is a 13-line bare function with no `--json` / `--limit` / `--origin`. No refactor to a shared helper — the new command needs a richer query shape and forcing the symmetry would have inflated the diff.

## Verification

- 12 unit tests in `tests/test_cli_speculative.py` cover: empty store, mixed-lock-level exclusion, `--origin` filter (match + no-match), `--limit` truncation, JSONL validity, numeric posterior fields, and α-desc sort order in both human and JSON outputs.
- `pytest tests/test_cli_speculative.py -x` → 12 passed.
- `tests/test_slash_commands.py` — `EXPECTED_COMMANDS` extended with `"speculative"`.
- Discretion grep on diff: clean.

## Out of scope

- Promote / lock UI in the listing (forbidden by issue body — read-only by design).
- Schema migration / `last_confirmed_at` (separate concern, tracked under #936).
- Statusline integration / staleness flagging (separate issues).

## Summary by Sourcery

Add a new CLI subcommand and backing store query to list non-user-locked (L1) beliefs, along with tests and slash-command docs.

New Features:
- Introduce `aelf speculative` CLI subcommand to list active non-user-locked beliefs with optional origin, limit, and JSONL output.
- Add `MemoryStore.list_speculative_beliefs` query to retrieve active speculative beliefs sorted by alpha descending.
- Document the `aelf:speculative` slash command for inspecting L1 beliefs.

Tests:
- Add CLI tests for `aelf speculative` covering empty stores, lock-level filtering, origin filtering, limiting, JSONL output, and sort order.
- Extend slash command expectations to include the new `speculative` command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `aelf speculative` command to list non-user-locked speculative beliefs with optional origin filtering, row limiting, and JSONL output format.

* **Documentation**
  * Added documentation for the `aelf speculative` command.

* **Tests**
  * Added comprehensive test coverage for the speculative command functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->