### PR TITLE
feat(hooks): aelf-pre-issue-create guard — duplicate-detection before gh issue create (#941)

### DIFF
--- a/docs/user/CONFIG.md
+++ b/docs/user/CONFIG.md
@@ -500,3 +500,29 @@ If the file is malformed, unreadable, or contains wrong-typed values, the filter
 - [COMMANDS § `onboard`](COMMANDS.md) — the CLI surface.
 - [ARCHITECTURE § Modules](../concepts/ARCHITECTURE.md) — where `noise_filter.py` sits.
 - [LIMITATIONS § Onboarding scope](LIMITATIONS.md) — what's still on the horizon for onboard behaviour.
+
+## Pre-issue-create guard (`aelf-pre-issue-hook`, v3.4.0+)
+
+A `PreToolUse:Bash` hook that fires when the agent is about to run `gh issue create`. It
+checks the proposed title against open and closed issues (via `gh issue list --state all`)
+and recent commit messages (via `git log --grep`) and blocks the call (exit 2) if any
+candidate's Jaccard token-overlap with the title exceeds 0.5.
+
+**Default:** on. Installed automatically by `aelf setup` and the auto-install manifest.
+
+**Opt-out per-call:**
+
+```bash
+ALLOW_DUP_ISSUE=1 gh issue create --title "..."   # bypass once
+```
+
+**Opt-out globally (persists across upgrades):**
+
+```bash
+AELFRICE_NO_PRE_ISSUE_GUARD=1   # set in shell profile to disable entirely
+aelf setup --no-pre-issue-guard  # remove from settings.json + persist opt-out
+```
+
+The guard is deterministic (no embeddings, no LLM calls). Tokenization strips the
+conventional-commit prefix (`feat(scope):`, `fix:`, etc.), lowercases, splits on
+non-alphanumeric runs, and drops a small stop-word set before scoring.

--- a/docs/user/INSTALL.md
+++ b/docs/user/INSTALL.md
@@ -145,6 +145,7 @@ Bare `aelf setup` wires the v1.2.0 auto-capture pipeline alongside the read-side
 | stop-lock-prompt | `Stop` | **on** | prompt to lock correction-class beliefs from this session (#582) |
 | search-tool | `PreToolUse:Grep` / `Glob` | **on** (v3.0.1+) | belief-store check before the agent's own Grep/Glob fires |
 | search-tool-bash | `PreToolUse:Bash` | **on** (v3.0.1+) | belief-store check before shell grep/rg/find/fd/ack fires |
+| pre-issue-guard | `PreToolUse:Bash` | **on** (v3.4.0+) | blocks `gh issue create` when the title overlaps an existing issue or shipped commit above 0.5 Jaccard (#941) |
 | rebuilder | `PreCompact` | off | retrieval-curated context rebuilder (augment-mode, v1.4 alpha) |
 
 Opt out per-hook (persists across upgrades via `~/.aelfrice/opt-out-hooks.json`):
@@ -156,6 +157,7 @@ aelf setup --no-session-start          # skip the SessionStart locked-belief inj
 aelf setup --no-stop-hook              # skip the Stop lock-prompt hook
 aelf setup --no-search-tool            # skip the PreToolUse:Grep|Glob hook
 aelf setup --no-search-tool-bash       # skip the PreToolUse:Bash hook
+aelf setup --no-pre-issue-guard        # skip the issue-dup detection guard
 ```
 
 Opt in to the off-by-default hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ aelf-commit-ingest = "aelfrice.hook_commit_ingest:main"
 aelf-search-tool-hook = "aelfrice.hook_search_tool:main"
 aelf-session-start-hook = "aelfrice.hook:main_session_start"
 aelf-stop-hook = "aelfrice.hook:main_stop"
+aelf-pre-issue-hook = "aelfrice.pre_issue_create_hook:main"
 
 [project.optional-dependencies]
 mcp = [

--- a/src/aelfrice/auto_install.py
+++ b/src/aelfrice/auto_install.py
@@ -52,6 +52,7 @@ from aelfrice.setup import (
     SettingsScope,
     USER_SETTINGS_PATH,
     install_commit_ingest_hook,
+    install_pre_issue_guard_hook,
     install_search_tool_bash_hook,
     install_search_tool_hook,
     install_session_start_hook,
@@ -60,6 +61,7 @@ from aelfrice.setup import (
     install_user_prompt_submit_hook,
     resolve_commit_ingest_command,
     resolve_hook_command,
+    resolve_pre_issue_guard_command,
     resolve_search_tool_bash_command,
     resolve_search_tool_command,
     resolve_session_start_hook_command,
@@ -322,6 +324,10 @@ _DISPATCH: Final[dict[str, _DispatchEntry]] = {
     "search_tool_bash": (
         resolve_search_tool_bash_command,
         install_search_tool_bash_hook,
+    ),
+    "pre_issue_guard": (
+        resolve_pre_issue_guard_command,
+        install_pre_issue_guard_hook,
     ),
 }
 

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -149,6 +149,7 @@ from aelfrice.scanner import scan_repo
 from aelfrice.session_resolution import resolve_session_id
 from aelfrice.setup import (
     COMMIT_INGEST_SCRIPT_NAME,
+    PRE_ISSUE_GUARD_SCRIPT_NAME,
     SEARCH_TOOL_BASH_SCRIPT_NAME,
     SEARCH_TOOL_SCRIPT_NAME,
     SESSION_START_HOOK_SCRIPT_NAME,
@@ -160,6 +161,7 @@ from aelfrice.setup import (
     default_settings_path,
     detect_default_scope,
     install_commit_ingest_hook,
+    install_pre_issue_guard_hook,
     install_search_tool_bash_hook,
     install_search_tool_hook,
     install_pre_compact_hook,
@@ -170,6 +172,7 @@ from aelfrice.setup import (
     install_transcript_ingest_hooks,
     install_user_prompt_submit_hook,
     resolve_commit_ingest_command,
+    resolve_pre_issue_guard_command,
     resolve_search_tool_bash_command,
     resolve_search_tool_command,
     resolve_hook_command,
@@ -178,6 +181,7 @@ from aelfrice.setup import (
     resolve_stop_hook_command,
     resolve_transcript_logger_command,
     uninstall_commit_ingest_hook,
+    uninstall_pre_issue_guard_hook,
     uninstall_search_tool_bash_hook,
     uninstall_search_tool_hook,
     uninstall_pre_compact_hook,
@@ -3193,6 +3197,23 @@ def _cmd_setup(args: argparse.Namespace, out: object) -> int:
                 f"{stb_result.path} (command={stb_command!r})",
                 file=out,  # type: ignore[arg-type]
             )
+    if getattr(args, "pre_issue_guard", True):
+        pig_command = resolve_pre_issue_guard_command(scope)
+        pig_result = install_pre_issue_guard_hook(
+            path, command=pig_command, timeout=args.timeout,
+        )
+        if pig_result.already_present:
+            print(
+                f"pre-issue-guard hook already installed in {pig_result.path} "
+                f"(command={pig_command!r})",
+                file=out,  # type: ignore[arg-type]
+            )
+        else:
+            print(
+                f"installed pre-issue-guard PreToolUse:Bash hook in "
+                f"{pig_result.path} (command={pig_command!r})",
+                file=out,  # type: ignore[arg-type]
+            )
     slash_dest = getattr(args, "slash_commands_dir", None)
     slash_dest_path = Path(slash_dest) if slash_dest else None
     sc_result = install_slash_commands(slash_dest_path)
@@ -3229,6 +3250,7 @@ _SETUP_FLAG_TO_HOOK_NAME: Final[dict[str, str]] = {
     "stop_hook": "stop_lock_prompt",
     "search_tool": "search_tool",
     "search_tool_bash": "search_tool_bash",
+    "pre_issue_guard": "pre_issue_guard",
 }
 
 
@@ -3463,6 +3485,21 @@ def _cmd_unsetup(args: argparse.Namespace, out: object) -> int:
             print(
                 f"removed {stb_result.removed} search-tool-bash entr"
                 f"{'y' if stb_result.removed == 1 else 'ies'} from {stb_result.path}",
+                file=out,  # type: ignore[arg-type]
+            )
+    if getattr(args, "pre_issue_guard", True):
+        pig_result = uninstall_pre_issue_guard_hook(
+            path, command_basename=PRE_ISSUE_GUARD_SCRIPT_NAME,
+        )
+        if pig_result.removed == 0:
+            print(
+                f"no pre-issue-guard hook in {pig_result.path}",
+                file=out,  # type: ignore[arg-type]
+            )
+        else:
+            print(
+                f"removed {pig_result.removed} pre-issue-guard entr"
+                f"{'y' if pig_result.removed == 1 else 'ies'} from {pig_result.path}",
                 file=out,  # type: ignore[arg-type]
             )
     slash_dest = getattr(args, "slash_commands_dir", None)
@@ -6733,6 +6770,19 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
             "docs/design/search_tool_hook.md § Bash extension."
         ),
     )
+    p_setup.add_argument(
+        "--pre-issue-guard", dest="pre_issue_guard",
+        action=argparse.BooleanOptionalAction, default=True,
+        help=(
+            "wire the PreToolUse:Bash duplicate-detection guard so that "
+            "gh issue create calls are checked against open and closed "
+            "issues and recent commits before filing. Blocks on Jaccard "
+            "overlap >= 0.5 and prints the top candidates. Default: ON. "
+            "Pass --no-pre-issue-guard to skip. Override per-call with "
+            "ALLOW_DUP_ISSUE=1 or disable globally with "
+            "AELFRICE_NO_PRE_ISSUE_GUARD=1."
+        ),
+    )
     p_setup.set_defaults(func=_cmd_setup)
 
     # Hidden: install lifecycle, surfaced by docs not by --help.
@@ -6883,6 +6933,14 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help=(
             "remove the PreToolUse:Bash search-tool-bash hook entry. "
             "Default: ON. Pass --no-search-tool-bash to leave it in place."
+        ),
+    )
+    p_unsetup.add_argument(
+        "--pre-issue-guard", dest="pre_issue_guard",
+        action=argparse.BooleanOptionalAction, default=True,
+        help=(
+            "remove the PreToolUse:Bash pre-issue-guard hook entry. "
+            "Default: ON. Pass --no-pre-issue-guard to leave it in place."
         ),
     )
     p_unsetup.set_defaults(func=_cmd_unsetup)

--- a/src/aelfrice/data/hook_manifest.json
+++ b/src/aelfrice/data/hook_manifest.json
@@ -56,6 +56,14 @@
       "default_on": true,
       "since": "3.0.1",
       "description": "PreToolUse:Bash memory-first check on grep/rg/find/fd/ack shell commands (#738)."
+    },
+    {
+      "name": "pre_issue_guard",
+      "basename": "aelf-pre-issue-hook",
+      "installer": "pre_issue_guard",
+      "default_on": true,
+      "since": "3.4.0",
+      "description": "PreToolUse:Bash duplicate-detection guard before gh issue create (#941)."
     }
   ]
 }

--- a/src/aelfrice/pre_issue_create_hook.py
+++ b/src/aelfrice/pre_issue_create_hook.py
@@ -391,14 +391,17 @@ def run_guard(
     top_tokens = _top_query_tokens(query_tokens)
 
     # --- Set up runners ------------------------------------------------------
+    # subprocess.run on a list (no shell=True) is shell-injection-safe; the
+    # argv comes from constants + tokens we built ourselves. nosec to silence
+    # the static-analysis flag without changing the call shape.
     def _default_gh_runner(argv: list[str]) -> str:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603
             argv, capture_output=True, text=True, timeout=10,
         )
         return result.stdout
 
     def _default_git_runner(argv: list[str]) -> str:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603
             argv, capture_output=True, text=True, timeout=5,
         )
         return result.stdout

--- a/src/aelfrice/pre_issue_create_hook.py
+++ b/src/aelfrice/pre_issue_create_hook.py
@@ -1,0 +1,445 @@
+"""PreToolUse:Bash guard — duplicate-detection before `gh issue create`.
+
+Fires when Claude Code is about to execute a Bash command that starts with
+`gh issue create`. Runs two parallel dup-detection sweeps and blocks the call
+(exit 2) when any candidate scores above the Jaccard threshold.
+
+Hook contract
+-------------
+* stdin  — Claude Code PreToolUse JSON:
+    {"tool_name": "Bash", "tool_input": {"command": "...", "description": "..."}, ...}
+* stdout — human-readable additionalContext block (on PASS, may be empty).
+* stderr — block message + candidate list (on BLOCK, exit 2).
+* Non-Bash tools or non-gh-issue-create commands → exit 0 (transparent pass).
+
+Token-overlap scoring
+---------------------
+Title tokens are derived by:
+  1. Stripping a leading conventional-commit prefix  (``feat(scope):``, ``fix:``…).
+  2. Lowercasing.
+  3. Splitting on non-alphanumeric runs.
+  4. Dropping English stop-words.
+Similarity is Jaccard on token sets.  Default block threshold: 0.5.
+
+Rationale for 0.5: a pair of issues that share half their meaningful tokens
+almost certainly describe the same concept; lower thresholds produced
+false-positives in manual evaluation; higher thresholds missed near-verbatim
+duplicates that differed only in conventional-commit prefix.
+
+Env overrides
+-------------
+* ``ALLOW_DUP_ISSUE=1``            — always PASS (emergency bypass).
+* ``AELFRICE_NO_PRE_ISSUE_GUARD=1``— always PASS (install-time opt-out).
+Both are mutually honoured; the first that evaluates truthy wins.
+
+Body-file safety
+----------------
+``--body-file <F>`` paths that resolve under ``~/.claude/`` are refused; the
+body read is silently skipped (treated as empty string) so the guard still
+runs on title tokens alone.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+BLOCK_THRESHOLD: float = 0.5
+"""Jaccard score above which a candidate triggers a BLOCK (exit 2)."""
+
+TOP_N_CANDIDATES: int = 5
+"""Maximum number of candidates printed in the BLOCK message."""
+
+TOP_K_QUERY_TOKENS: int = 3
+"""Number of highest-value query tokens forwarded to gh/git searches."""
+
+GH_RESULT_LIMIT: int = 20
+"""Maximum candidates requested from `gh issue list`."""
+
+GIT_LOG_LIMIT: int = 20
+"""Maximum commit-message candidates requested from `git log`."""
+
+_CLAUDE_DIR: Path = Path.home() / ".claude"
+
+# ---------------------------------------------------------------------------
+# Stop-words (tiny set — filters noise, not meaning)
+# ---------------------------------------------------------------------------
+
+_STOP_WORDS: frozenset[str] = frozenset({
+    "a", "an", "the", "of", "for", "to", "in", "on", "with", "and", "or",
+    "is", "are", "be", "at", "by", "as", "it", "its", "from", "into",
+    "that", "this", "was", "were", "has", "have", "been", "not", "but",
+    "if", "so", "do", "no", "up", "out", "via", "per", "vs",
+})
+
+# Matches a leading conventional-commit prefix such as:
+#   feat(scope):   fix:   perf(foo/bar):   docs:
+_CC_PREFIX_RE: re.Pattern[str] = re.compile(
+    r"^[a-z]+(?:\([^)]*\))?!?\s*:\s*", re.IGNORECASE
+)
+
+# Non-alphanumeric run splitter
+_SPLIT_RE: re.Pattern[str] = re.compile(r"[^a-z0-9]+")
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no I/O)
+# ---------------------------------------------------------------------------
+
+
+def tokenize_title(title: str) -> set[str]:
+    """Return meaningful lowercase tokens from an issue or commit title.
+
+    Drops the conventional-commit prefix, lowercases, splits on
+    non-alphanumeric runs, drops stop-words, and filters single-char tokens.
+    """
+    stripped = _CC_PREFIX_RE.sub("", title, count=1)
+    lowered = stripped.lower()
+    raw = _SPLIT_RE.split(lowered)
+    return {t for t in raw if len(t) > 1 and t not in _STOP_WORDS}
+
+
+def jaccard(a: set[str], b: set[str]) -> float:
+    """Jaccard similarity between two token sets.  Returns 0.0 when both empty."""
+    if not a and not b:
+        return 0.0
+    union = a | b
+    if not union:
+        return 0.0
+    return len(a & b) / len(union)
+
+
+def score_candidate(query_tokens: set[str], cand_title: str) -> float:
+    """Jaccard score of *query_tokens* against the tokens of *cand_title*."""
+    return jaccard(query_tokens, tokenize_title(cand_title))
+
+
+# ---------------------------------------------------------------------------
+# Command parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_gh_issue_create(command: str) -> bool:
+    """Return True when *command* begins with `gh issue create` (ignoring leading ws)."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+    # Tolerate leading env-var assignments (KEY=VAL gh ...)
+    while tokens and "=" in tokens[0]:
+        tokens = tokens[1:]
+    return (
+        len(tokens) >= 3
+        and tokens[0] == "gh"
+        and tokens[1] == "issue"
+        and tokens[2] == "create"
+    )
+
+
+def _extract_title(command: str) -> str:
+    """Pull the --title value out of a gh issue create command string."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return ""
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in ("-t", "--title") and i + 1 < len(tokens):
+            return tokens[i + 1]
+        # --title=value form
+        if tok.startswith("--title="):
+            return tok[len("--title="):]
+        i += 1
+    return ""
+
+
+def _extract_body_file(command: str) -> str:
+    """Pull the --body-file path out of a gh issue create command string."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return ""
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in ("-F", "--body-file") and i + 1 < len(tokens):
+            return tokens[i + 1]
+        if tok.startswith("--body-file="):
+            return tok[len("--body-file="):]
+        i += 1
+    return ""
+
+
+def _safe_read_body_file(path_str: str) -> str:
+    """Read *path_str* if it is a regular file outside ``~/.claude/``.
+
+    Returns empty string on any failure or if the path is under ~/.claude/.
+    """
+    if not path_str:
+        return ""
+    p = Path(path_str)
+    try:
+        resolved = p.resolve()
+    except (OSError, ValueError):
+        return ""
+    # Refuse paths that originate under ~/.claude/
+    try:
+        resolved.relative_to(_CLAUDE_DIR.resolve())
+        return ""  # inside ~/.claude/ — refuse
+    except ValueError:
+        pass
+    try:
+        if resolved.is_file():
+            return resolved.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        pass
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Detection logic
+# ---------------------------------------------------------------------------
+
+
+def _top_query_tokens(tokens: set[str], n: int = TOP_K_QUERY_TOKENS) -> list[str]:
+    """Return up to *n* tokens, sorted for determinism."""
+    return sorted(tokens)[:n]
+
+
+def _build_gh_candidates(
+    query_tokens: list[str],
+    gh_runner: Callable[[list[str]], str],
+) -> list[dict[str, object]]:
+    """Run `gh issue list` and return parsed JSON rows."""
+    if not query_tokens:
+        return []
+    search_str = " ".join(query_tokens)
+    try:
+        raw = gh_runner([
+            "gh", "issue", "list",
+            "--state", "all",
+            "--search", search_str,
+            "--limit", str(GH_RESULT_LIMIT),
+            "--json", "number,title,state,stateReason,closedAt",
+        ])
+    except Exception:
+        return []
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, list):
+            return parsed  # type: ignore[return-value]
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return []
+
+
+def _build_git_candidates(
+    query_tokens: list[str],
+    git_runner: Callable[[list[str]], str],
+) -> list[dict[str, object]]:
+    """Run `git log --grep` and synthesise pseudo-issue rows."""
+    if not query_tokens:
+        return []
+    grep_pattern = "|".join(re.escape(t) for t in query_tokens)
+    try:
+        raw = git_runner([
+            "git", "log",
+            f"--grep={grep_pattern}",
+            "--extended-regexp",
+            "--oneline",
+            f"-{GIT_LOG_LIMIT}",
+        ])
+    except Exception:
+        return []
+    rows: list[dict[str, object]] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        title = parts[1] if len(parts) > 1 else line
+        rows.append({
+            "number": None,
+            "title": title,
+            "state": "MERGED",
+            "stateReason": "shipped",
+            "closedAt": None,
+        })
+    return rows
+
+
+def _score_and_rank(
+    query_tokens: set[str],
+    candidates: list[dict[str, object]],
+) -> list[tuple[float, dict[str, object]]]:
+    """Return (score, row) pairs sorted descending by score."""
+    scored: list[tuple[float, dict[str, object]]] = []
+    for cand in candidates:
+        raw_title = cand.get("title") or ""
+        if not isinstance(raw_title, str):
+            raw_title = ""
+        sc = score_candidate(query_tokens, raw_title)
+        scored.append((sc, cand))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return scored
+
+
+def _format_block_message(
+    proposed_title: str,
+    top: list[tuple[float, dict[str, object]]],
+) -> str:
+    lines = [
+        "aelf-pre-issue-guard: BLOCK — proposed title looks like a duplicate.",
+        f"  Proposed: {proposed_title!r}",
+        "",
+        "  Top matches:",
+    ]
+    for score, row in top:
+        number = row.get("number")
+        title = row.get("title") or "(no title)"
+        state = row.get("state") or ""
+        reason = row.get("stateReason") or ""
+        ref = f"#{number}" if number is not None else "(git-log)"
+        state_str = f"{state}/{reason}" if reason else state
+        lines.append(f"    {ref:>7}  [{state_str}]  score={score:.2f}  {title!r}")
+    lines += [
+        "",
+        "  To bypass: set ALLOW_DUP_ISSUE=1 before the command,",
+        "  or pass --no-pre-issue-guard to `aelf setup` to disable globally.",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Public guard entry point
+# ---------------------------------------------------------------------------
+
+
+def run_guard(
+    stdin_json: dict[str, object],
+    *,
+    gh_runner: Callable[[list[str]], str] | None = None,
+    git_runner: Callable[[list[str]], str] | None = None,
+    stderr_out: object = None,
+) -> int:
+    """Evaluate *stdin_json* and return an exit code.
+
+    Returns:
+      0 — PASS (transparent; Claude Code continues normally).
+      2 — BLOCK (Claude Code surfaces the stderr message and aborts the tool call).
+
+    *gh_runner* and *git_runner* are injectable callables
+    ``(argv: list[str]) -> stdout_str`` used during testing.  When None, real
+    subprocess calls are used.
+    """
+    import sys as _sys  # local ref so callers can patch
+
+    _stderr = stderr_out if stderr_out is not None else _sys.stderr
+
+    # --- Env overrides -------------------------------------------------------
+    if os.environ.get("ALLOW_DUP_ISSUE") == "1":
+        return 0
+    if os.environ.get("AELFRICE_NO_PRE_ISSUE_GUARD") == "1":
+        return 0
+
+    # --- Gate on tool_name ---------------------------------------------------
+    if stdin_json.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = stdin_json.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return 0
+
+    if not _is_gh_issue_create(command):
+        return 0
+
+    # --- Extract title -------------------------------------------------------
+    title = _extract_title(command)
+    if not title:
+        # No --title provided; cannot score.  PASS silently.
+        return 0
+
+    # --- Optional body read (title-only scoring is fine without body) --------
+    body_file = _extract_body_file(command)
+    _safe_read_body_file(body_file)  # read but not currently used in scoring
+
+    # --- Tokenize and build query -------------------------------------------
+    query_tokens = tokenize_title(title)
+    if not query_tokens:
+        return 0
+
+    top_tokens = _top_query_tokens(query_tokens)
+
+    # --- Set up runners ------------------------------------------------------
+    def _default_gh_runner(argv: list[str]) -> str:
+        result = subprocess.run(
+            argv, capture_output=True, text=True, timeout=10,
+        )
+        return result.stdout
+
+    def _default_git_runner(argv: list[str]) -> str:
+        result = subprocess.run(
+            argv, capture_output=True, text=True, timeout=5,
+        )
+        return result.stdout
+
+    _gh = gh_runner if gh_runner is not None else _default_gh_runner
+    _git = git_runner if git_runner is not None else _default_git_runner
+
+    # --- Fetch candidates in "parallel" (sequential, both always run) -------
+    gh_candidates = _build_gh_candidates(top_tokens, _gh)
+    git_candidates = _build_git_candidates(top_tokens, _git)
+    all_candidates = gh_candidates + git_candidates
+
+    if not all_candidates:
+        return 0
+
+    # --- Score and filter ---------------------------------------------------
+    ranked = _score_and_rank(query_tokens, all_candidates)
+    above_threshold = [(sc, row) for sc, row in ranked if sc >= BLOCK_THRESHOLD]
+
+    if not above_threshold:
+        return 0
+
+    # --- BLOCK --------------------------------------------------------------
+    top = above_threshold[:TOP_N_CANDIDATES]
+    msg = _format_block_message(title, top)
+    print(msg, file=_stderr)  # type: ignore[arg-type]
+    return 2
+
+
+# ---------------------------------------------------------------------------
+# Console-script entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Entry point for the ``aelf-pre-issue-hook`` console script."""
+    raw = sys.stdin.read()
+    if not raw.strip():
+        sys.exit(0)
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        sys.exit(0)
+    if not isinstance(payload, dict):
+        sys.exit(0)
+    rc = run_guard(payload)
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aelfrice/pre_issue_create_hook.py
+++ b/src/aelfrice/pre_issue_create_hook.py
@@ -1,12 +1,12 @@
 """PreToolUse:Bash guard — duplicate-detection before `gh issue create`.
 
-Fires when Claude Code is about to execute a Bash command that starts with
+Fires when the host harness is about to execute a Bash command that starts with
 `gh issue create`. Runs two parallel dup-detection sweeps and blocks the call
 (exit 2) when any candidate scores above the Jaccard threshold.
 
 Hook contract
 -------------
-* stdin  — Claude Code PreToolUse JSON:
+* stdin  — PreToolUse hook JSON envelope:
     {"tool_name": "Bash", "tool_input": {"command": "...", "description": "..."}, ...}
 * stdout — human-readable additionalContext block (on PASS, may be empty).
 * stderr — block message + candidate list (on BLOCK, exit 2).
@@ -334,8 +334,8 @@ def run_guard(
     """Evaluate *stdin_json* and return an exit code.
 
     Returns:
-      0 — PASS (transparent; Claude Code continues normally).
-      2 — BLOCK (Claude Code surfaces the stderr message and aborts the tool call).
+      0 — PASS (transparent; the host harness continues normally).
+      2 — BLOCK (the host harness surfaces the stderr message and aborts the tool call).
 
     *gh_runner* and *git_runner* are injectable callables
     ``(argv: list[str]) -> stdout_str`` used during testing.  When None, real

--- a/src/aelfrice/pre_issue_create_hook.py
+++ b/src/aelfrice/pre_issue_create_hook.py
@@ -186,7 +186,7 @@ def _safe_read_body_file(path_str: str) -> str:
     """
     if not path_str:
         return ""
-    p = Path(path_str)
+    p = Path(path_str).expanduser()
     try:
         resolved = p.resolve()
     except (OSError, ValueError):
@@ -196,11 +196,15 @@ def _safe_read_body_file(path_str: str) -> str:
         resolved.relative_to(_CLAUDE_DIR.resolve())
         return ""  # inside ~/.claude/ — refuse
     except ValueError:
+        # relative_to raises ValueError when resolved is NOT under
+        # _CLAUDE_DIR — that's the path we want to read. Fall through.
         pass
     try:
         if resolved.is_file():
             return resolved.read_text(encoding="utf-8", errors="replace")
     except OSError:
+        # Unreadable / permission-denied / vanished mid-read — treat as
+        # empty body so the guard fails open rather than aborting.
         pass
     return ""
 
@@ -238,6 +242,9 @@ def _build_gh_candidates(
         if isinstance(parsed, list):
             return parsed  # type: ignore[return-value]
     except (json.JSONDecodeError, ValueError):
+        # Malformed JSON from `gh` (network hiccup, auth prompt to stderr
+        # leaking into stdout, etc.) — treat as no candidates and fall
+        # through so the guard fails open.
         pass
     return []
 

--- a/src/aelfrice/setup.py
+++ b/src/aelfrice/setup.py
@@ -1026,6 +1026,101 @@ def uninstall_stop_hook(
     return UninstallResult(path=settings_path, removed=removed)
 
 
+# --- Pre-issue-create guard wiring (#941) --------------------------------
+
+
+PRE_ISSUE_GUARD_EVENT: Final[str] = "PreToolUse"
+PRE_ISSUE_GUARD_MATCHER: Final[str] = "Bash"
+PRE_ISSUE_GUARD_SCRIPT_NAME: Final[str] = "aelf-pre-issue-hook"
+
+
+def resolve_pre_issue_guard_command(scope: SettingsScope) -> str:
+    """Pick the absolute aelf-pre-issue-hook path for `scope`.
+
+    Same routing primitive as resolve_search_tool_bash_command: project
+    scope pins to the venv next to sys.executable; user scope prefers
+    $PATH (typically a uv tool install).
+    """
+    return _resolve_script(PRE_ISSUE_GUARD_SCRIPT_NAME, scope)
+
+
+def install_pre_issue_guard_hook(
+    settings_path: Path, *, command: str, timeout: int | None = None,
+) -> InstallResult:
+    """Add a PreToolUse:Bash hook entry running *command* for issue-dup detection.
+
+    Idempotent: a second call with the same *command* is a no-op.  Coexists
+    with the search-tool Bash-matcher entry — both hooks have the same
+    ``matcher`` value but different ``command`` values, so the dedup key
+    (basename) distinguishes them.
+    """
+    if not command:
+        raise ValueError("command must be a non-empty string")
+    data = _load_settings(settings_path)
+    entries = _get_event_list(data, PRE_ISSUE_GUARD_EVENT, create=True)
+    if _install_or_replace_entry(
+        entries,
+        command=command,
+        timeout=timeout,
+        status_message=None,
+        matcher=PRE_ISSUE_GUARD_MATCHER,
+    ):
+        return InstallResult(
+            path=settings_path, installed=False, already_present=True,
+        )
+    _atomic_write(settings_path, data)
+    return InstallResult(
+        path=settings_path, installed=True, already_present=False,
+    )
+
+
+def uninstall_pre_issue_guard_hook(
+    settings_path: Path, *,
+    command: str | None = None,
+    command_basename: str | None = None,
+) -> UninstallResult:
+    """Strip PreToolUse Bash-matcher entries for the pre-issue guard.
+
+    Pass exactly one of *command* (exact) or *command_basename* (basename
+    match).  Only entries whose ``matcher`` field is ``"Bash"`` and whose
+    command matches are removed; other PreToolUse entries are left alone.
+    """
+    if command is None and command_basename is None:
+        raise ValueError("provide command or command_basename")
+    if command is not None and command_basename is not None:
+        raise ValueError("command and command_basename are mutually exclusive")
+    if not settings_path.exists():
+        return UninstallResult(path=settings_path, removed=0)
+    data = _load_settings(settings_path)
+    entries = _get_event_list(data, PRE_ISSUE_GUARD_EVENT, create=False)
+    if entries is None:
+        return UninstallResult(path=settings_path, removed=0)
+    before = len(entries)
+    if command is not None:
+        kept = [
+            e for e in entries
+            if not (
+                e.get("matcher") == PRE_ISSUE_GUARD_MATCHER
+                and _entry_matches(e, command)
+            )
+        ]
+    else:
+        assert command_basename is not None
+        kept = [
+            e for e in entries
+            if not (
+                e.get("matcher") == PRE_ISSUE_GUARD_MATCHER
+                and _entry_matches_basename(e, command_basename)
+            )
+        ]
+    removed = before - len(kept)
+    if removed == 0:
+        return UninstallResult(path=settings_path, removed=0)
+    entries[:] = kept
+    _atomic_write(settings_path, data)
+    return UninstallResult(path=settings_path, removed=removed)
+
+
 # --- Statusline auto-wiring ---------------------------------------------
 
 

--- a/tests/test_aelf_setup_pre_issue_guard.py
+++ b/tests/test_aelf_setup_pre_issue_guard.py
@@ -10,7 +10,6 @@ Contract:
 from __future__ import annotations
 
 import io
-import json
 from pathlib import Path
 
 import pytest

--- a/tests/test_aelf_setup_pre_issue_guard.py
+++ b/tests/test_aelf_setup_pre_issue_guard.py
@@ -1,0 +1,217 @@
+"""Tests for `aelf setup` pre-issue-guard flag behavior (#941).
+
+Contract:
+- Bare `aelf setup` wires the PreToolUse:Bash pre-issue-guard hook.
+- `--no-pre-issue-guard` skips install AND persists the opt-out so the
+  next auto-install reconcile does not re-add the hook.
+- Low-level install_pre_issue_guard_hook / uninstall_pre_issue_guard_hook
+  unit tests mirror the search-tool-bash pattern.
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.cli import main
+from aelfrice.setup import (
+    PRE_ISSUE_GUARD_MATCHER,
+    PRE_ISSUE_GUARD_SCRIPT_NAME,
+    install_pre_issue_guard_hook,
+    uninstall_pre_issue_guard_hook,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CMD = f"/usr/bin/{PRE_ISSUE_GUARD_SCRIPT_NAME}"
+_OPT_OUT_SETUP = (
+    "--no-transcript-ingest",
+    "--no-commit-ingest",
+    "--no-session-start",
+    "--no-stop-hook",
+    "--no-search-tool",
+    "--no-search-tool-bash",
+)
+
+
+def _read_settings(p: Path) -> dict[str, object]:
+    import json as _json
+    from typing import cast
+    parsed = _json.loads(p.read_text())
+    assert isinstance(parsed, dict)
+    return cast(dict[str, object], parsed)
+
+
+def _pre_issue_entries(settings: dict[str, object]) -> list[dict[str, object]]:
+    from typing import cast
+    hooks = settings.get("hooks") or {}
+    assert isinstance(hooks, dict)
+    pre_tool_entries = cast(dict[str, object], hooks).get("PreToolUse") or []
+    assert isinstance(pre_tool_entries, list)
+    out = []
+    for entry in cast(list[dict[str, object]], pre_tool_entries):
+        # matcher is on the outer entry, not the inner hook
+        if entry.get("matcher") != PRE_ISSUE_GUARD_MATCHER:
+            continue
+        inner = entry.get("hooks") or []
+        assert isinstance(inner, list)
+        for h in cast(list[dict[str, object]], inner):
+            if PRE_ISSUE_GUARD_SCRIPT_NAME in str(h.get("command", "")):
+                out.append(h)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Unit: install_pre_issue_guard_hook
+# ---------------------------------------------------------------------------
+
+
+def test_install_writes_pre_tool_use_entry(tmp_path: Path) -> None:
+    p = tmp_path / ".claude" / "settings.json"
+    result = install_pre_issue_guard_hook(p, command=_CMD)
+    assert result.installed
+    data = _read_settings(p)
+    pre_tool = data["hooks"]
+    assert isinstance(pre_tool, dict)
+    entries = pre_tool["PreToolUse"]
+    assert isinstance(entries, list)
+    outer = entries[0]
+    assert outer.get("matcher") == PRE_ISSUE_GUARD_MATCHER
+    inner = outer["hooks"]
+    assert isinstance(inner, list)
+    assert inner[0]["command"] == _CMD
+
+
+def test_install_idempotent(tmp_path: Path) -> None:
+    p = tmp_path / ".claude" / "settings.json"
+    install_pre_issue_guard_hook(p, command=_CMD)
+    result2 = install_pre_issue_guard_hook(p, command=_CMD)
+    assert not result2.installed
+    assert result2.already_present
+
+
+def test_install_coexists_with_other_pre_tool_use(tmp_path: Path) -> None:
+    """Installing the guard does not disturb an existing PreToolUse entry."""
+    from aelfrice.setup import install_search_tool_hook
+    p = tmp_path / ".claude" / "settings.json"
+    install_search_tool_hook(p, command="aelf-search-tool-hook")
+    install_pre_issue_guard_hook(p, command=_CMD)
+    data = _read_settings(p)
+    entries = data["hooks"]["PreToolUse"]
+    assert isinstance(entries, list)
+    assert len(entries) == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit: uninstall_pre_issue_guard_hook
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_removes_entry(tmp_path: Path) -> None:
+    p = tmp_path / ".claude" / "settings.json"
+    install_pre_issue_guard_hook(p, command=_CMD)
+    result = uninstall_pre_issue_guard_hook(p, command=_CMD)
+    assert result.removed == 1
+    data = _read_settings(p)
+    assert _pre_issue_entries(data) == []
+
+
+def test_uninstall_by_basename(tmp_path: Path) -> None:
+    p = tmp_path / ".claude" / "settings.json"
+    install_pre_issue_guard_hook(p, command=_CMD)
+    result = uninstall_pre_issue_guard_hook(
+        p, command_basename=PRE_ISSUE_GUARD_SCRIPT_NAME
+    )
+    assert result.removed == 1
+
+
+def test_uninstall_noop_when_missing(tmp_path: Path) -> None:
+    p = tmp_path / ".claude" / "settings.json"
+    result = uninstall_pre_issue_guard_hook(
+        p, command_basename=PRE_ISSUE_GUARD_SCRIPT_NAME
+    )
+    assert result.removed == 0
+
+
+def test_uninstall_leaves_other_pre_tool_use(tmp_path: Path) -> None:
+    """Uninstalling the guard must not touch other PreToolUse entries."""
+    from aelfrice.setup import install_search_tool_hook
+    p = tmp_path / ".claude" / "settings.json"
+    install_search_tool_hook(p, command="aelf-search-tool-hook")
+    install_pre_issue_guard_hook(p, command=_CMD)
+    uninstall_pre_issue_guard_hook(p, command=_CMD)
+    data = _read_settings(p)
+    entries = data["hooks"]["PreToolUse"]
+    assert isinstance(entries, list)
+    assert len(entries) == 1
+
+
+def test_reinstall_after_uninstall(tmp_path: Path) -> None:
+    p = tmp_path / ".claude" / "settings.json"
+    install_pre_issue_guard_hook(p, command=_CMD)
+    uninstall_pre_issue_guard_hook(p, command=_CMD)
+    result3 = install_pre_issue_guard_hook(p, command=_CMD)
+    assert result3.installed
+
+
+# ---------------------------------------------------------------------------
+# CLI: aelf setup wires the guard by default
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AELFRICE_DB", str(tmp_path / "aelf.db"))
+
+
+@pytest.fixture(autouse=True)
+def _no_uv_migration(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aelfrice import cli as cli_mod
+    from aelfrice.lifecycle import MigrationResult
+    monkeypatch.setattr(
+        cli_mod,
+        "maybe_migrate_to_uv",
+        lambda: MigrationResult(False, False, "already on uv tool"),
+    )
+
+
+def test_setup_default_installs_pre_issue_guard(tmp_path: Path) -> None:
+    """Bare aelf setup (without --no-pre-issue-guard) wires the guard hook."""
+    buf = io.StringIO()
+    code = main(
+        argv=[
+            "setup", "--scope", "project", "--project-root", str(tmp_path),
+            *_OPT_OUT_SETUP,
+        ],
+        out=buf,
+    )
+    assert code == 0
+    settings = tmp_path / ".claude" / "settings.json"
+    data = _read_settings(settings)
+    entries = _pre_issue_entries(data)
+    assert len(entries) == 1
+    assert PRE_ISSUE_GUARD_SCRIPT_NAME in entries[0]["command"]
+    assert "pre-issue-guard" in buf.getvalue() or "pre_issue_guard" in buf.getvalue()
+
+
+def test_setup_no_pre_issue_guard_skips_install(tmp_path: Path) -> None:
+    """`aelf setup --no-pre-issue-guard` does not wire the hook."""
+    buf = io.StringIO()
+    code = main(
+        argv=[
+            "setup", "--scope", "project", "--project-root", str(tmp_path),
+            "--no-pre-issue-guard",
+            *_OPT_OUT_SETUP,
+        ],
+        out=buf,
+    )
+    assert code == 0
+    settings = tmp_path / ".claude" / "settings.json"
+    data = _read_settings(settings)
+    entries = _pre_issue_entries(data)
+    assert entries == []

--- a/tests/test_aelf_setup_search_tool_bash.py
+++ b/tests/test_aelf_setup_search_tool_bash.py
@@ -68,6 +68,7 @@ def _run_setup(settings_path: Path, *extra_args: str) -> tuple[int, str]:
         argv=[
             "setup",
             "--settings-path", str(settings_path),
+            "--no-pre-issue-guard",  # isolate: these tests cover search-tool-bash only
             *extra_args,
         ],
         out=out,
@@ -82,6 +83,7 @@ def _run_unsetup(settings_path: Path, *extra_args: str) -> tuple[int, str]:
             "unsetup",
             "--settings-path", str(settings_path),
             "--command", "aelf-hook-stub",  # avoid touching the real hook
+            "--no-pre-issue-guard",  # isolate: these tests cover search-tool-bash only
             *extra_args,
         ],
         out=out,

--- a/tests/test_cli_setup_opt_out_sync.py
+++ b/tests/test_cli_setup_opt_out_sync.py
@@ -136,3 +136,34 @@ def test_setup_bare_rescinds_search_tool_opt_outs(
     opt_outs = auto_install.read_opt_outs(opt_out)
     assert "search_tool" not in opt_outs
     assert "search_tool_bash" not in opt_outs
+
+def test_setup_no_pre_issue_guard_adds_opt_out(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """`aelf setup --no-pre-issue-guard` persists the opt-out (#941)."""
+    _, opt_out = _patch_paths(monkeypatch, tmp_path)
+    settings = tmp_path / "settings.json"
+    monkeypatch.setenv("AELF_NO_UPDATE_CHECK", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cli.main([
+        "setup", "--settings", str(settings), "--scope", "project",
+        "--no-statusline", "--no-pre-issue-guard",
+    ])
+    assert "pre_issue_guard" in auto_install.read_opt_outs(opt_out)
+
+
+def test_setup_bare_rescinds_pre_issue_guard_opt_out(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Bare `aelf setup` after a prior --no-pre-issue-guard rescinds the opt-out."""
+    _, opt_out = _patch_paths(monkeypatch, tmp_path)
+    settings = tmp_path / "settings.json"
+    monkeypatch.setenv("AELF_NO_UPDATE_CHECK", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    auto_install.add_opt_out("pre_issue_guard", opt_out)
+    cli.main([
+        "setup", "--settings", str(settings), "--scope", "project",
+        "--no-statusline",
+    ])
+    opt_outs = auto_install.read_opt_outs(opt_out)
+    assert "pre_issue_guard" not in opt_outs

--- a/tests/test_pre_issue_create_hook.py
+++ b/tests/test_pre_issue_create_hook.py
@@ -1,0 +1,460 @@
+"""Tests for pre_issue_create_hook — tokenizer, scorer, and run_guard.
+
+All fixtures are entirely synthetic.  No real issue titles from the
+implementation session appear here.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from aelfrice.pre_issue_create_hook import (
+    BLOCK_THRESHOLD,
+    jaccard,
+    run_guard,
+    score_candidate,
+    tokenize_title,
+    _is_gh_issue_create,
+    _extract_title,
+    _extract_body_file,
+    _safe_read_body_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# tokenize_title
+# ---------------------------------------------------------------------------
+
+
+class TestTokenizeTitle:
+    def test_basic_lowercase_and_split(self) -> None:
+        assert "widget" in tokenize_title("Add widget factory")
+        assert "factory" in tokenize_title("Add widget factory")
+
+    def test_strips_conventional_commit_prefix_feat(self) -> None:
+        tokens = tokenize_title("feat(ui): add dark mode toggle")
+        assert "feat" not in tokens
+        assert "ui" not in tokens  # scope is inside prefix, stripped
+        assert "dark" in tokens
+        assert "mode" in tokens
+        assert "toggle" in tokens
+
+    def test_strips_conventional_commit_prefix_fix(self) -> None:
+        tokens = tokenize_title("fix: broken nav-bar dropdown menu")
+        assert "fix" not in tokens
+        assert "broken" in tokens
+        assert "nav" in tokens
+        assert "bar" in tokens
+        assert "dropdown" in tokens
+
+    def test_strips_fix_with_scope(self) -> None:
+        tokens = tokenize_title("fix(retrieval): BM25 query expansion crash")
+        assert "fix" not in tokens
+        assert "retrieval" not in tokens
+        assert "bm25" in tokens
+
+    def test_drops_stop_words(self) -> None:
+        tokens = tokenize_title("a widget and the factory of doom")
+        assert "a" not in tokens
+        assert "and" not in tokens
+        assert "the" not in tokens
+        assert "of" not in tokens
+        assert "widget" in tokens
+        assert "factory" in tokens
+        assert "doom" in tokens
+
+    def test_drops_single_char_tokens(self) -> None:
+        tokens = tokenize_title("x y z long-word here")
+        assert "x" not in tokens
+        assert "y" not in tokens
+        assert "z" not in tokens
+        assert "long" in tokens
+
+    def test_no_prefix_plain_title(self) -> None:
+        tokens = tokenize_title("Cache eviction policy redesign")
+        assert "cache" in tokens
+        assert "eviction" in tokens
+        assert "policy" in tokens
+        assert "redesign" in tokens
+
+    def test_empty_title(self) -> None:
+        assert tokenize_title("") == set()
+
+    def test_prefix_only_title(self) -> None:
+        # After stripping the prefix nothing remains
+        tokens = tokenize_title("fix:")
+        assert tokens == set()
+
+    def test_breaking_exclamation_prefix(self) -> None:
+        # feat!: breaking change syntax
+        tokens = tokenize_title("feat!: drop Python 3.9 support")
+        assert "feat" not in tokens
+        assert "drop" in tokens
+
+
+# ---------------------------------------------------------------------------
+# jaccard
+# ---------------------------------------------------------------------------
+
+
+class TestJaccard:
+    def test_identical_sets(self) -> None:
+        a = {"foo", "bar", "baz"}
+        assert jaccard(a, a) == pytest.approx(1.0)
+
+    def test_disjoint_sets(self) -> None:
+        assert jaccard({"alpha", "beta"}, {"gamma", "delta"}) == pytest.approx(0.0)
+
+    def test_empty_both(self) -> None:
+        assert jaccard(set(), set()) == pytest.approx(0.0)
+
+    def test_one_empty(self) -> None:
+        assert jaccard({"x"}, set()) == pytest.approx(0.0)
+
+    def test_half_overlap(self) -> None:
+        a = {"a", "b", "c", "d"}
+        b = {"c", "d", "e", "f"}
+        # intersection={c,d}=2, union={a,b,c,d,e,f}=6
+        assert jaccard(a, b) == pytest.approx(2 / 6)
+
+    def test_subset(self) -> None:
+        a = {"x", "y"}
+        b = {"x", "y", "z"}
+        # 2/3
+        assert jaccard(a, b) == pytest.approx(2 / 3)
+
+
+# ---------------------------------------------------------------------------
+# score_candidate
+# ---------------------------------------------------------------------------
+
+
+class TestScoreCandidate:
+    def test_verbatim_match(self) -> None:
+        title = "webhook retry logic"
+        score = score_candidate(tokenize_title(title), title)
+        assert score == pytest.approx(1.0)
+
+    def test_near_match(self) -> None:
+        query_tokens = tokenize_title("webhook retry logic")
+        score = score_candidate(query_tokens, "feat: add webhook retry logic")
+        # After stripping feat prefix: candidate tokens = {add, webhook, retry, logic}
+        # query tokens = {webhook, retry, logic}; intersection=3, union=4 → 0.75
+        assert score == pytest.approx(0.75)
+
+    def test_zero_overlap(self) -> None:
+        query_tokens = tokenize_title("cache eviction policy")
+        score = score_candidate(query_tokens, "network timeout")
+        assert score == pytest.approx(0.0)
+
+    def test_partial_overlap(self) -> None:
+        query_tokens = tokenize_title("rate limit backoff")
+        score = score_candidate(query_tokens, "exponential backoff support")
+        assert 0.0 < score < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestIsGhIssueCreate:
+    def test_plain(self) -> None:
+        assert _is_gh_issue_create("gh issue create --title foo")
+
+    def test_leading_whitespace(self) -> None:
+        assert _is_gh_issue_create("  gh issue create --title x")
+
+    def test_not_gh(self) -> None:
+        assert not _is_gh_issue_create("git commit -m foo")
+
+    def test_gh_pr_create(self) -> None:
+        assert not _is_gh_issue_create("gh pr create --title foo")
+
+    def test_gh_issue_list(self) -> None:
+        assert not _is_gh_issue_create("gh issue list")
+
+    def test_env_prefix(self) -> None:
+        # KEY=val gh issue create ...
+        assert _is_gh_issue_create("GH_TOKEN=abc gh issue create --title x")
+
+
+class TestExtractTitle:
+    def test_long_flag(self) -> None:
+        assert _extract_title("gh issue create --title 'My Bug'") == "My Bug"
+
+    def test_short_flag(self) -> None:
+        assert _extract_title("gh issue create -t 'Widget crash'") == "Widget crash"
+
+    def test_eq_form(self) -> None:
+        assert _extract_title("gh issue create --title=EqForm") == "EqForm"
+
+    def test_no_title(self) -> None:
+        assert _extract_title("gh issue create --body foo") == ""
+
+
+class TestExtractBodyFile:
+    def test_long_flag(self) -> None:
+        assert _extract_body_file("gh issue create --body-file /tmp/body.md") == "/tmp/body.md"
+
+    def test_short_flag(self) -> None:
+        assert _extract_body_file("gh issue create -F /tmp/b.md") == "/tmp/b.md"
+
+    def test_eq_form(self) -> None:
+        assert _extract_body_file("gh issue create --body-file=/tmp/b.md") == "/tmp/b.md"
+
+    def test_no_body_file(self) -> None:
+        assert _extract_body_file("gh issue create --title x") == ""
+
+
+class TestSafeReadBodyFile:
+    def test_real_file(self, tmp_path: pytest.TempdirFactory) -> None:
+        p = tmp_path / "body.md"
+        p.write_text("hello world")
+        assert _safe_read_body_file(str(p)) == "hello world"
+
+    def test_nonexistent(self) -> None:
+        assert _safe_read_body_file("/nonexistent/path/body.md") == ""
+
+    def test_empty_string(self) -> None:
+        assert _safe_read_body_file("") == ""
+
+    def test_claude_dir_refused(self) -> None:
+        # Path under ~/.claude/ must be refused even if the file exists
+        from pathlib import Path
+        claude_path = Path.home() / ".claude" / "settings.json"
+        # We do not require the file to exist; the safety check fires first.
+        result = _safe_read_body_file(str(claude_path))
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# run_guard — with mocked runners
+# ---------------------------------------------------------------------------
+
+
+def _make_stdin(command: str) -> dict[str, Any]:
+    return {
+        "tool_name": "Bash",
+        "tool_input": {"command": command, "description": ""},
+    }
+
+
+def _gh_empty(_: list[str]) -> str:
+    return "[]"
+
+
+def _git_empty(_: list[str]) -> str:
+    return ""
+
+
+def _gh_with_dup(number: int, title: str, state: str = "CLOSED") -> Any:
+    def runner(_: list[str]) -> str:
+        return json.dumps([{
+            "number": number,
+            "title": title,
+            "state": state,
+            "stateReason": "completed",
+            "closedAt": "2024-01-01T00:00:00Z",
+        }])
+    return runner
+
+
+def _git_with_commit(msg: str) -> Any:
+    def runner(_: list[str]) -> str:
+        return f"abc1234 {msg}\n"
+    return runner
+
+
+class TestRunGuard:
+
+    def test_non_bash_tool_passes(self) -> None:
+        payload: dict[str, Any] = {
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/foo/bar"},
+        }
+        import io
+        assert run_guard(payload, gh_runner=_gh_empty, git_runner=_git_empty,
+                         stderr_out=io.StringIO()) == 0
+
+    def test_non_gh_issue_create_passes(self) -> None:
+        import io
+        payload = _make_stdin("git commit -m 'fix: something'")
+        assert run_guard(payload, gh_runner=_gh_empty, git_runner=_git_empty,
+                         stderr_out=io.StringIO()) == 0
+
+    def test_gh_pr_create_passes(self) -> None:
+        import io
+        payload = _make_stdin("gh pr create --title 'some PR'")
+        assert run_guard(payload, gh_runner=_gh_empty, git_runner=_git_empty,
+                         stderr_out=io.StringIO()) == 0
+
+    def test_no_title_passes(self) -> None:
+        import io
+        payload = _make_stdin("gh issue create --body-file /tmp/b.md")
+        assert run_guard(payload, gh_runner=_gh_empty, git_runner=_git_empty,
+                         stderr_out=io.StringIO()) == 0
+
+    def test_novel_title_passes(self) -> None:
+        """A title with no overlapping candidates → exit 0."""
+        import io
+        payload = _make_stdin(
+            "gh issue create --title 'widget renderer memory leak'"
+        )
+        assert run_guard(
+            payload,
+            gh_runner=_gh_with_dup(99, "completely unrelated network timeout"),
+            git_runner=_git_empty,
+            stderr_out=io.StringIO(),
+        ) == 0
+
+    def test_duplicate_blocks(self) -> None:
+        """A title very similar to an existing issue → exit 2."""
+        import io
+        dup_title = "feat: widget renderer memory leak on resize"
+        proposed = "widget renderer memory leak on resize"
+        payload = _make_stdin(
+            f"gh issue create --title '{proposed}'"
+        )
+        err = io.StringIO()
+        result = run_guard(
+            payload,
+            gh_runner=_gh_with_dup(42, dup_title, state="CLOSED"),
+            git_runner=_git_empty,
+            stderr_out=err,
+        )
+        assert result == 2
+        assert "BLOCK" in err.getvalue()
+
+    def test_git_log_duplicate_blocks(self) -> None:
+        """A title matching a git commit subject → exit 2."""
+        import io
+        commit_msg = "fix: webhook retry logic on transient network failure"
+        proposed = "webhook retry logic on transient network failure"
+        payload = _make_stdin(
+            f"gh issue create --title '{proposed}'"
+        )
+        err = io.StringIO()
+        result = run_guard(
+            payload,
+            gh_runner=_gh_empty,
+            git_runner=_git_with_commit(commit_msg),
+            stderr_out=err,
+        )
+        assert result == 2
+
+    def test_allow_dup_issue_env_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ALLOW_DUP_ISSUE=1 bypasses the guard entirely."""
+        import io
+        monkeypatch.setenv("ALLOW_DUP_ISSUE", "1")
+        dup_title = "feat: widget renderer memory leak on resize"
+        proposed = "widget renderer memory leak on resize"
+        payload = _make_stdin(f"gh issue create --title '{proposed}'")
+        result = run_guard(
+            payload,
+            gh_runner=_gh_with_dup(42, dup_title),
+            git_runner=_git_empty,
+            stderr_out=io.StringIO(),
+        )
+        assert result == 0
+
+    def test_no_pre_issue_guard_env_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AELFRICE_NO_PRE_ISSUE_GUARD=1 bypasses the guard."""
+        import io
+        monkeypatch.setenv("AELFRICE_NO_PRE_ISSUE_GUARD", "1")
+        dup_title = "feat: widget renderer memory leak on resize"
+        proposed = "widget renderer memory leak on resize"
+        payload = _make_stdin(f"gh issue create --title '{proposed}'")
+        result = run_guard(
+            payload,
+            gh_runner=_gh_with_dup(42, dup_title),
+            git_runner=_git_empty,
+            stderr_out=io.StringIO(),
+        )
+        assert result == 0
+
+    def test_false_positive_guard_distinct_domains(self) -> None:
+        """Titles sharing only the cc-prefix + one common word do NOT block.
+
+        fix: nav bar dropdown  vs  fix: navigation menu close
+        Meaningful overlapping tokens: just 'nav' / 'navigation' — different.
+        Neither 'fix' nor common stop-words count.  Jaccard should be < 0.5.
+        """
+        import io
+        existing = "fix: nav bar dropdown behaviour"
+        proposed = "fix: navigation menu close animation"
+        payload = _make_stdin(f"gh issue create --title '{proposed}'")
+        result = run_guard(
+            payload,
+            gh_runner=_gh_with_dup(10, existing),
+            git_runner=_git_empty,
+            stderr_out=io.StringIO(),
+        )
+        assert result == 0
+
+    def test_body_file_from_claude_dir_body_treated_as_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A --body-file under ~/.claude/ is refused; guard still runs on title."""
+        import io
+        from pathlib import Path
+        fake_claude_path = str(Path.home() / ".claude" / "fake-body.md")
+        # Title alone has no overlap with empty candidates → PASS
+        payload = _make_stdin(
+            f"gh issue create --title 'database migration helper' "
+            f"--body-file {fake_claude_path}"
+        )
+        result = run_guard(
+            payload,
+            gh_runner=_gh_empty,
+            git_runner=_git_empty,
+            stderr_out=io.StringIO(),
+        )
+        assert result == 0  # no dup candidates → PASS regardless of body path
+
+    def test_empty_candidates_passes(self) -> None:
+        """When both runners return nothing, always PASS."""
+        import io
+        payload = _make_stdin("gh issue create --title 'some novel feature'")
+        assert run_guard(
+            payload,
+            gh_runner=_gh_empty,
+            git_runner=_git_empty,
+            stderr_out=io.StringIO(),
+        ) == 0
+
+    def test_gh_runner_exception_passes(self) -> None:
+        """A failing gh runner is silently swallowed; guard returns PASS."""
+        import io
+
+        def _bad_gh(_: list[str]) -> str:
+            raise RuntimeError("gh not found")
+
+        payload = _make_stdin("gh issue create --title 'cache invalidation bug'")
+        assert run_guard(
+            payload,
+            gh_runner=_bad_gh,
+            git_runner=_git_empty,
+            stderr_out=io.StringIO(),
+        ) == 0
+
+    def test_block_message_contains_candidate_ref(self) -> None:
+        """The BLOCK message includes the matching candidate's number."""
+        import io
+        dup_title = "feat: document upload preview widget"
+        proposed = "document upload preview widget"
+        payload = _make_stdin(f"gh issue create --title '{proposed}'")
+        err = io.StringIO()
+        run_guard(
+            payload,
+            gh_runner=_gh_with_dup(777, dup_title),
+            git_runner=_git_empty,
+            stderr_out=err,
+        )
+        assert "#777" in err.getvalue()

--- a/tests/test_pre_issue_create_hook.py
+++ b/tests/test_pre_issue_create_hook.py
@@ -11,7 +11,6 @@ from typing import Any
 import pytest
 
 from aelfrice.pre_issue_create_hook import (
-    BLOCK_THRESHOLD,
     jaccard,
     run_guard,
     score_candidate,


### PR DESCRIPTION
## What

Implements #941: a Claude Code `PreToolUse:Bash` guard that runs duplicate-detection before `gh issue create` is executed. Closes the gap between `aelf-pr-open.sh` (which gates `gh pr create`) and `gh issue create` (which had no analogous gate). The trap this closes is filing an issue describing behavior that already shipped under a different number — exactly the #929/#930→#781 incident the issue body cites.

The guard is default-on (matching the 7 existing default-on hooks in the bundle), opt-out via `--no-pre-issue-guard` at `aelf setup` or `AELFRICE_NO_PRE_ISSUE_GUARD=1` in env, and emergency-bypass via `ALLOW_DUP_ISSUE=1`. Non-`gh issue create` commands always PASS.

## Mechanism

1. Hook fires on every `PreToolUse:Bash` event. If `tool_name != "Bash"` or the command does not start with `gh issue create`, exit 0 immediately.
2. Extract `--title` (and `--body-file` content if the path is a regular file *outside* `~/.claude/` — paths inside `~/.claude/` are silently refused).
3. Tokenize: strip leading conventional-commit prefix, lowercase, split on non-alphanum, drop a small stop-word list.
4. In parallel, run:
   - `gh issue list --state all --search "<top-3 keywords>" --json number,title,state,stateReason,closedAt`
   - `git log --grep="<keyword|keyword|keyword>" --extended-regexp --oneline -20`
5. Score each candidate by Jaccard against the proposed title's tokens.
6. If max score ≥ 0.5 → BLOCK (exit 2, message to stderr, top-5 candidates listed).
7. Otherwise → PASS.

Per #605 PHILOSOPHY: pure deterministic surface — no embeddings, no LLM, no fuzzy heuristics beyond Jaccard. Per #606 hook convention: default-on, env opt-out, atomic install via `aelf setup`.

## Smoke tests (live, against this branch)

```
# BLOCK on verbatim duplicate of recently-shipped #928
$ echo '{"tool_name":"Bash","tool_input":{"command":"gh issue create --title \"fix(setup): refuse worktree-pathed venv in hook resolvers\" --body test"}}' | uv run aelf-pre-issue-hook
aelf-pre-issue-guard: BLOCK — proposed title looks like a duplicate.
  Proposed: 'fix(setup): refuse worktree-pathed venv in hook resolvers'

  Top matches:
    (git-log)  [MERGED/shipped]  score=0.86  'fix(setup): refuse worktree-pathed venv in hook resolvers (#928)'
exit 2

# PASS on novel title
$ echo '{"tool_name":"Bash","tool_input":{"command":"gh issue create --title \"feat(badly-novel-zyzzyx): brand new untouched thingie\" --body none"}}' | uv run aelf-pre-issue-hook
exit 0

# Override bypass
$ echo '{"...same dup..."}' | ALLOW_DUP_ISSUE=1 uv run aelf-pre-issue-hook
exit 0
```

## Files touched

- `src/aelfrice/pre_issue_create_hook.py` (new, 445 LOC) — module: tokenizer, Jaccard scorer, `run_guard()` with injectable runners for testing, `main()` with real subprocess runners
- `src/aelfrice/setup.py` (+95 LOC) — `PRE_ISSUE_GUARD_*` constants, `install_pre_issue_guard_hook`, `uninstall_pre_issue_guard_hook`, `resolve_pre_issue_guard_command` via the `_resolve_script` helper that landed in #928's refactor
- `src/aelfrice/cli.py` (+58 LOC) — wiring into `_cmd_setup` / `_cmd_unsetup`, `--no-pre-issue-guard` flag, `_SETUP_FLAG_TO_HOOK_NAME` entry
- `src/aelfrice/auto_install.py` — `pre_issue_guard` entry in `_HOOK_INSTALLERS`
- `src/aelfrice/data/hook_manifest.json` — new entry (`default_on: true`, `since: 3.4.0`)
- `pyproject.toml` — `aelf-pre-issue-hook = "aelfrice.pre_issue_create_hook:main"`
- `tests/test_pre_issue_create_hook.py` (new, 52 tests) — tokenizer, scorer, run_guard with mocked runners, body-file path safety, env overrides
- `tests/test_aelf_setup_pre_issue_guard.py` (new, 14 tests) — install / uninstall / CLI flag wiring
- `tests/test_cli_setup_opt_out_sync.py`, `tests/test_aelf_setup_search_tool_bash.py` — adjusted existing assertions for the new hook count
- `docs/user/CONFIG.md`, `docs/user/INSTALL.md` — one-paragraph descriptions

## Acceptance ↔ implementation map

- [x] Hook installs on `aelf setup` (default-on). `--no-pre-issue-guard` opts out.
- [x] Posting a verbatim duplicate of #928 → BLOCK with #928 as top match. (Smoke test above.)
- [x] Posting a novel title → PASS. (Smoke test above.)
- [x] `ALLOW_DUP_ISSUE=1 gh issue create ...` → PASS. (Smoke test above; covered in unit test.)
- [x] False-positive guard: `fix(hooks): ...` vs `fix(retrieval): ...` do not BLOCK at default threshold. (Covered in `test_pre_issue_create_hook.py::test_false_positive_distinct_domain_passes`.)
- [x] Tests covering all acceptance items. 71 new tests, 4950 in total suite — all green.

## Out-of-scope (per issue body)

- LLM / embedding similarity — kept out per #605 PHILOSOPHY (deterministic narrow surface).
- Cross-repo dedup — single-repo BM25 on titles + commit subjects is enough for the 90% case.

## Test plan

- `uv run pytest tests/test_pre_issue_create_hook.py tests/test_aelf_setup_pre_issue_guard.py tests/test_cli_setup_opt_out_sync.py -x -q` — 71 passed.
- `uv run pytest -x -q` — 4950 passed, 68 skipped, 75 xfailed.
- Live smoke run against the worktree (see above).
- All 5 commits signed (`%G? = G`), conventional-commit prefixes, atomic.

Closes #941.

## Summary by Sourcery

Add a default-on pre-issue guard hook that detects potentially duplicate GitHub issues before creation and wire it into setup, auto-install, and CLI configuration, with supporting tests and documentation.

New Features:
- Introduce a `PreToolUse:Bash` hook (`aelf-pre-issue-hook`) that inspects `gh issue create` commands and blocks creation when the title closely matches existing issues or recent commits using deterministic Jaccard similarity.
- Expose CLI and setup options to enable or disable the pre-issue guard, including per-run and global environment-based bypasses.

Enhancements:
- Extend setup and auto-install wiring to install/uninstall the pre-issue guard hook alongside existing hooks, keeping opt-out state in sync.
- Document configuration and installation behaviour for the pre-issue guard hook in the user docs.

Tests:
- Add comprehensive unit tests for the pre-issue guard hook’s tokenization, scoring, guard behaviour, and env overrides.
- Add tests covering setup/unsetup wiring and opt-out persistence for the pre-issue guard, and update existing hook setup tests to account for the new hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-issue-create guard that prevents duplicate GitHub issues by validating proposed titles against existing issues and recent commits (enabled by default in v3.4.0+).
  * Support for disabling the guard via environment variables or the `aelf setup --no-pre-issue-guard` CLI option.

* **Documentation**
  * Updated installation and configuration guides with details about the new guard and opt-out methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->