### PR TITLE
feat(search): AELF_SHOW_CONFLICTS — [!] slot-conflict column on aelf search (#938)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -753,7 +753,8 @@ def _cmd_search(args: argparse.Namespace, out: object) -> int:
         else:
             n_beliefs = -1  # not consulted on the success path
         # #938: pre-extract locked-set slots once per invocation (hot path).
-        # Zero cost when feature is off.
+        # Zero cost when feature is off — name only bound under the gate;
+        # all reads of locked_pairs below are inside `if show_conflicts:`.
         if show_conflicts:
             from aelfrice.contradiction import _slot_conflict_preextracted
             from aelfrice.value_compare import extract_values
@@ -761,8 +762,6 @@ def _cmd_search(args: argparse.Namespace, out: object) -> int:
             locked_pairs = [
                 (b, extract_values(b.content)) for b in locked_beliefs
             ]
-        else:
-            locked_pairs = []
     finally:
         store.close()
     if not hits and not peer_hits:

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -738,6 +738,7 @@ def _run_llm_onboard(
 
 
 def _cmd_search(args: argparse.Namespace, out: object) -> int:
+    show_conflicts = os.environ.get("AELF_SHOW_CONFLICTS", "0") == "1"
     store = _open_store()
     try:
         hits = retrieve(store, args.query, token_budget=args.budget)
@@ -751,6 +752,17 @@ def _cmd_search(args: argparse.Namespace, out: object) -> int:
             n_beliefs = store.count_beliefs()
         else:
             n_beliefs = -1  # not consulted on the success path
+        # #938: pre-extract locked-set slots once per invocation (hot path).
+        # Zero cost when feature is off.
+        if show_conflicts:
+            from aelfrice.contradiction import _slot_conflict_preextracted
+            from aelfrice.value_compare import extract_values
+            locked_beliefs = store.list_locked_beliefs()
+            locked_pairs = [
+                (b, extract_values(b.content)) for b in locked_beliefs
+            ]
+        else:
+            locked_pairs = []
     finally:
         store.close()
     if not hits and not peer_hits:
@@ -767,12 +779,39 @@ def _cmd_search(args: argparse.Namespace, out: object) -> int:
                 file=out,  # type: ignore[arg-type]
             )
         return 0
+    if getattr(args, "json", False):
+        import json as _json
+        rows = []
+        for h in hits:
+            row: dict = {"id": h.id, "content": h.content, "locked": h.lock_level == LOCK_USER}
+            if show_conflicts:
+                conflict_id = _slot_conflict_preextracted(h, locked_pairs)
+                if conflict_id is not None:
+                    row["slot_conflict_with"] = conflict_id
+            rows.append(row)
+        for belief, peer_name, _score in peer_hits:
+            row = {"id": belief.id, "content": belief.content, "scope": peer_name}
+            if show_conflicts:
+                conflict_id = _slot_conflict_preextracted(belief, locked_pairs)
+                if conflict_id is not None:
+                    row["slot_conflict_with"] = conflict_id
+            rows.append(row)
+        print(_json.dumps(rows, indent=2), file=out)  # type: ignore[arg-type]
+        return 0
     for h in hits:
         prefix = "[locked]" if h.lock_level == LOCK_USER else "        "
-        print(f"{prefix} {h.id}: {h.content}", file=out)  # type: ignore[arg-type]
+        conflict_marker = ""
+        if show_conflicts:
+            if _slot_conflict_preextracted(h, locked_pairs) is not None:
+                conflict_marker = "[!] "
+        print(f"{prefix} {conflict_marker}{h.id}: {h.content}", file=out)  # type: ignore[arg-type]
     for belief, peer_name, _score in peer_hits:
+        conflict_marker = ""
+        if show_conflicts:
+            if _slot_conflict_preextracted(belief, locked_pairs) is not None:
+                conflict_marker = "[!] "
         print(
-            f"[scope:{peer_name}] {belief.id}: {belief.content}",
+            f"[scope:{peer_name}] {conflict_marker}{belief.id}: {belief.content}",
             file=out,  # type: ignore[arg-type]
         )
     return 0
@@ -5285,6 +5324,10 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
     p_search.add_argument(
         "--budget", type=int, default=DEFAULT_TOKEN_BUDGET,
         help="output token budget (default 2000)",
+    )
+    p_search.add_argument(
+        "--json", action="store_true", default=False,
+        help="emit results as a JSON array",
     )
     p_search.set_defaults(func=_cmd_search)
 

--- a/src/aelfrice/contradiction.py
+++ b/src/aelfrice/contradiction.py
@@ -61,7 +61,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Final
+from typing import Final, Optional, Sequence
 
 from aelfrice.models import (
     BELIEF_CORRECTION,
@@ -77,6 +77,7 @@ from aelfrice.models import (
     Edge,
 )
 from aelfrice.store import MemoryStore
+from aelfrice.value_compare import ValueSlots, extract_values, find_conflicts
 
 # Precedence classes. Higher value wins. Names are stable wire-format
 # strings — they appear in feedback_history.source — so do not rename
@@ -349,3 +350,51 @@ def auto_resolve_all_contradictions(
             # Either endpoint missing — skip, do not abort batch.
             continue
     return out
+
+
+# ---------------------------------------------------------------------------
+# Slot-conflict check (#938)
+# ---------------------------------------------------------------------------
+
+
+def _slot_conflict(
+    belief: Belief,
+    locked_set: Sequence[Belief],
+) -> Optional[str]:
+    """Return the id of the first locked belief whose value-slots conflict
+    with ``belief``'s, or None if no conflict.
+
+    Conflict = ``value_compare.find_conflicts`` returns ≥1 SlotConflict.
+
+    Pure: no DB access, no state. Caller pre-computes ``locked_set`` once
+    per invocation.
+    """
+    if not locked_set:
+        return None
+    b_slots = extract_values(belief.content)
+    for locked in locked_set:
+        l_slots = extract_values(locked.content)
+        if find_conflicts(b_slots, l_slots):
+            return locked.id
+    return None
+
+
+def _slot_conflict_preextracted(
+    belief: Belief,
+    locked_pairs: Sequence[tuple[Belief, ValueSlots]],
+) -> Optional[str]:
+    """Hot-path variant accepting pre-extracted locked-set slots.
+
+    Avoids re-running ``extract_values`` on each locked belief per search
+    hit. Caller builds ``locked_pairs`` once per query:
+    ``[(b, extract_values(b.content)) for b in list_locked_beliefs()]``
+
+    Returns the id of the first conflicting locked belief, or None.
+    """
+    if not locked_pairs:
+        return None
+    b_slots = extract_values(belief.content)
+    for locked, l_slots in locked_pairs:
+        if find_conflicts(b_slots, l_slots):
+            return locked.id
+    return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -375,6 +375,131 @@ def test_search_with_dot_in_query_does_not_crash(isolated_db: Path) -> None:
     assert "regex" in out
 
 
+# --- AELF_SHOW_CONFLICTS (#938) -----------------------------------------
+
+
+def test_search_conflict_marker_shown_when_env_on(
+    isolated_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With AELF_SHOW_CONFLICTS=1, [!] appears next to a conflicting hit."""
+    # Lock a belief with alpha=1.0
+    _run("lock", "alpha = 1.0 is the configured value")
+    # Add a second belief (non-locked) with a conflicting alpha value
+    from aelfrice.store import MemoryStore
+    from aelfrice.models import Belief, BELIEF_FACTUAL, LOCK_NONE
+    import os
+    db = isolated_db
+    s = MemoryStore(str(db))
+    s.insert_belief(Belief(
+        id="b_conflict",
+        content="alpha = 0.5 in experiment",
+        content_hash="h_conflict",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    ))
+    s.close()
+    monkeypatch.setenv("AELF_SHOW_CONFLICTS", "1")
+    code, out = _run("search", "alpha")
+    assert code == 0
+    assert "[!]" in out
+
+
+def test_search_conflict_marker_absent_when_env_off(
+    isolated_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without AELF_SHOW_CONFLICTS, [!] is never emitted even if conflict exists."""
+    _run("lock", "alpha = 1.0 is the configured value")
+    from aelfrice.store import MemoryStore
+    from aelfrice.models import Belief, BELIEF_FACTUAL, LOCK_NONE
+    db = isolated_db
+    s = MemoryStore(str(db))
+    s.insert_belief(Belief(
+        id="b_conflict",
+        content="alpha = 0.5 in experiment",
+        content_hash="h_conflict",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    ))
+    s.close()
+    monkeypatch.delenv("AELF_SHOW_CONFLICTS", raising=False)
+    code, out = _run("search", "alpha")
+    assert code == 0
+    assert "[!]" not in out
+
+
+def test_search_json_includes_slot_conflict_field_when_env_on(
+    isolated_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--json + AELF_SHOW_CONFLICTS=1: slot_conflict_with field present on conflict rows."""
+    _run("lock", "alpha = 1.0 is the configured value")
+    from aelfrice.store import MemoryStore
+    from aelfrice.models import Belief, BELIEF_FACTUAL, LOCK_NONE
+    db = isolated_db
+    s = MemoryStore(str(db))
+    s.insert_belief(Belief(
+        id="b_conflict",
+        content="alpha = 0.5 in experiment",
+        content_hash="h_conflict",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    ))
+    s.close()
+    monkeypatch.setenv("AELF_SHOW_CONFLICTS", "1")
+    code, out = _run("search", "--json", "alpha")
+    assert code == 0
+    rows = json.loads(out)
+    conflict_rows = [r for r in rows if "slot_conflict_with" in r]
+    assert len(conflict_rows) >= 1
+
+
+def test_search_json_no_slot_conflict_field_when_env_off(
+    isolated_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--json without AELF_SHOW_CONFLICTS: slot_conflict_with never appears."""
+    _run("lock", "alpha = 1.0 is the configured value")
+    from aelfrice.store import MemoryStore
+    from aelfrice.models import Belief, BELIEF_FACTUAL, LOCK_NONE
+    db = isolated_db
+    s = MemoryStore(str(db))
+    s.insert_belief(Belief(
+        id="b_conflict",
+        content="alpha = 0.5 in experiment",
+        content_hash="h_conflict",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        created_at="2026-04-26T00:00:00Z",
+        last_retrieved_at=None,
+    ))
+    s.close()
+    monkeypatch.delenv("AELF_SHOW_CONFLICTS", raising=False)
+    code, out = _run("search", "--json", "alpha")
+    assert code == 0
+    rows = json.loads(out)
+    assert all("slot_conflict_with" not in r for r in rows)
+
+
 # --- stats --------------------------------------------------------------
 
 

--- a/tests/test_slot_conflict.py
+++ b/tests/test_slot_conflict.py
@@ -12,9 +12,6 @@ Covers:
 from __future__ import annotations
 
 import time
-from typing import Sequence
-
-import pytest
 
 from aelfrice.contradiction import _slot_conflict, _slot_conflict_preextracted
 from aelfrice.models import (
@@ -23,7 +20,7 @@ from aelfrice.models import (
     LOCK_USER,
     Belief,
 )
-from aelfrice.value_compare import ValueSlots, extract_values
+from aelfrice.value_compare import extract_values
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_slot_conflict.py
+++ b/tests/test_slot_conflict.py
@@ -1,0 +1,194 @@
+"""Tests for _slot_conflict and _slot_conflict_preextracted (#938).
+
+Covers:
+- Same slot, same object → no flag
+- Same slot, different object → flag
+- Different slots entirely → no flag
+- Empty locked set → no flag
+- Multiple locked beliefs, first match wins
+- Latency budget (≤5 ms p95 for 10 hits × 5 locked; budget is 2 ms per
+  spec but relaxed to 5 ms to accommodate slower CI hardware)
+"""
+from __future__ import annotations
+
+import time
+from typing import Sequence
+
+import pytest
+
+from aelfrice.contradiction import _slot_conflict, _slot_conflict_preextracted
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    LOCK_NONE,
+    LOCK_USER,
+    Belief,
+)
+from aelfrice.value_compare import ValueSlots, extract_values
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mk(
+    bid: str,
+    content: str,
+    *,
+    lock: str = LOCK_NONE,
+    locked_at: str | None = None,
+    created_at: str = "2026-04-26T00:00:00Z",
+    origin: str = "unknown",
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock,
+        locked_at=locked_at,
+        created_at=created_at,
+        last_retrieved_at=None,
+        origin=origin,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _slot_conflict — spec-matching public signature
+# ---------------------------------------------------------------------------
+
+
+def test_same_slot_same_value_no_flag() -> None:
+    """Belief and locked share the same numeric slot value → no conflict."""
+    hit = _mk("hit", "alpha = 0.5 prior")
+    locked = _mk("locked", "alpha = 0.5 in config", lock=LOCK_USER, locked_at="2026-04-26T00:00:00Z")
+    assert _slot_conflict(hit, [locked]) is None
+
+
+def test_same_slot_different_value_flags() -> None:
+    """Numeric slot with values outside tolerance → conflict fires."""
+    hit = _mk("hit", "alpha = 0.5 prior")
+    locked = _mk("locked", "alpha = 1.0 in config", lock=LOCK_USER, locked_at="2026-04-26T00:00:00Z")
+    result = _slot_conflict(hit, [locked])
+    assert result == "locked"
+
+
+def test_enum_same_group_no_flag() -> None:
+    """sync and synchronous are same group_id → no conflict."""
+    hit = _mk("hit", "use sync mode for hot path")
+    locked = _mk("locked", "synchronous everywhere", lock=LOCK_USER, locked_at="2026-04-26T00:00:00Z")
+    assert _slot_conflict(hit, [locked]) is None
+
+
+def test_enum_disjoint_groups_flags() -> None:
+    """sync vs async are disjoint groups → conflict fires."""
+    hit = _mk("hit", "async execution model")
+    locked = _mk("locked", "synchronous on hot path", lock=LOCK_USER, locked_at="2026-04-26T00:00:00Z")
+    result = _slot_conflict(hit, [locked])
+    assert result == "locked"
+
+
+def test_different_slots_no_flag() -> None:
+    """Belief and locked have no overlapping slots → no conflict."""
+    hit = _mk("hit", "synchronous on hot path")
+    locked = _mk("locked", "alpha = 0.5 prior", lock=LOCK_USER, locked_at="2026-04-26T00:00:00Z")
+    assert _slot_conflict(hit, [locked]) is None
+
+
+def test_empty_locked_set_no_flag() -> None:
+    """Empty locked_set → always None."""
+    hit = _mk("hit", "alpha = 0.5 prior")
+    assert _slot_conflict(hit, []) is None
+
+
+def test_multiple_locked_first_match_wins() -> None:
+    """When belief conflicts with two locked beliefs, first in sequence wins."""
+    hit = _mk("hit", "alpha = 0.5 prior")
+    locked_a = _mk("locked_a", "alpha = 1.0 first", lock=LOCK_USER, locked_at="2026-04-26T00:00:00Z")
+    locked_b = _mk("locked_b", "alpha = 2.0 second", lock=LOCK_USER, locked_at="2026-04-26T00:00:00Z")
+    result = _slot_conflict(hit, [locked_a, locked_b])
+    assert result == "locked_a"
+
+
+def test_no_conflict_with_first_locked_checks_second() -> None:
+    """When first locked doesn't conflict but second does, returns second."""
+    hit = _mk("hit", "alpha = 0.5 prior")
+    # locked_a has no overlapping slots with hit
+    locked_a = _mk("locked_a", "synchronous on hot path", lock=LOCK_USER, locked_at="2026-04-26T00:00:00Z")
+    locked_b = _mk("locked_b", "alpha = 1.0 in config", lock=LOCK_USER, locked_at="2026-04-26T00:00:00Z")
+    result = _slot_conflict(hit, [locked_a, locked_b])
+    assert result == "locked_b"
+
+
+# ---------------------------------------------------------------------------
+# _slot_conflict_preextracted — hot-path variant
+# ---------------------------------------------------------------------------
+
+
+def test_preextracted_same_as_spec_function_no_conflict() -> None:
+    hit = _mk("hit", "alpha = 0.5 prior")
+    locked = _mk("locked", "alpha = 0.5 in config", lock=LOCK_USER, locked_at="2026-04-26T00:00:00Z")
+    pairs = [(locked, extract_values(locked.content))]
+    assert _slot_conflict_preextracted(hit, pairs) is None
+
+
+def test_preextracted_same_as_spec_function_with_conflict() -> None:
+    hit = _mk("hit", "alpha = 0.5 prior")
+    locked = _mk("locked", "alpha = 1.0 in config", lock=LOCK_USER, locked_at="2026-04-26T00:00:00Z")
+    pairs = [(locked, extract_values(locked.content))]
+    assert _slot_conflict_preextracted(hit, pairs) == "locked"
+
+
+def test_preextracted_empty_no_flag() -> None:
+    hit = _mk("hit", "alpha = 0.5 prior")
+    assert _slot_conflict_preextracted(hit, []) is None
+
+
+# ---------------------------------------------------------------------------
+# Latency budget
+#
+# Spec: ≤2 ms p95 added per query with a small locked set.
+# We relax to ≤5 ms here to accommodate slower CI hardware while still
+# catching pathological regressions. The 2 ms target is met on developer
+# hardware — measured ~0.1 ms p95 in local runs.
+# ---------------------------------------------------------------------------
+
+_LATENCY_THRESHOLD_MS = 5.0  # relaxed from spec's 2 ms for CI tolerance
+
+
+def test_latency_budget() -> None:
+    """p95 of _slot_conflict_preextracted over 10 hits × 5 locked ≤ 5 ms."""
+    # Build 5 locked beliefs with distinct numeric slots
+    locked_beliefs = [
+        _mk(f"locked_{i}", f"param_{i} = {float(i + 1)} baseline",
+            lock=LOCK_USER, locked_at="2026-04-26T00:00:00Z")
+        for i in range(5)
+    ]
+    locked_pairs = [(b, extract_values(b.content)) for b in locked_beliefs]
+
+    # Build 10 hit beliefs (no conflicts — tests the non-conflicting path too)
+    hits = [
+        _mk(f"hit_{i}", f"depth = {float(i + 10)} max")
+        for i in range(10)
+    ]
+
+    ITERATIONS = 100
+    elapsed_ms_list: list[float] = []
+
+    for _ in range(ITERATIONS):
+        t0 = time.perf_counter_ns()
+        for h in hits:
+            _slot_conflict_preextracted(h, locked_pairs)
+        t1 = time.perf_counter_ns()
+        elapsed_ms_list.append((t1 - t0) / 1_000_000)
+
+    elapsed_ms_list.sort()
+    p95_idx = int(len(elapsed_ms_list) * 0.95)
+    p95_ms = elapsed_ms_list[p95_idx]
+
+    assert p95_ms <= _LATENCY_THRESHOLD_MS, (
+        f"p95 latency {p95_ms:.3f} ms exceeded threshold "
+        f"{_LATENCY_THRESHOLD_MS} ms (10 hits × 5 locked)"
+    )


### PR DESCRIPTION
Closes #938.

## What

Adds `_slot_conflict(belief, locked_set) -> Optional[str]` to `contradiction.py` and wires it into `_cmd_search` behind the `AELF_SHOW_CONFLICTS=1` env var. When set, hits whose value-slots collide with a locked belief's get a `[!]` marker; in `--json` mode, the row gains a `slot_conflict_with: <locked_id>` field.

```
$ AELF_SHOW_CONFLICTS=1 aelf search "rebuild p99"
[locked]  abc123: rebuild p99 is 4.5 ms
          [!] def456: rebuild p99 is 12 ms
```

## How

The exact-slot-equality primitive already shipped in `src/aelfrice/value_compare.py`: `ValueSlots` dataclass, `extract_values(text) -> ValueSlots`, `find_conflicts(slots_a, slots_b) -> tuple[SlotConflict, ...]`. `_slot_conflict` is a thin wrapper — extract the belief's slots, loop over the locked set, return the first id whose `find_conflicts` is non-empty.

`_cmd_search` pre-extracts the locked-set slots once per invocation and calls a sister helper `_slot_conflict_preextracted(belief, locked_pairs)` per hit (hot path). Both functions live in `contradiction.py` and are tested separately. When `AELF_SHOW_CONFLICTS` is unset, neither runs — zero overhead on the default search path.

## Spec deviations

1. **`aelf search` gained `--json`.** The issue body says "In `--json` mode, add `slot_conflict_with` field" but the search subparser didn't actually have `--json` on `main`. Added as a precondition. Output shape is `print(json.dumps(rows, indent=2))` — an array, not JSONL. This matches the closest existing payload-style emitters in `cli.py` but is a different convention from `_cmd_speculative` / `_cmd_locked`'s per-line JSONL. Worth a future harmonisation pass; not blocking here.
2. **Latency test asserts ≤5 ms, spec asks ≤2 ms.** Measured p95 on 10 hits × 5 locked, 100 iterations: ~0.05-0.1 ms. The 5 ms threshold is a CI-hardware safety margin; the real measurement is comfortably under the spec. The comment in the test calls this out — happy to tighten if reviewer prefers.
3. **A second helper `_slot_conflict_preextracted` was added** so the call site doesn't re-run `extract_values` per locked belief per hit. `_slot_conflict` (spec signature) remains the public, tested function; the hot-path variant is for callers who already extracted the locked-set slots.

## Verification

- `pytest tests/test_slot_conflict.py tests/test_cli.py -x` → 70 passed.
- Discretion grep on diff: clean.
- 12 new unit tests cover: same slot/same object (no flag), same slot/different object (flag), different slots (no flag), empty locked set (no flag), first-match-wins ordering, latency p95 budget, env-var on/off rendering, JSON `slot_conflict_with` field present/absent.

## Out of scope

- Cross-Claude-memory dedup audit (#935 — same primitive will compose into that issue's surface).
- Promoting `SlotConflict` details into the JSON row (only the locked-id is exposed per spec).
- Per-PR JSONL/array harmonisation across all `--json` outputs (separate concern).

## Summary by Sourcery

Add optional slot-conflict detection to `aelf search` and expose conflicts in both human and JSON output, gated by an environment flag.

New Features:
- Introduce `_slot_conflict` and `_slot_conflict_preextracted` helpers to detect value-slot conflicts between beliefs and a locked set.
- Extend `aelf search` with a `--json` option to emit results as a JSON array including optional conflict metadata.
- Add an `AELF_SHOW_CONFLICTS`-controlled `[!]` marker and `slot_conflict_with` field to highlight hits that conflict with locked beliefs in search results.

Tests:
- Add unit tests for slot-conflict helpers covering conflict/no-conflict scenarios, ordering semantics, empty locked set, and latency bounds.
- Add CLI tests to verify the conflict marker in text output and `slot_conflict_with` behavior in JSON output with `AELF_SHOW_CONFLICTS` on and off.