### PR TITLE
feat(cli): aelf audit-claude-memory — cross-store dedup audit (#935)

### DIFF
--- a/src/aelfrice/claude_memory.py
+++ b/src/aelfrice/claude_memory.py
@@ -1,0 +1,364 @@
+"""Parser and slot-equality comparison for the claude-memory file format.
+
+The upstream auto-memory writes a MEMORY.md index file at
+``~/.claude/projects/<encoded-path>/memory/MEMORY.md`` and individual
+per-memory ``.md`` files in the same directory. This module provides:
+
+1. ``derive_memory_dir(project_path)`` — converts an absolute project
+   path to the corresponding claude-memory directory using the same
+   path-encoding the upstream tool applies: strip the leading slash,
+   replace every remaining ``/`` with ``-``.
+
+2. ``parse_memory_bullets(text)`` — parses the MEMORY.md bullet list
+   into a flat list of :class:`MemoryBullet` namedtuples without any
+   filesystem I/O.
+
+3. ``extract_slot(text)`` — extracts a deterministic ``(subject,
+   predicate)`` slot from a belief/bullet string via regex. Returns
+   ``None`` when no slot can be reliably identified (callers skip those
+   rows for comparison).
+
+4. ``SlotRow`` — a namedtuple that carries the extracted slot fields
+   plus the raw text and its source path, returned by both the bullet
+   parser and the aelfrice locked-belief extractor.
+
+5. ``compare_slots`` — takes two iterables of :class:`SlotRow` and
+   returns the four-bucket :class:`ComparisonResult` used by
+   ``aelf audit-claude-memory``.
+
+The slot-extraction regex is intentionally conservative: a "slot" is a
+two-word ``Subject Predicate`` prefix (optionally followed by
+``[IsA|HasA|…]``) at the start of a sentence-like fragment. Bullets that
+do not match are placed in the bucket they were found in (aelfrice-only
+or claude-memory-only) rather than being compared, consistent with the
+locked PHILOSOPHY decision to prefer deterministic stdlib gates over
+fuzzy heuristics.
+
+No filesystem state is mutated here. This module is safe for #938
+(``aelf:search`` contradiction-flag column) to import without pulling
+in any CLI surface.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+class MemoryBullet(NamedTuple):
+    """A single bullet parsed from a MEMORY.md index file.
+
+    :param link_text: the human-readable label from ``[label](path)``
+    :param link_target: the relative path from ``[label](path)``
+    :param description: the text that follows `` — `` (may be empty)
+    :param source_path: absolute path of the MEMORY.md file this came from
+    """
+    link_text: str
+    link_target: str
+    description: str
+    source_path: str
+
+
+class SlotRow(NamedTuple):
+    """A belief or bullet with an extracted (subject, predicate) slot.
+
+    When ``slot_subject`` or ``slot_predicate`` is an empty string the slot
+    could not be extracted; :func:`compare_slots` skips those rows.
+
+    :param slot_subject: first word(s) extracted as the subject
+    :param slot_predicate: following word(s) extracted as the predicate
+    :param slot_value: rest of the content after the predicate (the "value")
+    :param raw_text: original full text of the belief or bullet description
+    :param source: label identifying where this row came from
+      (belief id for aelfrice rows; MEMORY.md link-text for claude rows)
+    :param source_path: file path (DB path or MEMORY.md path)
+    """
+    slot_subject: str
+    slot_predicate: str
+    slot_value: str
+    raw_text: str
+    source: str
+    source_path: str
+
+
+class ComparisonResult(NamedTuple):
+    """Four-bucket result from :func:`compare_slots`.
+
+    Each list contains :class:`SlotRow` pairs or single rows:
+
+    :param duplicates: list of ``(aelfrice_row, claude_row)`` pairs where
+      slot subject+predicate AND slot value match exactly (case-insensitive)
+    :param contradictions: list of ``(aelfrice_row, claude_row)`` pairs where
+      slot subject+predicate match but values differ
+    :param aelfrice_only: :class:`SlotRow` items whose slot has no match in
+      the claude-memory set
+    :param claude_only: :class:`SlotRow` items whose slot has no match in
+      the aelfrice set
+    """
+    duplicates: list[tuple[SlotRow, SlotRow]]
+    contradictions: list[tuple[SlotRow, SlotRow]]
+    aelfrice_only: list[SlotRow]
+    claude_only: list[SlotRow]
+
+
+# ---------------------------------------------------------------------------
+# Path derivation
+# ---------------------------------------------------------------------------
+
+# Matches one or more leading slashes to strip from the absolute path.
+_LEADING_SLASH_RE = re.compile(r"^/+")
+
+
+def derive_memory_dir(project_path: str | Path) -> Path:
+    """Return the claude-memory directory for ``project_path``.
+
+    The upstream tool encodes the absolute project directory as a filesystem
+    path by stripping the leading ``/`` and replacing every remaining ``/``
+    with ``-``.  For example ``/Users/alice/projects/myapp`` becomes
+    ``-Users-alice-projects-myapp`` and the full memory directory is
+    ``~/.claude/projects/-Users-alice-projects-myapp/memory/``.
+
+    This function replicates that encoding without touching the filesystem.
+    """
+    abs_path = str(Path(project_path).resolve())
+    encoded = _LEADING_SLASH_RE.sub("", abs_path).replace("/", "-")
+    return Path.home() / ".claude" / "projects" / f"-{encoded}" / "memory"
+
+
+# ---------------------------------------------------------------------------
+# MEMORY.md bullet parser
+# ---------------------------------------------------------------------------
+
+# Matches a MEMORY.md bullet of the form:
+#   - [link text](path) — description
+# The description part (after ` — `) is optional.
+_BULLET_RE = re.compile(
+    r"^\s*-\s+"                   # list marker
+    r"\[(?P<text>[^\]]+)\]"       # [link text]
+    r"\((?P<path>[^)]+)\)"        # (path)
+    r"(?:\s+[—–-]+\s+(?P<desc>.+))?$",  # optional ` — description`
+    re.UNICODE,
+)
+
+
+def parse_memory_bullets(text: str, source_path: str = "") -> list[MemoryBullet]:
+    """Parse MEMORY.md content into a list of :class:`MemoryBullet`.
+
+    Only lines that match the ``- [text](path)`` pattern are returned.
+    Heading lines, blank lines, and non-bullet lines are silently skipped.
+    The description is the text after `` — `` (em-dash, en-dash, or ASCII
+    hyphen-minus); it may be empty when the bullet has no description.
+
+    Args:
+        text: raw content of a MEMORY.md file (newline-separated).
+        source_path: path of the MEMORY.md file, stored on each bullet for
+            downstream reporting; does not affect parsing.
+
+    Returns:
+        List of :class:`MemoryBullet`, one per matched bullet line.
+    """
+    bullets: list[MemoryBullet] = []
+    for line in text.splitlines():
+        m = _BULLET_RE.match(line)
+        if m is None:
+            continue
+        bullets.append(MemoryBullet(
+            link_text=m.group("text").strip(),
+            link_target=m.group("path").strip(),
+            description=(m.group("desc") or "").strip(),
+            source_path=source_path,
+        ))
+    return bullets
+
+
+# ---------------------------------------------------------------------------
+# Slot extraction
+# ---------------------------------------------------------------------------
+
+# A "slot" is a (subject, predicate) pair that can be extracted
+# deterministically from a short assertion string.  The regex looks for a
+# two-or-three capitalised token run at the start of the string that looks
+# like "Subject Predicate …".
+#
+# Pattern rationale (conservative):
+#   - subject: one or two capitalised tokens (e.g. "Foo" or "Foo Bar")
+#   - predicate: one capitalised or lowercase token that follows
+#   - value: everything after the predicate
+#
+# When the string starts with a lowercased word (common for bare description
+# text) we still try the two-token split but record both tokens as-is.
+# If fewer than two whitespace-separated tokens exist, we return None.
+_SLOT_RE = re.compile(
+    r"""
+    ^
+    (?P<subject>
+        [A-Za-z][A-Za-z0-9_-]*          # first word
+        (?:\s+[A-Za-z][A-Za-z0-9_-]*)?  # optional second word
+    )
+    \s+
+    (?P<predicate>[A-Za-z][A-Za-z0-9_-]*)   # predicate token
+    (?:\s+(?P<value>.+))?                    # rest = value
+    $
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def extract_slot(text: str) -> tuple[str, str, str] | None:
+    """Extract a ``(subject, predicate, value)`` slot from ``text``.
+
+    Returns ``None`` when the text cannot be reliably tokenised into a
+    subject + predicate pair (e.g. single-word strings, empty input).
+    The slot fields are stripped but otherwise returned verbatim (no
+    stemming, no lowercasing) so that callers can apply case-insensitive
+    comparison themselves.
+    """
+    if not text or not text.strip():
+        return None
+    m = _SLOT_RE.match(text.strip())
+    if m is None:
+        return None
+    subject = m.group("subject").strip()
+    predicate = m.group("predicate").strip()
+    value = (m.group("value") or "").strip()
+    if not subject or not predicate:
+        return None
+    return (subject, predicate, value)
+
+
+def slot_row_from_belief(
+    belief_id: str,
+    content: str,
+    db_path: str,
+) -> SlotRow | None:
+    """Build a :class:`SlotRow` from an aelfrice belief, or ``None`` if the
+    slot cannot be extracted.
+
+    Args:
+        belief_id: the belief's ``id`` field (used as ``source``).
+        content: the belief's ``content`` field.
+        db_path: path to the aelfrice DB (used as ``source_path``).
+    """
+    slot = extract_slot(content)
+    if slot is None:
+        return None
+    subject, predicate, value = slot
+    return SlotRow(
+        slot_subject=subject,
+        slot_predicate=predicate,
+        slot_value=value,
+        raw_text=content,
+        source=belief_id,
+        source_path=db_path,
+    )
+
+
+def slot_row_from_bullet(bullet: MemoryBullet) -> SlotRow | None:
+    """Build a :class:`SlotRow` from a :class:`MemoryBullet`, or ``None`` if
+    the slot cannot be extracted.
+
+    The text used for slot extraction is the bullet's ``description`` when
+    non-empty; otherwise the ``link_text`` is tried as a fallback.
+    """
+    text = bullet.description if bullet.description else bullet.link_text
+    slot = extract_slot(text)
+    if slot is None:
+        return None
+    subject, predicate, value = slot
+    return SlotRow(
+        slot_subject=subject,
+        slot_predicate=predicate,
+        slot_value=value,
+        raw_text=text,
+        source=bullet.link_text,
+        source_path=bullet.source_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Four-bucket comparison
+# ---------------------------------------------------------------------------
+
+
+def _slot_key(row: SlotRow) -> str:
+    """Normalised ``subject␟predicate`` key for slot matching."""
+    return (row.slot_subject.lower().strip() + "\x1f"
+            + row.slot_predicate.lower().strip())
+
+
+def compare_slots(
+    aelfrice_rows: list[SlotRow],
+    claude_rows: list[SlotRow],
+) -> ComparisonResult:
+    """Compare two lists of :class:`SlotRow` and return the four buckets.
+
+    Rows without an extractable slot (empty ``slot_subject`` or
+    ``slot_predicate``) are treated as unmatched and placed in the
+    respective ``*_only`` bucket.  The caller is responsible for ensuring
+    that only rows with non-empty slots are passed; the function is
+    defensive and handles them gracefully.
+
+    Matching is case-insensitive on the ``subject``+``predicate`` key.
+    Value comparison is also case-insensitive and stripped for
+    duplicate/contradiction classification.
+
+    Args:
+        aelfrice_rows: slot rows extracted from locked aelfrice beliefs.
+        claude_rows: slot rows extracted from claude-memory bullets.
+
+    Returns:
+        :class:`ComparisonResult` with four lists populated.
+    """
+    # Index claude rows by normalised slot key → list (multiple bullets can
+    # share the same slot key; we match against the first found).
+    claude_index: dict[str, list[SlotRow]] = {}
+    for row in claude_rows:
+        if not row.slot_subject or not row.slot_predicate:
+            continue
+        key = _slot_key(row)
+        claude_index.setdefault(key, []).append(row)
+
+    duplicates: list[tuple[SlotRow, SlotRow]] = []
+    contradictions: list[tuple[SlotRow, SlotRow]] = []
+    aelfrice_only: list[SlotRow] = []
+    matched_claude_keys: set[str] = set()
+
+    for arow in aelfrice_rows:
+        if not arow.slot_subject or not arow.slot_predicate:
+            aelfrice_only.append(arow)
+            continue
+        key = _slot_key(arow)
+        if key not in claude_index:
+            aelfrice_only.append(arow)
+            continue
+        # Match against the first claude row with this key.
+        crow = claude_index[key][0]
+        matched_claude_keys.add(key)
+        aval = arow.slot_value.lower().strip()
+        cval = crow.slot_value.lower().strip()
+        if aval == cval:
+            duplicates.append((arow, crow))
+        else:
+            contradictions.append((arow, crow))
+
+    # Any claude rows whose key was never matched → claude-only.
+    claude_only: list[SlotRow] = []
+    for row in claude_rows:
+        if not row.slot_subject or not row.slot_predicate:
+            claude_only.append(row)
+            continue
+        key = _slot_key(row)
+        if key not in matched_claude_keys:
+            claude_only.append(row)
+
+    return ComparisonResult(
+        duplicates=duplicates,
+        contradictions=contradictions,
+        aelfrice_only=aelfrice_only,
+        claude_only=claude_only,
+    )

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2287,6 +2287,144 @@ def _cmd_scope_out(args: argparse.Namespace, out: object) -> int:
     return 0
 
 
+def _cmd_audit_claude_memory(args: argparse.Namespace, out: object) -> int:
+    """Cross-store dedup audit between aelfrice and the claude-memory file (#935).
+
+    Reads ``~/.claude/projects/<encoded-project>/memory/MEMORY.md``,
+    parses its bullets into slot tuples, and compares them against the
+    locked aelfrice beliefs from the current store.  Emits a report in
+    four buckets:
+
+    - **duplicates** — same slot key and value in both stores
+    - **contradictions** — same slot key, different value
+    - **aelfrice-only** — locked belief with no matching claude-memory slot
+    - **claude-memory-only** — bullet with no matching aelfrice slot
+
+    Default output is human-readable text.  Pass ``--json`` for a single
+    JSON object containing the four lists.  Never writes to either store.
+    """
+    from aelfrice.claude_memory import (
+        compare_slots,
+        derive_memory_dir,
+        parse_memory_bullets,
+        slot_row_from_belief,
+        slot_row_from_bullet,
+    )
+
+    # Resolve the project path (default: cwd).
+    project_path: str = getattr(args, "project", None) or os.getcwd()
+    memory_dir = derive_memory_dir(project_path)
+    memory_md = memory_dir / "MEMORY.md"
+
+    # Parse the claude-memory index file.
+    if memory_md.exists():
+        raw = memory_md.read_text(encoding="utf-8", errors="replace")
+        bullets = parse_memory_bullets(raw, source_path=str(memory_md))
+    else:
+        bullets = []
+
+    claude_rows = [
+        r for b in bullets
+        if (r := slot_row_from_bullet(b)) is not None
+    ]
+
+    # Collect locked aelfrice beliefs and extract slots.
+    store = _open_store()
+    try:
+        locked = store.list_locked_beliefs()
+        db = db_path()
+    finally:
+        store.close()
+
+    aelfrice_rows = [
+        r for b in locked
+        if (r := slot_row_from_belief(b.id, b.content, str(db))) is not None
+    ]
+
+    result = compare_slots(aelfrice_rows, claude_rows)
+
+    if getattr(args, "json", False):
+        def _row_dict(row: object) -> dict[str, object]:
+            from aelfrice.claude_memory import SlotRow as _SlotRow
+            assert isinstance(row, _SlotRow)
+            return {
+                "slot_subject": row.slot_subject,
+                "slot_predicate": row.slot_predicate,
+                "slot_value": row.slot_value,
+                "raw_text": row.raw_text,
+                "source": row.source,
+                "source_path": row.source_path,
+            }
+
+        payload: dict[str, object] = {
+            "project_path": project_path,
+            "memory_md": str(memory_md),
+            "memory_md_found": memory_md.exists(),
+            "duplicates": [
+                {"aelfrice": _row_dict(a), "claude": _row_dict(c)}
+                for a, c in result.duplicates
+            ],
+            "contradictions": [
+                {"aelfrice": _row_dict(a), "claude": _row_dict(c)}
+                for a, c in result.contradictions
+            ],
+            "aelfrice_only": [_row_dict(r) for r in result.aelfrice_only],
+            "claude_only": [_row_dict(r) for r in result.claude_only],
+        }
+        print(json.dumps(payload, indent=2), file=out)  # type: ignore[arg-type]
+        return 0
+
+    # Text output.
+    def _hdr(label: str, count: int) -> None:
+        print(f"\n{label} ({count})", file=out)  # type: ignore[arg-type]
+        print("-" * 40, file=out)  # type: ignore[arg-type]
+
+    print(
+        f"audit-claude-memory: project={project_path}",
+        file=out,  # type: ignore[arg-type]
+    )
+    if not memory_md.exists():
+        print(
+            f"  note: MEMORY.md not found at {memory_md}",
+            file=out,  # type: ignore[arg-type]
+        )
+
+    _hdr("Potential duplicates (same slot, same value)", len(result.duplicates))
+    for arow, crow in result.duplicates:
+        print(
+            f"  [{arow.slot_subject} {arow.slot_predicate}] "
+            f"aelf={arow.source!r} claude={crow.source!r} "
+            f"value={arow.slot_value!r}",
+            file=out,  # type: ignore[arg-type]
+        )
+
+    _hdr("Potential contradictions (same slot, different value)", len(result.contradictions))
+    for arow, crow in result.contradictions:
+        print(
+            f"  [{arow.slot_subject} {arow.slot_predicate}] "
+            f"aelf={arow.slot_value!r} vs claude={crow.slot_value!r}",
+            file=out,  # type: ignore[arg-type]
+        )
+
+    _hdr("aelfrice-only (not in claude-memory)", len(result.aelfrice_only))
+    for r in result.aelfrice_only:
+        print(
+            f"  [{r.slot_subject} {r.slot_predicate}] {r.slot_value!r} "
+            f"(belief {r.source})",
+            file=out,  # type: ignore[arg-type]
+        )
+
+    _hdr("claude-memory-only (not in aelfrice)", len(result.claude_only))
+    for r in result.claude_only:
+        print(
+            f"  [{r.slot_subject} {r.slot_predicate}] {r.slot_value!r} "
+            f"(bullet {r.source!r})",
+            file=out,  # type: ignore[arg-type]
+        )
+
+    return 0
+
+
 def _apply_scope_change(
     store: object,
     belief_id: str,
@@ -6103,6 +6241,36 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         help="empty the exclusion list for the active session",
     )
     p_scope_out.set_defaults(func=_cmd_scope_out)
+
+    # (#935) — cross-store dedup audit between aelfrice locked beliefs and
+    # the claude-memory MEMORY.md index. Pure read-only report; never writes
+    # to either store.
+    p_audit_cm = sub.add_parser(
+        "audit-claude-memory",
+        help=(
+            "compare locked aelfrice beliefs against the claude-memory "
+            "MEMORY.md index and report duplicates, contradictions, and "
+            "store-exclusive entries (#935)"
+        ),
+    )
+    p_audit_cm.add_argument(
+        "--project",
+        default=None,
+        metavar="PATH",
+        help=(
+            "absolute path to the project directory whose claude-memory "
+            "store to audit (default: current working directory). The "
+            "MEMORY.md path is derived from this using the same encoding "
+            "the upstream tool applies."
+        ),
+    )
+    p_audit_cm.add_argument(
+        "--json",
+        action="store_true",
+        dest="json",
+        help="emit a single JSON object instead of human-readable text",
+    )
+    p_audit_cm.set_defaults(func=_cmd_audit_claude_memory)
 
     # Read-only lens: load-bearing beliefs (locked ∪ corroborated ∪ high-posterior).
     p_core = sub.add_parser(

--- a/src/aelfrice/slash_commands/audit-claude-memory.md
+++ b/src/aelfrice/slash_commands/audit-claude-memory.md
@@ -1,0 +1,30 @@
+---
+name: aelf:audit-claude-memory
+description: Cross-store dedup audit between locked aelfrice beliefs and the claude-memory MEMORY.md index — reports duplicates, contradictions, and store-exclusive entries.
+allowed-tools:
+  - Bash
+---
+<objective>
+Compare the locked aelfrice belief store against the claude-memory
+MEMORY.md index for the current project and surface discrepancies.
+No writes are made to either store; this is a pure read-only audit.
+
+The report has four buckets:
+- **Potential duplicates** — same slot key and value in both stores
+- **Potential contradictions** — same slot key, different value
+- **aelfrice-only** — locked belief not present in claude-memory
+- **claude-memory-only** — bullet not present in aelfrice
+</objective>
+
+<process>
+Run: `uv run aelf audit-claude-memory`
+
+Optionally:
+- `uv run aelf audit-claude-memory --project /abs/path/to/project` to audit
+  a specific project directory (default: current working directory).
+- `uv run aelf audit-claude-memory --json` for a single machine-readable
+  JSON object.
+
+Display the output verbatim. Do not add commentary or act on the report
+unless the user explicitly asks for a follow-up action.
+</process>

--- a/tests/test_claude_memory.py
+++ b/tests/test_claude_memory.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from aelfrice.claude_memory import (
     ComparisonResult,
     MemoryBullet,

--- a/tests/test_claude_memory.py
+++ b/tests/test_claude_memory.py
@@ -1,0 +1,367 @@
+"""Unit tests for the claude_memory module — parser and slot-equality (#935).
+
+All fixtures are synthetic.  No real ~/.claude/ content is referenced.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aelfrice.claude_memory import (
+    ComparisonResult,
+    MemoryBullet,
+    SlotRow,
+    compare_slots,
+    derive_memory_dir,
+    extract_slot,
+    parse_memory_bullets,
+    slot_row_from_belief,
+    slot_row_from_bullet,
+)
+
+
+# ---------------------------------------------------------------------------
+# derive_memory_dir
+# ---------------------------------------------------------------------------
+
+
+def test_derive_memory_dir_basic() -> None:
+    result = derive_memory_dir("/projects/myapp")
+    home = Path.home()
+    expected = home / ".claude" / "projects" / "-projects-myapp" / "memory"
+    assert result == expected
+
+
+def test_derive_memory_dir_deep_path() -> None:
+    result = derive_memory_dir("/a/b/c")
+    home = Path.home()
+    expected = home / ".claude" / "projects" / "-a-b-c" / "memory"
+    assert result == expected
+
+
+def test_derive_memory_dir_single_segment() -> None:
+    result = derive_memory_dir("/workspace")
+    home = Path.home()
+    expected = home / ".claude" / "projects" / "-workspace" / "memory"
+    assert result == expected
+
+
+def test_derive_memory_dir_accepts_path_object() -> None:
+    result = derive_memory_dir(Path("/projects/myapp"))
+    home = Path.home()
+    expected = home / ".claude" / "projects" / "-projects-myapp" / "memory"
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# parse_memory_bullets — synthetic content only
+# ---------------------------------------------------------------------------
+
+_SYNTHETIC_MEMORY_MD = """\
+# Memory
+
+Some introductory text that is not a bullet.
+
+- [Fake topic](fake_topic.md) — synthetic memory line about topic A
+- [Another topic](another.md) — another synthetic bullet
+- [No description](no_desc.md)
+- plain line without list marker
+- [Missing close paren](broken.md — not a bullet
+
+## Section heading
+
+- [Final item](final.md) — last synthetic bullet
+"""
+
+
+def test_parse_memory_bullets_count() -> None:
+    bullets = parse_memory_bullets(_SYNTHETIC_MEMORY_MD, source_path="MEMORY.md")
+    # Three correctly-formed bullets: Fake topic, Another topic, No description, Final item
+    assert len(bullets) == 4
+
+
+def test_parse_memory_bullets_link_text() -> None:
+    bullets = parse_memory_bullets(_SYNTHETIC_MEMORY_MD)
+    texts = [b.link_text for b in bullets]
+    assert "Fake topic" in texts
+    assert "Another topic" in texts
+    assert "No description" in texts
+    assert "Final item" in texts
+
+
+def test_parse_memory_bullets_description_present() -> None:
+    bullets = parse_memory_bullets(_SYNTHETIC_MEMORY_MD)
+    fake = next(b for b in bullets if b.link_text == "Fake topic")
+    assert fake.description == "synthetic memory line about topic A"
+
+
+def test_parse_memory_bullets_description_absent() -> None:
+    bullets = parse_memory_bullets(_SYNTHETIC_MEMORY_MD)
+    no_desc = next(b for b in bullets if b.link_text == "No description")
+    assert no_desc.description == ""
+
+
+def test_parse_memory_bullets_source_path_propagated() -> None:
+    bullets = parse_memory_bullets("- [X](x.md) — desc\n", source_path="/path/MEMORY.md")
+    assert bullets[0].source_path == "/path/MEMORY.md"
+
+
+def test_parse_memory_bullets_empty_content() -> None:
+    assert parse_memory_bullets("") == []
+
+
+def test_parse_memory_bullets_no_bullets() -> None:
+    assert parse_memory_bullets("# Heading\n\nSome text.") == []
+
+
+def test_parse_memory_bullets_single_line() -> None:
+    line = "- [Widget cache](widget_cache.md) — cache invalidation policy"
+    bullets = parse_memory_bullets(line)
+    assert len(bullets) == 1
+    assert bullets[0].link_text == "Widget cache"
+    assert bullets[0].description == "cache invalidation policy"
+
+
+def test_parse_memory_bullets_returns_namedtuples() -> None:
+    bullets = parse_memory_bullets("- [X](x.md) — text\n")
+    assert isinstance(bullets[0], MemoryBullet)
+
+
+# ---------------------------------------------------------------------------
+# extract_slot
+# ---------------------------------------------------------------------------
+
+
+def test_extract_slot_simple_two_word() -> None:
+    # Regex may capture a one- or two-word subject depending on the input.
+    # "Database schema uses normalised form" → subject="Database schema",
+    # predicate="uses", value="normalised form".
+    result = extract_slot("Database schema uses normalised form")
+    assert result is not None
+    subject, predicate, value = result
+    assert "Database" in subject
+    assert predicate in ("schema", "uses")
+    assert value  # something captured after the predicate
+
+
+def test_extract_slot_three_word_subject() -> None:
+    # Two-word subject + predicate
+    result = extract_slot("Widget cache policy stores LRU entries")
+    assert result is not None
+    # Subject gets at most two tokens; predicate is the next token
+    subject, predicate, value = result
+    assert "Widget" in subject
+
+
+def test_extract_slot_single_word_returns_none() -> None:
+    assert extract_slot("Singleword") is None
+
+
+def test_extract_slot_empty_returns_none() -> None:
+    assert extract_slot("") is None
+
+
+def test_extract_slot_whitespace_only_returns_none() -> None:
+    assert extract_slot("   ") is None
+
+
+def test_extract_slot_returns_tuple_of_three() -> None:
+    result = extract_slot("Foo bar baz")
+    assert result is not None
+    assert len(result) == 3
+
+
+def test_extract_slot_value_may_be_empty() -> None:
+    # Exactly two tokens: subject and predicate only, no value
+    result = extract_slot("Auth disabled")
+    assert result is not None
+    subject, predicate, value = result
+    assert subject == "Auth"
+    assert predicate == "disabled"
+    assert value == ""
+
+
+# ---------------------------------------------------------------------------
+# slot_row_from_belief
+# ---------------------------------------------------------------------------
+
+
+def test_slot_row_from_belief_success() -> None:
+    row = slot_row_from_belief("abc123", "Cache policy uses LRU", "/data/aelf.db")
+    assert row is not None
+    assert isinstance(row, SlotRow)
+    assert row.source == "abc123"
+    assert row.source_path == "/data/aelf.db"
+    assert row.raw_text == "Cache policy uses LRU"
+
+
+def test_slot_row_from_belief_no_slot_returns_none() -> None:
+    assert slot_row_from_belief("abc123", "singleword", "/data/aelf.db") is None
+
+
+# ---------------------------------------------------------------------------
+# slot_row_from_bullet
+# ---------------------------------------------------------------------------
+
+
+def test_slot_row_from_bullet_uses_description() -> None:
+    bullet = MemoryBullet(
+        link_text="Fake topic",
+        link_target="fake.md",
+        description="Auth token expires after 24 hours",
+        source_path="MEMORY.md",
+    )
+    row = slot_row_from_bullet(bullet)
+    assert row is not None
+    assert row.raw_text == "Auth token expires after 24 hours"
+    assert row.source == "Fake topic"
+
+
+def test_slot_row_from_bullet_falls_back_to_link_text() -> None:
+    bullet = MemoryBullet(
+        link_text="Cache policy invalidated",
+        link_target="cache.md",
+        description="",
+        source_path="MEMORY.md",
+    )
+    row = slot_row_from_bullet(bullet)
+    assert row is not None
+    assert row.raw_text == "Cache policy invalidated"
+
+
+def test_slot_row_from_bullet_unextractable_returns_none() -> None:
+    bullet = MemoryBullet(
+        link_text="x",
+        link_target="x.md",
+        description="singleword",
+        source_path="MEMORY.md",
+    )
+    assert slot_row_from_bullet(bullet) is None
+
+
+# ---------------------------------------------------------------------------
+# compare_slots — four-bucket logic
+# ---------------------------------------------------------------------------
+
+
+def _make_slot(
+    subject: str,
+    predicate: str,
+    value: str,
+    source: str = "src",
+    source_path: str = "path",
+) -> SlotRow:
+    return SlotRow(
+        slot_subject=subject,
+        slot_predicate=predicate,
+        slot_value=value,
+        raw_text=f"{subject} {predicate} {value}",
+        source=source,
+        source_path=source_path,
+    )
+
+
+def test_compare_slots_empty_inputs() -> None:
+    result = compare_slots([], [])
+    assert isinstance(result, ComparisonResult)
+    assert result.duplicates == []
+    assert result.contradictions == []
+    assert result.aelfrice_only == []
+    assert result.claude_only == []
+
+
+def test_compare_slots_duplicate() -> None:
+    arow = _make_slot("Auth", "token", "lasts 24 hours", source="belief-1")
+    crow = _make_slot("Auth", "token", "lasts 24 hours", source="Fake bullet")
+    result = compare_slots([arow], [crow])
+    assert len(result.duplicates) == 1
+    assert result.contradictions == []
+    assert result.aelfrice_only == []
+    assert result.claude_only == []
+    a, c = result.duplicates[0]
+    assert a.source == "belief-1"
+    assert c.source == "Fake bullet"
+
+
+def test_compare_slots_contradiction() -> None:
+    arow = _make_slot("Auth", "token", "lasts 24 hours")
+    crow = _make_slot("Auth", "token", "lasts 48 hours")
+    result = compare_slots([arow], [crow])
+    assert result.duplicates == []
+    assert len(result.contradictions) == 1
+    assert result.aelfrice_only == []
+    assert result.claude_only == []
+
+
+def test_compare_slots_aelfrice_only() -> None:
+    arow = _make_slot("DB", "schema", "normalised")
+    result = compare_slots([arow], [])
+    assert result.aelfrice_only == [arow]
+    assert result.duplicates == []
+    assert result.contradictions == []
+    assert result.claude_only == []
+
+
+def test_compare_slots_claude_only() -> None:
+    crow = _make_slot("Cache", "policy", "LRU")
+    result = compare_slots([], [crow])
+    assert result.claude_only == [crow]
+    assert result.duplicates == []
+    assert result.contradictions == []
+    assert result.aelfrice_only == []
+
+
+def test_compare_slots_case_insensitive_key_match() -> None:
+    arow = _make_slot("auth", "Token", "lasts 24 hours")
+    crow = _make_slot("Auth", "token", "lasts 24 hours")
+    result = compare_slots([arow], [crow])
+    assert len(result.duplicates) == 1
+    assert result.contradictions == []
+
+
+def test_compare_slots_case_insensitive_value_match() -> None:
+    arow = _make_slot("Auth", "token", "Lasts 24 Hours")
+    crow = _make_slot("Auth", "token", "lasts 24 hours")
+    result = compare_slots([arow], [crow])
+    assert len(result.duplicates) == 1
+
+
+def test_compare_slots_mixed_buckets() -> None:
+    a_dup = _make_slot("Auth", "token", "lasts 24 hours", source="a-dup")
+    a_cont = _make_slot("DB", "schema", "normalised", source="a-cont")
+    a_only = _make_slot("Cache", "policy", "LRU", source="a-only")
+
+    c_dup = _make_slot("Auth", "token", "lasts 24 hours", source="c-dup")
+    c_cont = _make_slot("DB", "schema", "non-normalised", source="c-cont")
+    c_only = _make_slot("Retry", "logic", "exponential backoff", source="c-only")
+
+    result = compare_slots(
+        [a_dup, a_cont, a_only],
+        [c_dup, c_cont, c_only],
+    )
+    assert len(result.duplicates) == 1
+    assert result.duplicates[0][0].source == "a-dup"
+    assert result.duplicates[0][1].source == "c-dup"
+
+    assert len(result.contradictions) == 1
+    assert result.contradictions[0][0].source == "a-cont"
+    assert result.contradictions[0][1].source == "c-cont"
+
+    assert len(result.aelfrice_only) == 1
+    assert result.aelfrice_only[0].source == "a-only"
+
+    assert len(result.claude_only) == 1
+    assert result.claude_only[0].source == "c-only"
+
+
+def test_compare_slots_empty_slot_goes_to_respective_only() -> None:
+    # Rows with empty subject/predicate are unmatched but still land in
+    # the correct bucket.
+    arow = SlotRow("", "", "value", "raw", "src", "path")
+    result = compare_slots([arow], [])
+    assert arow in result.aelfrice_only
+
+    crow = SlotRow("", "", "value", "raw", "src", "path")
+    result2 = compare_slots([], [crow])
+    assert crow in result2.claude_only

--- a/tests/test_cli_audit_claude_memory.py
+++ b/tests/test_cli_audit_claude_memory.py
@@ -26,9 +26,16 @@ from aelfrice.store import MemoryStore
 
 @pytest.fixture(autouse=True)
 def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Point AELFRICE_DB at a fresh per-test DB."""
+    """Point AELFRICE_DB at a fresh per-test DB and sandbox Path.home.
+
+    Path.home is monkeypatched so derive_memory_dir() resolves under
+    tmp_path rather than the runner's real ~/.claude/projects/ tree.
+    Without this, _make_memory_md (which calls derive_memory_dir) would
+    write into the actual user home on every test run.
+    """
     p = tmp_path / "aelf.db"
     monkeypatch.setenv("AELFRICE_DB", str(p))
+    monkeypatch.setattr("aelfrice.claude_memory.Path.home", lambda: tmp_path)
     return p
 
 

--- a/tests/test_cli_audit_claude_memory.py
+++ b/tests/test_cli_audit_claude_memory.py
@@ -1,0 +1,236 @@
+"""Integration tests for `aelf audit-claude-memory` (#935).
+
+All fixtures are synthetic.  No real ~/.claude/ content is referenced.
+Each test builds a temporary project directory, a temporary DB, and a
+synthetic MEMORY.md — none of these paths touch the real user home.
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from aelfrice.cli import main
+from aelfrice.models import BELIEF_FACTUAL, LOCK_USER, Belief
+from aelfrice.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point AELFRICE_DB at a fresh per-test DB."""
+    p = tmp_path / "aelf.db"
+    monkeypatch.setenv("AELFRICE_DB", str(p))
+    return p
+
+
+def _run(*argv: str) -> tuple[int, str]:
+    buf = io.StringIO()
+    code = main(argv=list(argv), out=buf)
+    return code, buf.getvalue()
+
+
+def _seed_locked_belief(db: Path, content: str) -> str:
+    """Insert a user-locked belief and return its id."""
+    bid = uuid.uuid4().hex
+    chash = hashlib.sha256(content.encode()).hexdigest()
+    b = Belief(
+        id=bid,
+        content=content,
+        content_hash=chash,
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_USER,
+        locked_at="2026-01-01T00:00:00Z",
+        created_at="2026-01-01T00:00:00Z",
+        last_retrieved_at=None,
+        origin="user_stated",
+    )
+    s = MemoryStore(str(db))
+    try:
+        s.insert_belief(b)
+    finally:
+        s.close()
+    return bid
+
+
+def _make_memory_md(base_dir: Path, content: str) -> Path:
+    """Write a synthetic MEMORY.md under base_dir/memory/ and return its path.
+
+    The directory hierarchy mirrors what ``derive_memory_dir`` produces when
+    called with ``base_dir`` as the project path.  We bypass the path-encoding
+    step here and write directly into a caller-controlled location, then
+    pass ``--project`` pointing at ``base_dir`` so the CLI computes the same
+    derived path.
+    """
+    from aelfrice.claude_memory import derive_memory_dir
+    mem_dir = derive_memory_dir(str(base_dir))
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    path = mem_dir / "MEMORY.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Basic invocation
+# ---------------------------------------------------------------------------
+
+
+def test_audit_exits_zero_no_memory_md(tmp_path: Path, isolated_db: Path) -> None:
+    """No MEMORY.md + empty store: exits 0, reports nothing found."""
+    code, out = _run("audit-claude-memory", "--project", str(tmp_path))
+    assert code == 0
+
+
+def test_audit_reports_memory_md_not_found(tmp_path: Path, isolated_db: Path) -> None:
+    code, out = _run("audit-claude-memory", "--project", str(tmp_path))
+    assert "MEMORY.md not found" in out
+
+
+def test_audit_help_exits_zero() -> None:
+    buf = io.StringIO()
+    with pytest.raises(SystemExit) as exc:
+        main(argv=["audit-claude-memory", "--help"], out=buf)
+    assert exc.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Duplicate bucket
+# ---------------------------------------------------------------------------
+
+_SYNTHETIC_DUP_MD = """\
+# Synthetic memory
+
+- [Fake auth topic](fake_auth.md) — Auth token expires after 24 hours
+"""
+
+
+def test_audit_duplicate_bucket(tmp_path: Path, isolated_db: Path) -> None:
+    """Belief and bullet share slot + value → appears in duplicates section."""
+    _seed_locked_belief(isolated_db, "Auth token expires after 24 hours")
+    _make_memory_md(tmp_path, _SYNTHETIC_DUP_MD)
+
+    code, out = _run("audit-claude-memory", "--project", str(tmp_path))
+    assert code == 0
+    assert "Potential duplicates" in out
+    # At least the duplicate count is non-zero.
+    assert "(0)" not in out.split("Potential duplicates")[1].split("\n")[0]
+
+
+# ---------------------------------------------------------------------------
+# Contradiction bucket
+# ---------------------------------------------------------------------------
+
+_SYNTHETIC_CONT_MD = """\
+# Synthetic memory
+
+- [Fake auth topic](fake_auth.md) — Auth token expires after 48 hours
+"""
+
+
+def test_audit_contradiction_bucket(tmp_path: Path, isolated_db: Path) -> None:
+    """Same slot key, different values → contradiction row."""
+    _seed_locked_belief(isolated_db, "Auth token expires after 24 hours")
+    _make_memory_md(tmp_path, _SYNTHETIC_CONT_MD)
+
+    code, out = _run("audit-claude-memory", "--project", str(tmp_path))
+    assert code == 0
+    assert "Potential contradictions" in out
+
+
+# ---------------------------------------------------------------------------
+# aelfrice-only bucket
+# ---------------------------------------------------------------------------
+
+
+def test_audit_aelfrice_only_bucket(tmp_path: Path, isolated_db: Path) -> None:
+    """Locked belief with no matching bullet appears in aelfrice-only."""
+    _seed_locked_belief(isolated_db, "DB schema uses normalised form")
+    # No MEMORY.md written → no claude-memory bullets.
+    code, out = _run("audit-claude-memory", "--project", str(tmp_path))
+    assert code == 0
+    assert "aelfrice-only" in out
+
+
+# ---------------------------------------------------------------------------
+# claude-memory-only bucket
+# ---------------------------------------------------------------------------
+
+_SYNTHETIC_CLAUDE_ONLY_MD = """\
+# Synthetic memory
+
+- [Retry policy](retry.md) — Retry logic uses exponential backoff
+"""
+
+
+def test_audit_claude_only_bucket(tmp_path: Path, isolated_db: Path) -> None:
+    """Bullet with no matching belief appears in claude-memory-only."""
+    # Empty store.
+    _make_memory_md(tmp_path, _SYNTHETIC_CLAUDE_ONLY_MD)
+    code, out = _run("audit-claude-memory", "--project", str(tmp_path))
+    assert code == 0
+    assert "claude-memory-only" in out
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+_SYNTHETIC_JSON_MD = """\
+# Synthetic memory
+
+- [Fake cache](fake_cache.md) — Cache policy stores LRU entries
+"""
+
+
+def test_audit_json_valid(tmp_path: Path, isolated_db: Path) -> None:
+    """--json emits a single parseable JSON object."""
+    _seed_locked_belief(isolated_db, "Cache policy stores LRU entries")
+    _make_memory_md(tmp_path, _SYNTHETIC_JSON_MD)
+
+    code, out = _run("audit-claude-memory", "--project", str(tmp_path), "--json")
+    assert code == 0
+    obj = json.loads(out)
+    assert "duplicates" in obj
+    assert "contradictions" in obj
+    assert "aelfrice_only" in obj
+    assert "claude_only" in obj
+    assert "memory_md" in obj
+    assert "project_path" in obj
+
+
+def test_audit_json_memory_md_found_flag(tmp_path: Path, isolated_db: Path) -> None:
+    """memory_md_found is True when the file exists, False when absent."""
+    code, out = _run("audit-claude-memory", "--project", str(tmp_path), "--json")
+    assert code == 0
+    obj = json.loads(out)
+    assert obj["memory_md_found"] is False
+
+    _make_memory_md(tmp_path, "- [X](x.md) — Fake entry here\n")
+    code2, out2 = _run("audit-claude-memory", "--project", str(tmp_path), "--json")
+    obj2 = json.loads(out2)
+    assert obj2["memory_md_found"] is True
+
+
+def test_audit_json_duplicate_shape(tmp_path: Path, isolated_db: Path) -> None:
+    """Each duplicate entry has aelfrice and claude sub-objects."""
+    _seed_locked_belief(isolated_db, "Auth token expires after 24 hours")
+    _make_memory_md(tmp_path, _SYNTHETIC_DUP_MD)
+
+    code, out = _run("audit-claude-memory", "--project", str(tmp_path), "--json")
+    obj = json.loads(out)
+    if obj["duplicates"]:
+        dup = obj["duplicates"][0]
+        assert "aelfrice" in dup
+        assert "claude" in dup
+        assert "slot_subject" in dup["aelfrice"]
+        assert "slot_value" in dup["aelfrice"]

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -79,6 +79,9 @@ EXPECTED_COMMANDS = (
     # checkbox file of the oldest-unconfirmed beliefs and applies
     # verdicts (keep/remove/lock) from it.
     "review",
+    # (#935) — cross-store dedup audit between locked aelfrice beliefs and
+    # the claude-memory MEMORY.md index. Pure read-only report.
+    "audit-claude-memory",
 )
 
 


### PR DESCRIPTION
Closes #935.

## What

New CLI subcommand `aelf audit-claude-memory` plus a `src/aelfrice/claude_memory.py` module that compares locked aelfrice beliefs against the upstream auto-memory store at `~/.claude/projects/<encoded>/memory/MEMORY.md` and emits a four-bucket report.

```
aelf audit-claude-memory [--project PATH] [--json]
```

Buckets: `duplicates` (same slot + same value in both stores), `contradictions` (same slot, different value), `aelfrice_only`, `claude_only`. Pure read-only — never writes to either store, never auto-promotes / auto-locks.

## Why

#935 calls out the gap: the upstream auto-memory and aelfrice both store assertions, with no surface to compare them. Slot-equality is the deterministic primitive (#605 PHILOSOPHY) that lets us flag potential dupes / contradictions without dragging in embeddings.

## Surface choice

The issue body offered either an `aelf scope-out --vs-claude-memory` extension or a new `aelf audit-claude-memory` subcommand. Picked the new subcommand: `scope-out` is session-exclusion semantics (substring filter on retrieval), which is structurally different from a cross-store audit reporter. Cleaner separation; argparse help is also clearer.

## Files

- `src/aelfrice/claude_memory.py` (new) — parser (`parse_memory_bullets`), path derivation (`derive_memory_dir`), slot extractor (`extract_slot` + `SlotRow`), four-bucket comparison (`compare_slots` → `ComparisonResult`). Conservative regex slot-extraction — rows that don't tokenise cleanly land in the `*_only` bucket rather than being fuzzed.
- `src/aelfrice/cli.py` — `_cmd_audit_claude_memory` handler, subparser registration, store helper for locked-belief enumeration.
- `src/aelfrice/store.py` — small helper for locked-belief iteration (consumed by the audit command).
- `src/aelfrice/slash_commands/audit-claude-memory.md` — slash file mirroring the `scope-out.md` pattern.
- `tests/test_claude_memory.py` (34 unit tests) and `tests/test_cli_audit_claude_memory.py` (15 integration tests). All synthetic fixtures — no real `~/.claude/` content (locked discretion rule).
- `tests/test_slash_commands.py` — `EXPECTED_COMMANDS` updated.

## Verification

- `uv run pytest` — 4954 passed, 68 skipped, 75 xfailed, 0 failed.
- `uv run aelf audit-claude-memory --help` surfaces correctly.
- Smoke-tested against synthetic project dir + synthetic MEMORY.md; four buckets correct.
- Discretion grep on diff vs main: clean.
- Both commits signed (rrs SSH key), FF on current main.

## Sibling primitive for #938

`extract_slot` / `compare_slots` in `claude_memory.py` are the same primitive #938 (`aelf:search` `[!]` contradiction-flag column) wants. Importable without coupling to this subcommand's CLI surface.

## Summary by Sourcery

Add a new CLI subcommand and supporting module to audit locked aelfrice beliefs against Claude's auto-memory store and report cross-store duplicates, contradictions, and store-exclusive entries.

New Features:
- Introduce the `aelf audit-claude-memory` CLI subcommand to compare locked aelfrice beliefs with the upstream claude-memory `MEMORY.md` index and emit a four-bucket audit report.
- Add the `aelfrice.claude_memory` module for parsing claude MEMORY.md bullets, deriving project-specific memory paths, extracting deterministic slots, and classifying cross-store matches.
- Expose a slash command `aelf:audit-claude-memory` describing how to run the audit and interpret its four output buckets.

Enhancements:
- Extend the CLI parser configuration to register the new audit subcommand with human-readable and JSON output modes.
- Add a helper on the store for iterating locked beliefs used by the audit workflow.

Tests:
- Add unit tests for claude-memory parsing, slot extraction, and four-bucket comparison logic using synthetic fixtures.
- Add integration tests for the `aelf audit-claude-memory` CLI, covering text and JSON output, bucket classification, and absence/presence of MEMORY.md.
- Update slash command tests to include the new `audit-claude-memory` command.