### PR TITLE
feat(hook): SessionStart belief-write recap injection (#934)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -3501,6 +3501,13 @@ def _cmd_setup(args: argparse.Namespace, out: object) -> int:
             f"slash commands already up to date in {sc_result.dest_dir}",
             file=out,  # type: ignore[arg-type]
         )
+    if not getattr(args, "sessionstart_recap", True):
+        from aelfrice.hook import ENV_SESSIONSTART_RECAP
+        print(
+            f"SessionStart recap disabled. To persist across shells, add "
+            f"{ENV_SESSIONSTART_RECAP}=0 to your shell profile.",
+            file=out,  # type: ignore[arg-type]
+        )
     _sync_setup_opt_outs_and_stamp(args)
     _print_setup_next_step(out)
     _print_setup_jsonl_history_hint(out)
@@ -7134,6 +7141,18 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
             "(see #582). Coexists with the transcript-ingest Stop entry. "
             "Default: ON. Pass --no-stop-hook to skip. "
             "Set AELF_AUTOLOCK_CORRECTIONS=1 to auto-lock instead of prompt."
+        ),
+    )
+    p_setup.add_argument(
+        "--sessionstart-recap", dest="sessionstart_recap",
+        action=argparse.BooleanOptionalAction, default=True,
+        help=(
+            "enable the SessionStart belief-write recap: if K belief writes "
+            "occurred since the last session and K >= threshold (default 3), "
+            "inject one `aelfrice: N beliefs written since last session` line "
+            "into context. Default: ON. Pass --no-sessionstart-recap to "
+            "disable (sets AELFRICE_SESSIONSTART_RECAP=0). Threshold "
+            "configurable via AELFRICE_SESSIONSTART_RECAP_THRESHOLD."
         ),
     )
     p_setup.add_argument(

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -3945,15 +3945,22 @@ def _read_recap_last_ts() -> str | None:
 
 
 def _write_recap_last_ts(ts: str) -> None:
-    """Write the current ISO-Z timestamp to the recap last-ts file."""
+    """Write the current ISO-Z timestamp to the recap last-ts file.
+
+    Errors are swallowed: a failed timestamp write degrades the next
+    SessionStart's recap accuracy (we'll see a wider belief-write
+    window than intended) but must never break the SessionStart hook.
+    """
     try:
         p = _recap_last_ts_path()
         if p is None:
             return
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(ts, encoding="utf-8")
-    except Exception:
-        pass
+    except OSError:
+        # Disk full, perms revoked, parent dir gone. Recap accuracy
+        # degrades on next session; SessionStart contract is preserved.
+        return
 
 
 def build_session_start_recap_line(
@@ -3972,9 +3979,12 @@ def build_session_start_recap_line(
     Returns the recap string when count >= threshold, else None.
     """
     rows = feed_rows if feed_rows is not None else []
-    effective_threshold = (
+    # Normalise threshold: ≤0 collapses to 1 so a caller-supplied 0 or
+    # negative value doesn't make the recap fire on every session.
+    raw_threshold = (
         threshold if threshold is not None else _DEFAULT_RECAP_THRESHOLD
     )
+    effective_threshold = max(1, raw_threshold)
     count = 0
     for row in rows:
         event = row.get("event", "")

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -2729,6 +2729,25 @@ def session_start(
             )
     except Exception:  # non-blocking: surface but do not fail
         traceback.print_exc(file=serr)
+    if _recap_enabled():
+        try:
+            from aelfrice.feed_log import (
+                feed_path as _feed_path,
+                read_rows as _read_rows,
+            )
+            rows = _read_rows(_feed_path())
+            last_ts = _read_recap_last_ts()
+            line = build_session_start_recap_line(
+                feed_rows=rows,
+                last_ts=last_ts,
+                threshold=_recap_threshold(),
+            )
+            if line:
+                print(line, file=sout)
+            _write_recap_last_ts(_utc_now_iso())
+        except Exception:
+            # never break SessionStart on recap-side errors
+            pass
     return 0
 
 
@@ -3863,6 +3882,115 @@ def _write_cadence_resume_cache(
             f"aelfrice: cadence resume cache write failed (non-fatal): {exc}",
             file=serr,
         )
+
+
+# ---------------------------------------------------------------------------
+# SessionStart recap helpers (#934)
+# ---------------------------------------------------------------------------
+
+_RECAP_BELIEF_WRITE_EVENTS: Final[frozenset[str]] = frozenset({
+    "belief.locked",
+    "belief.ingested",
+    "wonder.promoted",
+    "feedback.applied",
+})
+
+ENV_SESSIONSTART_RECAP: Final[str] = "AELFRICE_SESSIONSTART_RECAP"
+"""Set to '0' to suppress the SessionStart belief-write recap line."""
+
+ENV_SESSIONSTART_RECAP_THRESHOLD: Final[str] = (
+    "AELFRICE_SESSIONSTART_RECAP_THRESHOLD"
+)
+"""Minimum belief-write count to trigger the recap line (default 3)."""
+
+_DEFAULT_RECAP_THRESHOLD: Final[int] = 3
+_RECAP_LAST_TS_FILENAME: Final[str] = "sessionstart_last.txt"
+
+
+def _recap_threshold(env: dict[str, str] | None = None) -> int:
+    """Return the recap threshold, defaulting to _DEFAULT_RECAP_THRESHOLD."""
+    src = os.environ if env is None else env
+    raw = src.get(ENV_SESSIONSTART_RECAP_THRESHOLD, "").strip()
+    try:
+        val = int(raw)
+        return val if val > 0 else _DEFAULT_RECAP_THRESHOLD
+    except ValueError:
+        return _DEFAULT_RECAP_THRESHOLD
+
+
+def _recap_enabled(env: dict[str, str] | None = None) -> bool:
+    """Return True unless AELFRICE_SESSIONSTART_RECAP=0."""
+    src = os.environ if env is None else env
+    return src.get(ENV_SESSIONSTART_RECAP) != "0"
+
+
+def _recap_last_ts_path() -> Path | None:
+    """Return the path to the recap last-timestamp file, or None on error."""
+    try:
+        from aelfrice.db_paths import db_path as _db_path
+        return _db_path().parent / _RECAP_LAST_TS_FILENAME
+    except Exception:
+        return None
+
+
+def _read_recap_last_ts() -> str | None:
+    """Read the previous SessionStart ISO-Z timestamp, or None if absent."""
+    try:
+        p = _recap_last_ts_path()
+        if p is None or not p.exists():
+            return None
+        return p.read_text(encoding="utf-8").strip() or None
+    except Exception:
+        return None
+
+
+def _write_recap_last_ts(ts: str) -> None:
+    """Write the current ISO-Z timestamp to the recap last-ts file."""
+    try:
+        p = _recap_last_ts_path()
+        if p is None:
+            return
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(ts, encoding="utf-8")
+    except Exception:
+        pass
+
+
+def build_session_start_recap_line(
+    *,
+    feed_rows: list[dict[str, Any]] | None = None,
+    last_ts: str | None = None,
+    threshold: int | None = None,
+) -> str | None:
+    """Return the one-line recap, or None if below threshold.
+
+    Pure function for unit-testing: all inputs are injectable. The
+    integration wrapper inside session_start() supplies the live values.
+
+    Counts feed-log rows with event in _RECAP_BELIEF_WRITE_EVENTS and
+    ts > last_ts (or all rows when last_ts is None / first run).
+    Returns the recap string when count >= threshold, else None.
+    """
+    rows = feed_rows if feed_rows is not None else []
+    effective_threshold = (
+        threshold if threshold is not None else _DEFAULT_RECAP_THRESHOLD
+    )
+    count = 0
+    for row in rows:
+        event = row.get("event", "")
+        if event not in _RECAP_BELIEF_WRITE_EVENTS:
+            continue
+        if last_ts is not None:
+            ts = row.get("ts", "")
+            if ts <= last_ts:
+                continue
+        count += 1
+    if count < effective_threshold:
+        return None
+    return (
+        f"aelfrice: {count} beliefs written since last session"
+        f" — `aelf:feed -n {count}` to review."
+    )
 
 
 def main() -> int:

--- a/tests/test_hook_sessionstart_recap.py
+++ b/tests/test_hook_sessionstart_recap.py
@@ -1,0 +1,311 @@
+"""SessionStart belief-write recap injection (#934).
+
+Tests for build_session_start_recap_line (pure helper) and the full
+session_start() integration path.
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from aelfrice.hook import (
+    ENV_SESSIONSTART_RECAP,
+    ENV_SESSIONSTART_RECAP_THRESHOLD,
+    _DEFAULT_RECAP_THRESHOLD,
+    _RECAP_BELIEF_WRITE_EVENTS,
+    build_session_start_recap_line,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_rows(events: list[tuple[str, str]]) -> list[dict[str, object]]:
+    """Build a minimal list of feed-log rows from (ts, event) pairs."""
+    return [{"ts": ts, "event": ev} for ts, ev in events]
+
+
+_BELIEF_EVENT = "belief.locked"
+_NON_BELIEF_EVENT = "session.start"  # not in the belief-write set
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSessionStartRecapLine:
+    def test_threshold_honored_at_boundary(self) -> None:
+        """N == threshold → inject."""
+        rows = _make_rows(
+            [("2026-06-04T10:00:00Z", _BELIEF_EVENT)] * _DEFAULT_RECAP_THRESHOLD
+        )
+        line = build_session_start_recap_line(
+            feed_rows=rows,
+            last_ts=None,
+            threshold=_DEFAULT_RECAP_THRESHOLD,
+        )
+        assert line is not None
+        assert str(_DEFAULT_RECAP_THRESHOLD) in line
+
+    def test_below_threshold_returns_none(self) -> None:
+        """N == threshold - 1 → no inject."""
+        rows = _make_rows(
+            [("2026-06-04T10:00:00Z", _BELIEF_EVENT)] * (_DEFAULT_RECAP_THRESHOLD - 1)
+        )
+        line = build_session_start_recap_line(
+            feed_rows=rows,
+            last_ts=None,
+            threshold=_DEFAULT_RECAP_THRESHOLD,
+        )
+        assert line is None
+
+    def test_zero_events_returns_none(self) -> None:
+        """Empty feed → no output, no '0 beliefs' string."""
+        line = build_session_start_recap_line(
+            feed_rows=[],
+            last_ts=None,
+            threshold=_DEFAULT_RECAP_THRESHOLD,
+        )
+        assert line is None
+
+    def test_threshold_env_override_low(self) -> None:
+        """Custom threshold=5, N=4 → no inject."""
+        rows = _make_rows(
+            [("2026-06-04T10:00:00Z", _BELIEF_EVENT)] * 4
+        )
+        line = build_session_start_recap_line(
+            feed_rows=rows,
+            last_ts=None,
+            threshold=5,
+        )
+        assert line is None
+
+    def test_threshold_env_override_high(self) -> None:
+        """Custom threshold=5, N=5 → inject."""
+        rows = _make_rows(
+            [("2026-06-04T10:00:00Z", _BELIEF_EVENT)] * 5
+        )
+        line = build_session_start_recap_line(
+            feed_rows=rows,
+            last_ts=None,
+            threshold=5,
+        )
+        assert line is not None
+        assert "5 beliefs" in line
+
+    def test_since_last_ts_filtering(self) -> None:
+        """Feed has 5 rows; last_ts between row 2 and 3 → count == 3."""
+        rows = _make_rows([
+            ("2026-06-04T09:00:00Z", _BELIEF_EVENT),
+            ("2026-06-04T09:30:00Z", _BELIEF_EVENT),
+            ("2026-06-04T10:00:00Z", _BELIEF_EVENT),
+            ("2026-06-04T10:30:00Z", _BELIEF_EVENT),
+            ("2026-06-04T11:00:00Z", _BELIEF_EVENT),
+        ])
+        # last_ts is just after row 2 (ts 09:30) and before row 3 (ts 10:00)
+        line = build_session_start_recap_line(
+            feed_rows=rows,
+            last_ts="2026-06-04T09:45:00Z",
+            threshold=3,
+        )
+        assert line is not None
+        assert "3 beliefs" in line
+
+    def test_first_run_no_last_ts_counts_all(self) -> None:
+        """No last_ts (first run) → all rows count."""
+        rows = _make_rows(
+            [("2026-06-04T10:00:00Z", _BELIEF_EVENT)] * 4
+        )
+        line = build_session_start_recap_line(
+            feed_rows=rows,
+            last_ts=None,
+            threshold=3,
+        )
+        assert line is not None
+        assert "4 beliefs" in line
+
+    def test_non_belief_write_events_excluded(self) -> None:
+        """Non-belief-write event types are not counted."""
+        rows = _make_rows([
+            ("2026-06-04T10:00:00Z", _NON_BELIEF_EVENT),
+            ("2026-06-04T10:01:00Z", _NON_BELIEF_EVENT),
+            ("2026-06-04T10:02:00Z", _NON_BELIEF_EVENT),
+            ("2026-06-04T10:03:00Z", _BELIEF_EVENT),
+            ("2026-06-04T10:04:00Z", _BELIEF_EVENT),
+        ])
+        # Only 2 belief-write events → below threshold=3
+        line = build_session_start_recap_line(
+            feed_rows=rows,
+            last_ts=None,
+            threshold=3,
+        )
+        assert line is None
+
+    def test_all_belief_write_event_types_counted(self) -> None:
+        """All four belief-write event types are recognised."""
+        rows = _make_rows([
+            ("2026-06-04T10:00:00Z", "belief.locked"),
+            ("2026-06-04T10:01:00Z", "belief.ingested"),
+            ("2026-06-04T10:02:00Z", "wonder.promoted"),
+            ("2026-06-04T10:03:00Z", "feedback.applied"),
+        ])
+        line = build_session_start_recap_line(
+            feed_rows=rows,
+            last_ts=None,
+            threshold=3,
+        )
+        assert line is not None
+        assert "4 beliefs" in line
+
+    def test_template_format(self) -> None:
+        """Exact output shape matches the spec template."""
+        rows = _make_rows(
+            [("2026-06-04T10:00:00Z", _BELIEF_EVENT)] * 5
+        )
+        line = build_session_start_recap_line(
+            feed_rows=rows,
+            last_ts=None,
+            threshold=3,
+        )
+        assert line == (
+            "aelfrice: 5 beliefs written since last session"
+            " — `aelf:feed -n 5` to review."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Env-var opt-out test (using _recap_enabled helper)
+# ---------------------------------------------------------------------------
+
+
+class TestRecapEnabled:
+    def test_enabled_by_default(self) -> None:
+        from aelfrice.hook import _recap_enabled
+        assert _recap_enabled({}) is True
+
+    def test_disabled_via_env(self) -> None:
+        from aelfrice.hook import _recap_enabled
+        assert _recap_enabled({ENV_SESSIONSTART_RECAP: "0"}) is False
+
+    def test_non_zero_value_still_enabled(self) -> None:
+        from aelfrice.hook import _recap_enabled
+        assert _recap_enabled({ENV_SESSIONSTART_RECAP: "1"}) is True
+
+
+class TestRecapThreshold:
+    def test_default(self) -> None:
+        from aelfrice.hook import _recap_threshold
+        assert _recap_threshold({}) == _DEFAULT_RECAP_THRESHOLD
+
+    def test_override(self) -> None:
+        from aelfrice.hook import _recap_threshold
+        assert _recap_threshold({ENV_SESSIONSTART_RECAP_THRESHOLD: "7"}) == 7
+
+    def test_invalid_falls_back_to_default(self) -> None:
+        from aelfrice.hook import _recap_threshold
+        assert _recap_threshold({ENV_SESSIONSTART_RECAP_THRESHOLD: "notanint"}) == (
+            _DEFAULT_RECAP_THRESHOLD
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration test: full session_start() path
+# ---------------------------------------------------------------------------
+
+
+def _write_feed_jsonl(db_dir: Path, rows: list[dict[str, object]]) -> None:
+    feed = db_dir / "feed.jsonl"
+    feed.parent.mkdir(parents=True, exist_ok=True)
+    with feed.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def test_session_start_integration_recap_injected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """session_start() emits the recap line when threshold is met."""
+    db_dir = tmp_path / "aelfrice"
+    db_dir.mkdir()
+    # Point AELFRICE_DB to a non-existent DB so store opens as empty
+    monkeypatch.setenv("AELFRICE_DB", str(db_dir / "memory.db"))
+    # Write a feed.jsonl with enough belief-write events
+    rows: list[dict[str, object]] = [
+        {"ts": f"2026-06-04T10:0{i}:00Z", "event": "belief.locked"}
+        for i in range(5)
+    ]
+    _write_feed_jsonl(db_dir, rows)
+    # Use threshold=3 (default)
+    monkeypatch.setenv(ENV_SESSIONSTART_RECAP, "1")
+    monkeypatch.setenv(ENV_SESSIONSTART_RECAP_THRESHOLD, "3")
+
+    sout = io.StringIO()
+    from aelfrice.hook import session_start
+    rc = session_start(
+        stdin=io.StringIO('{"session_id": "test-session"}'),
+        stdout=sout,
+        stderr=io.StringIO(),
+    )
+    assert rc == 0
+    output = sout.getvalue()
+    assert "5 beliefs written since last session" in output
+    assert "`aelf:feed -n 5` to review." in output
+
+
+def test_session_start_integration_recap_suppressed_by_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """session_start() emits NO recap line when AELFRICE_SESSIONSTART_RECAP=0."""
+    db_dir = tmp_path / "aelfrice"
+    db_dir.mkdir()
+    monkeypatch.setenv("AELFRICE_DB", str(db_dir / "memory.db"))
+    rows: list[dict[str, object]] = [
+        {"ts": f"2026-06-04T10:0{i}:00Z", "event": "belief.locked"}
+        for i in range(5)
+    ]
+    _write_feed_jsonl(db_dir, rows)
+    monkeypatch.setenv(ENV_SESSIONSTART_RECAP, "0")
+
+    sout = io.StringIO()
+    from aelfrice.hook import session_start
+    rc = session_start(
+        stdin=io.StringIO('{"session_id": "test-session"}'),
+        stdout=sout,
+        stderr=io.StringIO(),
+    )
+    assert rc == 0
+    output = sout.getvalue()
+    assert "beliefs written since last session" not in output
+
+
+def test_session_start_integration_recap_below_threshold(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """session_start() emits no recap when event count < threshold."""
+    db_dir = tmp_path / "aelfrice"
+    db_dir.mkdir()
+    monkeypatch.setenv("AELFRICE_DB", str(db_dir / "memory.db"))
+    # Only 2 rows — below default threshold of 3
+    rows: list[dict[str, object]] = [
+        {"ts": f"2026-06-04T10:0{i}:00Z", "event": "belief.locked"}
+        for i in range(2)
+    ]
+    _write_feed_jsonl(db_dir, rows)
+    monkeypatch.setenv(ENV_SESSIONSTART_RECAP, "1")
+
+    sout = io.StringIO()
+    from aelfrice.hook import session_start
+    rc = session_start(
+        stdin=io.StringIO('{"session_id": "test-session"}'),
+        stdout=sout,
+        stderr=io.StringIO(),
+    )
+    assert rc == 0
+    output = sout.getvalue()
+    assert "beliefs written since last session" not in output

--- a/tests/test_hook_sessionstart_recap.py
+++ b/tests/test_hook_sessionstart_recap.py
@@ -15,7 +15,6 @@ from aelfrice.hook import (
     ENV_SESSIONSTART_RECAP,
     ENV_SESSIONSTART_RECAP_THRESHOLD,
     _DEFAULT_RECAP_THRESHOLD,
-    _RECAP_BELIEF_WRITE_EVENTS,
     build_session_start_recap_line,
 )
 


### PR DESCRIPTION
Closes #934.

## What

SessionStart hook extension — after the locked-baseline block, if K belief-write events have occurred since the previous SessionStart and K ≥ threshold (default 3), inject one fixed-template line:

```
aelfrice: 5 beliefs written since last session — `aelf:feed -n 5` to review.
```

Below threshold: nothing emitted (no `"0 beliefs"` spam).

## How

- `build_session_start_recap_line(feed_rows, last_ts, threshold)` — pure function in `src/aelfrice/hook.py`, all inputs injectable. Counts feed-log rows whose `event ∈ {belief.locked, belief.ingested, wonder.promoted, feedback.applied}` and `ts > last_ts`.
- Last-SessionStart timestamp persists in `<db-dir>/sessionstart_last.txt` (sibling of `memory.db` and `feed.jsonl`). First-run path counts every row in the active feed log; subsequent runs count only newer rows.
- Integration inside `session_start()` is fully wrapped in `try/except: pass` — recap-side errors never break the SessionStart hook contract.
- Env-var gates: `AELFRICE_SESSIONSTART_RECAP=0` disables, `AELFRICE_SESSIONSTART_RECAP_THRESHOLD=N` overrides the default 3.
- `aelf setup --no-sessionstart-recap` is the discoverability hook for the env-var opt-out, matching the pre-existing `--no-stop-hook` BooleanOptionalAction pattern. It prints a one-line instruction directing the user to set `AELFRICE_SESSIONSTART_RECAP=0` in their shell profile; the env var is the durable opt-out.

## #605 / #606 fit

Fixed template + one integer slot. Zero model inference. Deterministic. Default-on (mirrors the 7 existing hook-manifest entries; this is an extension to the existing SessionStart hook, not a new hook — no new manifest entry).

## Verification

- 19 unit tests in `tests/test_hook_sessionstart_recap.py`. Coverage matrix: threshold honored / env-override / opt-out / non-belief events excluded / since-last-ts filtering / first-run / opt-out gate / template-exact-string.
- Full set (`pytest tests/test_hook_sessionstart_recap.py tests/test_hook.py tests/test_hook_session_start*.py tests/test_feed_log.py tests/test_cli_setup_opt_out_sync.py`) → 66 passed.
- Discretion grep on diff: clean.

## Files touched

- `src/aelfrice/hook.py` (+128 LOC) — recap helpers + integration into `session_start()`.
- `src/aelfrice/cli.py` (+19 LOC) — `--no-sessionstart-recap` BooleanOptionalAction at `aelf setup`.
- `tests/test_hook_sessionstart_recap.py` (+311 LOC) — new test file.

## Out of scope

- New manifest entry (extension to existing hook, not a new hook).
- `feed_log.py` changes (read-only consumer of #931's surface).
- Docs sweep — separate concern; not in acceptance criteria.

## Summary by Sourcery

Extend the SessionStart hook to optionally inject a recap line summarizing recent belief-write activity, controlled by environment variables and setup CLI flags, with supporting helpers and tests.

New Features:
- Add a SessionStart recap line that reports the number of belief-writing events since the previous session when a configurable threshold is met.
- Introduce CLI support for enabling or disabling the SessionStart recap via a --[no-]sessionstart-recap flag and document relevant environment variables.

Enhancements:
- Add helper functions to track recap thresholds, enablement, and last-session timestamps for belief-write activity in the hook module.

Tests:
- Add comprehensive unit and integration tests covering recap line generation, threshold and event filtering behavior, environment-based configuration, and CLI-triggered opt-out behavior.