### PR TITLE
fix(scanner): skip .claude directory during onboard scan

### DIFF
--- a/src/aelfrice/scanner.py
+++ b/src/aelfrice/scanner.py
@@ -44,12 +44,15 @@ from aelfrice.store import MemoryStore
 from typing import Protocol
 
 # Directories the scanner never descends into. Standard "build artefact"
-# locations and version-control internals.
+# locations, version-control internals, and coding-agent host config
+# (.claude holds settings plus full repo copies under worktrees/ —
+# scanning it inflates candidates ~27x and pollutes provenance, #954).
 _SKIP_DIRS: Final[frozenset[str]] = frozenset({
     ".venv",
     "venv",
     "__pycache__",
     ".git",
+    ".claude",
     "node_modules",
     ".egg-info",
     "target",

--- a/tests/test_scanner_filesystem.py
+++ b/tests/test_scanner_filesystem.py
@@ -139,6 +139,17 @@ def test_dot_git_directory_is_skipped(tmp_path: Path) -> None:
     assert extract_filesystem(tmp_path) == []
 
 
+def test_dot_claude_directory_is_skipped(tmp_path: Path) -> None:
+    """Coding-agent worktree copies under .claude/ are not project content (#954)."""
+    wt = tmp_path / ".claude" / "worktrees" / "abc123"
+    wt.mkdir(parents=True)
+    (wt / "README.md").write_text(
+        "the project ships only the regex fallback at v0.5",
+        encoding="utf-8",
+    )
+    assert extract_filesystem(tmp_path) == []
+
+
 def test_node_modules_directory_is_skipped(tmp_path: Path) -> None:
     nm = tmp_path / "node_modules"
     nm.mkdir()


### PR DESCRIPTION
## Problem

`aelf onboard <repo>` descends into `.claude/`, the coding-agent host-config directory. On a repo using Claude Code worktree isolation, `.claude/worktrees/` holds many full working copies of the repo, so the scan re-extracts every doc paragraph once per copy with a distinct source path — `(text, source)` dedup cannot collapse them.

Observed on a real repo: **224,398** new candidates with the current skip set vs **8,230** with `.claude` skipped (27x inflation; `already present` count unchanged, confirming all real beliefs came from the genuine project surface). Cost impact: hours + dollars of host-side classification instead of minutes, plus #219-family near-duplicate belief inflation if accepted.

## Fix

Add `.claude` to `_SKIP_DIRS` in `src/aelfrice/scanner.py`. `.claude/` is host tool config (settings, commands, worktrees) — same category as `.git`. Both walk sites (doc walk and the second `_SKIP_DIRS` consumer) honor the same constant, so one entry covers both.

## Test

`test_dot_claude_directory_is_skipped` mirrors the real failure shape: a doc file nested under `.claude/worktrees/<id>/` must not be extracted.

## Out of scope

Generalizing to other agent-host dirs (`.cursor`, `.codex`, `.opencode`) — noted in #954 as possible follow-up.

Closes #954

## Summary by Sourcery

Exclude coding-agent configuration directories from repository scanning to avoid indexing non-project content.

Bug Fixes:
- Prevent onboard scans from traversing .claude worktree copies and re-extracting duplicate project content as new candidates.

Tests:
- Add a filesystem scanner test ensuring files under .claude/worktrees/ are ignored during extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed scanner to properly exclude `.claude` directories from documentation extraction during filesystem traversal.

* **Tests**
  * Added test to verify that files within `.claude` directories are correctly skipped from documentation candidate analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->