### PR TITLE
docs(design): fix 20 broken links after historical/ relocation

### DIFF
--- a/docs/design/V2_REENTRY_QUEUE.md
+++ b/docs/design/V2_REENTRY_QUEUE.md
@@ -35,7 +35,7 @@ Each row references its public spec memo and the GitHub issue that tracks re-ent
 
 ### Phantom promotion-trigger rule — issue #229
 
-- **Spec:** [`docs/design/historical/v2_phantom_promotion_trigger.md`](v2_phantom_promotion_trigger.md)
+- **Spec:** [`docs/design/historical/v2_phantom_promotion_trigger.md`](historical/v2_phantom_promotion_trigger.md)
 - **Disposition:** bench-gated for v2.0 ship.
 - **Gate:** ≥90% precision and ≥70% recall on the labeled corpus described in the spec's § Labeled-corpus benchmark. The rule itself is binary (`aelf:validate` typed, or content-matching `aelf:lock` typed) and has no tunable threshold; the benchmark verifies that the rule has acceptable recall against phantoms users would validate if asked, and acceptable precision against phantoms users would reject.
 - **Why bench-gated:** three naive triggers (N positive feedback, retrieval count, user_corrected adjacency) were rejected for conflating posterior movement with explicit validation, selection bias on user query distribution, and adjacency ≠ acknowledgment respectively. Without the benchmark, there is no way to verify the explicit-acknowledgment rule has acceptable recall — and a low-recall promotion path is silently equivalent to "no promotion path" for most users.
@@ -47,7 +47,7 @@ For reference. These were considered for the queue and routed elsewhere:
 
 - **Compliance audit (enforcement H2)** — [`v2_enforcement.md`](v2_enforcement.md) § H2. **Dropped, not deferred.** Removing the temptation to revisit "just port the safe predicates" prevents incremental erosion of the security stance. A future user actually needing this should propose a separate, opt-in module with an allowlist and a security review.
 - **Deduplication (#197)** — [`v2_dedup.md`](v2_dedup.md). Ships at v2.0 per spec; the spec references this queue's decision #1 only as the gate language for `aelf:dedup`-as-MCP-tool, which is itself out of scope for v2.0.
-- **Semantic contradiction detector (#201)** — [`v2_relationship_detector.md`](v2_relationship_detector.md). Ships at v2.0 per spec.
+- **Semantic contradiction detector (#201)** — [`v2_relationship_detector.md`](historical/v2_relationship_detector.md). Ships at v2.0 per spec.
 
 ## Adding a row
 

--- a/docs/design/bfs_multihop.md
+++ b/docs/design/bfs_multihop.md
@@ -408,7 +408,7 @@ the new edge will participate.
 
 This was the load-bearing reason `RetrievalCache` was specified
 with edge mutators in the invalidation set at v1.0.1 — see
-[lru_query_cache.md § Invalidation](lru_query_cache.md#invalidation).
+[lru_query_cache.md § Invalidation](historical/lru_query_cache.md#invalidation).
 The v1.0.1 spec said: "A finer-grained policy ... is a later
 optimization. v1.0.1 ships the wipe-on-write version." v1.3.0
 inherits that decision.

--- a/docs/design/feature-type-aware-compression.md
+++ b/docs/design/feature-type-aware-compression.md
@@ -9,7 +9,7 @@
 
 ## Purpose
 
-At a fixed retrieval `token_budget`, today's path either includes a belief verbatim or trims it from the tail. Per [`docs/design/historical/belief_retention_class.md`](belief_retention_class.md), beliefs vary in expected lifetime: `fact` rows describe stable codebase state; `snapshot` rows are research-thought; `transient` rows are PR-window scratch. The retrieval pack treats them identically. Type-aware compression spends fewer tokens per `snapshot` and `transient` belief so more total beliefs fit, without sacrificing fidelity on the `fact` rows that carry load.
+At a fixed retrieval `token_budget`, today's path either includes a belief verbatim or trims it from the tail. Per [`docs/design/historical/belief_retention_class.md`](historical/belief_retention_class.md), beliefs vary in expected lifetime: `fact` rows describe stable codebase state; `snapshot` rows are research-thought; `transient` rows are PR-window scratch. The retrieval pack treats them identically. Type-aware compression spends fewer tokens per `snapshot` and `transient` belief so more total beliefs fit, without sacrificing fidelity on the `fact` rows that carry load.
 
 The compressor is **structural**: deterministic, byte-stable, no LLM. The contract is "same belief input → same compressed output, byte-for-byte" — issue #434 acceptance #3 makes this explicit, and is the single line that distinguishes this from a summariser.
 

--- a/docs/design/historical/v2_derivation_worker.md
+++ b/docs/design/historical/v2_derivation_worker.md
@@ -1,6 +1,6 @@
 # v2.x spec: derivation worker — beliefs become materialized state
 
-Spec for issue [#264](https://github.com/robotrocketscience/aelfrice/issues/264). Cascade addendum to [`design/write-log-as-truth.md`](write-log-as-truth.md). The actual refactor; #261/#262/#263 are scaffolding for this.
+Spec for issue [#264](https://github.com/robotrocketscience/aelfrice/issues/264). Cascade addendum to [`design/write-log-as-truth.md`](../write-log-as-truth.md). The actual refactor; #261/#262/#263 are scaffolding for this.
 
 Status: spec, no implementation. Recommendation included; decision is the user's.
 
@@ -85,6 +85,6 @@ The four decisions above are the design work. The body the issue lists at ~400 L
 
 ## Provenance
 
-- Source-of-truth: [`docs/design/write-log-as-truth.md`](write-log-as-truth.md) §§ "What changes under the proposed contract", "Costs and risks".
+- Source-of-truth: [`docs/design/write-log-as-truth.md`](../write-log-as-truth.md) §§ "What changes under the proposed contract", "Costs and risks".
 - Upstream chain: #205 → #261 → #262 → **#264 this issue** → #265.
 - Equality contract that the worker must satisfy: [`v2_replay.md`](v2_replay.md).

--- a/docs/design/historical/v2_phantom_promotion_trigger.md
+++ b/docs/design/historical/v2_phantom_promotion_trigger.md
@@ -1,6 +1,6 @@
 # v2.0 spec: phantom promotion-trigger rule
 
-Spec for issue [#229](https://github.com/robotrocketscience/aelfrice/issues/229). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B). Companion to [`v2_wonder_consolidation.md`](v2_wonder_consolidation.md) (#228) — that issue specifies the strategy that generates phantoms; this issue specifies the rule that promotes them to `origin = user_validated`.
+Spec for issue [#229](https://github.com/robotrocketscience/aelfrice/issues/229). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B). Companion to [`v2_wonder_consolidation.md`](../v2_wonder_consolidation.md) (#228) — that issue specifies the strategy that generates phantoms; this issue specifies the rule that promotes them to `origin = user_validated`.
 
 Status: spec, no implementation. **Recommendation included** for the rule shape; threshold tuning requires the labeled-corpus benchmark below.
 
@@ -176,5 +176,5 @@ deterministic-narrow-surface approach to phantom-lock matching.
 ## Provenance
 
 Lab memory cited in issue body: `103307e54dc4ee70` (2026-04-28).
-Companion: [v2_wonder_consolidation.md](v2_wonder_consolidation.md) (#228).
+Companion: [v2_wonder_consolidation.md](../v2_wonder_consolidation.md) (#228).
 Substrate ratification: [substrate_decision.md](substrate_decision.md) (Option B). Substrate-compatible; no per-axis state involved.

--- a/docs/design/historical/v2_replay.md
+++ b/docs/design/historical/v2_replay.md
@@ -1,6 +1,6 @@
 # v2.x spec: `replay_full_equality` — flip-readiness probe
 
-Spec for issue [#262](https://github.com/robotrocketscience/aelfrice/issues/262). Cascade addendum to [`design/write-log-as-truth.md`](write-log-as-truth.md). Gates the view-flip in [`v2_view_flip.md`](v2_view_flip.md).
+Spec for issue [#262](https://github.com/robotrocketscience/aelfrice/issues/262). Cascade addendum to [`design/write-log-as-truth.md`](../write-log-as-truth.md). Gates the view-flip in [`v2_view_flip.md`](v2_view_flip.md).
 
 Status: spec, no implementation. Recommendation included; decision is the user's.
 
@@ -85,6 +85,6 @@ kinds. The schema contract lives at
 
 ## Provenance
 
-- Source-of-truth: [`docs/design/write-log-as-truth.md`](write-log-as-truth.md) §§ "What changes under the proposed contract", "Smallest first step".
+- Source-of-truth: [`docs/design/write-log-as-truth.md`](../write-log-as-truth.md) §§ "What changes under the proposed contract", "Smallest first step".
 - Substrate ratification: [`substrate_decision.md`](substrate_decision.md) (#196 Option B). Beta-Bernoulli's posterior drift behavior is what motivates shape-equality over bit-equality here.
 - Upstream chain: #205 (parallel-write phase, merged) → #261 (derivation function) → **#262 this issue** → #403 (soak gate operationalization) → #264 (worker) → #265 (view-flip).

--- a/docs/design/historical/v2_view_flip.md
+++ b/docs/design/historical/v2_view_flip.md
@@ -1,6 +1,6 @@
 # v2.x spec: view-flip — `ingest_log` becomes canonical
 
-Spec for issue [#265](https://github.com/robotrocketscience/aelfrice/issues/265). Terminal step of [`design/write-log-as-truth.md`](write-log-as-truth.md). Highest-risk issue in the chain.
+Spec for issue [#265](https://github.com/robotrocketscience/aelfrice/issues/265). Terminal step of [`design/write-log-as-truth.md`](../write-log-as-truth.md). Highest-risk issue in the chain.
 
 Status: spec, no implementation. Recommendation included; decision is the user's.
 
@@ -87,8 +87,8 @@ The chain's correctness is verified up to this point against canonical-as-author
 
 ## Provenance
 
-- Source-of-truth: [`docs/design/write-log-as-truth.md`](write-log-as-truth.md) §§ "The contract", "What changes under the proposed contract".
-- Federation cross-link: [`docs/design/federation-primitives.md`](federation-primitives.md).
+- Source-of-truth: [`docs/design/write-log-as-truth.md`](../write-log-as-truth.md) §§ "The contract", "What changes under the proposed contract".
+- Federation cross-link: [`docs/design/federation-primitives.md`](../federation-primitives.md).
 - Upstream chain: #205 → #261 → #262 → #264 → **#265 this issue**.
 - Equality contract this issue's `aelf doctor --replay` invokes: [`v2_replay.md`](v2_replay.md).
 - Worker contract this issue assumes: [`v2_derivation_worker.md`](v2_derivation_worker.md).

--- a/docs/design/v2_dedup.md
+++ b/docs/design/v2_dedup.md
@@ -1,6 +1,6 @@
 # v2.0 evaluation: dedup module
 
-Spec for issue [#197](https://github.com/robotrocketscience/aelfrice/issues/197). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B).
+Spec for issue [#197](https://github.com/robotrocketscience/aelfrice/issues/197). Substrate-cascade addendum to [`substrate_decision.md`](historical/substrate_decision.md) (#196 ratified Option B).
 
 Status: read-path shipped. `src/aelfrice/dedup.py` is wired and exposed via `aelf doctor dedup` (audit-only mode); it's also imported by `relationship_detector.py`. The write-path `SUPERSEDES` hook (collapse-on-ingest) is bench-gated behind the corpus benchmark and remains deferred per V2_REENTRY_QUEUE.
 
@@ -40,4 +40,4 @@ Three reasons:
 
 Research-line module: `agentmemory/dedup.py` (254 LOC, stdlib-only).
 Lab parity audit: `aelfrice-lab/docs/agentmemory-parity-audit-2026-04-28.md` § 2.
-Substrate ratification: [substrate_decision.md](substrate_decision.md) (Option B).
+Substrate ratification: [substrate_decision.md](historical/substrate_decision.md) (Option B).

--- a/docs/design/v2_enforcement.md
+++ b/docs/design/v2_enforcement.md
@@ -1,6 +1,6 @@
 # v2.0 evaluation: enforcement triad
 
-Spec for issue [#199](https://github.com/robotrocketscience/aelfrice/issues/199). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B).
+Spec for issue [#199](https://github.com/robotrocketscience/aelfrice/issues/199). Substrate-cascade addendum to [`substrate_decision.md`](historical/substrate_decision.md) (#196 ratified Option B).
 
 Status: H3 reframed and superseded by [#379](https://github.com/robotrocketscience/aelfrice/issues/379) (locked beliefs are the always-injected pool — see § Downstream impact below); H1 split + deferred + bench-gated ([#374](https://github.com/robotrocketscience/aelfrice/issues/374)); H2 dropped per § H2 below.
 
@@ -60,4 +60,4 @@ If a future user actually needs compliance auditing, the right path is a separat
 
 Research-line module: `agentmemory/enforcement.py` (~347-373 LOC depending on extension surface).
 Lab parity audit: `aelfrice-lab/docs/agentmemory-parity-audit-2026-04-28.md` § 14.
-Substrate ratification: [substrate_decision.md](substrate_decision.md) (Option B). Substrate-neutral; H3 scoring works on scalar `posterior_mean`.
+Substrate ratification: [substrate_decision.md](historical/substrate_decision.md) (Option B). Substrate-neutral; H3 scoring works on scalar `posterior_mean`.

--- a/docs/design/v2_multimodel.md
+++ b/docs/design/v2_multimodel.md
@@ -1,6 +1,6 @@
 # v2.0 evaluation: multi-LLM consensus module
 
-Spec for issue [#198](https://github.com/robotrocketscience/aelfrice/issues/198). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B).
+Spec for issue [#198](https://github.com/robotrocketscience/aelfrice/issues/198). Substrate-cascade addendum to [`substrate_decision.md`](historical/substrate_decision.md) (#196 ratified Option B).
 
 Status: spec, no implementation. **Recommendation: defer to v2.x with a strict evidence-gate.**
 
@@ -42,4 +42,4 @@ Five reasons:
 
 Research-line module: `agentmemory/multimodel.py` (~143-189 LOC depending on extension surface).
 Lab parity audit: `aelfrice-lab/docs/agentmemory-parity-audit-2026-04-28.md` § 5.
-Substrate ratification: [substrate_decision.md](substrate_decision.md) (Option B). Note: the substrate decision removed multimodel's strongest historical justification.
+Substrate ratification: [substrate_decision.md](historical/substrate_decision.md) (Option B). Note: the substrate decision removed multimodel's strongest historical justification.

--- a/docs/design/v2_posterior_ranking_residual.md
+++ b/docs/design/v2_posterior_ranking_residual.md
@@ -121,6 +121,6 @@ The five calls above are the queen work. Once thresholds and sequencing are sett
 - v1.3 partial spec: [`bayesian_ranking.md`](bayesian_ranking.md). This memo extends rather than replaces.
 - Pipeline contract: [#154](https://github.com/robotrocketscience/aelfrice/issues/154) defines `retrieve()` composing the three terms.
 - Re-scope comment: [#151 closing comment](https://github.com/robotrocketscience/aelfrice/issues/151#issuecomment) handed v2.0 the residual after #146 shipped the core.
-- Substrate: [`substrate_decision.md`](substrate_decision.md) — independent of this spec; either substrate option preserves the scalar `posterior_mean` interface this spec consumes.
+- Substrate: [`substrate_decision.md`](historical/substrate_decision.md) — independent of this spec; either substrate option preserves the scalar `posterior_mean` interface this spec consumes.
 - BM25F dependency: #148 (shipped). Heat-kernel dependency: #150 (not started).
-- Adjacent specs: [`v2_replay.md`](v2_replay.md), [`v2_view_flip.md`](v2_view_flip.md), [`v2_derivation_worker.md`](v2_derivation_worker.md) — all v2.x cascade addenda; this memo follows the same pattern.
+- Adjacent specs: [`v2_replay.md`](historical/v2_replay.md), [`v2_view_flip.md`](historical/v2_view_flip.md), [`v2_derivation_worker.md`](historical/v2_derivation_worker.md) — all v2.x cascade addenda; this memo follows the same pattern.

--- a/docs/design/v2_sentiment_feedback.md
+++ b/docs/design/v2_sentiment_feedback.md
@@ -1,6 +1,6 @@
 # v2.0 evaluation: sentiment-from-prose feedback
 
-Spec for issue [#193](https://github.com/robotrocketscience/aelfrice/issues/193). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B).
+Spec for issue [#193](https://github.com/robotrocketscience/aelfrice/issues/193). Substrate-cascade addendum to [`substrate_decision.md`](historical/substrate_decision.md) (#196 ratified Option B).
 
 Status: module shipped, hook integration pending. `src/aelfrice/sentiment_feedback.py` ports the research-line module (detect_sentiment, distribute, is_enabled). `aelf health` surfaces enabled/disabled state via `_sentiment_from_prose_state`. The transcript-ingest hook does not yet call `detect_sentiment` per turn — that wire-up is the open work. Recommended posture is unchanged: opt-in via `.aelfrice.toml`, off by default.
 
@@ -50,4 +50,4 @@ The privacy story is "we are now doing more with prompts you already submitted t
 
 Research-line module: `agentmemory/sentiment_feedback.py` (~174 LOC, stdlib-only).
 Lab parity audit: `aelfrice-lab/docs/agentmemory-parity-audit-2026-04-28.md` § 9.
-Substrate ratification: [substrate_decision.md](substrate_decision.md) (Option B). Substrate-neutral; this module emits scalar feedback events.
+Substrate ratification: [substrate_decision.md](historical/substrate_decision.md) (Option B). Substrate-neutral; this module emits scalar feedback events.

--- a/docs/design/v2_wonder_consolidation.md
+++ b/docs/design/v2_wonder_consolidation.md
@@ -1,6 +1,6 @@
 # v2.0 research spec: wonder-consolidation generation strategy bake-off
 
-Spec for issue [#228](https://github.com/robotrocketscience/aelfrice/issues/228). Substrate-cascade addendum to [`substrate_decision.md`](substrate_decision.md) (#196 ratified Option B). Companion to [`v2_phantom_promotion_trigger.md`](v2_phantom_promotion_trigger.md) (#229) — that issue specifies the rule applied to the phantoms this issue's strategy generates.
+Spec for issue [#228](https://github.com/robotrocketscience/aelfrice/issues/228). Substrate-cascade addendum to [`substrate_decision.md`](historical/substrate_decision.md) (#196 ratified Option B). Companion to [`v2_phantom_promotion_trigger.md`](historical/v2_phantom_promotion_trigger.md) (#229) — that issue specifies the rule applied to the phantoms this issue's strategy generates.
 
 Status: lifecycle and dispatch shipped at v2.1+. `src/aelfrice/wonder_consolidation.py` is wired; the `aelf:wonder` MCP tool and the `aelf wonder --axes` CLI verb both ship. The generation-strategy bake-off (RW / TC / STS / ensemble) below is still the open question — gated on lab pre-registration close.
 
@@ -70,4 +70,4 @@ These commit the public side regardless of campaign outcome:
 
 Lab pre-registration: `aelfrice-lab/experiments/wonder-consolidation/HYPOTHESES.md` (2026-04-28).
 Lab beliefs cited in the issue body: `c7202e80`, `85951e1d`, `2677f4f2`, `0ebc73d68a`.
-Substrate ratification: [substrate_decision.md](substrate_decision.md) (Option B). Substrate-compatible; `α ≥ 12` promotion threshold uses scalar form.
+Substrate ratification: [substrate_decision.md](historical/substrate_decision.md) (Option B). Substrate-compatible; `α ≥ 12` promotion threshold uses scalar form.

--- a/docs/design/v3_multimodel_scope.md
+++ b/docs/design/v3_multimodel_scope.md
@@ -53,7 +53,7 @@ Multi-provider voting on a single prompt is a narrower mechanism than research-a
 ## Refs
 
 - [`v2_multimodel.md`](v2_multimodel.md) — predecessor deferral memo (five reasons reaffirmed)
-- [`substrate_decision.md`](substrate_decision.md) — Option B ratified; removes multimodel's strongest historical justification (per-aspect classification)
+- [`substrate_decision.md`](historical/substrate_decision.md) — Option B ratified; removes multimodel's strongest historical justification (per-aspect classification)
 - [`v3_relatedness_philosophy.md`](v3_relatedness_philosophy.md) — sibling v3 design-cut memo; same determinism-property posture
 - [`PHILOSOPHY.md`](../concepts/PHILOSOPHY.md) § *Determinism is the property*
 - [`PRIVACY.md`](../user/PRIVACY.md) § *Optional outbound*


### PR DESCRIPTION
## Problem

The 2026-06-08 link-check run (#953) found 20 broken relative links across `docs/design/`. Root cause: 096b01c3 relocated 12 shipped specs into `docs/design/historical/` without updating inbound links.

## Fix

Repointed 29 link occurrences across 14 files (several files repeat the same broken link, so 20 unique error lines → 29 rewrites):

- References **into** the moved set (`substrate_decision.md`, `lru_query_cache.md`, `belief_retention_class.md`, `v2_derivation_worker.md`, `v2_replay.md`, `v2_view_flip.md`, `v2_phantom_promotion_trigger.md`, `v2_relationship_detector.md`) gain the `historical/` prefix.
- References **from inside** `historical/` back to still-live specs (`write-log-as-truth.md`, `federation-primitives.md`, `v2_wonder_consolidation.md`) gain `../`.

## Verification

- Offline rescan of every relative `.md` link under `docs/`: 0 broken (the only remaining miss is `docs/adr/template.md` → `NNNN-other.md`, a placeholder inside a code fence that lychee does not parse — absent from the #953 error list).
- The `#invalidation` anchor referenced from `bfs_multihop.md` exists in `historical/lru_query_cache.md` (`### Invalidation`).

Closes #953

## Summary by Sourcery

Documentation:
- Update design documentation links to point to relocated historical specs and correct cross-references between historical and active design memos.