### PR TITLE
fix(ingest): INEDIBLE marker propagates to ingest-transcript paths

### DIFF
--- a/src/aelfrice/inedible.py
+++ b/src/aelfrice/inedible.py
@@ -19,11 +19,12 @@ Marker policy:
   reflexively.
 - Anywhere in the basename. `INEDIBLE_secrets.md`,
   `notes_INEDIBLE.txt`, and `partINEDIBLEpart.py` all match.
-- Basename only. A directory named `INEDIBLE/` does not propagate to
-  files underneath; users who want directory-scoped exclusion should
-  rename the directory itself (which then matches via its basename
-  during the walk) or use `.gitignore`-style patterns (deferred to a
-  future feature).
+- `is_inedible` inspects the basename only. The walkers that need
+  directory-scoped exclusion (the `ingest_jsonl` transcript paths,
+  which glob a tree rather than recursing entry-by-entry) call
+  `is_inedible_path`, which also inspects ancestor directory names so
+  a file beneath an `INEDIBLE/` directory is excluded — matching
+  `scan_repo`, which prunes such directories during its walk.
 
 The marker string and predicate are deliberately tiny and side-effect
 free so they're cheap to call on every file the walkers visit.
@@ -43,3 +44,35 @@ def is_inedible(path: Path | str) -> bool:
     Path() so callers don't have to normalise.
     """
     return INEDIBLE_MARKER in Path(path).name
+
+
+def is_inedible_path(path: Path | str, *, root: Path | str | None = None) -> bool:
+    """Return True iff `path`'s basename OR any ancestor directory name
+    carries the INEDIBLE marker.
+
+    `is_inedible` checks the basename only, which is correct for
+    `scan_repo` (it prunes INEDIBLE-named directories entry-by-entry, so
+    a file beneath one is never reached). The `ingest_jsonl` transcript
+    paths glob a whole tree instead of recursing, so they would descend
+    into an INEDIBLE-named directory unless the ancestor names are
+    inspected too. This helper closes that gap (issue #958).
+
+    `root`, when given, bounds the ancestor check to the directory
+    components strictly between `root` and the file — the root's own
+    name is not inspected, matching `scan_repo`, which pushes its walk
+    root unconditionally. Use it for the batch path. With `root=None`
+    (the single-file path, which has no walk root) every ancestor up to
+    the filesystem root is inspected.
+    """
+    p = Path(path)
+    if INEDIBLE_MARKER in p.name:
+        return True
+    if root is not None:
+        try:
+            ancestor_names = p.relative_to(Path(root)).parts[:-1]
+        except ValueError:
+            # `path` is not under `root`; fall back to the full walk.
+            ancestor_names = tuple(parent.name for parent in p.parents)
+    else:
+        ancestor_names = tuple(parent.name for parent in p.parents)
+    return any(INEDIBLE_MARKER in name for name in ancestor_names)

--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -409,7 +409,7 @@ def ingest_jsonl(
     snapshots, tool-result entries, malformed) are counted under
     `skipped_lines` and ignored without raising.
     """
-    from aelfrice.inedible import is_inedible
+    from aelfrice.inedible import is_inedible_path
 
     path = Path(jsonl_path)
     lines_read = 0
@@ -422,9 +422,10 @@ def ingest_jsonl(
 
     if not path.is_file():
         return IngestJsonlResult(0, 0, 0, 0, 0)
-    if is_inedible(path):
-        # Privacy opt-out — file is excluded from the brain graph by
-        # name. No content read, zero side effects on the store.
+    if is_inedible_path(path):
+        # Privacy opt-out — file (or an ancestor directory) carries the
+        # INEDIBLE marker, so it is excluded from the brain graph by
+        # name. No content read, zero side effects on the store (#958).
         return IngestJsonlResult(0, 0, 0, 0, 0)
 
     with path.open("r", encoding="utf-8") as f:
@@ -540,7 +541,7 @@ def ingest_jsonl_dir(
     `ingest_jsonl`'s per-line dedup. Skips files that do not exist
     or cannot be stat'd without raising. Issue #115.
     """
-    from aelfrice.inedible import is_inedible
+    from aelfrice.inedible import is_inedible_path
 
     root = Path(directory)
     if not root.is_dir():
@@ -559,7 +560,7 @@ def ingest_jsonl_dir(
         if not path.is_file():
             continue
         walked += 1
-        if is_inedible(path):
+        if is_inedible_path(path, root=root):
             skipped_inedible += 1
             continue
         if cutoff_ts is not None:

--- a/tests/test_inedible_filter.py
+++ b/tests/test_inedible_filter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from aelfrice.inedible import INEDIBLE_MARKER, is_inedible
+from aelfrice.inedible import INEDIBLE_MARKER, is_inedible, is_inedible_path
 from aelfrice.ingest import ingest_jsonl, ingest_jsonl_dir
 from aelfrice.scanner import scan_repo
 from aelfrice.store import MemoryStore
@@ -46,10 +46,46 @@ def test_is_inedible_does_not_match_titlecase() -> None:
 
 
 def test_is_inedible_only_inspects_basename() -> None:
-    """A directory ancestor named INEDIBLE does NOT propagate to
-    files; users want directory-scoped exclusion via gitignore-style
+    """The `is_inedible` primitive inspects the basename only — a
+    directory ancestor named INEDIBLE does NOT propagate through it.
+    Directory-scoped exclusion is `is_inedible_path`'s job (see
     patterns, deferred."""
     assert not is_inedible("/path/INEDIBLE/file.md")
+
+
+# --- is_inedible_path (directory-aware) --------------------------------
+
+
+def test_is_inedible_path_matches_basename() -> None:
+    assert is_inedible_path("/path/INEDIBLE_secrets.txt")
+
+
+def test_is_inedible_path_propagates_from_ancestor_dir() -> None:
+    """Unlike is_inedible, the path-aware helper excludes a file beneath
+    an INEDIBLE-named directory (#958)."""
+    assert is_inedible_path("/path/INEDIBLE_drafts/notes.jsonl")
+    assert is_inedible_path("/a/b/INEDIBLE/c/d/session.jsonl")
+
+
+def test_is_inedible_path_clean_path_is_not_inedible() -> None:
+    assert not is_inedible_path("/path/projects/myapp/session.jsonl")
+
+
+def test_is_inedible_path_root_bounds_ancestor_check() -> None:
+    """With `root` set, the root's own name (and anything above it) is
+    not inspected — matching scan_repo, which pushes its walk root
+    unconditionally. Components strictly between root and the file are."""
+    root = Path("/home/u/INEDIBLE_x/proj")
+    # root itself carries the marker, but it is not inspected:
+    assert not is_inedible_path(root / "a/session.jsonl", root=root)
+    # a directory between root and the file IS inspected:
+    assert is_inedible_path(root / "INEDIBLE_sub/session.jsonl", root=root)
+
+
+def test_is_inedible_path_root_unrelated_falls_back_to_full_walk() -> None:
+    """If the path is not under `root`, the helper walks all ancestors
+    rather than silently passing."""
+    assert is_inedible_path("/other/INEDIBLE_dir/x.jsonl", root=Path("/home/u"))
 
 
 def test_is_inedible_accepts_path_or_string() -> None:
@@ -196,3 +232,59 @@ def test_ingest_jsonl_dir_skips_inedible_and_counts(tmp_path: Path) -> None:
     assert "secret content" not in contents
     assert "uv for environment management" in contents
     assert "atomic commits" in contents
+
+
+def test_ingest_jsonl_single_file_skips_inedible_ancestor_dir(
+    tmp_path: Path,
+) -> None:
+    """A single-file ingest of a JSONL beneath an INEDIBLE-named
+    directory is a no-op, even though the file's own name is clean
+    (#958)."""
+    nested = tmp_path / "INEDIBLE_old" / "projects"
+    nested.mkdir(parents=True)
+    p = nested / "session.jsonl"
+    p.write_text(
+        '{"role": "user", "text": "the production database password is secret content", '
+        '"session_id": "s1", "ts": "2026-01-01T00:00:00Z"}\n'
+    )
+    s = MemoryStore(":memory:")
+    try:
+        result = ingest_jsonl(s, p)
+        rows = s._conn.execute(  # type: ignore[attr-defined]
+            "SELECT content FROM beliefs"
+        ).fetchall()
+    finally:
+        s.close()
+    assert result.lines_read == 0
+    assert rows == []
+
+
+def test_ingest_jsonl_dir_skips_files_under_inedible_dir(
+    tmp_path: Path,
+) -> None:
+    """The batch path prunes files nested under an INEDIBLE-named
+    directory, matching scan_repo's directory pruning (#958)."""
+    (tmp_path / "ok.jsonl").write_text(
+        '{"role": "user", "text": "this project always uses uv for environment management", '
+        '"session_id": "s1", "ts": "2026-01-01T00:00:00Z"}\n'
+    )
+    secret_dir = tmp_path / "INEDIBLE_drafts"
+    secret_dir.mkdir()
+    (secret_dir / "clean_name.jsonl").write_text(
+        '{"role": "user", "text": "the production database password is secret content", '
+        '"session_id": "s2", "ts": "2026-01-01T00:00:00Z"}\n'
+    )
+    s = MemoryStore(":memory:")
+    try:
+        result = ingest_jsonl_dir(s, tmp_path)
+        rows = s._conn.execute(  # type: ignore[attr-defined]
+            "SELECT content FROM beliefs"
+        ).fetchall()
+    finally:
+        s.close()
+    # Both files are walked; the nested one is skipped as inedible.
+    assert result.files_walked == 2
+    assert result.files_skipped_inedible == 1
+    contents = "\n".join(row["content"] for row in rows)
+    assert "secret content" not in contents
+    assert "uv for environment management" in contents

--- a/tests/test_inedible_filter.py
+++ b/tests/test_inedible_filter.py
@@ -60,6 +60,23 @@ def test_is_inedible_path_matches_basename() -> None:
     assert is_inedible_path("/path/INEDIBLE_secrets.txt")
 
 
+def test_is_inedible_path_accepts_path_or_string(tmp_path: Path) -> None:
+    """is_inedible_path accepts Path or str for both `path` and `root`,
+    mirroring test_is_inedible_accepts_path_or_string and keeping the
+    polymorphic API contract explicit (`root` is keyword-only)."""
+    root = tmp_path / "root"
+    nested = root / "INEDIBLE_drafts"
+    nested.mkdir(parents=True)
+    f = nested / "notes.jsonl"
+    assert is_inedible_path(f, root=root)
+    assert is_inedible_path(str(f), root=root)
+    assert is_inedible_path(f, root=str(root))
+    assert is_inedible_path(str(f), root=str(root))
+    # root=None path also accepts both types
+    assert is_inedible_path("/a/INEDIBLE/b.jsonl")
+    assert is_inedible_path(Path("/a/INEDIBLE/b.jsonl"))
+
+
 def test_is_inedible_path_propagates_from_ancestor_dir() -> None:
     """Unlike is_inedible, the path-aware helper excludes a file beneath
     an INEDIBLE-named directory (#958)."""


### PR DESCRIPTION
## Problem

`docs/user/PRIVACY.md` promised the INEDIBLE directory-basename exclusion holds on **every** ingest path. It held only for `aelf onboard`: `scan_repo` prunes INEDIBLE-named directories entry-by-entry during its walk, but the `ingest_jsonl` transcript paths glob a whole tree (`**/*.jsonl`) and only checked each file's own basename. A transcript JSONL inside e.g. `~/.claude/projects/INEDIBLE_old/` was ingested unless the file name itself carried the marker — a documented privacy control silently failing, after which the content is injectable into cloud-LLM prompts by normal retrieval.

Found by the #957 docs↔code audit; PRIVACY.md was updated there to *disclose* the actual behavior. This PR closes the gap on the code side.

## Fix

- New `is_inedible_path(path, *, root=None)` in `inedible.py` — checks the basename **and** ancestor directory names. With `root` set it bounds the ancestor check to components strictly between root and the file (matching `scan_repo`, which never inspects its own walk root); with `root=None` it walks all ancestors.
- `ingest_jsonl` (single file) → `is_inedible_path(path)`; `ingest_jsonl_dir` (batch) → `is_inedible_path(path, root=root)`.
- `is_inedible` stays the basename-only primitive `scan_repo` uses — its contract and test are unchanged.

## Tests

7 new cases: `is_inedible_path` basename/ancestor/clean/root-bounded/unrelated-root, plus single-file and batch ingest of a clean-named JSONL under an `INEDIBLE_*` directory (both must no-op). 44 inedible+scanner tests green; 151 ingest/scanner/inedible tests green.

## Doc follow-up (not in this PR)

PRIVACY.md's #958 disclosure (added in the open #960) should be reverted to "directory exclusion holds across all ingest paths" once both land. I kept it out of this PR because #960 edits the same paragraph — a one-line docs commit after both merge avoids a same-paragraph conflict between the two open PRs.

Closes #958

## Summary by Sourcery

Propagate INEDIBLE directory-based privacy exclusions to JSONL transcript ingestion paths by introducing a directory-aware path filter and wiring it into ingest routines.

Bug Fixes:
- Ensure ingest_jsonl skips JSONL files whose own name or any ancestor directory name carries the INEDIBLE marker, matching documented privacy guarantees.
- Ensure ingest_jsonl_dir skips JSONL files nested under INEDIBLE-named directories during batch ingestion, aligning behavior with scan_repo directory pruning.

Enhancements:
- Introduce an is_inedible_path helper that checks both basenames and ancestor directory names, with optional root scoping for walker-style use.

Tests:
- Add unit tests for is_inedible_path covering basename matches, ancestor directory propagation, root-bounded checks, and behavior when the path is outside the provided root.
- Add integration-style tests verifying single-file and batch JSONL ingestion no-op when files reside under INEDIBLE-named directories while still ingesting safe files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy filtering so ingestion skips files located under privacy-marked ancestor directories (not just when the filename itself is marked). Directory-scoped boundaries are respected during batch imports.

* **Tests**
  * Expanded test coverage for privacy-marker detection, including ancestor-directory cases, boundary/root-limited checks, and batch ingestion scenarios to validate skipped and ingested items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->