### PR TITLE
docs(code): align stale docstrings and help text with shipped behavior

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -3135,8 +3135,10 @@ def _cmd_eval(args: argparse.Namespace, out: object) -> int:
     Reuses ``aelfrice.eval_harness`` to score a synthetic corpus of
     ``(query, known_belief, noise_beliefs)`` fixtures and report
     P@K / ROC-AUC / Spearman ρ. Default corpus is the public synthetic
-    fixture bundled with the wheel; ``--corpus PATH`` points at any
-    JSONL with the same row schema.
+    fixture at ``benchmarks/posterior_ranking/fixtures/default.jsonl``,
+    present only in a repo checkout (not packaged in the wheel — wheel
+    installs must pass ``--corpus PATH``); ``--corpus PATH`` points at
+    any JSONL with the same row schema.
 
     Determinism contract (#365 ship gate): same ``(corpus, --k, --seed)``
     -> bytes-identical output across reruns.
@@ -7449,8 +7451,9 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         metavar="PATH",
         help=(
             "JSONL corpus with (query, known_belief_content, "
-            "noise_belief_contents) rows. Default: bundled public "
-            "synthetic corpus."
+            "noise_belief_contents) rows. Default: the repo-checkout "
+            "synthetic corpus (not in the wheel; required for wheel "
+            "installs)."
         ),
     )
     p_eval.add_argument(

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -5832,9 +5832,12 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         const=True,
         default=None,
         help=(
-            "opt in to the LLM-Haiku classifier (v1.3.0+). Requires the "
-            "[onboard-llm] extra and ANTHROPIC_API_KEY. Default: off. "
-            "Pass --llm-classify=false to override [onboard.llm].enabled."
+            "control the direct-API LLM classifier (v1.3.0+). Requires "
+            "the [onboard-llm] extra and ANTHROPIC_API_KEY. The classifier "
+            "resolves ON by default since v1.5.0, but soft-falls to the "
+            "regex path when the extra/key/consent gates are unmet. Pass "
+            "--llm-classify=false to force off; default reads "
+            "[onboard.llm].enabled."
         ),
     )
     p_onboard.add_argument(

--- a/src/aelfrice/context_rebuilder.py
+++ b/src/aelfrice/context_rebuilder.py
@@ -626,9 +626,10 @@ class RebuilderConfig:
     v1.4 (issue #141) adds two trigger-mode fields:
 
     * `trigger_mode`  -- one of `manual`, `threshold`, `dynamic`.
-                         Default `manual`. `dynamic` is parked at
-                         v1.4 and raises in the hook path.
-    * `threshold_fraction` -- float in (0.0, 1.0]; default 0.7 from
+                         Default `threshold` since v3.1 (#746; was
+                         `manual` at v1.4). `dynamic` is parked and
+                         raises in the hook path.
+    * `threshold_fraction` -- float in (0.0, 1.0]; default 0.6 from
                               calibration. Documents the operating
                               point at which threshold-mode is tuned;
                               the actual gate is the harness's own

--- a/src/aelfrice/eval_harness.py
+++ b/src/aelfrice/eval_harness.py
@@ -7,7 +7,9 @@ without duplicating code.
 
 Public API:
 
-- ``DEFAULT_CALIBRATION_CORPUS`` — bundled synthetic corpus path.
+- ``DEFAULT_CALIBRATION_CORPUS`` — repo-checkout synthetic corpus path
+  (``benchmarks/posterior_ranking/fixtures/default.jsonl``; not packaged
+  in the wheel — wheel installs must pass ``--corpus``).
 - ``DEFAULT_K`` / ``DEFAULT_SEED`` — defaults.
 - ``load_calibration_fixtures(path)`` — fail-soft JSONL loader.
 - ``build_calibration_store(fixture, seed)`` — fresh in-memory store.

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -29,6 +29,7 @@ Tool surface (all under the `aelf:` namespace at the host):
   aelf:confirm         {belief_id, source?, note?}       -> affirmed priors
   aelf:stats           {}                                -> counts
   aelf:health          {}                                -> regime report
+  aelf:wonder          {query, budget?, depth?, agent_count?} -> research axes
   aelf:wonder_persist  {query, budget?, depth?, top?, seed?} -> insert summary
   aelf:wonder_gc       {ttl_days?, dry_run?}            -> gc summary
 
@@ -800,9 +801,11 @@ def tool_stats(
         "kind": "stats.snapshot",
         "version": _aelf_version,
         "beliefs": store.count_beliefs(),
-        # `edges` is the v1.0 key. v1.1.0 adds `threads` as the
-        # forward-compatible alias and emits both for one minor; v1.2.0
-        # drops `edges`. Clients should migrate now.
+        # `edges` is the v1.0 key; v1.1.0 added `threads` as the
+        # forward-compatible alias. Both are emitted with the same value.
+        # The originally-planned v1.2.0 drop of `edges` did not happen
+        # and is no longer scheduled — both remain emitted indefinitely.
+        # Prefer `threads` in new code; legacy `edges` clients keep working.
         "edges": n_edges,
         "threads": n_edges,
         "locked": store.count_locked(),
@@ -1603,7 +1606,7 @@ def serve() -> None:
 
         Returns: {"kind": "stats.snapshot",
                   "beliefs": int,
-                  "edges": int,    # v1.0 key (deprecated, removed v1.2)
+                  "edges": int,    # v1.0 key (retained indefinitely; prefer threads)
                   "threads": int,  # v1.1 key (forward-compatible alias)
                   "locked": int,
                   "feedback_events": int,

--- a/src/aelfrice/pre_issue_create_hook.py
+++ b/src/aelfrice/pre_issue_create_hook.py
@@ -320,8 +320,10 @@ def _format_block_message(
         lines.append(f"    {ref:>7}  [{state_str}]  score={score:.2f}  {title!r}")
     lines += [
         "",
-        "  To bypass: set ALLOW_DUP_ISSUE=1 before the command,",
-        "  or pass --no-pre-issue-guard to `aelf setup` to disable globally.",
+        "  To bypass: set ALLOW_DUP_ISSUE=1 in the host's environment",
+        "  (an inline KEY=VAL prefix on the gh command does not reach this",
+        "  hook), or pass --no-pre-issue-guard to `aelf setup` to disable",
+        "  globally.",
     ]
     return "\n".join(lines)
 


### PR DESCRIPTION
## What this is

Six code-side strings (docstrings / argparse help / hook stderr) that contradicted shipped behavior, surfaced by the #957 docs↔code audit. The audit fixed the user-facing docs in #960; this PR aligns the code strings. No behavior change — comments, docstrings, and help text only.

## Fixes (one atomic commit each)

1. **mcp_server.py** — the `aelf:stats` comment + docstring still said "v1.2.0 drops `edges`"; we're at v3.5.0 and still emit both `edges` and `threads`. MCP.md already documents the drop as no-longer-scheduled. Also added the missing `aelf:wonder` row to the module-docstring tool list.
2. **eval_harness.py + cli.py** — `DEFAULT_CALIBRATION_CORPUS` resolves to `benchmarks/posterior_ranking/fixtures/default.jsonl`, which is **not** in the wheel; three strings said "bundled with the wheel". A wheel-installed user running bare `aelf eval` would hit a missing path — help now says `--corpus` is required there.
3. **context_rebuilder.py** — `RebuildConfig` docstring named the v1.4 defaults (`manual` / `0.7`); the constants have been `threshold` / `0.6` since v3.1 (#746).
4. **pre_issue_create_hook.py** — the block message said "set ALLOW_DUP_ISSUE=1 before the command", but the hook reads the var from the host process's env and strips leading `KEY=VAL` prefixes (lines 136-138), so an inline prefix never reaches it. Now says to set it in the host environment.
5. **cli.py** — `--llm-classify` help said "Default: off", contradicting `resolve_enabled` (defaults **on** since the v1.5.0 flip). Vanilla installs are regex-only because the extra/key/consent gates are unmet, not because the flag defaults off — reworded to state default-on with the soft-fall caveat.

## Out of scope (audit's optional 7th)

`benchmarks/mab_reader.py`'s prompt could add the context-only sentence BENCHMARKS.md once mandated, but that's a prompt-behavior tweak, not a doc-string fix — left for a separate change if wanted.

## Verification

701 tests pass across the eval / mcp / slash / llm-classifier / rebuilder / pre-issue / context-rebuilder surfaces; all five edited modules import clean.

Closes #959

## Summary by Sourcery

Align code-side documentation and CLI help text with current shipped behavior across eval, MCP server, context rebuilder, pre-issue hook, and LLM classifier surfaces, without changing runtime behavior.

New Features:
- Document the aelf:wonder MCP tool in the MCP server module docstring.

Bug Fixes:
- Correct misleading CLI and eval harness help text about the default calibration corpus location and wheel packaging requirements.
- Clarify the LLM classifier flag help to reflect that it now resolves enabled by default, with fallback to regex when prerequisites are unmet.
- Fix the pre-issue create hook bypass instructions to describe setting ALLOW_DUP_ISSUE in the host environment rather than via inline KEY=VAL prefixes.

Enhancements:
- Update MCP stats comments and docstrings to reflect that both edges and threads keys are emitted indefinitely, preferring threads for new clients.
- Refresh context rebuilder configuration docstrings to match current default trigger mode and threshold fraction values.

Documentation:
- Align internal docstrings and public-facing descriptions of defaults and behavior for evaluation harness, MCP tools, context rebuilder, pre-issue hook, and LLM classifier.