### PR TITLE
docs: v3.5.0 audit punch-list — compare-link precision + stale module docstrings

### DIFF
--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -473,8 +473,8 @@ The cadence-policy completion + conversation-aware retrieval wave.
 - **`urllib3` 2.6.3 → 2.7.0 for CVE patches** ([#640](https://github.com/robotrocketscience/aelfrice/issues/640)). Lockfile-only dependency bump pulled in via `uv lock` to clear two CVEs flagged by GitHub's dependency scanner. `urllib3` is a transitive dep (via `requests` in the publish workflow and the `gh` CLI's Python shim); aelfrice itself does not import it. No source change.
 
 [Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v3.5.0...HEAD
-[3.5.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.3.0...v3.5.0
-[3.4.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.3.0...v3.5.0
+[3.5.0]: https://github.com/robotrocketscience/aelfrice/compare/51cea5c4...v3.5.0
+[3.4.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.3.0...51cea5c4
 [3.3.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.0.1...v3.1.0

--- a/src/aelfrice/bm25.py
+++ b/src/aelfrice/bm25.py
@@ -24,12 +24,13 @@ Two complementary changes:
    plus a length-normalisation broadcast — constant overhead per
    query rather than O(n_docs) Python work.
 
-The standard FTS5 BM25 path in `aelfrice.store.search_beliefs`
-remains the default L1 lane at v1.5.0. `BM25Index` lands as an
-**opt-in alternative** behind the `use_bm25f_anchors` flag in
-`aelfrice.retrieval`. Default-on flip is gated on a benchmark
-follow-up after v1.5.x telemetry — see #154 for the composition
-tracker that handles that flip.
+`BM25Index` is the **default L1 lane** since v1.7.0: the
+`use_bm25f_anchors` flag defaults to True per the #154 bench
+evidence (see `resolve_use_bm25f_anchors` in `aelfrice.retrieval`,
+precedence step 4). The standard FTS5 BM25 path in
+`aelfrice.store.search_beliefs` remains available by disabling the
+flag — set `AELFRICE_BM25F=0`, pass `use_bm25f_anchors=False`, or
+write `[retrieval] use_bm25f_anchors = false` in `.aelfrice.toml`.
 
 The module imports numpy + scipy unconditionally. The v1.5.0
 release promotes both to runtime deps; see CHANGELOG and

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -1,26 +1,8 @@
-"""Eleven-command CLI matching the MVP user surface.
+"""Command-line interface for aelfrice persistent memory.
 
-Commands:
-  onboard <path>                   scan a project and ingest beliefs
-  search <query> [--budget N]      L0 locked + L1 FTS5 retrieval
-  lock <statement>                 insert (or upgrade) a user-locked belief
-  locked                           list locked beliefs
-  demote <id>                      manually demote a lock to none
-  confirm <id> [--source S]        explicitly affirm a belief (bumps Beta-Bernoulli alpha)
-  feedback <id> <used|harmful>     apply one Bayesian feedback event
-  stats                            summary of belief / lock / history counts
-  health                           structural auditor (orphan threads, FTS5 sync, locked contradictions)
-  status                           alias for health
-  regime                           v1.0 regime classifier (supersede / ignore / mixed)
-  migrate                          copy beliefs from legacy ~/.aelfrice/memory.db
-  doctor                           verify hook commands resolve in settings.json
-  setup                            install UserPromptSubmit hook in Claude Code
-  unsetup                          remove UserPromptSubmit hook from Claude Code
-  upgrade-cmd                      print the right pip-upgrade command line (renamed from `upgrade` at #427)
-  uninstall                        tear down aelfrice locally + handle DB
-  statusline                       emit Claude Code statusline snippet
-  bench                            run the v0.9.0-rc benchmark harness
-  project-warm <path>              CwdChanged hook entry — pre-load the project's belief cache
+This module defines every `aelf` subcommand. The full, current command
+list lives in `aelf --help` and `docs/user/COMMANDS.md`; the inventory
+is too large (and changes too often) to duplicate here.
 
 DB path resolves from AELFRICE_DB environment variable when set,
 otherwise from <git-common-dir>/aelfrice/memory.db when cwd is inside


### PR DESCRIPTION
Closes #964.

Three drift items from the 2026-06-10 full-repo docs audit (the remainder after the #952/#957/#959/#960/#962/#963 reconciliation wave):

1. **CHANGELOG/v3.md footnotes** — `[3.4.0]` and `[3.5.0]` both pointed at the identical `v3.3.0...v3.5.0` range. Now split at `51cea5c4`, the main-history fork point of the untagged 3.4.0 cut, so each link shows only its own release's changes.
2. **cli.py module docstring** — dropped the stale "Eleven-command CLI" list (~20 of 68 commands, plus a pip-upgrade reference dead since v3.0.1 #730) in favor of a pointer to `aelf --help` / `docs/user/COMMANDS.md`. The DB-path-resolution paragraph is kept verbatim.
3. **bm25.py module docstring** — the paragraph still described BM25F anchors as a v1.5-era opt-in pending a default-flip decision; the flag has defaulted to True since v1.7.0 (#154). Reworded to default-on with the three documented disable mechanisms.

Three atomic commits, one per file. Docs/docstring-only — no behavior change. Smoke: `pytest -k "cli or bm25"` 538 passed.

## Summary by Sourcery

Refresh documentation and docstrings to reflect current CLI surface, BM25 defaults, and accurate changelog compare links.

Documentation:
- Update CHANGELOG v3 compare links so 3.4.0 and 3.5.0 each reference their correct commit ranges.
- Revise cli.py module docstring to describe the CLI at a high level and defer to `aelf --help` and COMMANDS.md for the full command list.
- Update bm25.py module docstring to document BM25F as the default L1 retrieval path and clarify how to disable it via configuration or environment.