### PR TITLE
release: v3.5.1

### DIFF
--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1] - 2026-06-10
+
+Patch release: two privacy-adjacent ingest/scan fixes, plus the v3.5.0
+docs-vs-code reconciliation wave.
+
+### Fixed
+- **Scanner skips `.claude/` during onboard scan** ([PR #955](https://github.com/robotrocketscience/aelfrice/pull/955)). `aelf onboard` no longer descends into a project's `.claude/` directory, so host-agent settings, hooks, and local memory artifacts are not ingested as beliefs.
+- **INEDIBLE marker propagates to ingest-transcript paths** ([#958](https://github.com/robotrocketscience/aelfrice/issues/958)). The INEDIBLE directory-exclusion marker now holds across all ingest paths, including transcript ingest; previously only the onboard scanner honored it.
+
+### Documentation
+- Full docs-vs-code audit and reconciliation wave ([#952](https://github.com/robotrocketscience/aelfrice/issues/952), [#957](https://github.com/robotrocketscience/aelfrice/issues/957)): README conversion-first rewrite, COMMANDS/CONFIG/INSTALL/SLASH/MCP true-ups, ARCHITECTURE/ROADMAP/design-doc de-drift, 20 broken design-doc links fixed ([#953](https://github.com/robotrocketscience/aelfrice/issues/953)), stale docstrings and help text aligned with shipped behavior ([#959](https://github.com/robotrocketscience/aelfrice/issues/959), [#964](https://github.com/robotrocketscience/aelfrice/issues/964)), CHANGELOG 3.4.0/3.5.0 compare links made range-precise ([#964](https://github.com/robotrocketscience/aelfrice/issues/964)).
+
 ## [3.5.0] - 2026-06-04
 
 The visibility / observability wave. Every belief-write surface gained a
@@ -472,7 +484,8 @@ The cadence-policy completion + conversation-aware retrieval wave.
 
 - **`urllib3` 2.6.3 → 2.7.0 for CVE patches** ([#640](https://github.com/robotrocketscience/aelfrice/issues/640)). Lockfile-only dependency bump pulled in via `uv lock` to clear two CVEs flagged by GitHub's dependency scanner. `urllib3` is a transitive dep (via `requests` in the publish workflow and the `gh` CLI's Python shim); aelfrice itself does not import it. No source change.
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v3.5.0...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v3.5.1...HEAD
+[3.5.1]: https://github.com/robotrocketscience/aelfrice/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/robotrocketscience/aelfrice/compare/51cea5c4...v3.5.0
 [3.4.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.3.0...51cea5c4
 [3.3.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.2.0...v3.3.0

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Scopes: `--scope all` (everything, capped by `--max-notes`), `--scope recent` (n
 
 ## Status
 
-Latest stable: **v3.5.0** (2026-06-04). Per-entry detail in [CHANGELOG § 3.5.0](CHANGELOG/v3.md). Per-version history: [docs/concepts/ROADMAP.md](docs/concepts/ROADMAP.md). Known limits: [docs/user/LIMITATIONS.md](docs/user/LIMITATIONS.md).
+Latest stable: **v3.5.1** (2026-06-10). Per-entry detail in [CHANGELOG § 3.5.1](CHANGELOG/v3.md). Per-version history: [docs/concepts/ROADMAP.md](docs/concepts/ROADMAP.md). Known limits: [docs/user/LIMITATIONS.md](docs/user/LIMITATIONS.md).
 
 [![OSSInsight](https://img.shields.io/badge/OSSInsight-analytics-blue)](https://ossinsight.io/analyze/robotrocketscience/aelfrice)
 <!-- bench-canonical-badge:start -->

--- a/docs/concepts/ROADMAP.md
+++ b/docs/concepts/ROADMAP.md
@@ -9,7 +9,7 @@ Per-issue tracking: [LIMITATIONS.md](../user/LIMITATIONS.md). Release log: [CHAN
 
 aelfrice is a rebuild of an earlier research line on Bayesian + graph-backed memory for AI coding agents. The research codebase explored FTS5 retrieval, vocabulary bridging, BFS multi-hop traversal, entity-indexed retrieval, type-aware compression, correction detection, and a multi-tool MCP surface, with results against MAB, LoCoMo, LongMemEval, StructMemEval, and AMA-Bench.
 
-v1.0 shipped the foundation (SQLite store, Beta-Bernoulli scoring, BM25 retrieval, CLI, MCP, host hook wiring, synthetic benchmark harness). The v1.x line recovered the remaining features incrementally; v2.0 reached feature parity with the research line plus the reproducibility-harness scaffolding; v3.0 added wonder lifecycle, wonder/reason parity, read-only federation, and the eval-harness completion. The current line is **v3.5.0**.
+v1.0 shipped the foundation (SQLite store, Beta-Bernoulli scoring, BM25 retrieval, CLI, MCP, host hook wiring, synthetic benchmark harness). The v1.x line recovered the remaining features incrementally; v2.0 reached feature parity with the research line plus the reproducibility-harness scaffolding; v3.0 added wonder lifecycle, wonder/reason parity, read-only federation, and the eval-harness completion. The current line is **v3.5.1**.
 
 This is a rebuild, not a port. Structural issues that survived the research line were fixed at the foundation layer. Every behavioural claim is backed by a test or a benchmark, with a transparent issue trail for items that are not.
 
@@ -36,6 +36,7 @@ This is a rebuild, not a port. Structural issues that survived the research line
 | **v3.3.0** | shipped 2026-05-21 | `user_transcript` origin tier added (#888 — distinguishes user-stated content captured from transcript ingest from `user_stated` explicit-lock content and `agent_inferred` derivation); session-start recent-work block (#887 — surfaces current branch, recent commits, referenced issue numbers); P3 cadence policy + turn-density scoring (#876); aelf graph CLI for DOT/JSON subgraph emission (#629); aelf scope-out for federation denylist control (#856); aelf label CLI for relevance-corpus labelling (#859); aelf export-obsidian for one-way Obsidian rendering (#630). |
 | **v3.4.0** | merged 2026-05-26; never tagged standalone — published with the v3.5.0 cut (see [CHANGELOG/v3.md § 3.4.0](../../CHANGELOG/v3.md)) | cadence-policy completion + conversation-aware retrieval — `p3_substantive` policy live, 4-policy shadow capture, offline cadence replay bench (#876, #920); UPS retrieval conversation-aware (#909 — folds recent turns into BM25 query) |
 | **v3.5.0** | shipped 2026-06-04 | visibility/observability wave — per-project feed log + `aelf feed` (#931), SessionStart recap (#934), contradiction marker on `aelf search` (#938), `aelf speculative` (#937), `aelf stale` (#933), `aelf audit-claude-memory` (#935), `aelf review` (#936), duplicate-issue PreToolUse guard (#941), statusline counts (#932) |
+| **v3.5.1** | shipped 2026-06-10 | patch — scanner skips `.claude/` on onboard (#955); INEDIBLE marker propagation to ingest-transcript paths (#958); v3.5.0 docs-vs-code reconciliation wave (#952, #957, #964) |
 
 ## What shipped
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "3.5.0"
+version = "3.5.1"
 description = "Persistent memory for AI coding agents. Local SQLite + UserPromptSubmit hook — matched beliefs in the prompt before the model sees it. Deterministic, auditable, no embeddings, no cloud."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "3.5.0"
+version = "3.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Closes #966.

v3.5.1 patch release cut. Single `release:` commit: pyproject 3.5.0 → 3.5.1, `uv lock` re-resolve, CHANGELOG `[3.5.1]` section + compare-link footnotes, README latest-stable pointer, ROADMAP row.

Ships everything on main since the v3.5.0 tag:
- **fix(scanner)**: skip `.claude/` directory during onboard scan (PR #955)
- **fix(ingest)**: INEDIBLE marker propagates to ingest-transcript paths (#958)
- **docs**: full docs-vs-code reconciliation wave (#952, #957, #953, #959, #964)

After merge, the release goes live with: `git tag v3.5.1 && git push github v3.5.1` (triggers publish.yml → PyPI). Tag push left to the operator.

## Summary by Sourcery

Cut the v3.5.1 patch release with updated metadata, changelog entry, and docs pointers to the new version.

Bug Fixes:
- Document scanner release notes highlight skipping `.claude/` directories during onboard scans.
- Document ingest behavior change where INEDIBLE markers now also exclude ingest-transcript paths.

Build:
- Bump project version from 3.5.0 to 3.5.1 in pyproject metadata and refresh the dependency lockfile.

Documentation:
- Add v3.5.1 section to the v3 changelog with notes on scanner, ingest, and documentation reconciliation changes.
- Update README and ROADMAP to mark v3.5.1 as the current latest stable release and roadmap entry.