### PR TITLE
fix(transcript_logger): consecutive-duplicate turn guard (#968)

### DIFF
--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -40,6 +40,18 @@ from typing import IO, Any, Final, cast
 
 try:
     from aelfrice.db_paths import active_project_context, db_path
+    from aelfrice.hook_audit import (
+        AUDIT_ROTATED_SUFFIX,
+        HookAuditConfig,
+        _append_audit,
+        _audit_path_for_db,
+        _CONFIG_FILENAME,
+        load_hook_audit_config,
+    )
+    # Re-exported so existing `from aelfrice.hook import ...` callers keep
+    # working after the #968 extraction into aelfrice.hook_audit.
+    from aelfrice.hook_audit import AUDIT_DEFAULT_MAX_BYTES  # noqa: F401
+    from aelfrice.hook_audit import AUDIT_FILENAME  # noqa: F401
     from aelfrice.context_rebuilder import (
         TRIGGER_MODE_DYNAMIC,
         TRIGGER_MODE_MANUAL,
@@ -175,7 +187,6 @@ _CWD_KEY: Final[str] = "cwd"
 _UPS_SECTION: Final[str] = "user_prompt_submit_hook"
 _COLLAPSE_KEY: Final[str] = "collapse_duplicate_hashes"
 _PROMPT_SHAPE_GATE_KEY: Final[str] = "prompt_shape_gate_enabled"
-_CONFIG_FILENAME: Final[str] = ".aelfrice.toml"
 # #909: conversation-aware retrieval. The live per-prompt UPS retrieval
 # BM25s the literal prompt only; when the topic vocabulary lives in the
 # dialog history (paraphrase / pronoun / numeric reference) and not in
@@ -510,164 +521,17 @@ def _append_telemetry(
 # ---------------------------------------------------------------------------
 # Per-turn audit log (#280 mitigation 3)
 # ---------------------------------------------------------------------------
-
-AUDIT_DEFAULT_MAX_BYTES: Final[int] = 10 * 1024 * 1024
-"""Default size cap before rotation (10 MB). Overridable via .aelfrice.toml."""
+# Config, path resolution, and append/rotate primitives now live in
+# aelfrice.hook_audit (#968) so callers off the heavy retrieval import path
+# can reuse the sink; they are imported at the top of this module. The
+# Belief-coupled record builders stay below.
 
 AUDIT_PROMPT_PREFIX_CAP: Final[int] = 200
 """Maximum characters of the user prompt stored in an audit record."""
 
-AUDIT_FILENAME: Final[str] = "hook_audit.jsonl"
-"""Live audit log filename, sibling of memory.db under <git-common-dir>/aelfrice/."""
-
-AUDIT_ROTATED_SUFFIX: Final[str] = ".1"
-"""Single-slot rotation suffix. Rollover renames hook_audit.jsonl -> hook_audit.jsonl.1."""
-
-_AUDIT_SECTION: Final[str] = "hook_audit"
-_AUDIT_ENABLED_KEY: Final[str] = "enabled"
-_AUDIT_MAX_BYTES_KEY: Final[str] = "max_bytes"
-_AUDIT_ENV_DISABLE: Final[str] = "AELFRICE_HOOK_AUDIT"
-
 AUDIT_HOOK_USER_PROMPT_SUBMIT: Final[str] = "user_prompt_submit"
 AUDIT_HOOK_SESSION_START: Final[str] = "session_start"
 AUDIT_HOOK_SENTIMENT_FEEDBACK: Final[str] = "sentiment_feedback"
-
-
-@dataclass(frozen=True)
-class HookAuditConfig:
-    """Resolved configuration for the per-turn hook audit log.
-
-    `enabled` defaults True (audit-on) per #280 ratification — the surface
-    is monitored unless the operator explicitly opts out via env var or
-    TOML. `max_bytes` controls when the live file is rotated.
-    """
-
-    enabled: bool = True
-    max_bytes: int = AUDIT_DEFAULT_MAX_BYTES
-
-
-def load_hook_audit_config(
-    start: Path | None = None,
-    *,
-    env: dict[str, str] | None = None,
-    stderr: IO[str] | None = None,
-) -> HookAuditConfig:
-    """Resolve the [hook_audit] config.
-
-    Resolution order:
-    1. `AELFRICE_HOOK_AUDIT=0` env var → disabled (overrides TOML).
-    2. Walk up from `start` looking for `.aelfrice.toml`; first hit wins.
-    3. Default (enabled=True, max_bytes=AUDIT_DEFAULT_MAX_BYTES).
-
-    Missing file / missing section / malformed TOML / wrong-typed values
-    all degrade to the safe default with a stderr trace; never raises.
-    """
-    serr: IO[str] = stderr if stderr is not None else sys.stderr
-    env_map = env if env is not None else dict(os.environ)
-    env_val = env_map.get(_AUDIT_ENV_DISABLE)
-    if env_val is not None and env_val.strip() == "0":
-        return HookAuditConfig(enabled=False)
-    current = (start if start is not None else Path.cwd()).resolve()
-    seen: set[Path] = set()
-    while current not in seen:
-        seen.add(current)
-        candidate = current / _CONFIG_FILENAME
-        if candidate.is_file():
-            try:
-                raw = candidate.read_bytes()
-            except OSError as exc:
-                print(
-                    f"aelfrice hook: cannot read {candidate}: {exc}",
-                    file=serr,
-                )
-                return HookAuditConfig()
-            try:
-                parsed: dict[str, Any] = tomllib.loads(
-                    raw.decode("utf-8", errors="replace"),
-                )
-            except tomllib.TOMLDecodeError as exc:
-                print(
-                    f"aelfrice hook: malformed TOML in {candidate}: {exc}",
-                    file=serr,
-                )
-                return HookAuditConfig()
-            section_obj: Any = parsed.get(_AUDIT_SECTION, {})
-            if not isinstance(section_obj, dict):
-                return HookAuditConfig()
-            section = cast(dict[str, Any], section_obj)
-            enabled_obj: Any = section.get(_AUDIT_ENABLED_KEY, True)
-            if not isinstance(enabled_obj, bool):
-                print(
-                    f"aelfrice hook: ignoring [{_AUDIT_SECTION}] "
-                    f"{_AUDIT_ENABLED_KEY} in {candidate} (expected bool)",
-                    file=serr,
-                )
-                enabled_obj = True
-            max_bytes_obj: Any = section.get(
-                _AUDIT_MAX_BYTES_KEY, AUDIT_DEFAULT_MAX_BYTES,
-            )
-            if not isinstance(max_bytes_obj, int) or max_bytes_obj <= 0:
-                if not (
-                    isinstance(max_bytes_obj, int)
-                    and max_bytes_obj == AUDIT_DEFAULT_MAX_BYTES
-                ):
-                    print(
-                        f"aelfrice hook: ignoring [{_AUDIT_SECTION}] "
-                        f"{_AUDIT_MAX_BYTES_KEY} in {candidate} "
-                        f"(expected positive int)",
-                        file=serr,
-                    )
-                max_bytes_obj = AUDIT_DEFAULT_MAX_BYTES
-            return HookAuditConfig(
-                enabled=enabled_obj,
-                max_bytes=max_bytes_obj,
-            )
-        parent = current.parent
-        if parent == current:
-            break
-        current = parent
-    return HookAuditConfig()
-
-
-def _audit_path_for_db(db_path_val: Path) -> Path:
-    """Derive the audit log path from the DB path. Sibling of memory.db."""
-    return db_path_val.parent / AUDIT_FILENAME
-
-
-def _append_audit(
-    audit_path: Path,
-    record: dict[str, object],
-    max_bytes: int,
-    *,
-    stderr: IO[str] | None = None,
-) -> None:
-    """Append one record to the audit JSONL. Rotate if size cap exceeded.
-
-    Append-then-rotate semantics: the record always lands. If, after
-    writing, the live file exceeds `max_bytes`, it is renamed to
-    `<path>.1` (overwriting any prior `.1`) and a fresh empty file is
-    started for the next call. Single-slot rotation by spec; no archive.
-
-    Fail-soft: any I/O error is logged to stderr and swallowed.
-    """
-    try:
-        audit_path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(record) + "\n"
-        with open(audit_path, "a", encoding="utf-8") as f:
-            f.write(line)
-            f.flush()
-            os.fsync(f.fileno())
-        if audit_path.stat().st_size > max_bytes:
-            rotated = audit_path.with_name(
-                audit_path.name + AUDIT_ROTATED_SUFFIX,
-            )
-            os.replace(audit_path, rotated)
-    except Exception as exc:
-        serr = stderr if stderr is not None else sys.stderr
-        print(
-            f"aelfrice: hook audit write failed (non-fatal): {exc}",
-            file=serr,
-        )
 
 
 AUDIT_BELIEF_SNIPPET_CAP: Final[int] = 120

--- a/src/aelfrice/hook_audit.py
+++ b/src/aelfrice/hook_audit.py
@@ -1,0 +1,180 @@
+"""Per-turn hook audit log: config, path resolution, and append/rotate.
+
+These primitives were extracted from `hook.py` (#968) so the audit sink can
+be reused by callers that must stay off `hook.py`'s import path. Importing
+`aelfrice.hook` pulls in the retrieval stack (scipy, ~220ms cold), which
+blows the sub-10ms budget of the transcript logger's hook process — this
+module has no such dependency, so `transcript_logger` and `hook_tail` import
+the audit primitives from here directly.
+
+The belief-coupled record builders (`_write_hook_audit_record`,
+`_serialize_belief_for_audit`) stay in `hook.py`: they depend on the Belief
+model and are only called from the retrieval hook, which already pays the
+heavy import.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, Any, Final, cast
+
+# ---------------------------------------------------------------------------
+# Per-turn audit log (#280 mitigation 3)
+# ---------------------------------------------------------------------------
+
+_CONFIG_FILENAME: Final[str] = ".aelfrice.toml"
+
+AUDIT_DEFAULT_MAX_BYTES: Final[int] = 10 * 1024 * 1024
+"""Default size cap before rotation (10 MB). Overridable via .aelfrice.toml."""
+
+AUDIT_FILENAME: Final[str] = "hook_audit.jsonl"
+"""Live audit log filename, sibling of memory.db under <git-common-dir>/aelfrice/."""
+
+AUDIT_ROTATED_SUFFIX: Final[str] = ".1"
+"""Single-slot rotation suffix. Rollover renames hook_audit.jsonl -> hook_audit.jsonl.1."""
+
+_AUDIT_SECTION: Final[str] = "hook_audit"
+_AUDIT_ENABLED_KEY: Final[str] = "enabled"
+_AUDIT_MAX_BYTES_KEY: Final[str] = "max_bytes"
+_AUDIT_ENV_DISABLE: Final[str] = "AELFRICE_HOOK_AUDIT"
+
+
+@dataclass(frozen=True)
+class HookAuditConfig:
+    """Resolved configuration for the per-turn hook audit log.
+
+    `enabled` defaults True (audit-on) per #280 ratification — the surface
+    is monitored unless the operator explicitly opts out via env var or
+    TOML. `max_bytes` controls when the live file is rotated.
+    """
+
+    enabled: bool = True
+    max_bytes: int = AUDIT_DEFAULT_MAX_BYTES
+
+
+def load_hook_audit_config(
+    start: Path | None = None,
+    *,
+    env: dict[str, str] | None = None,
+    stderr: IO[str] | None = None,
+) -> HookAuditConfig:
+    """Resolve the [hook_audit] config.
+
+    Resolution order:
+    1. `AELFRICE_HOOK_AUDIT=0` env var → disabled (overrides TOML).
+    2. Walk up from `start` looking for `.aelfrice.toml`; first hit wins.
+    3. Default (enabled=True, max_bytes=AUDIT_DEFAULT_MAX_BYTES).
+
+    Missing file / missing section / malformed TOML / wrong-typed values
+    all degrade to the safe default with a stderr trace; never raises.
+    """
+    serr: IO[str] = stderr if stderr is not None else sys.stderr
+    env_map = env if env is not None else dict(os.environ)
+    env_val = env_map.get(_AUDIT_ENV_DISABLE)
+    if env_val is not None and env_val.strip() == "0":
+        return HookAuditConfig(enabled=False)
+    current = (start if start is not None else Path.cwd()).resolve()
+    seen: set[Path] = set()
+    while current not in seen:
+        seen.add(current)
+        candidate = current / _CONFIG_FILENAME
+        if candidate.is_file():
+            try:
+                raw = candidate.read_bytes()
+            except OSError as exc:
+                print(
+                    f"aelfrice hook: cannot read {candidate}: {exc}",
+                    file=serr,
+                )
+                return HookAuditConfig()
+            try:
+                parsed: dict[str, Any] = tomllib.loads(
+                    raw.decode("utf-8", errors="replace"),
+                )
+            except tomllib.TOMLDecodeError as exc:
+                print(
+                    f"aelfrice hook: malformed TOML in {candidate}: {exc}",
+                    file=serr,
+                )
+                return HookAuditConfig()
+            section_obj: Any = parsed.get(_AUDIT_SECTION, {})
+            if not isinstance(section_obj, dict):
+                return HookAuditConfig()
+            section = cast(dict[str, Any], section_obj)
+            enabled_obj: Any = section.get(_AUDIT_ENABLED_KEY, True)
+            if not isinstance(enabled_obj, bool):
+                print(
+                    f"aelfrice hook: ignoring [{_AUDIT_SECTION}] "
+                    f"{_AUDIT_ENABLED_KEY} in {candidate} (expected bool)",
+                    file=serr,
+                )
+                enabled_obj = True
+            max_bytes_obj: Any = section.get(
+                _AUDIT_MAX_BYTES_KEY, AUDIT_DEFAULT_MAX_BYTES,
+            )
+            if not isinstance(max_bytes_obj, int) or max_bytes_obj <= 0:
+                if not (
+                    isinstance(max_bytes_obj, int)
+                    and max_bytes_obj == AUDIT_DEFAULT_MAX_BYTES
+                ):
+                    print(
+                        f"aelfrice hook: ignoring [{_AUDIT_SECTION}] "
+                        f"{_AUDIT_MAX_BYTES_KEY} in {candidate} "
+                        f"(expected positive int)",
+                        file=serr,
+                    )
+                max_bytes_obj = AUDIT_DEFAULT_MAX_BYTES
+            return HookAuditConfig(
+                enabled=enabled_obj,
+                max_bytes=max_bytes_obj,
+            )
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return HookAuditConfig()
+
+
+def _audit_path_for_db(db_path_val: Path) -> Path:
+    """Derive the audit log path from the DB path. Sibling of memory.db."""
+    return db_path_val.parent / AUDIT_FILENAME
+
+
+def _append_audit(
+    audit_path: Path,
+    record: dict[str, object],
+    max_bytes: int,
+    *,
+    stderr: IO[str] | None = None,
+) -> None:
+    """Append one record to the audit JSONL. Rotate if size cap exceeded.
+
+    Append-then-rotate semantics: the record always lands. If, after
+    writing, the live file exceeds `max_bytes`, it is renamed to
+    `<path>.1` (overwriting any prior `.1`) and a fresh empty file is
+    started for the next call. Single-slot rotation by spec; no archive.
+
+    Fail-soft: any I/O error is logged to stderr and swallowed.
+    """
+    try:
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record) + "\n"
+        with open(audit_path, "a", encoding="utf-8") as f:
+            f.write(line)
+            f.flush()
+            os.fsync(f.fileno())
+        if audit_path.stat().st_size > max_bytes:
+            rotated = audit_path.with_name(
+                audit_path.name + AUDIT_ROTATED_SUFFIX,
+            )
+            os.replace(audit_path, rotated)
+    except Exception as exc:
+        serr = stderr if stderr is not None else sys.stderr
+        print(
+            f"aelfrice: hook audit write failed (non-fatal): {exc}",
+            file=serr,
+        )

--- a/src/aelfrice/hook_tail.py
+++ b/src/aelfrice/hook_tail.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import IO, Final, Iterable
 
-from aelfrice.hook import (
+from aelfrice.hook_audit import (
     AUDIT_FILENAME,
     AUDIT_ROTATED_SUFFIX,
     _audit_path_for_db,

--- a/src/aelfrice/transcript_logger.py
+++ b/src/aelfrice/transcript_logger.py
@@ -56,6 +56,17 @@ EVENT_STOP: Final[str] = "Stop"
 EVENT_PRE_COMPACT: Final[str] = "PreCompact"
 EVENT_POST_COMPACT: Final[str] = "PostCompact"
 
+# #968: consecutive-duplicate guard. A turn whose (session_id, role, text)
+# matches the file's previous turn line within this window is treated as a
+# re-fire of one event (duplicated hook registration produces N identical
+# lines ~20ms apart) and dropped. Wide enough to absorb a burst, narrow
+# enough that a deliberate resend of the same prompt seconds later still logs.
+DUP_WINDOW_SECONDS: Final[float] = 2.0
+# Bytes scanned from the tail of turns.jsonl to find the previous line.
+# Bounds the dedup read at O(1) in file size, holding the per-append cost
+# inside the sub-10ms budget even when rotation has not run recently.
+_TAIL_READ_BYTES: Final[int] = 65536
+
 
 def transcripts_dir() -> Path:
     """Resolve the transcripts directory path.
@@ -127,6 +138,135 @@ def _append_jsonl(path: Path, line: dict[str, object]) -> None:
     with path.open("a", encoding="utf-8") as f:
         f.write(serialized)
         f.write("\n")
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _read_last_turn_line(path: Path) -> dict[str, object] | None:
+    """Return the last non-empty JSONL record in `path`, or None.
+
+    Bounded tail read: only the final `_TAIL_READ_BYTES` are scanned, so
+    the cost is O(1) in file size. A record whose serialized form is the
+    sole line in the window but begins before it (truncated) fails to
+    parse and yields None — the guard then fails open to append, never
+    dropping a turn it cannot positively confirm as a duplicate.
+    """
+    try:
+        with path.open("rb") as f:
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            start = max(0, size - _TAIL_READ_BYTES)
+            _ = f.seek(start)
+            chunk = f.read()
+    except OSError:
+        return None
+    if not chunk:
+        return None
+    segments = chunk.split(b"\n")
+    # When the window starts mid-file the first segment is a partial line;
+    # drop it so a truncated record is never mistaken for a complete one.
+    if start > 0 and len(segments) > 1:
+        segments = segments[1:]
+    for raw in reversed(segments):
+        if not raw.strip():
+            continue
+        try:
+            obj = json.loads(raw.decode("utf-8"))  # pyright: ignore[reportAny]
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        if isinstance(obj, dict):
+            return cast(dict[str, object], obj)
+        return None
+    return None
+
+
+def _is_consecutive_duplicate(
+    last: dict[str, object] | None, candidate: dict[str, object],
+) -> bool:
+    """True when `candidate` repeats `last` within DUP_WINDOW_SECONDS.
+
+    Match key is (session_id, role, text); turn_id is deliberately not in
+    the key — the burst that motivates this guard carries distinct
+    turn_ids (#968). Compaction markers (no role/text) and any record
+    missing a parseable `ts` compare unequal, so they never trigger a skip.
+    """
+    if last is None:
+        return False
+    for field in ("role", "text", "session_id"):
+        if last.get(field) != candidate.get(field):
+            return False
+    last_ts = _parse_iso(last.get("ts"))
+    cand_ts = _parse_iso(candidate.get("ts"))
+    if last_ts is None or cand_ts is None:
+        return False
+    return abs((cand_ts - last_ts).total_seconds()) <= DUP_WINDOW_SECONDS
+
+
+def _record_skipped_duplicate(*, role: str, session_id: str | None) -> None:
+    """Note a dropped consecutive-duplicate turn in hook_audit.jsonl.
+
+    Observability only (#968 acceptance): reuses the hook-audit sink so
+    `aelf tail` and other readers see the skip alongside belief-injection
+    rows, and inherits its rotation. Lazy import keeps this off the normal
+    append path — it runs only when a duplicate is actually detected, which
+    is rare. Fully fail-soft: audit-disabled, an in-memory DB, or any
+    import / I/O error is swallowed per the non-blocking contract.
+    """
+    try:
+        from aelfrice.db_paths import db_path  # noqa: PLC0415
+        from aelfrice.hook_audit import (  # noqa: PLC0415
+            _append_audit,
+            _audit_path_for_db,
+            load_hook_audit_config,
+        )
+
+        cfg = load_hook_audit_config()
+        if not cfg.enabled:
+            return
+        p = db_path()
+        if str(p) == ":memory:":
+            return
+        record: dict[str, object] = {
+            "ts": _now_iso(),
+            "hook": "transcript_logger",
+            "event": "skipped_duplicate",
+            "role": role,
+            "session_id": session_id,
+        }
+        _append_audit(_audit_path_for_db(p), record, cfg.max_bytes)
+    except Exception:
+        pass
+
+
+def _append_turn(line: dict[str, object]) -> None:
+    """Append a turn line, dropping a consecutive duplicate (#968).
+
+    Guards only turn lines (user/assistant); compaction markers append via
+    `_append_jsonl` directly and are never deduped. When the previous
+    record in turns.jsonl matches on (session_id, role, text) within
+    DUP_WINDOW_SECONDS, the write is skipped and the drop is noted in
+    hook_audit.jsonl. The guard targets the sequential burst of re-fires a
+    duplicated hook registration produces; it adds no locking, preserving
+    the lock-free non-blocking contract.
+    """
+    path = turns_path()
+    last = _read_last_turn_line(path)
+    if _is_consecutive_duplicate(last, line):
+        role = line.get("role")
+        sid = line.get("session_id")
+        _record_skipped_duplicate(
+            role=role if isinstance(role, str) else "",
+            session_id=sid if isinstance(sid, str) else None,
+        )
+        return
+    _append_jsonl(path, line)
 
 
 def _build_turn_line(
@@ -225,7 +365,7 @@ def _handle_user_prompt_submit(payload: dict[str, object]) -> None:
     line = _build_turn_line(
         role="user", text=prompt, session_id=sid, ctx=_turn_context(),
     )
-    _append_jsonl(turns_path(), line)
+    _append_turn(line)
 
 
 def _handle_stop(payload: dict[str, object]) -> None:
@@ -243,7 +383,7 @@ def _handle_stop(payload: dict[str, object]) -> None:
     line = _build_turn_line(
         role="assistant", text=text, session_id=sid, ctx=_turn_context(),
     )
-    _append_jsonl(turns_path(), line)
+    _append_turn(line)
 
 
 def _handle_pre_compact(payload: dict[str, object]) -> None:

--- a/src/aelfrice/transcript_logger.py
+++ b/src/aelfrice/transcript_logger.py
@@ -242,6 +242,9 @@ def _record_skipped_duplicate(*, role: str, session_id: str | None) -> None:
         }
         _append_audit(_audit_path_for_db(p), record, cfg.max_bytes)
     except Exception:
+        # Fail-soft by design: this audit write is observability-only, so
+        # any import or I/O error must be swallowed rather than propagate
+        # and break the non-blocking transcript-logger hook path (#968).
         pass
 
 

--- a/tests/test_transcript_logger.py
+++ b/tests/test_transcript_logger.py
@@ -230,6 +230,130 @@ def test_turn_ids_unique_across_sequential_writes(tdir: Path) -> None:
     assert len(ids) == 5
 
 
+def test_duplicate_burst_collapses_to_one_line(tdir: Path) -> None:
+    """#968: N identical hook fires (duplicated registration) -> one line.
+
+    Same session/role/text within the dedup window; distinct turn_ids and
+    sub-second spacing — the burst shape the issue describes.
+    """
+    for _ in range(4):
+        rc = _run_main({
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "what storage does this use?",
+            "session_id": "sess-burst",
+        })
+        assert rc == 0
+    lines = _read_jsonl(tdir / "turns.jsonl")
+    assert len(lines) == 1
+    assert lines[0]["text"] == "what storage does this use?"
+
+
+def test_assistant_stub_burst_collapses(tdir: Path) -> None:
+    """A repeated Stop with no accessible text writes one empty stub, not N."""
+    for _ in range(3):
+        _run_main({"hook_event_name": "Stop", "session_id": "sess-stop"})
+    lines = _read_jsonl(tdir / "turns.jsonl")
+    assert len(lines) == 1
+    assert lines[0]["role"] == "assistant"
+    assert lines[0]["text"] == ""
+
+
+def test_distinct_text_within_window_not_deduped(tdir: Path) -> None:
+    """Acceptance: distinct-text appends within the window are unaffected."""
+    _run_main({
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "first", "session_id": "s",
+    })
+    _run_main({
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "second", "session_id": "s",
+    })
+    lines = _read_jsonl(tdir / "turns.jsonl")
+    assert len(lines) == 2
+    assert [line["text"] for line in lines] == ["first", "second"]
+
+
+def test_same_text_different_session_not_deduped(tdir: Path) -> None:
+    for sid in ("sess-a", "sess-b"):
+        _run_main({
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "identical", "session_id": sid,
+        })
+    lines = _read_jsonl(tdir / "turns.jsonl")
+    assert len(lines) == 2
+
+
+def test_duplicate_inside_window_is_dropped(
+    tdir: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stamps = iter(["2026-06-18T00:00:00+00:00", "2026-06-18T00:00:01+00:00"])
+    monkeypatch.setattr(tl, "_now_iso", lambda: next(stamps))
+    for _ in range(2):
+        _run_main({
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "dup", "session_id": "s",
+        })
+    lines = _read_jsonl(tdir / "turns.jsonl")
+    assert len(lines) == 1
+
+
+def test_duplicate_outside_window_is_appended(
+    tdir: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same text deliberately resent past the window still logs (not a burst)."""
+    stamps = iter(["2026-06-18T00:00:00+00:00", "2026-06-18T00:00:05+00:00"])
+    monkeypatch.setattr(tl, "_now_iso", lambda: next(stamps))
+    for _ in range(2):
+        _run_main({
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "dup", "session_id": "s",
+        })
+    lines = _read_jsonl(tdir / "turns.jsonl")
+    assert len(lines) == 2
+
+
+def test_compaction_markers_never_deduped(tdir: Path) -> None:
+    """Markers append directly and are exempt from the turn-dedup guard."""
+    _run_main({"hook_event_name": "PostCompact"})
+    _run_main({"hook_event_name": "PostCompact"})
+    lines = _read_jsonl(tdir / "turns.jsonl")
+    assert len(lines) == 2
+    assert all(line["event"] == "compaction_complete" for line in lines)
+
+
+def test_turn_after_marker_is_appended(tdir: Path) -> None:
+    """A turn whose previous line is a compaction marker is never dropped."""
+    _run_main({"hook_event_name": "PostCompact"})
+    _run_main({
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "after marker", "session_id": "s",
+    })
+    lines = _read_jsonl(tdir / "turns.jsonl")
+    assert len(lines) == 2
+    assert lines[0]["event"] == "compaction_complete"
+    assert lines[1]["text"] == "after marker"
+
+
+def test_skipped_duplicate_recorded_in_hook_audit(
+    tdir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#968 acceptance: skip count is observable in hook_audit.jsonl."""
+    monkeypatch.setenv("AELFRICE_DB", str(tmp_path / "memory.db"))
+    monkeypatch.delenv("AELFRICE_HOOK_AUDIT", raising=False)
+    for _ in range(4):
+        _run_main({
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "dup", "session_id": "sess-audit",
+        })
+    assert len(_read_jsonl(tdir / "turns.jsonl")) == 1
+    audit = _read_jsonl(tmp_path / "hook_audit.jsonl")
+    skips = [r for r in audit if r.get("event") == "skipped_duplicate"]
+    assert len(skips) == 3
+    assert skips[0]["hook"] == "transcript_logger"
+    assert skips[0]["role"] == "user"
+    assert skips[0]["session_id"] == "sess-audit"
+
+
 def test_per_turn_latency_under_budget(tdir: Path) -> None:
     """Sub-10ms p99 is the spec target; we run 50 turns and assert p95
     stays under 50ms locally as a soft guard. p99 timing on dev


### PR DESCRIPTION
Closes #968.

## Problem
A duplicated hook registration (stacked settings in a worktree) fires `UserPromptSubmit`/`Stop` N times for one event, so `transcript_logger` appends N identical turn lines ~20ms apart (same `role`/`text`/`session_id`, distinct `turn_id`s). Because `turns.jsonl` is ground truth downstream — the PreCompact rebuilder's recent-turns window, cadence turn-density scoring, eval-fixture extraction — a 4x-duplicated session silently reads as 4x its real density.

## Fix
Consecutive-duplicate guard at append time:
- A turn whose `(session_id, role, text)` matches the file's previous turn line within `DUP_WINDOW_SECONDS` (2s) is dropped.
- The drop is recorded as a `skipped_duplicate` row in `hook_audit.jsonl` (observability).
- The previous line is found via a bounded tail read (`_TAIL_READ_BYTES`), keeping the per-append cost O(1) in file size and inside the sub-10ms budget. No new locking — the non-blocking contract holds.
- Compaction markers append directly and are exempt.
- Fails open: any record not positively confirmed as a duplicate is appended, so distinct text and deliberate resends past the window are unaffected.

## Supporting refactor (separate commit)
Writing the skip to `hook_audit.jsonl` required reaching the audit sink, but importing `aelfrice.hook` pulls in the retrieval stack (scipy, ~220ms cold) — fatal on a sub-10ms hook path. The first commit extracts the scipy-free audit primitives (`HookAuditConfig`, `load_hook_audit_config`, `_audit_path_for_db`, `_append_audit`, constants) into a new `aelfrice.hook_audit` module. `hook.py` re-exports them (no caller breaks); `hook_tail` imports from the new module directly. Behavior-preserving.

## Acceptance (from #968)
- [x] A 4x-burst of identical hook fires produces one transcript line.
- [x] Skip count is observable in `hook_audit.jsonl`.
- [x] Test covers the burst shape (identical text/role/session, distinct turn_ids, sub-second spacing).
- [x] Distinct-text appends within the window are unaffected.

## Verification
- `tests/test_transcript_logger.py` (+9 new tests), `tests/test_hook_audit.py`, `tests/test_hook_tail.py`, `tests/test_hook_user_prompt_submit.py`, `tests/test_hook_import_resilience.py`: 150 passed.
- `aelfrice.hook_audit` / `aelfrice.transcript_logger` confirmed scipy-free (8–36ms import).

## Summary by Sourcery

Add a consecutive-duplicate guard to transcript logging to collapse bursty duplicate turns while recording skips in the hook audit log, and extract audit primitives into a lightweight module for reuse off the heavy retrieval import path.

Enhancements:
- Introduce a time-windowed consecutive-duplicate filter for user and assistant turns in transcript_logger, preserving lock-free writes and exempting compaction markers.
- Record skipped duplicate turns as structured entries in the hook audit log for observability, using lazy access to the existing audit sink.
- Extract per-turn audit configuration, path resolution, and append/rotate helpers from hook.py into a new aelfrice.hook_audit module and re-export them for backward compatibility.

Tests:
- Add tests covering burst deduplication behavior, window-bound duplicate handling, compaction marker interactions, and audit logging of skipped duplicates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Consecutive duplicate detection: Identical message submissions within a time window are automatically detected and deduplicated, preventing accidental re-submissions from being logged.
  * Audit visibility: Skipped duplicate turns are recorded in the audit log for tracking and observability.

* **Tests**
  * Added comprehensive test suite validating duplicate detection across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->