### PR TITLE
feat(project_context): repo-identity population + auto-tag + backfill + migrate provenance (#970)

### DIFF
--- a/docs/adr/0003-project-context-repo-identity-convention.md
+++ b/docs/adr/0003-project-context-repo-identity-convention.md
@@ -1,0 +1,38 @@
+# 0003 — `project_context` holds repo identity
+
+- **Status:** Accepted
+- **Date:** 2026-06-18
+- **Deciders:** @robotrocketscience
+
+## Context
+
+`beliefs.project_context` was added in #858 (v3.2) as a within-repo retrieval-scope axis: two worktrees of the same repo share one DB (via `db_path()`'s git-common-dir routing), and the column was meant to let them see different *slices* of that shared store. The retrieval filter (`hook._filter_by_project_context`) reads it, and `db_paths.active_project_context()` resolves the active value from `AELFRICE_PROJECT_CONTEXT`.
+
+In practice the column was dead weight (#970): no writer ever set a non-empty value, so 100% of rows were `''` and the filter was a no-op. Worse, `aelf migrate` dropped the column entirely, collapsing two repos' beliefs into one mutually-visible pool — the column could not provide defense-in-depth for the one case (a deliberate merge) where physical DB separation does not.
+
+A convention had to be chosen, because the candidate meanings conflict at the data layer (single-string equality match — a row holds one or the other):
+
+1. **Repo identity** — doubles as merge/federation provenance, but forecloses fine-grained within-repo slicing on this axis.
+2. **Within-repo slice** — keeps #858's original intent, but needs a *separate* provenance column for the merge case.
+
+## Decision
+
+`project_context` holds **repo identity**: `<repo-root-basename>-<8 hex blake2b of the absolute git-common-dir>`, derived in `db_paths` from the same git-common-dir `db_path()` already keys on. Decisions 2–4 from #970:
+
+- **Derivation (decision 2):** reuse the git-common-dir identity `db_path()` computes; no new identity source. Two worktrees of one repo share an identity.
+- **Locked / global rows (decision 3):** L0 user-locked truths and federation-shared (`scope != 'project'`) beliefs stay `''` (always-visible). A repo-tag backfill must not scope a user's global preferences to a single repo, where an `aelf migrate` would then hide them.
+- **Active-context resolution (decision 4):** the resolver default stays **env-driven** — `active_project_context()` returns `''` (no filter) unless `AELFRICE_PROJECT_CONTEXT` is set. Scoping is **opt-in**: export `AELFRICE_PROJECT_CONTEXT="$(repo identity)"` to activate it. This commit populates the column and makes it migrate-safe but does **not** silently reverse #858's documented "unset = no filter" contract.
+
+Mechanics: `insert_belief` stamps the store's repo identity onto new eligible rows; a one-shot idempotent, reversible backfill stamps pre-existing eligible rows on first open; `aelf migrate` preserves an already-stamped value and stamps source-`''` eligible rows with the *source* repo's identity so provenance survives the merge.
+
+## Alternatives considered
+
+- **Within-repo slice (keep #858 intent).** Rejected: nothing populated it for nine months, and it provides no merge/federation provenance, which was the concrete gap. An explicit `project_context` value on a belief is still honoured verbatim, so per-slice tagging remains possible by opting in; it is just not the default.
+- **Flip the resolver default to repo identity (auto-consult, decision 4 = yes).** Rejected for now: it reverses the documented "unset = no filter" contract and changes retrieval behaviour for every store (a no-op for a single repo, but a silent semantics change). Left as a follow-up the operator can ratify; the column and migrate provenance land first.
+- **A separate provenance column (e.g. reuse `local_scope_id`).** `local_scope_id` (#204) is an opaque per-DB UUID for version-vector provenance, not a stable, legible, cross-repo retrieval-scope key. Keeping provenance on `project_context` avoids a second axis for the chosen convention.
+
+## Consequences
+
+- **Positive:** the column is populated and consulted (when opted in); `aelf migrate` no longer collapses provenance; merged stores can attribute each belief to its origin repo.
+- **Negative:** fine-grained within-repo slicing is no longer the default meaning of the column (only available via explicit per-belief values). Scoping is opt-in, so the defense-in-depth filter is inert until `AELFRICE_PROJECT_CONTEXT` is set.
+- **Neutral:** a new `schema_meta` backfill marker (`project_context_backfill_complete`) and a `<repo-root-basename>-<hash>` token format now appear in stores. The home-dir fallback store carries no identity (`''`), so non-repo usage is unchanged.

--- a/docs/adr/0003-project-context-repo-identity-convention.md
+++ b/docs/adr/0003-project-context-repo-identity-convention.md
@@ -28,7 +28,7 @@ Mechanics: `insert_belief` stamps the store's repo identity onto new eligible ro
 ## Alternatives considered
 
 - **Within-repo slice (keep #858 intent).** Rejected: nothing populated it for nine months, and it provides no merge/federation provenance, which was the concrete gap. An explicit `project_context` value on a belief is still honoured verbatim, so per-slice tagging remains possible by opting in; it is just not the default.
-- **Flip the resolver default to repo identity (auto-consult, decision 4 = yes).** Rejected for now: it reverses the documented "unset = no filter" contract and changes retrieval behaviour for every store (a no-op for a single repo, but a silent semantics change). Left as a follow-up the operator can ratify; the column and migrate provenance land first.
+- **Flip the resolver default to repo identity (auto-consult, decision 4 = yes).** Rejected for now: it reverses the documented "unset = no filter" contract and changes retrieval behaviour for every store (a no-op for a single repo, but a silent semantics change). Left as a follow-up that the operator can ratify; the column and migrate provenance land first.
 - **A separate provenance column (e.g. reuse `local_scope_id`).** `local_scope_id` (#204) is an opaque per-DB UUID for version-vector provenance, not a stable, legible, cross-repo retrieval-scope key. Keeping provenance on `project_context` avoids a second axis for the chosen convention.
 
 ## Consequences

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,6 +6,7 @@ Each ADR documents one technical decision: context, the choice made, alternative
 
 - [0001 — Record architecture decisions](0001-record-architecture-decisions.md)
 - [0002 — Two-repo physical separation for public/private boundary](0002-two-repo-physical-separation.md)
+- [0003 — `project_context` holds repo identity](0003-project-context-repo-identity-convention.md)
 
 ## Format
 

--- a/src/aelfrice/db_paths.py
+++ b/src/aelfrice/db_paths.py
@@ -91,7 +91,15 @@ def _identity_from_git_common_dir(git_dir: Path) -> str:
     name is the repo root basename — included for human legibility in
     `aelf` output and migrate provenance. The 8-hex BLAKE2b digest of the
     absolute git-common-dir disambiguates two same-named repos.
+
+    `git_dir` is resolved to an absolute path before hashing so the same
+    physical repo yields one identity regardless of how the path reached
+    here. `repo_identity()` already passes a resolved path, but `migrate`
+    can receive a relative `--from` legacy path; without this a relative
+    source would digest a different string than the in-repo `repo_identity`
+    and break cross-tool consistency.
     """
+    git_dir = git_dir.resolve()
     root = git_dir.parent
     basename = root.name or "repo"
     digest = hashlib.blake2b(str(git_dir).encode("utf-8"), digest_size=4).hexdigest()

--- a/src/aelfrice/db_paths.py
+++ b/src/aelfrice/db_paths.py
@@ -161,6 +161,15 @@ def active_project_context() -> str:
     the filter to drop project-scope beliefs whose stored
     project_context is neither '' nor an exact match.
 
+    Per ADR 0003 (#970) the stored project_context convention is repo
+    identity (see `repo_identity`). Scoping is opt-in: this resolver
+    stays env-driven, so the default (unset) is still "no filter". To
+    activate per-repo scoping, export
+    ``AELFRICE_PROJECT_CONTEXT="$(python -c 'from aelfrice.db_paths import
+    repo_identity; print(repo_identity())')"`` (or set it to the repo
+    identity by any means). The column is populated and migrate-safe
+    regardless of whether the filter is active.
+
     Distinct from `db_path()` (which picks WHICH DB to read). Two
     worktrees of the same repo share one DB via --git-common-dir; this
     resolver is what lets those two worktrees see DIFFERENT slices of

--- a/src/aelfrice/db_paths.py
+++ b/src/aelfrice/db_paths.py
@@ -16,12 +16,17 @@ imports `models` + `ulid`) is the only intra-package dep.
 """
 from __future__ import annotations
 
+import hashlib
 import os
 import subprocess
 from pathlib import Path
 from typing import Final
 
 from aelfrice.store import MemoryStore
+
+# #970 repo-store on-disk layout: db_path() places the store at
+# <git-common-dir>/aelfrice/memory.db, so the parent dir name is this.
+_REPO_STORE_PARENT_DIRNAME: Final[str] = "aelfrice"
 
 DEFAULT_DB_DIR: Final[Path] = Path.home() / ".aelfrice"
 DEFAULT_DB_FILENAME: Final[str] = "memory.db"
@@ -78,11 +83,62 @@ def _ensure_parent_dir(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
 
+def _identity_from_git_common_dir(git_dir: Path) -> str:
+    """Build a stable repo-identity token from a git-common-dir (#970).
+
+    Format: ``<repo-root-basename>-<8 hex>``. git-common-dir is
+    ``<root>/.git`` (shared across a repo's worktrees), so its parent's
+    name is the repo root basename — included for human legibility in
+    `aelf` output and migrate provenance. The 8-hex BLAKE2b digest of the
+    absolute git-common-dir disambiguates two same-named repos.
+    """
+    root = git_dir.parent
+    basename = root.name or "repo"
+    digest = hashlib.blake2b(str(git_dir).encode("utf-8"), digest_size=4).hexdigest()
+    return f"{basename}-{digest}"
+
+
+def repo_identity_from_db_path(p: Path) -> str:
+    """Repo identity for a store at `p`, derived from its on-disk layout.
+
+    The repo store lives at ``<git-common-dir>/aelfrice/memory.db``
+    (`db_path()`), so the git-common-dir is `p.parent.parent` when the
+    parent dir is the `aelfrice` subdir. Returns '' for the home-dir
+    fallback (`~/.aelfrice/memory.db`), an in-memory DB, or any path that
+    does not match the repo-store layout — those stores carry no repo
+    identity, so their rows stay cross-context. Reuses the already-resolved
+    path instead of re-forking `git`, so it adds no subprocess cost to the
+    store-open hot path.
+    """
+    if str(p) == ":memory:":
+        return ""
+    if p.parent.name != _REPO_STORE_PARENT_DIRNAME:
+        return ""
+    return _identity_from_git_common_dir(p.parent.parent)
+
+
+def repo_identity() -> str:
+    """Stable repo identity for the cwd's git repo, or '' outside one.
+
+    Reuses the git-common-dir `db_path()` keys on, so two worktrees of one
+    repo share an identity. This is the value a user exports as
+    ``AELFRICE_PROJECT_CONTEXT`` to activate project-context retrieval
+    scoping for the current repo (the column is populated and migrate-safe
+    regardless; the resolver default stays env-driven per #970). Forks
+    `git` once; prefer `repo_identity_from_db_path()` when a resolved DB
+    path is already in hand.
+    """
+    git_dir = _git_common_dir()
+    if git_dir is None:
+        return ""
+    return _identity_from_git_common_dir(git_dir)
+
+
 def _open_store() -> MemoryStore:
     p = db_path()
     if str(p) != ":memory:":
         _ensure_parent_dir(p)
-    return MemoryStore(str(p))
+    return MemoryStore(str(p), project_context_default=repo_identity_from_db_path(p))
 
 
 # v3.2 #858 active project context resolver.

--- a/src/aelfrice/migrate.py
+++ b/src/aelfrice/migrate.py
@@ -35,7 +35,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
 
-from aelfrice.models import ORIGIN_UNKNOWN, Belief, Edge
+from aelfrice.db_paths import repo_identity_from_db_path
+from aelfrice.models import (
+    BELIEF_SCOPE_PROJECT,
+    LOCK_USER,
+    ORIGIN_UNKNOWN,
+    Belief,
+    Edge,
+)
 from aelfrice.store import MemoryStore
 
 LEGACY_DB_NAME: Final[str] = "memory.db"
@@ -79,12 +86,37 @@ def _belongs_to_project(content: str, project_root: Path) -> bool:
     return abs_root in content
 
 
-def _read_legacy_beliefs(conn: sqlite3.Connection) -> list[Belief]:
+def _read_legacy_beliefs(
+    conn: sqlite3.Connection, *, source_identity: str = "",
+) -> list[Belief]:
+    """Read beliefs from a source DB, preserving project_context provenance.
+
+    #970: a migrate must not collapse every row to project_context=''. An
+    already-stamped source value is carried over verbatim. A source row
+    still at '' (pre-#970 data) is stamped with `source_identity` — the
+    repo identity of the *source* store — when it is project-scope and not
+    user-locked, so the merged store can still tell which repo each belief
+    came from. Locked/global rows stay '' (cross-context). `source_identity`
+    is '' for a home-dir / non-repo source, which leaves rows '' as before.
+    """
     cur = conn.execute("SELECT * FROM beliefs")
     rows = cur.fetchall()
-    has_origin = bool(rows) and "origin" in rows[0].keys()
+    keys = set(rows[0].keys()) if rows else set()
+    has_origin = "origin" in keys
+    has_scope = "scope" in keys
+    has_project_context = "project_context" in keys
     out: list[Belief] = []
     for row in rows:
+        scope = row["scope"] if has_scope else BELIEF_SCOPE_PROJECT
+        lock_level = row["lock_level"]
+        pc = row["project_context"] if has_project_context else ""
+        if (
+            pc == ""
+            and source_identity
+            and scope == BELIEF_SCOPE_PROJECT
+            and lock_level != LOCK_USER
+        ):
+            pc = source_identity
         out.append(Belief(
             id=row["id"],
             content=row["content"],
@@ -92,11 +124,13 @@ def _read_legacy_beliefs(conn: sqlite3.Connection) -> list[Belief]:
             alpha=float(row["alpha"]),
             beta=float(row["beta"]),
             type=row["type"],
-            lock_level=row["lock_level"],
+            lock_level=lock_level,
             locked_at=row["locked_at"],
             created_at=row["created_at"],
             last_retrieved_at=row["last_retrieved_at"],
             origin=row["origin"] if has_origin else ORIGIN_UNKNOWN,
+            scope=scope,
+            project_context=pc,
         ))
     return out
 
@@ -149,8 +183,14 @@ def migrate(
     legacy_uri = f"file:{legacy_path}?mode=ro"
     legacy_conn = sqlite3.connect(legacy_uri, uri=True)
     legacy_conn.row_factory = sqlite3.Row
+    # #970: stamp source-'' project rows with the SOURCE repo identity so
+    # provenance survives the merge instead of collapsing to ''. '' for a
+    # home-dir / non-repo source.
+    source_identity = repo_identity_from_db_path(legacy_path)
     try:
-        legacy_beliefs = _read_legacy_beliefs(legacy_conn)
+        legacy_beliefs = _read_legacy_beliefs(
+            legacy_conn, source_identity=source_identity,
+        )
         legacy_edges = _read_legacy_edges(legacy_conn)
     finally:
         legacy_conn.close()

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -320,12 +320,17 @@ class Belief:
     or 'shared:<name>' (named peer group). Validated at write time by
     `validate_belief_scope`; invalid values raise ``ValueError``.
 
-    `project_context` (v3.2 #858) is the within-repo retrieval scope
-    tag. Default '' means "cross-context — visible regardless of active
-    project context". Distinct from `scope` (federation visibility):
-    `project_context` filters retrieval against the active in-process
-    context resolved by `db_paths.active_project_context()`, whereas
-    `scope` controls whether peer DBs may surface the row.
+    `project_context` (v3.2 #858) is the retrieval scope tag. Per ADR
+    0003 (#970) the convention is **repo identity** (the
+    `<repo-root-basename>-<hash>` token from `db_paths.repo_identity`),
+    auto-stamped on write for project-scope, non-user-locked beliefs.
+    Default '' means "cross-context — visible regardless of active project
+    context"; L0 user-locked truths and federation-shared rows keep ''.
+    Distinct from `scope` (federation visibility): `project_context`
+    filters retrieval against the active in-process context resolved by
+    `db_paths.active_project_context()` (opt-in via
+    `AELFRICE_PROJECT_CONTEXT`), whereas `scope` controls whether peer DBs
+    may surface the row.
 
     `last_confirmed_at` (v3.5 #936) is an ISO timestamp set by
     `aelf review --apply` when the user marks a belief `keep`. NULL

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -21,6 +21,7 @@ from typing import Callable, Final, Iterable, Iterator
 
 from aelfrice.models import (
     BELIEF_SCOPE_PROJECT,
+    LOCK_USER,
     CORROBORATION_SOURCE_CONSOLIDATION_MIGRATION,
     CORROBORATION_SOURCE_TYPES,
     CORROBORATION_SOURCE_WONDER_INGEST,
@@ -520,6 +521,16 @@ SCHEMA_META_ENTITY_BACKFILL: Final[str] = "entity_backfill_complete"
 # just a UUID. When federation ships at v3, peer scopes appear
 # alongside this one in the version-vector dicts.
 SCHEMA_META_LOCAL_SCOPE_ID: Final[str] = "local_scope_id"
+# v3.x #970. Marker for the one-shot backfill that stamps the store's
+# repo identity (passed in as `project_context_default`) onto every
+# pre-existing project-scope, non-user-locked belief whose
+# project_context is still '' (the #858 default). Locked/global rows
+# stay '' (always-visible) per the #970 convention. ISO timestamp on
+# completion; absence triggers the backfill on next open when a
+# non-empty default is supplied.
+SCHEMA_META_PROJECT_CONTEXT_BACKFILL: Final[str] = (
+    "project_context_backfill_complete"
+)
 # Marker for the v1.5.0 backfill that stamps `{local_scope: 1}`
 # on every pre-#204 belief and edge row. ISO timestamp on
 # completion; absence triggers the backfill on next open.
@@ -841,7 +852,13 @@ def _row_to_onboard_session(row: sqlite3.Row) -> OnboardSession:
 class MemoryStore:
     """SQLite store. Pass `:memory:` for tests, a path otherwise."""
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str, *, project_context_default: str = "") -> None:
+        # #970: repo identity stamped on new project-scope, non-user-locked
+        # beliefs whose project_context is ''. Empty (the default) disables
+        # stamping and the backfill — direct callers that open a store
+        # without a repo identity keep the pre-#970 cross-context behaviour.
+        # db_paths._open_store() injects the value derived from the DB path.
+        self._project_context_default: str = project_context_default
         self._conn: sqlite3.Connection = sqlite3.connect(path)
         self._conn.row_factory = sqlite3.Row
         # WAL only meaningful on-disk; harmless on :memory:.
@@ -893,6 +910,11 @@ class MemoryStore:
         # `{local_scope: 1}` on every pre-existing belief and edge
         # the first time a v1.5+ binary opens this DB. Idempotent.
         self._maybe_backfill_version_vectors()
+        # v3.x #970 project_context backfill. Stamps the repo identity
+        # onto pre-existing eligible rows the first time a binary opens
+        # this DB with a non-empty default. Idempotent; no-op when the
+        # default is '' (direct opens). Locked/global rows stay ''.
+        self._maybe_backfill_project_context()
         # v2.x #263 legacy log synthesis. Must run BEFORE the log
         # version-vector backfill so synthesized rows are included in
         # the backfill's INSERT OR IGNORE pass on the same open.
@@ -1108,6 +1130,40 @@ class MemoryStore:
             datetime.now(timezone.utc).isoformat(),
         )
         return belief_inserted + edge_inserted
+
+    def _maybe_backfill_project_context(self) -> int:
+        """One-shot backfill stamping the repo identity on eligible rows.
+
+        Stamps `_project_context_default` onto every project-scope,
+        non-user-locked belief whose `project_context` is still '' (the
+        #858 default). Locked (L0) and federation-shared rows are left ''
+        so user-global truths and shared beliefs stay visible across
+        contexts and survive an `aelf migrate` without being scoped to one
+        repo (#970 decision 3).
+
+        Idempotent: stamped marker short-circuits subsequent opens. No-op
+        when no default is set (direct opens), so it never touches a store
+        opened without a repo identity. Reversible by design —
+        `UPDATE beliefs SET project_context=''` restores the prior state.
+
+        Returns the count of rows stamped.
+        """
+        if not self._project_context_default:
+            return 0
+        if self.get_schema_meta(SCHEMA_META_PROJECT_CONTEXT_BACKFILL):
+            return 0
+        cur = self._conn.execute(
+            "UPDATE beliefs SET project_context = ? "
+            "WHERE project_context = '' AND scope = ? AND lock_level != ?",
+            (self._project_context_default, BELIEF_SCOPE_PROJECT, LOCK_USER),
+        )
+        stamped = cur.rowcount or 0
+        self._conn.commit()
+        self.set_schema_meta(
+            SCHEMA_META_PROJECT_CONTEXT_BACKFILL,
+            datetime.now(timezone.utc).isoformat(),
+        )
+        return stamped
 
     def _maybe_backfill_log_version_vectors(self) -> int:
         """Stamp `{local_scope: 1}` on every pre-existing ingest_log row.
@@ -1815,6 +1871,25 @@ class MemoryStore:
 
     # --- Belief CRUD ------------------------------------------------------
 
+    def _project_context_for_insert(self, b: Belief) -> str:
+        """Resolve the project_context to persist for a new belief (#970).
+
+        An explicit non-empty `b.project_context` is always honoured. An
+        empty one is stamped with the store's repo identity
+        (`_project_context_default`) only for project-scope, non-user-locked
+        beliefs — federation-shared rows (`scope != 'project'`) and L0
+        user-locked truths stay '' so they remain cross-context / always
+        visible. When no default is set (direct opens), the value is left ''
+        and behaviour is identical to pre-#970.
+        """
+        if b.project_context != "":
+            return b.project_context
+        if not self._project_context_default:
+            return ""
+        if b.scope != BELIEF_SCOPE_PROJECT or b.lock_level == LOCK_USER:
+            return ""
+        return self._project_context_default
+
     def insert_belief(self, b: Belief) -> None:
         _check_insert_belief_authority()
         if b.retention_class not in RETENTION_CLASSES:
@@ -1823,6 +1898,7 @@ class MemoryStore:
                 f"must be one of {sorted(RETENTION_CLASSES)}"
             )
         validate_belief_scope(b.scope)
+        project_context = self._project_context_for_insert(b)
         self._conn.execute(
             """
             INSERT INTO beliefs (
@@ -1839,7 +1915,7 @@ class MemoryStore:
                 b.lock_level, b.locked_at,
                 b.created_at, b.last_retrieved_at, b.session_id, b.origin,
                 b.hibernation_score, b.activation_condition,
-                b.retention_class, b.valid_to, b.scope, b.project_context,
+                b.retention_class, b.valid_to, b.scope, project_context,
                 b.last_confirmed_at,
             ),
         )

--- a/tests/test_db_paths_repo_identity_970.py
+++ b/tests/test_db_paths_repo_identity_970.py
@@ -1,0 +1,99 @@
+"""Repo-identity derivation + _open_store injection for #970.
+
+`project_context` is stamped with a repo identity derived from the
+store's on-disk location (no extra git fork). These tests cover the
+derivation helpers and that `_open_store()` threads the identity into
+the store so writes get stamped.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aelfrice import db_paths
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
+
+
+def _b(bid: str) -> Belief:
+    return Belief(
+        id=bid,
+        content=f"belief {bid}",
+        content_hash=f"{bid}-hash",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        created_at="2026-06-18T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def test_identity_is_deterministic_and_formatted() -> None:
+    git_dir = Path("/home/u/projects/myrepo/.git")
+    ident = db_paths._identity_from_git_common_dir(git_dir)
+    assert ident == db_paths._identity_from_git_common_dir(git_dir)
+    assert ident.startswith("myrepo-")
+    assert len(ident.split("-")[-1]) == 8
+
+
+def test_identity_distinguishes_same_named_repos() -> None:
+    a = db_paths._identity_from_git_common_dir(Path("/a/myrepo/.git"))
+    b = db_paths._identity_from_git_common_dir(Path("/b/myrepo/.git"))
+    assert a != b
+    assert a.startswith("myrepo-") and b.startswith("myrepo-")
+
+
+def test_repo_identity_from_db_path_repo_layout() -> None:
+    p = Path("/home/u/proj/.git/aelfrice/memory.db")
+    expected = db_paths._identity_from_git_common_dir(Path("/home/u/proj/.git"))
+    assert db_paths.repo_identity_from_db_path(p) == expected
+
+
+def test_repo_identity_from_db_path_home_fallback_is_empty() -> None:
+    assert db_paths.repo_identity_from_db_path(Path.home() / ".aelfrice" / "memory.db") == ""
+
+
+def test_repo_identity_from_db_path_memory_is_empty() -> None:
+    assert db_paths.repo_identity_from_db_path(Path(":memory:")) == ""
+
+
+def test_repo_identity_none_outside_git(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db_paths, "_git_common_dir", lambda: None)
+    assert db_paths.repo_identity() == ""
+
+
+def test_repo_identity_uses_git_common_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        db_paths, "_git_common_dir", lambda: Path("/x/somerepo/.git"),
+    )
+    assert db_paths.repo_identity() == db_paths._identity_from_git_common_dir(
+        Path("/x/somerepo/.git"),
+    )
+
+
+def test_open_store_stamps_writes_in_repo_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "aelfrice" / "memory.db"  # repo-store layout
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    expected = db_paths.repo_identity_from_db_path(db)
+    assert expected != ""
+    store = db_paths._open_store()
+    store.insert_belief(_b("b1"))
+    got = store.get_belief("b1")
+    assert got is not None
+    assert got.project_context == expected
+
+
+def test_open_store_no_identity_for_non_layout_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "memory.db"  # not under an 'aelfrice' dir
+    monkeypatch.setenv("AELFRICE_DB", str(db))
+    store = db_paths._open_store()
+    store.insert_belief(_b("b1"))
+    got = store.get_belief("b1")
+    assert got is not None
+    assert got.project_context == ""

--- a/tests/test_migrate_project_context_970.py
+++ b/tests/test_migrate_project_context_970.py
@@ -1,0 +1,113 @@
+"""Migrate must preserve project_context provenance (#970).
+
+Before #970, `aelf migrate` dropped project_context, collapsing every
+migrated row to '' so two repos' beliefs became mutually visible in the
+merged store. These tests pin: already-stamped rows are carried over,
+source-'' project rows are stamped with the *source* repo identity, and
+locked/global rows stay ''.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from aelfrice import db_paths
+from aelfrice.migrate import migrate
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    BELIEF_SCOPE_GLOBAL,
+    BELIEF_SCOPE_PROJECT,
+    LOCK_NONE,
+    LOCK_USER,
+    Belief,
+)
+from aelfrice.store import MemoryStore
+
+
+def _b(
+    bid: str,
+    *,
+    project_context: str = "",
+    scope: str = BELIEF_SCOPE_PROJECT,
+    lock_level: str = LOCK_NONE,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=f"belief {bid}",
+        content_hash=f"{bid}-hash",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=None,
+        created_at="2026-06-18T00:00:00Z",
+        last_retrieved_at=None,
+        scope=scope,
+        project_context=project_context,
+    )
+
+
+def _seed_source(path: Path, beliefs: list[Belief]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    src = MemoryStore(str(path))  # no default → values land verbatim
+    for b in beliefs:
+        src.insert_belief(b)
+    src.close()
+
+
+def _migrate(src: Path, tgt: Path) -> None:
+    migrate(
+        legacy_path=src,
+        target_path=tgt,
+        project_root=Path("/"),
+        apply=True,
+        copy_all=True,
+    )
+
+
+def _pc(path: Path, bid: str) -> str:
+    store = MemoryStore(str(path))
+    try:
+        b = store.get_belief(bid)
+        assert b is not None
+        return b.project_context
+    finally:
+        store.close()
+
+
+def test_migrate_preserves_already_stamped_context(tmp_path: Path) -> None:
+    src = tmp_path / "src" / "aelfrice" / "memory.db"
+    tgt = tmp_path / "tgt" / "memory.db"  # non-layout target → no re-stamp
+    _seed_source(src, [_b("b1", project_context="prior-ctx")])
+    _migrate(src, tgt)
+    assert _pc(tgt, "b1") == "prior-ctx"
+
+
+def test_migrate_stamps_source_identity_on_empty_project_rows(tmp_path: Path) -> None:
+    src = tmp_path / "src" / "aelfrice" / "memory.db"  # repo-layout source
+    tgt = tmp_path / "tgt" / "memory.db"
+    _seed_source(src, [_b("b1")])  # project_context=''
+    expected = db_paths.repo_identity_from_db_path(src)
+    assert expected != ""
+    _migrate(src, tgt)
+    assert _pc(tgt, "b1") == expected
+
+
+def test_migrate_leaves_locked_and_global_unstamped(tmp_path: Path) -> None:
+    src = tmp_path / "src" / "aelfrice" / "memory.db"
+    tgt = tmp_path / "tgt" / "memory.db"
+    _seed_source(src, [
+        _b("locked", lock_level=LOCK_USER),
+        _b("global", scope=BELIEF_SCOPE_GLOBAL),
+    ])
+    _migrate(src, tgt)
+    assert _pc(tgt, "locked") == ""
+    assert _pc(tgt, "global") == ""
+
+
+def test_migrate_non_repo_source_leaves_empty(tmp_path: Path) -> None:
+    src = tmp_path / "memory.db"  # not under 'aelfrice' → source_identity ''
+    tgt = tmp_path / "tgt" / "memory.db"
+    _seed_source(src, [_b("b1")])
+    assert db_paths.repo_identity_from_db_path(src) == ""
+    _migrate(src, tgt)
+    assert _pc(tgt, "b1") == ""

--- a/tests/test_store_project_context_970.py
+++ b/tests/test_store_project_context_970.py
@@ -1,0 +1,136 @@
+"""Store-side project_context auto-stamp + backfill for #970.
+
+Covers `insert_belief` stamping the store's repo identity
+(`project_context_default`) onto eligible new beliefs, and the one-shot
+`_maybe_backfill_project_context` pass over pre-existing rows. The
+convention (chosen in #970): project_context holds repo identity;
+project-scope non-user-locked rows get stamped; locked (L0) and
+federation-shared rows stay '' (always-visible).
+"""
+from __future__ import annotations
+
+import pytest
+
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    BELIEF_SCOPE_GLOBAL,
+    BELIEF_SCOPE_PROJECT,
+    LOCK_NONE,
+    LOCK_USER,
+    Belief,
+)
+from aelfrice.store import (
+    SCHEMA_META_PROJECT_CONTEXT_BACKFILL,
+    MemoryStore,
+)
+
+_IDENTITY = "myrepo-deadbeef"
+
+
+def _b(
+    bid: str,
+    *,
+    project_context: str = "",
+    scope: str = BELIEF_SCOPE_PROJECT,
+    lock_level: str = LOCK_NONE,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=f"belief {bid}",
+        content_hash=f"{bid}-hash",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=None,
+        created_at="2026-06-18T00:00:00Z",
+        last_retrieved_at=None,
+        scope=scope,
+        project_context=project_context,
+    )
+
+
+def _pc(store: MemoryStore, bid: str) -> str:
+    b = store.get_belief(bid)
+    assert b is not None
+    return b.project_context
+
+
+# --- insert-time stamping ------------------------------------------------
+
+def test_insert_stamps_default_on_empty_project_scope() -> None:
+    store = MemoryStore(":memory:", project_context_default=_IDENTITY)
+    store.insert_belief(_b("b1"))
+    assert _pc(store, "b1") == _IDENTITY
+
+
+def test_insert_honours_explicit_project_context() -> None:
+    store = MemoryStore(":memory:", project_context_default=_IDENTITY)
+    store.insert_belief(_b("b1", project_context="explicit-slice"))
+    assert _pc(store, "b1") == "explicit-slice"
+
+
+def test_insert_leaves_user_locked_unstamped() -> None:
+    store = MemoryStore(":memory:", project_context_default=_IDENTITY)
+    store.insert_belief(_b("b1", lock_level=LOCK_USER))
+    assert _pc(store, "b1") == ""
+
+
+def test_insert_leaves_non_project_scope_unstamped() -> None:
+    store = MemoryStore(":memory:", project_context_default=_IDENTITY)
+    store.insert_belief(_b("b1", scope=BELIEF_SCOPE_GLOBAL))
+    assert _pc(store, "b1") == ""
+
+
+def test_insert_no_default_preserves_pre_970_behaviour() -> None:
+    store = MemoryStore(":memory:")  # no repo identity → no stamping
+    store.insert_belief(_b("b1"))
+    assert _pc(store, "b1") == ""
+
+
+# --- backfill ------------------------------------------------------------
+
+def _seed_pre_970_rows(store: MemoryStore) -> None:
+    """Insert rows that look like pre-#970 data: all project_context=''."""
+    store.insert_belief(_b("plain"))
+    store.insert_belief(_b("locked", lock_level=LOCK_USER))
+    store.insert_belief(_b("global", scope=BELIEF_SCOPE_GLOBAL))
+
+
+def test_backfill_stamps_only_eligible_rows() -> None:
+    # Seed with no default so every row lands as ''.
+    seed = MemoryStore(":memory:")
+    _seed_pre_970_rows(seed)
+    # Same connection, re-driven backfill with an identity present.
+    seed._project_context_default = _IDENTITY  # pyright: ignore[reportPrivateUsage]
+    stamped = seed._maybe_backfill_project_context()  # pyright: ignore[reportPrivateUsage]
+    assert stamped == 1
+    assert _pc(seed, "plain") == _IDENTITY
+    assert _pc(seed, "locked") == ""
+    assert _pc(seed, "global") == ""
+
+
+def test_backfill_is_idempotent() -> None:
+    seed = MemoryStore(":memory:")
+    _seed_pre_970_rows(seed)
+    seed._project_context_default = _IDENTITY  # pyright: ignore[reportPrivateUsage]
+    first = seed._maybe_backfill_project_context()  # pyright: ignore[reportPrivateUsage]
+    second = seed._maybe_backfill_project_context()  # pyright: ignore[reportPrivateUsage]
+    assert first == 1
+    assert second == 0
+    assert seed.get_schema_meta(SCHEMA_META_PROJECT_CONTEXT_BACKFILL) is not None
+
+
+def test_backfill_no_default_is_noop() -> None:
+    seed = MemoryStore(":memory:")
+    _seed_pre_970_rows(seed)
+    assert seed._maybe_backfill_project_context() == 0  # pyright: ignore[reportPrivateUsage]
+    assert seed.get_schema_meta(SCHEMA_META_PROJECT_CONTEXT_BACKFILL) is None
+    assert _pc(seed, "plain") == ""
+
+
+def test_backfill_does_not_touch_already_stamped_rows() -> None:
+    store = MemoryStore(":memory:", project_context_default=_IDENTITY)
+    store.insert_belief(_b("explicit", project_context="other-context"))
+    # The on-open backfill already ran in __init__; explicit row untouched.
+    assert _pc(store, "explicit") == "other-context"

--- a/tests/test_store_project_context_970.py
+++ b/tests/test_store_project_context_970.py
@@ -9,8 +9,6 @@ federation-shared rows stay '' (always-visible).
 """
 from __future__ import annotations
 
-import pytest
-
 from aelfrice.models import (
     BELIEF_FACTUAL,
     BELIEF_SCOPE_GLOBAL,


### PR DESCRIPTION
Closes #970.

## Problem
`project_context` (added in #858, v3.2) was dead weight: the column existed and the retrieval filter read it, but **nothing ever wrote a non-empty value** (100% of rows `''`), and `aelf migrate` dropped the column, collapsing two repos' beliefs into one mutually-visible pool — the one case physical DB separation can't cover.

## Convention chosen (ADR 0003)
The four #970 "crux" decisions, resolved per the issue's recommendations:

1. **What it holds → repo identity** (not a within-repo slice). Format `<repo-root-basename>-<8 hex blake2b of the abs git-common-dir>`.
2. **Derivation → reuse the git-common-dir** `db_path()` already keys on (no new identity source). Two worktrees of one repo share an identity.
3. **Locked/global rows → stay `''`** (always-visible). A repo-tag backfill must not scope a user's global truths to one repo where `aelf migrate` would then hide them.
4. **Active-context resolution → opt-in.** The resolver default stays env-driven (`unset = no filter`); scoping activates by exporting `AELFRICE_PROJECT_CONTEXT="$(repo identity)"`.

## What this PR does (4 atomic commits)
- **feat(store):** `insert_belief` auto-stamps the store's repo identity onto eligible new beliefs; an idempotent, reversible, locked-exempt backfill stamps pre-existing rows on first open. No-op when no identity is set (direct opens) → exact pre-#970 behaviour preserved.
- **feat(db_paths):** `repo_identity()` / `repo_identity_from_db_path()` (the latter derives identity from the store's on-disk layout with **no extra git fork**); `_open_store()` injects it.
- **feat(migrate):** `aelf migrate` now preserves an already-stamped `project_context` and stamps source-`''` eligible rows with the **source** repo's identity, so provenance survives the merge instead of collapsing to `''`.
- **docs(adr):** ADR 0003 records the convention; Belief/resolver docstrings reconciled.

## Decision 4 — flagged for your call
I implemented decision 4 as **opt-in** (column populated + migrate-safe, but the resolver default left env-driven). I deliberately did **not** flip the resolver to default to repo identity, because that silently reverses #858's documented "unset = no filter" contract and changes retrieval for every store (a no-op for a single repo, but a semantics change). If you want auto-consult-by-default, that's a one-line resolver change + filter-test update — say the word and I'll add a commit.

## Acceptance (#970 proposed scope)
- [x] Convention decided and documented (ADR 0003).
- [x] Auto-populate `project_context` on write (store choke point covers ingest/commit-ingest/promotion).
- [x] Idempotent, reversible backfill for existing stores.
- [x] `aelf migrate` preserves/stamps source provenance.
- [x] Tests: writer populates; backfill eligibility (locked/global exempt); migrate preserves provenance.

## Verification
- New: `test_store_project_context_970.py` (9), `test_db_paths_repo_identity_970.py` (9), `test_migrate_project_context_970.py` (4).
- Regression sweep across store/ingest/migrate/federation/cli/hook suites: green (full-suite result in PR gate).

## Summary by Sourcery

Populate and preserve the `project_context` column using a stable repo identity so beliefs gain per-repo provenance without changing default retrieval behaviour.

New Features:
- Auto-stamp new project-scope, non-user-locked beliefs with a repo identity–based project_context derived from the store’s on-disk git layout.
- Expose helpers to compute a stable repo identity from the git common directory or an already-resolved DB path and integrate this identity when opening stores.
- Have `aelf migrate` carry forward existing project_context values and tag previously empty project-scope beliefs with the source store’s repo identity to retain provenance across merges.
- Document the chosen convention for project_context as repo identity in ADR 0003 and update Belief documentation accordingly.

Enhancements:
- Add an idempotent, reversible backfill to stamp repo identity into eligible existing beliefs while leaving locked and global rows always-visible.
- Keep project-context scoping opt-in by retaining the environment-driven active_project_context resolver while ensuring the column is consistently populated.

Tests:
- Add tests validating store-side project_context stamping and backfill behaviour for various scopes and lock levels.
- Add tests covering repo-identity derivation from git paths and DB paths, and verifying that store opens in repo layout propagate the identity into writes.
- Add tests ensuring migrate preserves or stamps project_context correctly for stamped, empty, locked, global, and non-repo source rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beliefs are now automatically tagged with repository identity information for improved tracking and scoping
  * Migration preserves or derives repository identity for eligible beliefs

* **Documentation**
  * Added Architecture Decision Record (ADR 0003) documenting project context and repo identity conventions
  * Updated field documentation with new repository identity stamping behavior

* **Tests**
  * Comprehensive coverage for repository identity derivation, store stamping, and migration behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->