### PR TITLE
release: v3.6.0

### DIFF
--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-06-19
+
+The `project_context` provenance wave: a column added in v3.2 (#858) but never
+written is now auto-populated with a stable per-repo identity and preserved
+across `aelf migrate`, plus a transcript-logger fix that stops duplicated hook
+registrations from inflating turn density.
+
+### Added
+
+- **`project_context` repo-identity population, auto-tag, backfill, and migrate provenance ([#970](https://github.com/robotrocketscience/aelfrice/issues/970), [PR #972](https://github.com/robotrocketscience/aelfrice/pull/972)).** The `project_context` column added in #858 (v3.2) was dead weight — the retrieval filter read it but nothing ever wrote a non-empty value, and `aelf migrate` dropped it, collapsing two repos' beliefs into one mutually-visible pool. Now `insert_belief` auto-stamps the store's repo identity (`<repo-root-basename>-<8-hex blake2b of the abs git-common-dir>`, reusing the git-common-dir `db_path()` already keys on — two worktrees of one repo share an identity) onto eligible new beliefs. An idempotent, reversible, locked/global-exempt backfill stamps pre-existing rows on first open. `aelf migrate` preserves an already-stamped value and stamps source-`''` eligible rows with the **source** repo's identity, so provenance survives the merge. No-op when no identity is set (direct opens) → exact pre-#970 behaviour preserved. New `repo_identity()` / `repo_identity_from_db_path()` in `db_paths` (the latter derives identity from the on-disk layout with no extra git fork).
+- **ADR 0003 records the repo-identity convention ([#970](https://github.com/robotrocketscience/aelfrice/issues/970)).** The four crux decisions (what it holds → repo identity; derivation → git-common-dir reuse; locked/global rows → stay `''`/always-visible; active-context resolution → opt-in). Decision 4 was ratified **keep-opt-in** by the operator ([#973](https://github.com/robotrocketscience/aelfrice/issues/973), [PR #974](https://github.com/robotrocketscience/aelfrice/pull/974)): the resolver default stays env-driven (`active_project_context()` returns `''`/no filter unless `AELFRICE_PROJECT_CONTEXT` is set), rather than flipping to repo-identity auto-consult, which would silently hide differently-stamped beliefs in a merged store and reverse #858's documented "unset = no filter" contract.
+
+### Fixed
+
+- **Transcript logger drops consecutive-duplicate turns ([#968](https://github.com/robotrocketscience/aelfrice/issues/968), [PR #971](https://github.com/robotrocketscience/aelfrice/pull/971)).** A duplicated hook registration (e.g. stacked settings in a worktree) fired `UserPromptSubmit`/`Stop` N times per event, appending N identical turn lines ~20ms apart. Because `turns.jsonl` is ground truth downstream — the PreCompact rebuilder's recent-turns window, cadence turn-density scoring, eval-fixture extraction — a 4x-duplicated session silently read as 4x its real density. A turn whose `(session_id, role, text)` matches the previous line within `DUP_WINDOW_SECONDS` (2s) is now dropped and recorded as a `skipped_duplicate` row in `hook_audit.jsonl`. The previous line is found via a bounded tail read, keeping per-append cost O(1) in file size and inside the sub-10ms budget; no new locking. Compaction markers are exempt and the guard fails open, so distinct text and deliberate resends past the window are unaffected.
+
+### Internal
+
+- **Extract `hook_audit` sink from `hook.py` ([#968](https://github.com/robotrocketscience/aelfrice/issues/968)).** The duplicate-skip audit write needed the audit sink, but importing `aelfrice.hook` pulls in the retrieval stack (scipy, ~220ms cold) — fatal on the sub-10ms hook path. The scipy-free audit primitives (`HookAuditConfig`, `load_hook_audit_config`, `_audit_path_for_db`, `_append_audit`) moved into a new `aelfrice.hook_audit` module; `hook.py` re-exports them so no caller breaks. Behaviour-preserving.
+
 ## [3.5.1] - 2026-06-10
 
 Patch release: two privacy-adjacent ingest/scan fixes, plus the v3.5.0
@@ -484,7 +504,8 @@ The cadence-policy completion + conversation-aware retrieval wave.
 
 - **`urllib3` 2.6.3 → 2.7.0 for CVE patches** ([#640](https://github.com/robotrocketscience/aelfrice/issues/640)). Lockfile-only dependency bump pulled in via `uv lock` to clear two CVEs flagged by GitHub's dependency scanner. `urllib3` is a transitive dep (via `requests` in the publish workflow and the `gh` CLI's Python shim); aelfrice itself does not import it. No source change.
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v3.5.1...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v3.6.0...HEAD
+[3.6.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.5.1...v3.6.0
 [3.5.1]: https://github.com/robotrocketscience/aelfrice/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/robotrocketscience/aelfrice/compare/51cea5c4...v3.5.0
 [3.4.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.3.0...51cea5c4

--- a/docs/concepts/ROADMAP.md
+++ b/docs/concepts/ROADMAP.md
@@ -9,7 +9,7 @@ Per-issue tracking: [LIMITATIONS.md](../user/LIMITATIONS.md). Release log: [CHAN
 
 aelfrice is a rebuild of an earlier research line on Bayesian + graph-backed memory for AI coding agents. The research codebase explored FTS5 retrieval, vocabulary bridging, BFS multi-hop traversal, entity-indexed retrieval, type-aware compression, correction detection, and a multi-tool MCP surface, with results against MAB, LoCoMo, LongMemEval, StructMemEval, and AMA-Bench.
 
-v1.0 shipped the foundation (SQLite store, Beta-Bernoulli scoring, BM25 retrieval, CLI, MCP, host hook wiring, synthetic benchmark harness). The v1.x line recovered the remaining features incrementally; v2.0 reached feature parity with the research line plus the reproducibility-harness scaffolding; v3.0 added wonder lifecycle, wonder/reason parity, read-only federation, and the eval-harness completion. The current line is **v3.5.1**.
+v1.0 shipped the foundation (SQLite store, Beta-Bernoulli scoring, BM25 retrieval, CLI, MCP, host hook wiring, synthetic benchmark harness). The v1.x line recovered the remaining features incrementally; v2.0 reached feature parity with the research line plus the reproducibility-harness scaffolding; v3.0 added wonder lifecycle, wonder/reason parity, read-only federation, and the eval-harness completion. The current line is **v3.6.0**.
 
 This is a rebuild, not a port. Structural issues that survived the research line were fixed at the foundation layer. Every behavioural claim is backed by a test or a benchmark, with a transparent issue trail for items that are not.
 
@@ -37,6 +37,7 @@ This is a rebuild, not a port. Structural issues that survived the research line
 | **v3.4.0** | merged 2026-05-26; never tagged standalone — published with the v3.5.0 cut (see [CHANGELOG/v3.md § 3.4.0](../../CHANGELOG/v3.md)) | cadence-policy completion + conversation-aware retrieval — `p3_substantive` policy live, 4-policy shadow capture, offline cadence replay bench (#876, #920); UPS retrieval conversation-aware (#909 — folds recent turns into BM25 query) |
 | **v3.5.0** | shipped 2026-06-04 | visibility/observability wave — per-project feed log + `aelf feed` (#931), SessionStart recap (#934), contradiction marker on `aelf search` (#938), `aelf speculative` (#937), `aelf stale` (#933), `aelf audit-claude-memory` (#935), `aelf review` (#936), duplicate-issue PreToolUse guard (#941), statusline counts (#932) |
 | **v3.5.1** | shipped 2026-06-10 | patch — scanner skips `.claude/` on onboard (#955); INEDIBLE marker propagation to ingest-transcript paths (#958); v3.5.0 docs-vs-code reconciliation wave (#952, #957, #964) |
+| **v3.6.0** | shipped 2026-06-19 | `project_context` provenance — repo-identity auto-stamp on write + idempotent backfill + migrate provenance preservation (#970, ADR 0003; decision 4 ratified keep-opt-in #973); transcript-logger consecutive-duplicate turn guard so duplicated hook registrations don't inflate turn density (#968); `hook_audit` sink extracted from `hook.py` off the heavy retrieval import path (#968) |
 
 ## What shipped
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "3.5.1"
+version = "3.6.0"
 description = "Persistent memory for AI coding agents. Local SQLite + UserPromptSubmit hook — matched beliefs in the prompt before the model sees it. Deterministic, auditable, no embeddings, no cloud."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "3.5.1"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Release v3.6.0

Cuts the next release off `main`. Contains the unreleased work accumulated since v3.5.1.

### Included

**Added — `project_context` provenance wave (#970, PR #972, ADR 0003)**
- `project_context` (added in #858/v3.2 but never written) now auto-stamps the store's repo identity (`<repo-root-basename>-<8-hex blake2b of abs git-common-dir>`) onto eligible new beliefs at the `insert_belief` choke point. Idempotent, reversible, locked/global-exempt backfill on first open. No-op when no identity is set → exact pre-#970 behaviour preserved.
- `aelf migrate` preserves an already-stamped value and stamps source-`''` rows with the **source** repo's identity, so provenance survives a merge instead of collapsing to `''`.
- ADR 0003 decision 4 ratified **keep-opt-in** by the operator (#973, PR #974): resolver default stays env-driven (`unset = no filter`), no auto-consult flip.

**Fixed — transcript-logger consecutive-duplicate guard (#968, PR #971)**
- Duplicated hook registrations no longer inflate `turns.jsonl` density. A turn matching the previous line's `(session_id, role, text)` within 2s is dropped and logged as `skipped_duplicate` in `hook_audit.jsonl`. Bounded tail read, sub-10ms budget, fails open.

**Internal (#968)**
- Extracted the scipy-free `hook_audit` sink from `hook.py` so the duplicate-skip audit write stays off the heavy retrieval import path.

### Release mechanics
- `pyproject.toml` 3.5.1 → 3.6.0; `uv.lock` relocked.
- `CHANGELOG/v3.md`: `[3.6.0]` dated section + compare-link; `[Unreleased]` drained.
- `docs/concepts/ROADMAP.md`: current line → v3.6.0, v3.6.0 row added.

### Post-merge
Tag `v3.6.0` on the merge commit and push; `publish.yml` triggers on the `v*` tag.

## Summary by Sourcery

Cut v3.6.0 release with project-scoped provenance improvements and transcript logging robustness updates.

New Features:
- Populate the `project_context` column with a stable per-repo identity, including automatic tagging on write, idempotent backfill, and provenance preservation across migrations.
- Document the repo-identity convention and `project_context` behaviour in ADR 0003, including the decision to keep project-context filtering opt-in.

Bug Fixes:
- Prevent duplicated transcript hook registrations from inflating turn density by dropping and auditing consecutive duplicate turns.

Enhancements:
- Extract a lightweight `hook_audit` sink module so audit logging no longer pulls in the heavy retrieval stack on the hot hook path.

Build:
- Bump project version from 3.5.1 to 3.6.0 and refresh the lockfile for the new release.

Documentation:
- Add v3.6.0 section to the changelog with details of the provenance and transcript-logger changes.
- Update the roadmap to mark v3.6.0 as the current line and record its shipped features in the release table.