### PR TITLE
fix(test): anchor temporal-sort half-life test to real now (#982)

### DIFF
--- a/tests/test_retrieve_v2_temporal_sort.py
+++ b/tests/test_retrieve_v2_temporal_sort.py
@@ -30,8 +30,9 @@ def _belief(
     content: str,
     age_seconds: float,
     locked: bool = False,
+    anchor: datetime = NOW,
 ) -> Belief:
-    created = NOW - timedelta(seconds=age_seconds)
+    created = anchor - timedelta(seconds=age_seconds)
     return Belief(
         id=f"b{idx}",
         content=content,
@@ -226,9 +227,22 @@ def store(tmp_path: Path) -> Iterator[MemoryStore]:
     s.close()
 
 
-def _insert(store: MemoryStore, idx: int, content: str, age_days: float, locked: bool = False) -> None:
+def _insert(
+    store: MemoryStore,
+    idx: int,
+    content: str,
+    age_days: float,
+    locked: bool = False,
+    anchor: datetime = NOW,
+) -> None:
     store.insert_belief(
-        _belief(idx=idx, content=content, age_seconds=age_days * 86400.0, locked=locked)
+        _belief(
+            idx=idx,
+            content=content,
+            age_seconds=age_days * 86400.0,
+            locked=locked,
+            anchor=anchor,
+        )
     )
 
 
@@ -270,8 +284,16 @@ def test_retrieve_v2_temporal_sort_explicit_half_life_kwarg(
     very short half-life, even a moderately old belief gets crushed
     relative to a fresh one regardless of upstream rank order."""
     monkeypatch.delenv(ENV_TEMPORAL_HALF_LIFE, raising=False)
-    _insert(store, 1, "alpha factual statement old", age_days=10)
-    _insert(store, 2, "alpha factual statement new", age_days=0)
+    # retrieve_v2 decays against real wall-clock now (it accepts no clock
+    # injection), so anchor these fixtures to real now rather than the module's
+    # fixed NOW. With a 1h half-life and a "fresh" belief that is dozens of days
+    # old in real time, both decay weights underflow to 0.0 in float64, the
+    # temporal signal collapses to a tie, and the ordering this test asserts is
+    # lost. Anchoring to real now keeps b2 genuinely age~=0 (weight 1.0) and b1
+    # crushed (2**-240), so b2 strictly outranks b1 regardless of the date.
+    real_now = datetime.now(timezone.utc)
+    _insert(store, 1, "alpha factual statement old", age_days=10, anchor=real_now)
+    _insert(store, 2, "alpha factual statement new", age_days=0, anchor=real_now)
     result = retrieve_v2(
         store,
         "alpha factual statement",


### PR DESCRIPTION
Closes #982.

## Problem

`tests/test_retrieve_v2_temporal_sort.py::test_retrieve_v2_temporal_sort_explicit_half_life_kwarg`
went red on `github/main` (v3.6.0) as of ~2026-06-22, blocking **every PR's
full-pytest gate** (`aelf-pr-open` / staging-gate), not just one feature.

It is a wall-clock time-bomb. The fixtures anchor `created_at` to a hardcoded
`NOW = datetime(2026, 5, 8)`, but `retrieve_v2` decays against real
`datetime.now(timezone.utc)` (`retrieval.py:3055` → `_apply_temporal_decay`,
default `now`, `retrieval.py:1467`). With `temporal_half_life_seconds=3600.0`
and a "fresh" belief that is ~45 days old in real time, `2 ** (-age/half_life)`
underflows to exactly `0.0` (float64) for **both** rows, the temporal signal
collapses to a tie, and the stable sort keeps `b1` ahead of `b2` → `assert
b2 < b1` fails.

It shipped green at v3.6.0 (2026-06-19, ~42 days: `2**-1008` was still a nonzero
denormal that preserved ordering) and detonated ~2026-06-22 (~45 days, both
underflow to `0.0`).

## Fix (minimal, test-only)

Add an optional `anchor` param to `_belief` / `_insert` defaulting to `NOW` (so
all other tests stay byte-identical), and anchor the failing test's two fixtures
to real `datetime.now(timezone.utc)`. The fresh belief is then genuinely
age≈0 (decay weight ~1.0) and the 10-day-old belief decays to ~`2**-240`, so
`b2` strictly outranks `b1` regardless of the calendar date.

## Verification

- The previously-failing test passes 5/5 deterministically.
- Full `tests/test_retrieve_v2_temporal_sort.py`: `23 passed` (was `22 passed,
  1 failed`).

## Follow-up (out of scope here)

The deeper issue is that `retrieve_v2` exposes no clock-injection seam, so the
sibling retrieve_v2-level temporal tests share the same wall-clock-vs-fixed-`NOW`
mismatch and are latent time-bombs (they survive today only because their
half-lives are large enough not to underflow yet, or they assert on lock-pinning).
A follow-up should thread an optional `now` into `retrieve_v2` →
`_apply_temporal_decay` (which already accepts `now=`) so integration tests can
pin the clock like the unit tests do. Tracked in the #982 body.

## Summary by Sourcery

Bug Fixes:
- Fix a time-dependent retrieve_v2 temporal sort test that could intermittently fail as real time advanced due to floating-point underflow in decay weights.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test helper flexibility by adding customizable timestamp anchoring for temporal sorting validation.
  * Enhanced test robustness against timing variations and clock drift in temporal ordering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->