### PR TITLE
test(retrieval): assert γ rerank reorders by posterior at retrieve() level (#978)

### DIFF
--- a/tests/test_retrieve_gamma_flag.py
+++ b/tests/test_retrieve_gamma_flag.py
@@ -161,3 +161,46 @@ def test_flag_on_versus_off_runs_clean(populated_store, monkeypatch) -> None:
     # Both produced something; the content / order is the bench's job.
     assert isinstance(off, list)
     assert isinstance(on, list)
+
+
+def test_flag_on_reorders_by_posterior(populated_store, monkeypatch) -> None:
+    """γ at the default T=1.0 keeps high-posterior beliefs ranked above
+    low-posterior beliefs when BM25 is similar across rows.
+
+    The corpus has α/β = (10,1), (1,10), (5,5), (1,1) — posterior means
+    0.91, 0.09, 0.5, 0.5. On a generic ``letter`` query (all four rows
+    match equally well), the high-posterior ``alpha`` belief must outrank
+    the low-posterior ``beta`` belief with γ on. This is the γ analogue of
+    ``tests/test_retrieve_zeta_flag.py::test_flag_on_reorders_by_posterior``
+    and proves γ actually consumes the posterior through ``retrieve()`` —
+    not merely that the flag-on path runs without raising.
+    """
+    monkeypatch.setenv(_ENV_FLAG, "1")
+    out = retrieve(populated_store, "letter alphabet")
+    contents = [b.content for b in out]
+    assert any(c.startswith("alpha") for c in contents), contents
+    assert any(c.startswith("beta") for c in contents), contents
+    alpha_idx = next(i for i, c in enumerate(contents) if c.startswith("alpha"))
+    beta_idx = next(i for i, c in enumerate(contents) if c.startswith("beta"))
+    assert alpha_idx < beta_idx
+
+
+def test_flag_on_t_one_matches_posterior_weight_one(
+    populated_store, monkeypatch,
+) -> None:
+    """``retrieve()``-level T=1.0 contract.
+
+    With no meta-belief the resolver pins T=1.0, at which
+    ``gamma_posterior_score`` is byte-identical to
+    ``partial_bayesian_score(.., posterior_weight=1.0)`` (the scorer-level
+    contract in ``tests/test_scoring_gamma.py``). So γ-on must produce the
+    same belief ordering as the γ-off log-additive path pinned to
+    ``posterior_weight=1.0``. Both calls fix ``posterior_weight=1.0`` so the
+    only difference is the γ flag; this lifts the scorer contract up to the
+    ``retrieve()`` surface.
+    """
+    monkeypatch.delenv(_ENV_FLAG, raising=False)
+    baseline = retrieve(populated_store, "letter alphabet", posterior_weight=1.0)
+    monkeypatch.setenv(_ENV_FLAG, "1")
+    gamma_on = retrieve(populated_store, "letter alphabet", posterior_weight=1.0)
+    assert [b.id for b in gamma_on] == [b.id for b in baseline]


### PR DESCRIPTION
Closes #978.

## What

The γ rerank lane (`use_gamma_posterior_temperature`, #796) previously had only
determinism and runs-clean coverage through `retrieve()`. Its core promise —
Boltzmann-temperature reweighting of the posterior log-term — was never asserted
end-to-end, unlike its ζ sibling
(`test_retrieve_zeta_flag.py::test_flag_on_reorders_by_posterior`).

Two tests added to `tests/test_retrieve_gamma_flag.py` (test-only; no source change):

- `test_flag_on_reorders_by_posterior` — the γ analogue of the ζ test. On a query
  where BM25 is tied across rows, the high-posterior belief must outrank the
  low-posterior belief with γ on.
- `test_flag_on_t_one_matches_posterior_weight_one` — lifts the scorer-level T=1.0
  byte-identity contract (already pinned in
  `test_scoring_gamma.py::test_t_one_byte_identical_to_partial_bayesian_pw_one`)
  up to the `retrieve()` surface: γ-on at T=1.0 must produce the same ordering as
  the γ-off path with `posterior_weight=1.0`. This guards the retrieve()-level
  wiring the scorer unit test cannot reach.

Relevant to #977's evaluation of flipping γ default-on: γ should not become a
default without a retrieve-level correctness assertion matching the bar ζ
already meets.

## Verification

- BM25F is byte-identical (`0.105361`) across all four fixture rows on the test
  query, so the posterior term is the sole separator; the log-posterior gap
  (`+2.30`) fully determines order.
- Non-vacuity: sign-flipping the posterior contribution makes both tests fail
  deterministically; collapsing γ to BM25-only makes the contract test fail 5/5.
  Reverting restores green. (Isolation: γ-on ranks high-posterior first 200/200
  trials; with the posterior unconsumed it is a 97/200 uuid coin-flip.)
- Determinism: 25/25 passes across hash seeds (fixture uses random uuids with id
  as the sort tiebreak).
- No regression: `test_retrieve_gamma_flag.py` + `test_retrieve_zeta_flag.py` +
  `test_scoring_gamma.py` + `test_posterior_temperature_meta.py` → 66 passed.

## Summary by Sourcery

Add retrieve-level tests to assert γ posterior reranking behavior and its T=1.0 contract with the posterior_weight=1.0 path.

Tests:
- Add a test ensuring γ-on reorders tied-BM25 results so higher-posterior beliefs rank above lower-posterior beliefs at the retrieve() level.
- Add a test asserting γ-on at T=1.0 produces the same ordering as the γ-off path with posterior_weight=1.0, lifting the scorer contract to retrieve().