### PR TITLE
fix(store): exclude soft-deleted beliefs from all retrieval lanes (#980)

### DIFF
--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -2040,14 +2040,22 @@ class MemoryStore:
 
         Only moves beliefs from active (valid_to IS NULL) to soft-deleted.
         Calling this on an already-GC'd belief is a no-op (idempotent via
-        the WHERE clause). Does not remove edges or corroboration rows —
-        the phantom's evidence trail is preserved for audit.
+        the WHERE clause). Does not remove edges, entity-index, or
+        corroboration rows — the phantom's evidence trail is preserved for
+        audit. The derived FTS index row *is* pruned (mirrors
+        ``delete_belief``) so the soft-deleted belief stops matching
+        keyword search; read-side queries also filter ``valid_to IS NULL``,
+        so this is index hygiene plus defense-in-depth (#980).
         """
         now = ts if ts is not None else datetime.now(timezone.utc).isoformat()
-        self._conn.execute(
+        cur = self._conn.execute(
             "UPDATE beliefs SET valid_to = ? WHERE id = ? AND valid_to IS NULL",
             (now, belief_id),
         )
+        if cur.rowcount > 0:
+            self._conn.execute(
+                "DELETE FROM beliefs_fts WHERE id = ?", (belief_id,)
+            )
         self._bump_belief_version(belief_id)
         self._conn.commit()
         self._fire_invalidation()
@@ -2242,12 +2250,19 @@ class MemoryStore:
         # 16 entities per call so this is generous).
         keys = list(dict.fromkeys(keys))[:512]
         placeholders = ",".join("?" * len(keys))
+        # JOIN beliefs to exclude soft-deleted rows (valid_to NOT NULL):
+        # a GC'd phantom or review-removed belief must not surface via the
+        # entity-index lane. The belief_entities rows themselves are left
+        # intact so the soft-deleted belief's entity audit trail survives;
+        # the filter is applied at read time only (#980).
         sql = (
-            "SELECT belief_id, COUNT(DISTINCT entity_lower) AS overlap "
-            "FROM belief_entities "
-            f"WHERE entity_lower IN ({placeholders}) "
-            "GROUP BY belief_id "
-            "ORDER BY overlap DESC, belief_id ASC "
+            "SELECT be.belief_id, COUNT(DISTINCT be.entity_lower) AS overlap "
+            "FROM belief_entities be "
+            "JOIN beliefs b ON b.id = be.belief_id "
+            f"WHERE be.entity_lower IN ({placeholders}) "
+            "AND b.valid_to IS NULL "
+            "GROUP BY be.belief_id "
+            "ORDER BY overlap DESC, be.belief_id ASC "
             "LIMIT ?"
         )
         cur = self._conn.execute(sql, (*keys, limit))
@@ -2353,6 +2368,7 @@ class MemoryStore:
             FROM beliefs b
             JOIN beliefs_fts f ON f.id = b.id
             WHERE beliefs_fts MATCH ?
+              AND b.valid_to IS NULL
             ORDER BY bm25(beliefs_fts)
             LIMIT ?
             """,
@@ -2388,6 +2404,7 @@ class MemoryStore:
             FROM beliefs b
             JOIN beliefs_fts f ON f.id = b.id
             WHERE beliefs_fts MATCH ?
+              AND b.valid_to IS NULL
             ORDER BY bm25(beliefs_fts)
             LIMIT ?
             """,
@@ -3598,6 +3615,7 @@ class MemoryStore:
                     WHERE bc.belief_id = b.id) AS corroboration_count
             FROM beliefs b
             WHERE b.lock_level != 'none'
+              AND b.valid_to IS NULL
             ORDER BY b.locked_at DESC, b.id ASC
             """
         )
@@ -4183,8 +4201,14 @@ class MemoryStore:
             yield (str(row["dst"]), str(row["anchor_text"]))
 
     def list_beliefs_for_indexing(self) -> list[tuple[str, str]]:
-        """Return `[(belief_id, content)]` for every belief, ordered by
-        `belief_id ASC` for deterministic indexing.
+        """Return `[(belief_id, content)]` for every active belief, ordered
+        by `belief_id ASC` for deterministic indexing.
+
+        Soft-deleted beliefs (`valid_to NOT NULL` — GC'd phantoms or
+        review-removed beliefs) are excluded so they cannot resurface via
+        the BM25/BM25F retrieval lane, dedup, or relationship detection
+        (#980). Determinism is preserved: the same store state yields the
+        same id-ASC filtered set.
 
         Used by `aelfrice.bm25.BM25Index.build` to walk the corpus once
         and assemble the (n_docs × n_terms) sparse term-frequency
@@ -4193,7 +4217,8 @@ class MemoryStore:
         `tf` and entry `i` of `dl`.
         """
         cur = self._conn.execute(
-            "SELECT id, content FROM beliefs ORDER BY id ASC"
+            "SELECT id, content FROM beliefs "
+            "WHERE valid_to IS NULL ORDER BY id ASC"
         )
         return [(str(r["id"]), str(r["content"])) for r in cur.fetchall()]
 

--- a/tests/test_soft_deleted_retrieval_exclusion_980.py
+++ b/tests/test_soft_deleted_retrieval_exclusion_980.py
@@ -1,0 +1,147 @@
+"""Soft-deleted beliefs must not be retrievable through any lane (#980).
+
+A belief is soft-deleted (``valid_to`` set) by two production paths:
+``wonder_gc`` (stale phantom GC) and ``aelf review`` with a ``remove``
+verdict -- both call ``MemoryStore.soft_delete_belief``. Before #980 the
+retrieval candidate lanes did not filter ``valid_to``, so a soft-deleted
+belief still surfaced in keyword search, the default-on BM25F lane, the
+entity index, the locked lane, and end-to-end ``retrieve()``.
+
+These tests pin the invariant: once soft-deleted, a belief is absent from
+every read path, while its audit rows (beliefs / belief_entities) survive.
+"""
+from __future__ import annotations
+
+from aelfrice.bm25 import BM25Index
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    LOCK_NONE,
+    LOCK_USER,
+    Belief,
+)
+from aelfrice.retrieval import retrieve
+from aelfrice.store import MemoryStore
+
+
+def _mk(
+    bid: str,
+    content: str,
+    *,
+    lock_level: str = LOCK_NONE,
+    locked_at: str | None = None,
+) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash="h_" + bid,
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=lock_level,
+        locked_at=locked_at,
+        created_at="2026-04-25T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _store_with_pair() -> MemoryStore:
+    """Two beliefs sharing the token 'alpha'; b2 is soft-deleted."""
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("b1", "alpha factual statement active"))
+    s.insert_belief(_mk("b2", "alpha factual statement removed"))
+    s.soft_delete_belief("b2")
+    return s
+
+
+def test_search_beliefs_excludes_soft_deleted() -> None:
+    s = _store_with_pair()
+    ids = [b.id for b in s.search_beliefs("alpha")]
+    assert "b1" in ids
+    assert "b2" not in ids
+
+
+def test_search_beliefs_scored_excludes_soft_deleted() -> None:
+    s = _store_with_pair()
+    ids = [b.id for b, _ in s.search_beliefs_scored("alpha")]
+    assert "b1" in ids
+    assert "b2" not in ids
+
+
+def test_soft_delete_prunes_fts_row() -> None:
+    s = _store_with_pair()
+    # The derived FTS row for the soft-deleted belief is gone; the active
+    # one remains.
+    rows = s._conn.execute(
+        "SELECT id FROM beliefs_fts ORDER BY id"
+    ).fetchall()
+    fts_ids = {r["id"] for r in rows}
+    assert "b1" in fts_ids
+    assert "b2" not in fts_ids
+
+
+def test_soft_deleted_belief_row_survives_for_audit() -> None:
+    s = _store_with_pair()
+    # The belief itself is retained (valid_to set) so the audit trail and
+    # fetch-by-id still work -- only retrieval excludes it.
+    got = s.get_belief("b2")
+    assert got is not None
+    assert got.valid_to is not None
+
+
+def test_list_beliefs_for_indexing_excludes_soft_deleted() -> None:
+    # Covers the BM25/BM25F retrieval lane, dedup, and relationship
+    # detection -- all three consume this method.
+    s = _store_with_pair()
+    ids = [bid for bid, _ in s.list_beliefs_for_indexing()]
+    assert "b1" in ids
+    assert "b2" not in ids
+
+
+def test_bm25_index_excludes_soft_deleted() -> None:
+    s = _store_with_pair()
+    idx = BM25Index.build(s)
+    assert "b2" not in idx.belief_ids
+    scored_ids = {bid for bid, _ in idx.score("alpha")}
+    assert "b1" in scored_ids
+    assert "b2" not in scored_ids
+
+
+def test_lookup_entities_excludes_soft_deleted() -> None:
+    s = MemoryStore(":memory:")
+    content = "uses aelfrice.retrieval and src/store.py daily"
+    s.insert_belief(_mk("b1", content))
+    s.insert_belief(_mk("b2", content))
+    # A shared entity key exists for both; pick one actually extracted.
+    keys = [k for k, _, _ in s.belief_entities_for("b2")]
+    assert keys, "fixture must produce at least one entity"
+    s.soft_delete_belief("b2")
+    hit_ids = {bid for bid, _ in s.lookup_entities(keys, limit=10)}
+    assert "b1" in hit_ids
+    assert "b2" not in hit_ids
+    # belief_entities rows for the soft-deleted belief are preserved (audit).
+    assert s.belief_entities_for("b2") != []
+
+
+def test_list_locked_beliefs_excludes_soft_deleted() -> None:
+    s = MemoryStore(":memory:")
+    s.insert_belief(
+        _mk("L1", "locked active", lock_level=LOCK_USER,
+            locked_at="2026-04-25T00:00:00Z")
+    )
+    s.insert_belief(
+        _mk("L2", "locked removed", lock_level=LOCK_USER,
+            locked_at="2026-04-25T00:00:00Z")
+    )
+    s.soft_delete_belief("L2")
+    ids = [b.id for b in s.list_locked_beliefs()]
+    assert "L1" in ids
+    assert "L2" not in ids
+
+
+def test_retrieve_excludes_soft_deleted_end_to_end() -> None:
+    # The user-facing assertion: retrieve() (default lanes, BM25F default-on)
+    # never surfaces a soft-deleted belief.
+    s = _store_with_pair()
+    ids = [b.id for b in retrieve(s, "alpha")]
+    assert "b1" in ids
+    assert "b2" not in ids


### PR DESCRIPTION
## Summary

Soft-deleted beliefs (`valid_to NOT NULL`) were retrievable through **every**
candidate-generation lane. This is the correctness precursor in #980's
recommended-work list (item 1) — the fix that must land before auto-GC is
turned on.

A belief is soft-deleted by two production paths, both via
`MemoryStore.soft_delete_belief`:
- `wonder_gc` — stale-phantom garbage collection (`aelf wonder --gc`)
- `aelf review` with a **`remove`** verdict (shipped v3.5, #936) — a
  user-facing path, so this is not phantom-only.

`retrieval.py` applies **no** `valid_to` filter anywhere, so a soft-deleted
belief surfaced in results and in the hook-injected block.

## Scope correction vs the #980 findings comment

The findings comment scoped the leak to `search_beliefs` / `search_beliefs_scored`
(the FTS lane). Investigation found it is **systemic** — the soft-deleted
belief leaks through all four candidate lanes, including the **default-on**
BM25F lane:

| Lane | Source | Leaked? |
|---|---|---|
| L1 FTS | `search_beliefs`, `search_beliefs_scored` | yes |
| L1 BM25F (default-on) | `list_beliefs_for_indexing` → `BM25Index` | yes |
| L2.5 entity index | `lookup_entities` | yes |
| L0 locked | `list_locked_beliefs` | yes |

`list_beliefs_for_indexing` also feeds `dedup` and `relationship_detector`,
which likewise should not see soft-deleted rows.

## Fix

Add `valid_to IS NULL` at each read boundary, and prune the derived
`beliefs_fts` row in `soft_delete_belief` (mirrors `delete_belief`).

**Audit trail preserved:** the `beliefs`, `edges`, `belief_entities`, and
corroboration rows are all retained — only the derived FTS index is pruned and
reads are filtered. `get_belief(id)` still returns the soft-deleted row.

**Determinism preserved:** `list_beliefs_for_indexing` still returns an
id-ASC set; it is just filtered. Empirically a **no-op on all current data** —
0 soft-deleted beliefs exist across local stores — so no existing test or
bench corpus changes. Latent today, but real: the first `aelf review` remove
or `aelf wonder --gc` would otherwise leave the removed belief retrievable.

## Tests

`tests/test_soft_deleted_retrieval_exclusion_980.py` pins the invariant at
every lane (FTS ×2, `list_beliefs_for_indexing` + `BM25Index`, `lookup_entities`,
`list_locked_beliefs`) plus an end-to-end `retrieve()`, and asserts
`soft_delete` prunes the FTS row while the `beliefs` / `belief_entities` audit
rows survive.

## Scope

Part of #980 (recommended-work **item 1**). Does **not** close the umbrella —
items 2–4 (make GC run, trigger-driven generation, observability) remain.

## Summary by Sourcery

Exclude soft-deleted beliefs from all retrieval and indexing paths while preserving their audit trail.

Bug Fixes:
- Ensure soft-deleted beliefs are filtered out from FTS search, scored search, entity lookup, locked-belief listing, and BM25/BM25F indexing.
- Prune the corresponding FTS index row when a belief is soft-deleted so it no longer participates in keyword search.

Enhancements:
- Clarify store and indexing docstrings around active vs soft-deleted beliefs and retrieval behavior.

Tests:
- Add regression tests to assert soft-deleted beliefs are excluded from every retrieval lane and BM25 index while their underlying audit rows remain accessible.