### PR TITLE
refactor(retrieval): give retrieve_v2 a clock-injection seam (#986)

### DIFF
--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -2927,6 +2927,7 @@ def retrieve_v2(
     hrr_struct_index_cache: HRRStructIndexCache | None = None,
     with_doc_anchors: bool = False,
     now_ts: int | None = None,
+    now: datetime | None = None,
 ) -> RetrievalResult:
     """Lab-compatible retrieval wrapper for academic-suite adapters.
 
@@ -3052,7 +3053,12 @@ def retrieve_v2(
             now_ts=effective_now_ts,
             explicit=temporal_half_life_seconds,
         )
-        beliefs = _apply_temporal_decay(beliefs, half_life)
+        # `now` pins the temporal-decay clock so retrieve_v2-level temporal
+        # tests are deterministic; default None -> _apply_temporal_decay uses
+        # datetime.now(timezone.utc), leaving the production path unchanged.
+        # Distinct from `now_ts`, which pins the meta-belief *resolver* clock
+        # (half-life / BFS-depth resolvers). (#986)
+        beliefs = _apply_temporal_decay(beliefs, half_life, now=now)
         # #756 latency-signal update. Only fires when the meta-belief
         # feature flag is on; the env check matches the resolver above
         # so the read/write paths flip together. update_meta_belief is

--- a/tests/test_retrieve_v2_temporal_sort.py
+++ b/tests/test_retrieve_v2_temporal_sort.py
@@ -30,9 +30,8 @@ def _belief(
     content: str,
     age_seconds: float,
     locked: bool = False,
-    anchor: datetime = NOW,
 ) -> Belief:
-    created = anchor - timedelta(seconds=age_seconds)
+    created = NOW - timedelta(seconds=age_seconds)
     return Belief(
         id=f"b{idx}",
         content=content,
@@ -233,7 +232,6 @@ def _insert(
     content: str,
     age_days: float,
     locked: bool = False,
-    anchor: datetime = NOW,
 ) -> None:
     store.insert_belief(
         _belief(
@@ -241,7 +239,6 @@ def _insert(
             content=content,
             age_seconds=age_days * 86400.0,
             locked=locked,
-            anchor=anchor,
         )
     )
 
@@ -284,22 +281,20 @@ def test_retrieve_v2_temporal_sort_explicit_half_life_kwarg(
     very short half-life, even a moderately old belief gets crushed
     relative to a fresh one regardless of upstream rank order."""
     monkeypatch.delenv(ENV_TEMPORAL_HALF_LIFE, raising=False)
-    # retrieve_v2 decays against real wall-clock now (it accepts no clock
-    # injection), so anchor these fixtures to real now rather than the module's
-    # fixed NOW. With a 1h half-life and a "fresh" belief that is dozens of days
-    # old in real time, both decay weights underflow to 0.0 in float64, the
-    # temporal signal collapses to a tie, and the ordering this test asserts is
-    # lost. Anchoring to real now keeps b2 genuinely age~=0 (weight 1.0) and b1
-    # crushed (2**-240), so b2 strictly outranks b1 regardless of the date.
-    real_now = datetime.now(timezone.utc)
-    _insert(store, 1, "alpha factual statement old", age_days=10, anchor=real_now)
-    _insert(store, 2, "alpha factual statement new", age_days=0, anchor=real_now)
+    # retrieve_v2 now accepts a `now` clock seam (#986), so pin it to the
+    # module's fixed NOW like the sibling temporal tests rather than anchoring
+    # the fixtures to real wall-clock. The fresh belief (age 0) keeps decay
+    # weight 1.0 and the 10-day-old belief is crushed (2**-240), so b2 strictly
+    # outranks b1 deterministically, irrespective of the calendar date.
+    _insert(store, 1, "alpha factual statement old", age_days=10)
+    _insert(store, 2, "alpha factual statement new", age_days=0)
     result = retrieve_v2(
         store,
         "alpha factual statement",
         budget=10_000,
         temporal_sort=True,
         temporal_half_life_seconds=3600.0,
+        now=NOW,
     )
     ids = [b.id for b in result.beliefs]
     assert ids.index("b2") < ids.index("b1")


### PR DESCRIPTION
## Summary

Closes #986. Follow-up to #982 / PR #983.

`retrieve_v2` was the only temporal path that decayed beliefs against real
wall-clock with no clock-injection seam — `_apply_temporal_decay` was called
without `now`, so retrieve_v2-level temporal tests could not pin a fixed
instant the way every other decay test does. That gap is what forced #982 to
anchor its fixtures to real `datetime.now()` as a workaround.

## Change

- Thread an optional `now: datetime | None = None` through `retrieve_v2` to
  `_apply_temporal_decay` (which already accepts `now=`). Default `None` →
  `datetime.now(timezone.utc)` — **production default path is byte-identical**.
- `now` is distinct from the existing `now_ts` (which pins the meta-belief
  *resolver* clock: half-life / BFS-depth), documented inline at the call site.
- Revert #982's real-now anchor on
  `test_retrieve_v2_temporal_sort_explicit_half_life_kwarg` and the `anchor`
  param it added to the `_belief`/`_insert` helpers; the test now pins the
  decay clock via `now=NOW` like its siblings — deterministic regardless of
  the calendar date, without depending on real wall-clock.

## Notes

LOW priority per the issue: testability/robustness only. A suite audit (in
#982) confirmed no other date-bombs, and production is safe (default 7-day
half-life). No correctness or behavior change.

## Verification

- `tests/test_retrieve_v2_temporal_sort.py` — 23 passed.
- retrieve_v2 suite (v2 / temporal / hrr / γ / ζ) — 63 passed.
- gate pytest green.

## Summary by Sourcery

Inject a configurable wall-clock seam into retrieve_v2’s temporal decay path and align temporal tests to use it for deterministic behavior.

Enhancements:
- Add an optional datetime `now` parameter to retrieve_v2 and thread it into temporal decay to allow clock injection without changing production behavior.

Tests:
- Update temporal sort tests to stop anchoring fixtures to real wall-clock time and instead pin the decay clock via the new `now` seam for deterministic ordering.