### PR TITLE
feat(ingest): build semantic-edge substrate at ingest behind default-off flag (#988)

### DIFF
--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -296,6 +296,21 @@ def _ingest_turn_ids(
             anchor_text=anchor,
         ))
 
+    # #988: optionally build the semantic-edge substrate at ingest. Writes
+    # CONTRADICTS edges across the store for this turn's new beliefs so the
+    # graph lanes (HRR-expand #981, BFS) are no longer inert on benchmark
+    # corpora. Default-OFF (is_auto_relationship_detection_enabled): when
+    # off, this branch is never entered and ingest is byte-identical to
+    # today. Gated on `inserted` so corroboration-only turns skip the audit.
+    if inserted:
+        from aelfrice.relationship_detector import (
+            is_auto_relationship_detection_enabled,
+            write_semantic_edges,
+        )
+
+        if is_auto_relationship_detection_enabled():
+            write_semantic_edges(store)
+
     return inserted
 
 

--- a/src/aelfrice/relationship_detector.py
+++ b/src/aelfrice/relationship_detector.py
@@ -108,7 +108,8 @@ AUTO_DETECT_KEY: Final[str] = "auto_detect"
 # Write-gate: per-belief cap on auto-written semantic edges. Bounds the
 # Exp-48 coverage-dilution failure mode (unbounded edge growth tanks
 # retrieval coverage) by capping how many edges any one belief accretes.
-MAX_EDGES_PER_BELIEF_KEY: Final[str] = "max_edges_per_belief"
+# Caller-supplied kwarg only (no TOML key wired yet); falls back to this
+# default.
 DEFAULT_MAX_EDGES_PER_BELIEF: Final[int] = 8
 
 _ENV_TRUTHY: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})

--- a/src/aelfrice/relationship_detector.py
+++ b/src/aelfrice/relationship_detector.py
@@ -51,6 +51,7 @@ Detection is regex / token-set heuristics — no LLM, no embedding.
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
 import tomllib
@@ -93,6 +94,25 @@ DEFAULT_RESIDUAL_OVERLAP_MIN: Final[float] = 0.4
 # the deferred write-path hook.
 DEFAULT_CONFIDENCE_MIN: Final[float] = 0.5
 DEFAULT_MAX_CANDIDATE_PAIRS: Final[int] = 5000
+
+# --- Ingest-time auto-detection flag + write-gate (#988) ----------------
+
+# Default-OFF flag that wires the deterministic detector into the ingest
+# path so it writes CONTRADICTS / REFINES edges (the #201-ratified R2
+# write-path hook, until now deferred). When off, ingest is byte-identical
+# to today — no edges are written. Resolution precedence mirrors the
+# retrieval flags: env > explicit kwarg > `[relationship_detector]
+# auto_detect` in `.aelfrice.toml` > default False.
+ENV_AUTO_RELATIONSHIPS: Final[str] = "AELFRICE_AUTO_RELATIONSHIPS"
+AUTO_DETECT_KEY: Final[str] = "auto_detect"
+# Write-gate: per-belief cap on auto-written semantic edges. Bounds the
+# Exp-48 coverage-dilution failure mode (unbounded edge growth tanks
+# retrieval coverage) by capping how many edges any one belief accretes.
+MAX_EDGES_PER_BELIEF_KEY: Final[str] = "max_edges_per_belief"
+DEFAULT_MAX_EDGES_PER_BELIEF: Final[int] = 8
+
+_ENV_TRUTHY: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+_ENV_FALSY: Final[frozenset[str]] = frozenset({"0", "false", "no", "off"})
 
 # --- Modality vocabulary -----------------------------------------------
 
@@ -570,6 +590,86 @@ def load_relationship_detector_config(
             break
         current = current.parent
     return RelationshipDetectorConfig()
+
+
+# --- Ingest-time auto-detection resolver (#988) ------------------------
+
+
+def _env_auto_relationships_override() -> bool | None:
+    """Return True/False if ``AELFRICE_AUTO_RELATIONSHIPS`` is set to a
+    recognised truthy / falsy value, else None (env not decisive)."""
+    raw = os.environ.get(ENV_AUTO_RELATIONSHIPS)
+    if raw is None:
+        return None
+    norm = raw.strip().lower()
+    if norm in _ENV_TRUTHY:
+        return True
+    if norm in _ENV_FALSY:
+        return False
+    return None
+
+
+def _read_auto_detect_toml(start: Path | None = None) -> bool | None:
+    """Read ``[relationship_detector] auto_detect`` from the nearest
+    `.aelfrice.toml`. Returns None on missing file / section / key /
+    malformed TOML / non-bool value; never raises."""
+    serr: IO[str] = sys.stderr
+    current = (start if start is not None else Path.cwd()).resolve()
+    seen: set[Path] = set()
+    while current not in seen:
+        seen.add(current)
+        candidate = current / CONFIG_FILENAME
+        if candidate.is_file():
+            try:
+                parsed: dict[str, Any] = tomllib.loads(
+                    candidate.read_bytes().decode("utf-8", errors="replace"),
+                )
+            except (OSError, tomllib.TOMLDecodeError) as exc:
+                print(
+                    f"aelfrice relationship_detector: cannot read "
+                    f"{AUTO_DETECT_KEY} in {candidate}: {exc}",
+                    file=serr,
+                )
+                return None
+            section_obj: Any = parsed.get(SECTION, {})
+            if not isinstance(section_obj, dict):
+                return None
+            val: Any = cast(dict[str, Any], section_obj).get(AUTO_DETECT_KEY)
+            if isinstance(val, bool):
+                return val
+            return None
+        if current.parent == current:
+            break
+        current = current.parent
+    return None
+
+
+def is_auto_relationship_detection_enabled(
+    explicit: bool | None = None,
+    *,
+    start: Path | None = None,
+) -> bool:
+    """Resolve the ingest-time auto-relationship-detection flag (#988).
+
+    Precedence (first decisive wins):
+      1. ``AELFRICE_AUTO_RELATIONSHIPS`` env var (truthy / falsy normalised).
+      2. Explicit ``explicit`` kwarg from the caller.
+      3. ``[relationship_detector] auto_detect`` in `.aelfrice.toml`.
+      4. Default: False (default-OFF).
+
+    Default-off is load-bearing: a fresh install must not start writing
+    semantic edges at ingest, which would reverse the #605/#897 scope
+    ratification. Flipping the default requires re-opening #897.
+    """
+    env = _env_auto_relationships_override()
+    if env is not None:
+        return env
+    if explicit is not None:
+        return explicit
+    toml_value = _read_auto_detect_toml(start)
+    if toml_value is not None:
+        return toml_value
+    return False
 
 
 # --- Report formatter --------------------------------------------------

--- a/src/aelfrice/relationship_detector.py
+++ b/src/aelfrice/relationship_detector.py
@@ -850,6 +850,141 @@ def format_write_report(report: PotentiallyStaleWriteReport) -> str:
     return "\n".join(lines)
 
 
+# --- CONTRADICTS edge writer (#988 — the #201-ratified R2 hook) ---------
+
+
+@dataclass(frozen=True)
+class SemanticEdgeWriteReport:
+    """Summary of one ``write_semantic_edges`` run.
+
+    ``n_contradicts_high``
+        High-confidence (``score >= confidence_min``) contradicting pairs
+        returned by the audit — the candidate set this writer acts on.
+        (Sub-confidence contradicts are the ``write_potentially_stale_edges``
+        domain; the two writers partition the contradicts pairs by score.)
+
+    ``n_edges_written``
+        Pairs that produced a new CONTRADICTS edge this run.
+
+    ``n_edges_skipped_existing``
+        Pairs whose edge already existed (idempotency guard fired).
+
+    ``n_edges_skipped_gated``
+        Pairs dropped because an endpoint hit ``max_edges_per_belief``
+        (the Exp-48 coverage-dilution write-gate).
+
+    ``n_edges_skipped_self_pair``
+        Defensive counter — should always be 0; pairs where a == b.
+    """
+
+    n_contradicts_high: int
+    n_edges_written: int
+    n_edges_skipped_existing: int
+    n_edges_skipped_gated: int
+    n_edges_skipped_self_pair: int
+
+
+def write_semantic_edges(
+    store: "MemoryStore",
+    *,
+    jaccard_min: float = DEFAULT_JACCARD_MIN,
+    residual_overlap_min: float = DEFAULT_RESIDUAL_OVERLAP_MIN,
+    confidence_min: float = DEFAULT_CONFIDENCE_MIN,
+    max_candidate_pairs: int = DEFAULT_MAX_CANDIDATE_PAIRS,
+    max_edges_per_belief: int = DEFAULT_MAX_EDGES_PER_BELIEF,
+) -> SemanticEdgeWriteReport:
+    """Emit CONTRADICTS edges for high-confidence contradicting pairs (#988).
+
+    This is the #201-ratified R2 write-path hook, deferred until a corpus
+    benchmark could measure it. It is wired into ingest only behind the
+    default-off ``auto_detect`` flag (``is_auto_relationship_detection_enabled``),
+    so a fresh install writes no edges and the #605/#897 scope decision
+    stands unchanged.
+
+    Scope: **CONTRADICTS only.** The deterministic detector emits exactly
+    ``contradicts`` / ``refines``; of those only CONTRADICTS has a model
+    edge type, and it is the verdict the #201 ratification names. REFINES
+    (no ``EDGE_REFINES`` type) and SUPPORTS (not produced by the detector)
+    are out of scope for this writer.
+
+    For each ``contradicts`` pair whose score is **>=** ``confidence_min``
+    (the complement of the ``write_potentially_stale_edges`` sub-confidence
+    set), insert one CONTRADICTS edge. The relation is symmetric, so the
+    edge direction is canonicalised to ``src = min(id)``, ``dst = max(id)``
+    — stable regardless of audit pair ordering.
+
+    **Idempotent.** Each ``(src, dst, CONTRADICTS)`` triple is checked
+    before insert and skipped if present.
+
+    **Write-gated.** ``max_edges_per_belief`` caps how many CONTRADICTS
+    edges any one belief accretes (Exp-48 coverage-dilution guard).
+    Pre-existing edges encountered for an endpoint count toward its
+    budget, so the cap is a hard per-belief bound across repeated runs,
+    not merely per-call. Pairs are processed in the audit's deterministic
+    ``(belief_a_id, belief_b_id)`` order, so which edges survive the cap is
+    itself deterministic.
+
+    Stdlib-only: no LLM, no embedding. Delegates detection to
+    ``relationships_audit``.
+    """
+    from aelfrice.models import Edge, EDGE_CONTRADICTS
+
+    report = relationships_audit(
+        store,
+        jaccard_min=jaccard_min,
+        residual_overlap_min=residual_overlap_min,
+        confidence_min=confidence_min,
+        max_candidate_pairs=max_candidate_pairs,
+    )
+
+    high_pairs = [
+        p for p in report.pairs
+        if p.label == LABEL_CONTRADICTS and p.score >= confidence_min
+    ]
+    # `report.pairs` is already sorted by (belief_a_id, belief_b_id);
+    # preserve that order so the write-gate is deterministic.
+
+    edges_per_belief: dict[str, int] = {}
+    n_written = 0
+    n_skipped_existing = 0
+    n_gated = 0
+    n_self = 0
+    for pair in high_pairs:
+        a_id, b_id = pair.belief_a_id, pair.belief_b_id
+        if a_id == b_id:
+            n_self += 1
+            continue
+        # Write-gate: drop if either endpoint is already at the cap.
+        if (
+            edges_per_belief.get(a_id, 0) >= max_edges_per_belief
+            or edges_per_belief.get(b_id, 0) >= max_edges_per_belief
+        ):
+            n_gated += 1
+            continue
+        src_id, dst_id = (a_id, b_id) if a_id < b_id else (b_id, a_id)
+        if store.get_edge(src_id, dst_id, EDGE_CONTRADICTS) is not None:
+            n_skipped_existing += 1
+            # Count existing edges toward the budget for a hard per-belief
+            # bound across re-runs.
+            edges_per_belief[a_id] = edges_per_belief.get(a_id, 0) + 1
+            edges_per_belief[b_id] = edges_per_belief.get(b_id, 0) + 1
+            continue
+        store.insert_edge(
+            Edge(src=src_id, dst=dst_id, type=EDGE_CONTRADICTS, weight=1.0)
+        )
+        n_written += 1
+        edges_per_belief[a_id] = edges_per_belief.get(a_id, 0) + 1
+        edges_per_belief[b_id] = edges_per_belief.get(b_id, 0) + 1
+
+    return SemanticEdgeWriteReport(
+        n_contradicts_high=len(high_pairs),
+        n_edges_written=n_written,
+        n_edges_skipped_existing=n_skipped_existing,
+        n_edges_skipped_gated=n_gated,
+        n_edges_skipped_self_pair=n_self,
+    )
+
+
 __all__ = [
     "DEFAULT_CONFIDENCE_MIN",
     "DEFAULT_JACCARD_MIN",
@@ -864,13 +999,16 @@ __all__ = [
     "RelationshipPair",
     "RelationshipVerdict",
     "RelationshipsAuditReport",
+    "SemanticEdgeWriteReport",
     "Signals",
     "analyze",
     "classify",
     "extract_signals",
     "format_audit_report",
     "format_write_report",
+    "is_auto_relationship_detection_enabled",
     "load_relationship_detector_config",
     "relationships_audit",
     "write_potentially_stale_edges",
+    "write_semantic_edges",
 ]

--- a/tests/test_relationship_detector_semantic_writer.py
+++ b/tests/test_relationship_detector_semantic_writer.py
@@ -1,0 +1,232 @@
+"""Unit tests for the #988 CONTRADICTS edge writer + ingest wiring.
+
+Covers ``write_semantic_edges`` (high-confidence CONTRADICTS edges, the
+complement of the sub-confidence ``write_potentially_stale_edges`` set),
+the default-off ``auto_detect`` flag resolver, the determinism guarantee,
+the per-belief write-gate, and the byte-identical off-path through
+``ingest_turn``.
+
+All tests use a real ``MemoryStore(":memory:")`` — no mocks.
+"""
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CONTRADICTS,
+    LOCK_NONE,
+    Belief,
+)
+from aelfrice.relationship_detector import (
+    DEFAULT_MAX_EDGES_PER_BELIEF,
+    ENV_AUTO_RELATIONSHIPS,
+    is_auto_relationship_detection_enabled,
+    write_semantic_edges,
+)
+from aelfrice.store import MemoryStore
+
+# High-confidence contradiction: "always X" vs "never X" — universal
+# affirmation vs negation over identical residual content → score 1.0.
+_ALWAYS = "the deployment script always runs the database migration step"
+_NEVER = "the deployment script never runs the database migration step"
+# Lexically distant filler that relates to nothing else.
+_UNRELATED = "the harbor seals bask on the warm rocks at noon each day"
+
+
+def _make_belief(
+    store: MemoryStore,
+    *,
+    belief_id: str,
+    content: str,
+    created_at: str = "2026-01-01T00:00:00Z",
+) -> Belief:
+    b = Belief(
+        id=belief_id,
+        content=content,
+        content_hash=hashlib.sha256(content.encode()).hexdigest(),
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        created_at=created_at,
+        last_retrieved_at=None,
+    )
+    store.insert_belief(b)
+    return b
+
+
+def _contradicts_edges(store: MemoryStore) -> list[tuple[str, str]]:
+    """Return all CONTRADICTS edges as sorted (src, dst) tuples."""
+    rows = store._conn.execute(  # type: ignore[attr-defined]
+        "SELECT src, dst FROM edges WHERE type = ? ORDER BY src, dst",
+        (EDGE_CONTRADICTS,),
+    ).fetchall()
+    return [(r[0], r[1]) for r in rows]
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    return MemoryStore(":memory:")
+
+
+# ---------------------------------------------------------------------------
+# Flag resolver precedence
+# ---------------------------------------------------------------------------
+
+
+def test_flag_defaults_off(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.delenv(ENV_AUTO_RELATIONSHIPS, raising=False)
+    # start at an empty dir so no repo .aelfrice.toml is found
+    assert is_auto_relationship_detection_enabled(start=tmp_path) is False
+
+
+def test_flag_env_wins_over_kwarg(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_AUTO_RELATIONSHIPS, "off")
+    assert is_auto_relationship_detection_enabled(explicit=True) is False
+    monkeypatch.setenv(ENV_AUTO_RELATIONSHIPS, "on")
+    assert is_auto_relationship_detection_enabled(explicit=False) is True
+
+
+def test_flag_unrecognised_env_is_not_decisive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(ENV_AUTO_RELATIONSHIPS, "maybe")
+    assert is_auto_relationship_detection_enabled(explicit=True) is True
+
+
+def test_flag_toml_read(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.delenv(ENV_AUTO_RELATIONSHIPS, raising=False)
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[relationship_detector]\nauto_detect = true\n"
+    )
+    assert is_auto_relationship_detection_enabled(start=tmp_path) is True
+
+
+# ---------------------------------------------------------------------------
+# write_semantic_edges — write / scope / idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_writes_contradicts_edge_for_high_confidence_pair(
+    store: MemoryStore,
+) -> None:
+    _make_belief(store, belief_id="b1", content=_ALWAYS)
+    _make_belief(store, belief_id="b2", content=_NEVER)
+    report = write_semantic_edges(store)
+    assert report.n_contradicts_high == 1
+    assert report.n_edges_written == 1
+    # Canonical direction: src = min(id), dst = max(id).
+    assert _contradicts_edges(store) == [("b1", "b2")]
+
+
+def test_idempotent_second_run_writes_nothing(store: MemoryStore) -> None:
+    _make_belief(store, belief_id="b1", content=_ALWAYS)
+    _make_belief(store, belief_id="b2", content=_NEVER)
+    write_semantic_edges(store)
+    report = write_semantic_edges(store)
+    assert report.n_edges_written == 0
+    assert report.n_edges_skipped_existing == 1
+    assert _contradicts_edges(store) == [("b1", "b2")]
+
+
+def test_unrelated_pair_writes_no_edge(store: MemoryStore) -> None:
+    _make_belief(store, belief_id="b1", content=_ALWAYS)
+    _make_belief(store, belief_id="b2", content=_UNRELATED)
+    report = write_semantic_edges(store)
+    assert report.n_edges_written == 0
+    assert _contradicts_edges(store) == []
+
+
+def test_agreeing_modality_is_refines_not_contradicts(
+    store: MemoryStore,
+) -> None:
+    # Two "never" statements over the same residual content agree in
+    # modality → refines, which this CONTRADICTS-only writer ignores.
+    _make_belief(store, belief_id="b1", content=_NEVER)
+    _make_belief(
+        store,
+        belief_id="b2",
+        content=_NEVER + " before launch",
+    )
+    report = write_semantic_edges(store)
+    assert report.n_edges_written == 0
+    assert _contradicts_edges(store) == []
+
+
+# ---------------------------------------------------------------------------
+# Determinism — byte-equal edge sets across two fresh stores
+# ---------------------------------------------------------------------------
+
+
+def test_determinism_byte_equal_edges() -> None:
+    def build() -> list[tuple[str, str]]:
+        s = MemoryStore(":memory:")
+        _make_belief(s, belief_id="b1", content=_ALWAYS)
+        _make_belief(s, belief_id="b2", content=_NEVER)
+        _make_belief(s, belief_id="b3", content=_UNRELATED)
+        write_semantic_edges(s)
+        return _contradicts_edges(s)
+
+    assert build() == build()
+
+
+# ---------------------------------------------------------------------------
+# Write-gate — per-belief edge cap (Exp-48 dilution guard)
+# ---------------------------------------------------------------------------
+
+
+def test_write_gate_caps_per_belief_edges(store: MemoryStore) -> None:
+    # b1 contradicts both b2 and b3 (both negate b1's universal claim).
+    # b2 and b3 agree with each other (both "never") → no edge between them.
+    _make_belief(store, belief_id="b1", content=_ALWAYS)
+    _make_belief(store, belief_id="b2", content=_NEVER)
+    _make_belief(
+        store, belief_id="b3", content=_NEVER + " before each launch"
+    )
+    report = write_semantic_edges(store, max_edges_per_belief=1)
+    # b1 may only accrue one CONTRADICTS edge; the second pair is gated.
+    assert report.n_edges_written == 1
+    assert report.n_edges_skipped_gated == 1
+    edges = _contradicts_edges(store)
+    assert len(edges) == 1
+    # The surviving edge is the first in deterministic (a_id, b_id) order.
+    assert edges == [("b1", "b2")]
+
+
+def test_default_cap_is_positive() -> None:
+    assert DEFAULT_MAX_EDGES_PER_BELIEF >= 1
+
+
+# ---------------------------------------------------------------------------
+# Ingest wiring — off-path byte-identical, on-path writes
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_off_path_writes_no_contradicts_edges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aelfrice.ingest import ingest_turn
+
+    monkeypatch.delenv(ENV_AUTO_RELATIONSHIPS, raising=False)
+    s = MemoryStore(":memory:")
+    ingest_turn(s, _ALWAYS, source="t", session_id="sess")
+    ingest_turn(s, _NEVER, source="t", session_id="sess")
+    assert _contradicts_edges(s) == []
+
+
+def test_ingest_on_path_writes_contradicts_edge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aelfrice.ingest import ingest_turn
+
+    monkeypatch.setenv(ENV_AUTO_RELATIONSHIPS, "1")
+    s = MemoryStore(":memory:")
+    ingest_turn(s, _ALWAYS, source="t", session_id="sess")
+    ingest_turn(s, _NEVER, source="t", session_id="sess")
+    assert len(_contradicts_edges(s)) == 1


### PR DESCRIPTION
## Summary

Closes #988 (acceptance items 1–3; item 4 ablation is a follow-up bench run).

aelfrice does not build the semantic-edge substrate at ingest, so the graph
retrieval lanes (HRR-expand #981, BFS multi-hop #977) are **inert on every
benchmark corpus** — they walk typed edges (`CONTRADICTS`/…) that no real
ingested store contains. This PR lands the single upstream change that makes
those lanes measurable: wire the existing **deterministic** detector
(`relationship_detector.py`, regex/token heuristics, no LLM/embedding) into
the ingest path behind a **default-off** flag.

## Change (4 atomic commits)

1. **Flag resolver** `is_auto_relationship_detection_enabled` — `env > kwarg >
   TOML > default-False`, mirroring the retrieval flag resolvers. Reads
   `AELFRICE_AUTO_RELATIONSHIPS` and `[relationship_detector] auto_detect`.
2. **`write_semantic_edges`** — writes a `CONTRADICTS` edge for each
   **high-confidence** (`score >= confidence_min`) contradicting pair. This is
   the complement of `write_potentially_stale_edges` (sub-confidence →
   `POTENTIALLY_STALE`); the two partition the contradicts pairs by score with
   no overlap. Deterministic (audit's sorted pair order, canonical
   `src=min(id)` direction), idempotent (`get_edge` guard), and **write-gated**
   (`max_edges_per_belief` caps per-belief growth — the Exp-48
   coverage-dilution guard; pre-existing edges count toward the budget for a
   hard cross-run bound).
3. **Ingest wiring** — lazy, guarded hook at end of `_ingest_turn_ids`. With
   the flag off (default), the branch is never entered and ingest output is
   **byte-identical** to today.
4. **Tests** — 13 tests: resolver precedence, high-confidence write, scope,
   idempotency, byte-equal determinism, write-gate cap, byte-identical
   off-path vs on-path through `ingest_turn`.

## Scope honesty: CONTRADICTS-only

The deterministic detector emits only `contradicts`/`refines`. Of those, only
`CONTRADICTS` has a model edge type (there is **no** `EDGE_REFINES`), and it is
the verdict the #201 ratification names as the deferred R2 write-path hook.
`SUPPORTS` is **not** produced by the detector. So this writer is
CONTRADICTS-only by necessity; `REFINES`/`SUPPORTS` substrate would be separate
follow-ups, not silently faked here.

## Decision gate (#605 / #897)

Default stays **OFF** — a fresh install writes no edges, so the #605/#897 scope
ratification is unchanged. This PR lands the lane + write-gate only. **Flipping
the default reverses #605 and requires re-opening #897** with isolated bench
evidence; per #897, bench uplift alone is insufficient to re-trigger that
decision. This PR does not flip it.

## Verification

- New suite `tests/test_relationship_detector_semantic_writer.py` — 13 passed.
- Regression: `test_relationship_detector*.py` + `test_ingest.py` — 44 passed.
- Off-path proven byte-identical (flag off → 0 `CONTRADICTS` edges through
  `ingest_turn`).

## Follow-ups (not in this PR)

- The #977 ablation matrix with `+auto_relationships` arms (issue item 4),
  bench readers dispatched as separate agents (no API key).
- Per-turn full-store audit is O(candidates) per turn; an incremental
  new-belief-only candidate path is a perf follow-up (default-off, bench-only
  today, so not blocking).

## Summary by Sourcery

Wire deterministic relationship detection into ingest behind a default-off flag to build a CONTRADICTS semantic-edge substrate while preserving current behavior by default.

New Features:
- Add an ingest-time auto-relationship-detection flag resolved from environment, explicit kwargs, or configuration to control semantic edge writing.
- Introduce a semantic edge writer that emits high-confidence CONTRADICTS edges with deterministic, idempotent behavior and a per-belief write cap.
- Hook semantic edge writing into the ingest pipeline so new beliefs can populate the graph-based retrieval substrate when auto-detection is enabled.

Tests:
- Add unit tests covering flag precedence and default-off behavior, semantic edge writing scope and idempotency, determinism guarantees, the per-belief write gate, and ingest on/off-path behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic semantic relationship detection during ingest can now be enabled via environment variable, configuration file, or programmatic override.
  * Contradiction detection identifies opposing belief pairs and creates semantic edges between them with configurable confidence thresholds and write limits.
  * Added comprehensive test coverage for relationship detection and ingest integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->