### PR TITLE
feat(store): surface phantom lifecycle in aelf status + aelf:stats (#980)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -2916,6 +2916,7 @@ def _cmd_stats(args: argparse.Namespace, out: object) -> int:
         n_threads = store.count_edges()
         n_locked = store.count_locked()
         n_history = store.count_feedback_events()
+        phantoms = store.count_phantom_lifecycle()
     finally:
         store.close()
     print(f"version:           {_aelf_version}", file=out)  # type: ignore[arg-type]
@@ -2925,6 +2926,15 @@ def _cmd_stats(args: argparse.Namespace, out: object) -> int:
     print(f"threads:           {n_threads}", file=out)  # type: ignore[arg-type]
     print(f"locked:            {n_locked}", file=out)  # type: ignore[arg-type]
     print(f"feedback events:   {n_history}", file=out)  # type: ignore[arg-type]
+    # #980: phantom (speculative) lifecycle visibility. `latest` is the
+    # ISO timestamp of the most recent live phantom; show the date only.
+    ph_latest = phantoms.latest[:10] if phantoms.latest else "—"
+    print(  # type: ignore[arg-type]
+        f"phantoms:          {phantoms.active} active · "
+        f"{phantoms.promoted} promoted · {phantoms.retired} retired "
+        f"(latest: {ph_latest})",
+        file=out,
+    )
     print(_format_hrr_persist_status_line(), file=out)  # type: ignore[arg-type]
     return 0
 

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -183,6 +183,8 @@ def _render_locked_markdown(payload: dict[str, Any]) -> str:
 
 
 def _render_stats_markdown(payload: dict[str, Any]) -> str:
+    ph = payload.get("phantoms", {})
+    ph_latest = ph.get("latest") or "—"
     return (
         "# Aelfrice store snapshot\n\n"
         f"- Version: {payload.get('version', 'unknown')}\n"
@@ -192,6 +194,9 @@ def _render_stats_markdown(payload: dict[str, Any]) -> str:
         f"- Feedback events: {payload.get('feedback_events', 0)}\n"
         f"- Onboard sessions (total): "
         f"{payload.get('onboard_sessions_total', 0)}\n"
+        f"- Phantoms: {ph.get('active', 0)} active, "
+        f"{ph.get('promoted', 0)} promoted, {ph.get('retired', 0)} retired "
+        f"(latest: {ph_latest})\n"
     )
 
 
@@ -811,6 +816,15 @@ def tool_stats(
         "locked": store.count_locked(),
         "feedback_events": store.count_feedback_events(),
         "onboard_sessions_total": store.count_onboard_sessions(),
+    }
+    # #980: phantom (speculative) lifecycle visibility, parallel to the
+    # `aelf status` CLI line.
+    _phantoms = store.count_phantom_lifecycle()
+    payload["phantoms"] = {
+        "active": _phantoms.active,
+        "promoted": _phantoms.promoted,
+        "retired": _phantoms.retired,
+        "latest": _phantoms.latest,
     }
     if response_format == _RESPONSE_FORMAT_MARKDOWN:
         return _wrap_markdown(payload, _render_stats_markdown(payload))

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -463,3 +463,21 @@ class Phantom:
     score: float
 
 
+@dataclass(frozen=True)
+class PhantomLifecycleCounts:
+    """Snapshot of the phantom (speculative) belief lifecycle (#980).
+
+    Produced by ``MemoryStore.count_phantom_lifecycle`` and surfaced by
+    ``aelf status`` / the MCP ``aelf:stats`` tool so phantom generation,
+    promotion, and GC are observable rather than silent. The three counts
+    partition every ``type='speculative'`` belief into mutually exclusive
+    lifecycle states; ``latest`` is the ISO ``created_at`` of the most
+    recent live phantom, or ``None`` when none exist.
+    """
+
+    active: int
+    promoted: int
+    retired: int
+    latest: str | None
+
+

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -38,6 +38,7 @@ from aelfrice.models import (
     Edge,
     FeedbackEvent,
     OnboardSession,
+    PhantomLifecycleCounts,
     Session,
     validate_belief_scope,
 )
@@ -3766,6 +3767,53 @@ class MemoryStore:
             "SELECT type, COUNT(*) AS n FROM beliefs GROUP BY type ORDER BY type"
         )
         return {str(r["type"]): int(r["n"]) for r in cur.fetchall()}
+
+    def count_phantom_lifecycle(self) -> PhantomLifecycleCounts:
+        """Lifecycle snapshot of phantom (``type='speculative'``) beliefs (#980).
+
+        ``type='speculative'`` is the immutable phantom marker: it is set at
+        ``wonder_ingest`` and is *not* changed by promotion (which flips only
+        ``origin``) or GC (which sets only ``valid_to``). So the type column
+        partitions every belief that was ever born a phantom into three
+        mutually exclusive lifecycle states, computed in a single scan:
+
+        - ``active``   — still a phantom (``origin='speculative'``) and live
+          (``valid_to IS NULL``); awaiting promotion or GC.
+        - ``promoted`` — origin flipped off ``'speculative'`` (``aelf promote``
+          / lock-auto-promote, #550) and still live.
+        - ``retired``  — soft-deleted (``valid_to IS NOT NULL``), i.e. GC'd by
+          ``wonder_gc``. GC only ever soft-deletes speculative-origin rows, so
+          this count is exactly the GC'd phantoms.
+
+        ``latest`` is the ISO ``created_at`` of the most recent *live* phantom
+        ingest, or ``None`` when no live phantoms exist. Read-only and
+        deterministic — no clock, no network.
+        """
+        row = self._conn.execute(
+            """
+            SELECT
+              COALESCE(SUM(
+                CASE WHEN origin = 'speculative' AND valid_to IS NULL
+                     THEN 1 ELSE 0 END), 0) AS active,
+              COALESCE(SUM(
+                CASE WHEN origin != 'speculative' AND valid_to IS NULL
+                     THEN 1 ELSE 0 END), 0) AS promoted,
+              COALESCE(SUM(
+                CASE WHEN valid_to IS NOT NULL
+                     THEN 1 ELSE 0 END), 0) AS retired,
+              MAX(CASE WHEN origin = 'speculative' AND valid_to IS NULL
+                       THEN created_at ELSE NULL END) AS latest
+            FROM beliefs
+            WHERE type = 'speculative'
+            """
+        ).fetchone()
+        latest = row["latest"]
+        return PhantomLifecycleCounts(
+            active=int(row["active"]),
+            promoted=int(row["promoted"]),
+            retired=int(row["retired"]),
+            latest=str(latest) if latest is not None else None,
+        )
 
     def count_beliefs_by_scope(self) -> dict[str, int]:
         """Return a mapping of scope value → count across all beliefs.

--- a/tests/test_phantom_lifecycle_counts.py
+++ b/tests/test_phantom_lifecycle_counts.py
@@ -1,0 +1,210 @@
+"""Phantom (speculative) lifecycle counts surfaced by `aelf status` (#980).
+
+`MemoryStore.count_phantom_lifecycle` partitions every `type='speculative'`
+belief into three mutually-exclusive lifecycle states (active / promoted /
+retired) plus the latest live-phantom timestamp. These tests pin the
+transitions — ingest -> promote -> GC — and the two surfaces that render
+them (CLI `aelf status`, MCP `aelf:stats`).
+"""
+from __future__ import annotations
+
+import argparse
+import io
+
+import pytest
+
+from aelfrice.cli import _cmd_stats
+from aelfrice.mcp_server import tool_stats
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    LOCK_NONE,
+    PhantomLifecycleCounts,
+    RETENTION_FACT,
+    Belief,
+    Phantom,
+)
+from aelfrice.promotion import promote
+from aelfrice.store import MemoryStore
+from aelfrice.wonder.lifecycle import wonder_ingest
+
+
+def _constituent(bid: str) -> Belief:
+    return Belief(
+        id=bid,
+        content=f"constituent content for {bid}",
+        content_hash=f"ch_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        created_at="2026-05-01T00:00:00+00:00",
+        last_retrieved_at=None,
+        retention_class=RETENTION_FACT,
+    )
+
+
+def _phantom(content: str, *, score: float = 0.75) -> Phantom:
+    # wonder_ingest dedups on (sorted constituents, generator), so vary the
+    # generator per phantom to persist distinct rows from the same anchors.
+    return Phantom(
+        constituent_belief_ids=("a", "b"),
+        generator=f"gen-{content}",
+        content=content,
+        score=score,
+    )
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    s = MemoryStore(":memory:")
+    s.insert_belief(_constituent("a"))
+    s.insert_belief(_constituent("b"))
+    return s
+
+
+def _speculative_ids(store: MemoryStore) -> list[str]:
+    return [
+        b.id
+        for bid in store.list_belief_ids()
+        if (b := store.get_belief(bid)) is not None and b.type == "speculative"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Store method: lifecycle partition
+# ---------------------------------------------------------------------------
+
+
+def test_empty_store_reports_zeroes_and_no_latest(store: MemoryStore) -> None:
+    counts = store.count_phantom_lifecycle()
+    assert counts == PhantomLifecycleCounts(
+        active=0, promoted=0, retired=0, latest=None
+    )
+
+
+def test_ingest_makes_phantoms_active(store: MemoryStore) -> None:
+    wonder_ingest(store, [_phantom("p1"), _phantom("p2")])
+    counts = store.count_phantom_lifecycle()
+    assert counts.active == 2
+    assert counts.promoted == 0
+    assert counts.retired == 0
+    assert counts.latest is not None
+
+
+def test_promotion_moves_active_to_promoted(store: MemoryStore) -> None:
+    wonder_ingest(store, [_phantom("p1"), _phantom("p2")])
+    spec_id = _speculative_ids(store)[0]
+
+    promote(store, spec_id)
+
+    counts = store.count_phantom_lifecycle()
+    assert counts.active == 1
+    assert counts.promoted == 1
+    assert counts.retired == 0
+
+
+def test_soft_delete_moves_active_to_retired(store: MemoryStore) -> None:
+    wonder_ingest(store, [_phantom("p1"), _phantom("p2")])
+    spec_id = _speculative_ids(store)[0]
+
+    store.soft_delete_belief(spec_id, ts="2026-06-01T00:00:00+00:00")
+
+    counts = store.count_phantom_lifecycle()
+    assert counts.active == 1
+    assert counts.promoted == 0
+    assert counts.retired == 1
+
+
+def test_states_are_mutually_exclusive_across_full_lifecycle(
+    store: MemoryStore,
+) -> None:
+    wonder_ingest(
+        store, [_phantom("p1"), _phantom("p2"), _phantom("p3")]
+    )
+    ids = _speculative_ids(store)
+    promote(store, ids[0])
+    store.soft_delete_belief(ids[1], ts="2026-06-01T00:00:00+00:00")
+
+    counts = store.count_phantom_lifecycle()
+    # one promoted, one retired, one still active — sum equals ingested.
+    assert (counts.active, counts.promoted, counts.retired) == (1, 1, 1)
+
+
+def test_latest_tracks_most_recent_live_phantom(store: MemoryStore) -> None:
+    wonder_ingest(store, [_phantom("p1")])
+    counts = store.count_phantom_lifecycle()
+    # wonder_ingest stamps created_at at ingest time; just assert it is the
+    # ISO string of the one live phantom.
+    live_id = _speculative_ids(store)[0]
+    live = store.get_belief(live_id)
+    assert live is not None
+    assert counts.latest == live.created_at
+
+
+def test_retired_phantom_does_not_count_as_latest(store: MemoryStore) -> None:
+    wonder_ingest(store, [_phantom("p1")])
+    spec_id = _speculative_ids(store)[0]
+    store.soft_delete_belief(spec_id, ts="2026-06-01T00:00:00+00:00")
+
+    counts = store.count_phantom_lifecycle()
+    assert counts.retired == 1
+    assert counts.latest is None
+
+
+# ---------------------------------------------------------------------------
+# Surfaces: CLI `aelf status` + MCP `aelf:stats`
+# ---------------------------------------------------------------------------
+
+
+def test_cli_status_prints_phantom_line(
+    monkeypatch: pytest.MonkeyPatch, store: MemoryStore
+) -> None:
+    wonder_ingest(store, [_phantom("p1"), _phantom("p2")])
+    promote(store, _speculative_ids(store)[0])
+
+    monkeypatch.setattr("aelfrice.cli._open_store", lambda: store)
+    monkeypatch.setattr(store, "close", lambda: None)
+
+    buf = io.StringIO()
+    rc = _cmd_stats(argparse.Namespace(), buf)
+    assert rc == 0
+
+    out = buf.getvalue()
+    assert "phantoms:" in out
+    assert "1 active" in out
+    assert "1 promoted" in out
+    assert "0 retired" in out
+
+
+def test_cli_status_phantom_line_empty_store(
+    monkeypatch: pytest.MonkeyPatch, store: MemoryStore
+) -> None:
+    monkeypatch.setattr("aelfrice.cli._open_store", lambda: store)
+    monkeypatch.setattr(store, "close", lambda: None)
+
+    buf = io.StringIO()
+    _cmd_stats(argparse.Namespace(), buf)
+    out = buf.getvalue()
+    assert "0 active · 0 promoted · 0 retired" in out
+    assert "latest: —" in out
+
+
+def test_mcp_stats_payload_includes_phantoms(store: MemoryStore) -> None:
+    wonder_ingest(store, [_phantom("p1")])
+    payload = tool_stats(store)
+    assert payload["phantoms"] == {
+        "active": 1,
+        "promoted": 0,
+        "retired": 0,
+        "latest": payload["phantoms"]["latest"],
+    }
+    assert payload["phantoms"]["latest"] is not None
+
+
+def test_mcp_stats_markdown_renders_phantom_line(store: MemoryStore) -> None:
+    wonder_ingest(store, [_phantom("p1")])
+    result = tool_stats(store, response_format="markdown")
+    markdown = result["text"]
+    assert "Phantoms:" in markdown
+    assert "1 active" in markdown


### PR DESCRIPTION
## What

Surfaces the phantom (speculative) belief lifecycle in `aelf status` and the
MCP `aelf:stats` tool, so phantom generation / promotion / GC are observable
rather than silent. Addresses **item 4** of the #980 phantom-lifecycle umbrella.

## Why

The #980 audit found **74 phantoms across all local stores, 0 ever promoted,
0 ever GC'd** — and no surface that makes any of this visible. The operator's
opening observation ("phantoms don't seem to show up recently") could not be
checked without ad-hoc SQLite queries. This adds the missing observability
line.

## How

- `MemoryStore.count_phantom_lifecycle()` — one-scan conditional aggregation
  over `type='speculative'` (the immutable phantom marker: promotion flips
  only `origin`, GC sets only `valid_to`). Partitions into mutually-exclusive
  `active` / `promoted` / `retired`, plus the ISO `created_at` of the most
  recent **live** phantom. Read-only, deterministic — no clock, no network.
- `aelf status` gains a `phantoms:` line:
  `N active · N promoted · N retired (latest: YYYY-MM-DD)`.
- MCP `aelf:stats` gains a `phantoms` JSON sub-object and a markdown line.

## Tests

`tests/test_phantom_lifecycle_counts.py` — pins the ingest → promote → GC
transitions, mutual exclusivity, `latest` semantics (excludes retired), and
both render surfaces. 11 tests.

## Scope note

This is item 4 only. The umbrella stays open for items 2 (make GC actually
run) and 3 (trigger-driven generation in normal turns) — both carry
operator-level decisions (auto-GC default; the #605 determinism boundary for
in-turn LLM-dispatched generation), surfaced for disposition rather than
decided here.

Closes nothing — `#980` remains open as the umbrella.

## Summary by Sourcery

Surface phantom (speculative) belief lifecycle statistics through the store API, CLI status command, and MCP stats tool.

New Features:
- Expose phantom lifecycle counts via MemoryStore.count_phantom_lifecycle returning a PhantomLifecycleCounts snapshot.
- Show phantom lifecycle metrics in the aelf status CLI output, including latest live phantom date.
- Include phantom lifecycle data in the aelf:stats MCP tool payload and markdown rendering.

Tests:
- Add tests covering phantom lifecycle counting across ingest, promotion, and GC, and verifying both CLI and MCP stats outputs.