### PR TITLE
fix(store): exclude soft-deleted beliefs from the federation peer-search lane (#980)

### DIFF
--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -2591,6 +2591,7 @@ class MemoryStore:
                     FROM beliefs b
                     JOIN beliefs_fts f ON f.id = b.id
                     WHERE beliefs_fts MATCH ?
+                      AND b.valid_to IS NULL
                     {scope_sql}
                     ORDER BY bm25(beliefs_fts)
                     LIMIT ?

--- a/tests/test_federation_readonly.py
+++ b/tests/test_federation_readonly.py
@@ -98,6 +98,41 @@ def _wire_peer(tmp_path: Path, peer_path: Path, monkeypatch) -> Path:
     return deps_file
 
 
+def test_search_peer_beliefs_excludes_soft_deleted(
+    tmp_path: Path, monkeypatch
+):
+    """A soft-deleted belief on a peer must not surface via the federation
+    overlay (#980 invariant extends to the peer-search lane).
+
+    valid_to is set directly here, leaving the peer's FTS row intact, to
+    simulate a peer that has not run the FTS-pruning soft_delete (or a
+    legacy pre-#980 soft-delete). That isolates the read-side
+    `valid_to IS NULL` filter in search_peer_beliefs: without it, the
+    soft-deleted row still MATCHes and surfaces.
+    """
+    peer_path = tmp_path / "peerA.db"
+    peer = MemoryStore(str(peer_path))
+    try:
+        peer.insert_belief(_belief("peer-active", "shared cat token active"))
+        peer.insert_belief(_belief("peer-removed", "shared cat token removed"))
+        peer._conn.execute(
+            "UPDATE beliefs SET valid_to = ? WHERE id = ?",
+            ("2026-05-12T00:00:00+00:00", "peer-removed"),
+        )
+        peer._conn.commit()
+    finally:
+        peer.close()
+    _wire_peer(tmp_path, peer_path, monkeypatch)
+
+    local = MemoryStore(str(tmp_path / "local.db"))
+    try:
+        ids = [b.id for b, _, _ in local.search_peer_beliefs("shared cat token")]
+        assert "peer-active" in ids
+        assert "peer-removed" not in ids
+    finally:
+        local.close()
+
+
 def test_two_scope_smoke_peer_belief_surfaces_in_local_search(
     tmp_path: Path, monkeypatch
 ):

--- a/tests/test_federation_readonly.py
+++ b/tests/test_federation_readonly.py
@@ -108,7 +108,7 @@ def test_search_peer_beliefs_excludes_soft_deleted(
     simulate a peer that has not run the FTS-pruning soft_delete (or a
     legacy pre-#980 soft-delete). That isolates the read-side
     `valid_to IS NULL` filter in search_peer_beliefs: without it, the
-    soft-deleted row still MATCHes and surfaces.
+    soft-deleted row still matches the FTS query and surfaces.
     """
     peer_path = tmp_path / "peerA.db"
     peer = MemoryStore(str(peer_path))


### PR DESCRIPTION
## Summary

Follow-up to #980 / PR #987. Surfaced by the release-prep code audit.

PR #987 added `valid_to IS NULL` at the four **local** retrieval lanes
(FTS `search_beliefs`/`_scored`, BM25 `list_beliefs_for_indexing`, entity-index
`lookup_entities`, locked-L0 `list_locked_beliefs`) and pruned the FTS row on
`soft_delete_belief`. It missed the **fifth** lane: `search_peer_beliefs`
(federation read-only overlay, #655) runs its own FTS query against peer DBs:

```sql
FROM beliefs b JOIN beliefs_fts f ON f.id = b.id
WHERE beliefs_fts MATCH ? AND b.scope IN (...)
```

— no `valid_to` filter, so a soft-deleted belief on a **peer** store still
surfaces through the overlay.

## Fix

Add `AND b.valid_to IS NULL` to the peer query (`store.py:2575`). The local
`soft_delete` FTS-prune can't be relied on across the federation boundary —
a peer may run unpatched code or carry legacy pre-#980 soft-deletes whose FTS
rows persist — so the read-side filter is the robust guarantee.

## Test

`test_search_peer_beliefs_excludes_soft_deleted` sets `valid_to` directly on
the peer (leaving the peer's FTS row intact) to isolate the read-side filter.
Non-vacuity verified: the test **fails** without this change, passes with it.
Full `test_federation_readonly.py` green (13 passed).

## Scope

Completes the #980 item-1 invariant ("soft-deleted ⇒ not retrievable") across
**all five** lanes. Latent today (zero soft-deleted beliefs in stores) but a
correctness gap that should land before the release tag.

## Summary by Sourcery

Ensure federation peer search excludes soft-deleted beliefs from results.

Bug Fixes:
- Filter peer belief search results to omit beliefs that have been soft-deleted in remote stores.

Tests:
- Add a federation read-only test verifying that soft-deleted peer beliefs do not appear in search results.