### PR TITLE
feat(retrieval): restore deterministic HRR vocabulary-bridge expansion lane behind default-off use_hrr_expand, then ablate (#981)

### DIFF
--- a/benchmarks/hrr_expand_ablation.py
+++ b/benchmarks/hrr_expand_ablation.py
@@ -130,7 +130,10 @@ def run_arm_on_store(
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--data", default=DEFAULT_DATA_PATH)
-    ap.add_argument("--out", default="/tmp/hrr_expand_ablation.json")
+    ap.add_argument(
+        "--out",
+        default=os.path.join(tempfile.gettempdir(), "hrr_expand_ablation.json"),
+    )
     ap.add_argument("--budget", type=int, default=2000)
     ap.add_argument("--subset-convs", type=int, default=None)
     ap.add_argument("--subset-qa", type=int, default=None)

--- a/benchmarks/hrr_expand_ablation.py
+++ b/benchmarks/hrr_expand_ablation.py
@@ -1,0 +1,271 @@
+"""#981 HRR vocabulary-bridge expansion-lane ablation (the #977-sweep arm).
+
+Runs LoCoMo under four retrieval configurations to isolate the
+``use_hrr_expand`` lane:
+
+    baseline    — BFS off, HRR-expand off  (production-style default)
+    +hrr-expand — HRR-expand on,  BFS off
+    +bfs        — BFS on,         HRR-expand off
+    all-on      — BFS on,         HRR-expand on
+
+Scoring is the LoCoMo adapter's deterministic retrieval-overlap F1
+(``score_qa`` over the concatenated retrieved context, incl. the cat-5
+"No information available" length heuristic). This is exactly the scorer the
+#981 issue's honest-uplift caveat references — no LLM reader is involved, so
+the arm comparison is fully reproducible. Absolute F1 is a retrieval-recall
+proxy, not reader accuracy; the *relative* arm deltas are the deliverable.
+
+Ingest is arm-independent (the flags only change retrieval), so each
+conversation is ingested once, its struct index + neighbour table built once,
+then all four arms run against the same DB.
+
+LongMemEval / MAB / StructMemEval are intentionally out of scope here: their
+full corpora are not present locally (only micro smoke fixtures) and per the
+project's bench notes several are structurally unscorable. The headline
+delta this issue addresses (66.1%→40.88%) is LoCoMo, so LoCoMo is the arm.
+
+Usage:
+    uv run python -m benchmarks.hrr_expand_ablation \
+        --data /tmp/LoCoMo/data/locomo10.json --out /tmp/hrr_expand_ablation.json
+    # smoke: --subset-convs 1 --subset-qa 20
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+import time
+from dataclasses import dataclass, field
+from typing import Final
+
+from aelfrice.hrr_expand import precompute_expand_neighbors
+from aelfrice.hrr_index import HRRStructIndexCache
+from aelfrice.relationship_detector import write_semantic_edges
+from aelfrice.retrieval import retrieve_v2
+from aelfrice.store import MemoryStore
+
+from benchmarks.locomo_adapter import (
+    CATEGORY_NAMES,
+    DEFAULT_DATA_PATH,
+    ingest_conversation,
+    load_locomo,
+    score_qa,
+)
+
+
+@dataclass(frozen=True)
+class Arm:
+    key: str
+    use_bfs: bool
+    use_hrr_expand: bool
+
+
+ARMS: Final[tuple[Arm, ...]] = (
+    Arm("baseline", use_bfs=False, use_hrr_expand=False),
+    Arm("+hrr-expand", use_bfs=False, use_hrr_expand=True),
+    Arm("+bfs", use_bfs=True, use_hrr_expand=False),
+    Arm("all-on", use_bfs=True, use_hrr_expand=True),
+)
+
+# Edge-substrate dimension. The HRR-expand and BFS lanes traverse semantic
+# edges; vanilla LoCoMo ingest writes none, so both lanes are inert (#977).
+# #988's deterministic relationship detection mints CONTRADICTS edges at
+# ingest behind a default-off flag — the substrate these lanes consume. The
+# ablation runs the arms under both so the lane's substrate-gating is visible.
+SUBSTRATE_NONE: Final[str] = "none"
+SUBSTRATE_988: Final[str] = "contradicts-988"
+SUBSTRATES: Final[tuple[str, ...]] = (SUBSTRATE_NONE, SUBSTRATE_988)
+
+
+@dataclass
+class ArmScore:
+    total_qa: int = 0
+    total_f1: float = 0.0
+    cat_f1: dict[int, list[float]] = field(default_factory=dict)
+    expand_hits: int = 0  # total beliefs the lane merged across questions
+
+    def add(self, category: int, f1: float) -> None:
+        self.total_qa += 1
+        self.total_f1 += f1
+        self.cat_f1.setdefault(category, []).append(f1)
+
+    @property
+    def overall(self) -> float:
+        return self.total_f1 / self.total_qa if self.total_qa else 0.0
+
+
+def _context(beliefs: list) -> str:
+    return " ".join(b.content for b in beliefs)
+
+
+def run_arm_on_store(
+    store: MemoryStore,
+    cache: HRRStructIndexCache,
+    qa_pairs: list,
+    arm: Arm,
+    budget: int,
+    score: ArmScore,
+) -> None:
+    from aelfrice import retrieval as _R
+
+    for qa in qa_pairs:
+        result = retrieve_v2(
+            store=store,
+            query=qa.question,
+            budget=budget,
+            include_locked=False,
+            use_bfs=arm.use_bfs,
+            use_hrr_expand=arm.use_hrr_expand,
+            hrr_struct_index_cache=cache,
+        )
+        score.expand_hits += _R._LAST_TELEMETRY.hrr_expand
+        prediction = _context(result.beliefs)
+        if qa.category == 5 and len(prediction.split()) < 10:
+            prediction = "No information available"
+        answer = qa.answer if qa.category != 5 else ""
+        score.add(qa.category, score_qa(prediction, answer, qa.category))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--data", default=DEFAULT_DATA_PATH)
+    ap.add_argument("--out", default="/tmp/hrr_expand_ablation.json")
+    ap.add_argument("--budget", type=int, default=2000)
+    ap.add_argument("--subset-convs", type=int, default=None)
+    ap.add_argument("--subset-qa", type=int, default=None)
+    args = ap.parse_args()
+
+    # Resolver reads env; clear any ambient overrides so the explicit kwargs
+    # this runner passes are authoritative.
+    for var in ("AELFRICE_HRR_EXPAND", "AELFRICE_BFS"):
+        os.environ.pop(var, None)
+
+    convs = load_locomo(args.data)
+    if args.subset_convs is not None:
+        convs = convs[: args.subset_convs]
+
+    scores: dict[tuple[str, str], ArmScore] = {
+        (sub, a.key): ArmScore() for sub in SUBSTRATES for a in ARMS
+    }
+    edge_counts: dict[str, int] = {sub: 0 for sub in SUBSTRATES}
+    t0 = time.monotonic()
+
+    with tempfile.TemporaryDirectory() as db_dir:
+        for ci, conv in enumerate(convs):
+            db_path = f"{db_dir}/{conv.sample_id}.db"
+            store = MemoryStore(db_path)
+            ingest_conversation(store, conv)
+            qa_pairs = conv.qa_pairs
+            if args.subset_qa is not None:
+                qa_pairs = qa_pairs[: args.subset_qa]
+            # SUBSTRATE_NONE must run before edges are written (edges only
+            # add). For SUBSTRATE_988, mint CONTRADICTS edges, then rebuild a
+            # fresh index/cache over the now-edged store.
+            for sub in SUBSTRATES:
+                if sub == SUBSTRATE_988:
+                    write_semantic_edges(store)
+                edge_counts[sub] += store._conn.execute(  # noqa: SLF001
+                    "SELECT COUNT(*) FROM edges"
+                ).fetchone()[0]
+                cache = HRRStructIndexCache(store=store, store_path=db_path)
+                precompute_expand_neighbors(store, cache.get())
+                for arm in ARMS:
+                    run_arm_on_store(
+                        store, cache, qa_pairs, arm, args.budget,
+                        scores[(sub, arm.key)],
+                    )
+            print(
+                f"[{ci + 1}/{len(convs)}] {conv.sample_id}: "
+                f"{len(qa_pairs)} QA × {len(ARMS)} arms × {len(SUBSTRATES)} "
+                f"substrates done",
+                flush=True,
+            )
+
+    elapsed = time.monotonic() - t0
+    report = _build_report(scores, edge_counts, elapsed, args)
+    with open(args.out, "w") as f:
+        json.dump(report, f, indent=2)
+    _print_report(report)
+    print(f"\nWrote {args.out}  ({elapsed:.1f}s)")
+
+
+def _build_report(
+    scores: dict[tuple[str, str], ArmScore],
+    edge_counts: dict[str, int],
+    elapsed: float,
+    args: argparse.Namespace,
+) -> dict:
+    all_cats = sorted({c for s in scores.values() for c in s.cat_f1})
+    substrates_out: dict[str, dict] = {}
+    for sub in SUBSTRATES:
+        base = scores[(sub, "baseline")].overall
+        arms_out: dict[str, dict] = {}
+        for arm in ARMS:
+            s = scores[(sub, arm.key)]
+            arms_out[arm.key] = {
+                "use_bfs": arm.use_bfs,
+                "use_hrr_expand": arm.use_hrr_expand,
+                "total_qa": s.total_qa,
+                "overall_f1": round(s.overall, 4),
+                "delta_vs_baseline": round(s.overall - base, 4),
+                "expand_hits": s.expand_hits,
+                "category_f1": {
+                    str(c): round(sum(s.cat_f1[c]) / len(s.cat_f1[c]), 4)
+                    for c in all_cats
+                    if s.cat_f1.get(c)
+                },
+            }
+        substrates_out[sub] = {
+            "total_edges": edge_counts[sub],
+            "arms": arms_out,
+        }
+    return {
+        "benchmark": "locomo",
+        "scorer": "retrieval_overlap_f1 (locomo_adapter.score_qa)",
+        "issue": 981,
+        "note": (
+            "Retrieval-overlap F1 (no LLM reader); relative arm deltas are "
+            "the deliverable. HRR-expand/BFS traverse semantic edges — "
+            "inert without an edge substrate (#977). 'contradicts-988' "
+            "enables #988 relationship detection at ingest."
+        ),
+        "data": args.data,
+        "budget": args.budget,
+        "elapsed_s": round(elapsed, 1),
+        "category_names": CATEGORY_NAMES,
+        "substrates": substrates_out,
+    }
+
+
+def _print_report(report: dict) -> None:
+    cats = sorted({
+        int(c)
+        for sub in report["substrates"].values()
+        for a in sub["arms"].values()
+        for c in a["category_f1"]
+    })
+    print("\n" + "=" * 78)
+    print(f"#981 HRR-expand ablation — LoCoMo ({report['scorer']})")
+    print("=" * 78)
+    for sub, subdata in report["substrates"].items():
+        print(f"\n[substrate={sub}]  total_edges={subdata['total_edges']}")
+        header = (
+            f"  {'arm':<13}{'overall':>9}{'Δ':>7}{'expand':>8}  "
+            + "".join(f"c{c}:{CATEGORY_NAMES.get(c, '?')[:5]:>7}" for c in cats)
+        )
+        print(header)
+        for key, a in subdata["arms"].items():
+            row = (
+                f"  {key:<13}{a['overall_f1'] * 100:>8.1f}%"
+                f"{a['delta_vs_baseline'] * 100:>+6.1f}{a['expand_hits']:>8}  "
+            )
+            row += "".join(
+                f"{a['category_f1'].get(str(c), 0.0) * 100:>13.1f}"
+                for c in cats
+            )
+            print(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/design/feature-hrr-expand-lane.md
+++ b/docs/design/feature-hrr-expand-lane.md
@@ -1,0 +1,131 @@
+# HRR vocabulary-bridge expansion lane (#981)
+
+Status: **implemented, default-OFF; ablation landed.** Default-flip is out of
+scope (reverses locked #605; routed to a re-opened #897).
+
+## What this is
+
+A deterministic, embeddings-free retrieval lane that probes the HRR
+structural index for **single-hop semantic neighbours of the FTS5 seeds** and
+merges them into the candidate set before scoring. It restores the
+`use_hrr=True` L3 step the predecessor's docstring labelled "HRR
+vocabulary-bridge expansion" — the lane the v3.0.1 calibration notes name as
+the cause of the LoCoMo delta (66.1% → 40.88%) — re-expressed on the current
+`HRRStructIndex` substrate rather than the removed predecessor `HRRGraph`.
+
+It is **not**:
+
+- the `use_hrr_structural` lane (#152) — that is a marker-routed query path
+  (`<KIND>:<target_id>`) that *replaces* the textual lane; this lane is an
+  *additive candidate source* that runs alongside L1/BFS;
+- the `vocab_bridge.py` query-rewrite cascade (#433/#536, removed, `TypeError`
+  by design);
+- the `(subject,predicate)`-collision SUPERSEDES prototype (#895, wontfix).
+
+## Mechanics
+
+The struct index encodes each belief's outgoing edges as a superposition of
+bound role–filler pairs: `struct[b] = Σ bind(role[e.kind], id[e.dst])`. From a
+seed belief the lane recovers both edge directions:
+
+- **forward** out-neighbours: `unbind(role[kind], struct[seed])` recovers the
+  superposed `id` vectors of `kind`-typed destinations; a cleanup matvec
+  against the id-vector matrix ranks candidate beliefs;
+- **reverse** in-neighbours: the existing `HRRStructIndex.probe(kind, seed)`
+  ranks beliefs whose outgoing structure contains `bind(role[kind], id[seed])`.
+
+Probed edge kinds are the predecessor's semantic set ∩ the live
+`models.EDGE_TYPES`: `SUPERSEDES, CONTRADICTS, SUPPORTS, CITES, TESTS,
+IMPLEMENTS` (`CALLS` is not in the current schema). Co-occurrence/structural
+kinds (`RELATES_TO`, `DERIVED_FROM`, `TEMPORAL_NEXT`, `RESOLVES`) are excluded
+as noise.
+
+`precompute_expand_neighbors` materialises a byte-stable
+`hrr_expand_neighbors` SQLite table (forward + reverse, per active belief);
+`expand_seeds` reads it at query time with a live-probe fallback. The lane's
+results also seed BFS, matching the predecessor.
+
+### Similarity floor
+
+Single-hop typed edges are **bimodal** under this algebra: a present edge
+recovers its bound term exactly (`unbind(role_k, bind(role_k, id_t)) · id_t ==
+1.0` forward; the matching `bind` self-dot `≈ 1.0` reverse), independent of
+the belief's degree — only additive crosstalk from the belief's *other*
+bindings varies, at `~1/sqrt(dim)` (~0.044 at dim=512) per term. True matches
+cluster at ~1.0 and absent edges at ~noise, so the floor (`0.5`) sits squarely
+in the gap. Empirically a spurious hit on a no-such-edge belief scores
+~0.12–0.17 at dim=512 — well below 0.5.
+
+## Determinism (#605, #437)
+
+Every operation is a numpy FFT / matvec over the deterministically-seeded
+struct matrix. There is no `random` / `betavariate` / Thompson sampling
+anywhere in the lane (asserted by an AST scan in `tests/test_hrr_expand.py`).
+The neighbour table is byte-equal across two runs over the same store
+(tie-break: similarity DESC, neighbor_id ASC). Default-OFF keeps `retrieve_v2`
+output byte-identical to the pre-#981 path.
+
+## Flag
+
+`use_hrr_expand`, resolved env (`AELFRICE_HRR_EXPAND`) > kwarg > TOML
+(`[retrieval] use_hrr_expand`) > **default False**, via
+`retrieval.is_hrr_expand_enabled`. Passing it never raises (AC1).
+
+## Ablation (`benchmarks/hrr_expand_ablation.py`)
+
+The #977-sweep arm for this lane. LoCoMo under a 2×4 matrix — edge substrate
+{`none`, `contradicts-988`} × flag arms {`baseline`, `+hrr-expand`, `+bfs`,
+`all-on`} — scored with the LoCoMo adapter's deterministic retrieval-overlap
+F1 (the scorer the issue's honest-uplift caveat references; no LLM reader, so
+the arm comparison is fully reproducible). Absolute F1 is a retrieval-recall
+proxy, not reader accuracy — the **relative arm deltas** are the deliverable.
+
+**Scope note.** Only LoCoMo is run: it is the corpus the 66.1%→40.88% delta
+is measured on, and the full LongMemEval / MAB / StructMemEval corpora are not
+present locally (only micro smoke fixtures), with several structurally
+unscorable per the project's bench notes. They are deferred.
+
+### Headline finding
+
+The HRR-expand and BFS lanes **traverse semantic edges**, and vanilla LoCoMo
+ingest writes **zero** edges (1240 beliefs, 0 edges per conversation). So:
+
+- **without an edge substrate** (`substrate=none`) every arm is identical and
+  `expand_hits=0` — the lane is **inert**. This is the #977 "BFS inert / 0
+  edges" finding, generalised to HRR-expand.
+- **with the #988 substrate** (`substrate=contradicts-988`,
+  `write_semantic_edges` minting 1394 CONTRADICTS edges across LoCoMo10,
+  ~139/conversation) the lane **activates** — it merges 446 beliefs across the
+  corpus — but the CONTRADICTS-only bridge yields **no measurable
+  retrieval-overlap F1 uplift** (flat-to-marginally-negative).
+
+This empirically confirms the issue's "do not pre-bank the 25.2 pp" caveat and
+the #988-reframes-#981/#977 framing: HRR-expand is a *consumer* of a semantic-
+edge substrate. Its uplift is gated on that substrate existing and being
+dense/typed enough to bridge answer-bearing beliefs — which the current
+default-off, CONTRADICTS-only #988 writer does not yet provide on LoCoMo.
+
+### Full LoCoMo10 results
+
+Full LoCoMo10 (1947 QA, retrieval-overlap F1, budget 2000):
+
+| substrate | arm | overall | Δ vs base | lane merges | c1 multi-hop | c2 temporal | c3 open | c4 single-hop | c5 adversarial |
+|---|---|--:|--:|--:|--:|--:|--:|--:|--:|
+| none (0 edges) | baseline | 2.11% | — | 0 | 10.46% | 0.75% | 0.80% | 1.10% | 0.0% |
+| none | +hrr-expand | 2.11% | +0.00 | 0 | 10.46% | 0.75% | 0.80% | 1.10% | 0.0% |
+| none | +bfs | 2.11% | +0.00 | 0 | 10.46% | 0.75% | 0.80% | 1.10% | 0.0% |
+| none | all-on | 2.11% | +0.00 | 0 | 10.46% | 0.75% | 0.80% | 1.10% | 0.0% |
+| contradicts-988 (1394 edges) | baseline | 2.11% | — | 0 | 10.46% | 0.75% | 0.80% | 1.10% | 0.0% |
+| contradicts-988 | **+hrr-expand** | 2.11% | **−0.00** | **446** | 10.46% | 0.74% | 0.79% | 1.09% | 0.0% |
+| contradicts-988 | +bfs | 2.11% | +0.00 | 0 | 10.46% | 0.75% | 0.80% | 1.10% | 0.0% |
+| contradicts-988 | all-on | 2.11% | −0.00 | 446 | 10.46% | 0.74% | 0.79% | 1.09% | 0.0% |
+
+Reading: with no edge substrate every arm is byte-identical (lane inert). With #988's 1394 CONTRADICTS edges the HRR-expand lane **activates** — it merges 446 beliefs across the corpus — yet overall F1 is unchanged and the per-category effect is a marginal **negative** (temporal/open/single-hop each down ~0.0001). `+bfs` stays byte-identical to baseline even with edges (BFS inert, per #977). Absolute F1 is low because this is retrieval-token-overlap against the concatenated context, not reader accuracy; the arm *deltas* are the deliverable, and they are flat-to-slightly-negative.
+
+## Decision gate
+
+Per #897 (reaffirm #605, no bench-number floor re-triggers reconsideration):
+this lands the lane + ablation **default-OFF**. A default flip reverses #605
+and requires re-opening #897 with isolated bench evidence and an explicit
+philosophy amendment — bench uplift alone is insufficient. The ablation above
+shows no uplift to bank regardless.

--- a/src/aelfrice/hrr_expand.py
+++ b/src/aelfrice/hrr_expand.py
@@ -79,13 +79,18 @@ DEFAULT_SEED_CAP: Final[int] = 5
 DEFAULT_PER_PROBE_K: Final[int] = 3
 DEFAULT_EXPAND_TOP_K: Final[int] = 5
 DEFAULT_MAX_NODES: Final[int] = 2000
-# Similarity floor on the raw HRR inner product. A true single-hop bound term
-# scores ~1.0 (bind/unbind of unit vectors); orthogonal noise from unrelated
-# bindings is ~1/sqrt(dim) (~0.044 at the default dim=512). 0.1 sits well
-# above the noise floor and well below a true match, rejecting cleanup spuria
-# in both directions (forward unbind-cleanup and reverse probe use the same
-# raw-dot scale).
-DEFAULT_SIM_FLOOR: Final[float] = 0.1
+# Similarity floor on the raw HRR inner product. Single-hop typed edges are
+# *bimodal* under this algebra: a present edge recovers its bound term exactly
+# (``unbind(role_k, bind(role_k, id_t)) · id_t == 1.0`` forward; the matching
+# ``bind`` self-dot ``≈ 1.0`` reverse), independent of the belief's degree —
+# only the additive crosstalk from the belief's *other* bindings varies, at
+# ~1/sqrt(dim) (~0.044 at the default dim=512) per term. So true matches
+# cluster at ~1.0 and absent edges at ~noise; 0.5 sits squarely in the gap,
+# keeping every present edge while rejecting cleanup spuria. (Empirically a
+# spurious TESTS-typed hit on a no-TESTS-edge belief scores ~0.12-0.17 at
+# dim=512 — well below 0.5; a false positive would need ~128 same-role
+# crosstalk terms to clear the floor.)
+DEFAULT_SIM_FLOOR: Final[float] = 0.5
 
 FORWARD: Final[str] = "forward"
 REVERSE: Final[str] = "reverse"
@@ -243,7 +248,7 @@ def precompute_expand_neighbors(
     ``None`` the current UTC time is used (the table's byte-equality test
     pins it, production does not need to).
     """
-    conn: sqlite3.Connection = store.connection
+    conn: sqlite3.Connection = store._conn  # noqa: SLF001 — same pattern as replay.py/telemetry.py
     if now_iso is None:
         now_iso = datetime.now(timezone.utc).isoformat()
     kinds = hrr_expand_edge_types()
@@ -293,7 +298,7 @@ def _neighbors_from_table(
     missing table (pre-migration DB) returns ``None`` so the caller falls back
     to a live probe.
     """
-    conn: sqlite3.Connection = store.connection
+    conn: sqlite3.Connection = store._conn  # noqa: SLF001 — same pattern as replay.py/telemetry.py
     placeholders = ",".join("?" for _ in seed_ids)
     try:
         rows = conn.execute(

--- a/src/aelfrice/hrr_expand.py
+++ b/src/aelfrice/hrr_expand.py
@@ -269,28 +269,29 @@ def precompute_expand_neighbors(
         ).fetchall()
     ]
 
-    conn.execute("DELETE FROM hrr_expand_neighbors")
-    written = 0
-    for seed_id in seed_ids:
-        rows = neighbor_rows(
+    # Compute every neighbour row *before* mutating the table so a mid-loop
+    # probe failure cannot leave a partially-rebuilt (or empty-after-DELETE)
+    # cache visible to a later same-connection read. The DELETE + insert then
+    # run as one transaction via ``with conn`` (commit on success, rollback on
+    # error), keeping the rebuild atomic (#981 robustness fix).
+    insert_rows: list[tuple[str, str, float, str, str, str]] = [
+        (seed_id, nid, sim, etype, direction, now_iso)
+        for seed_id in seed_ids
+        for (nid, etype, direction, sim) in neighbor_rows(
             index, seed_id,
             id_matrix=id_matrix, kinds=kinds,
             per_probe_k=per_probe_k, sim_floor=sim_floor,
         )
-        if not rows:
-            continue
+    ]
+    with conn:
+        conn.execute("DELETE FROM hrr_expand_neighbors")
         conn.executemany(
             "INSERT OR REPLACE INTO hrr_expand_neighbors "
             "(belief_id, neighbor_id, similarity, edge_type, direction, "
             "created_at) VALUES (?, ?, ?, ?, ?, ?)",
-            [
-                (seed_id, nid, sim, etype, direction, now_iso)
-                for (nid, etype, direction, sim) in rows
-            ],
+            insert_rows,
         )
-        written += len(rows)
-    conn.commit()
-    return written
+    return len(insert_rows)
 
 
 def _neighbors_from_table(

--- a/src/aelfrice/hrr_expand.py
+++ b/src/aelfrice/hrr_expand.py
@@ -1,0 +1,368 @@
+"""HRR vocabulary-bridge expansion lane (#981).
+
+Restores the deterministic, embeddings-free FFT bind/probe *expansion* lane
+that the v3.0.1 calibration notes name as the cause of the LoCoMo delta
+(66.1% -> 40.88%). Default-OFF behind ``use_hrr_expand`` on
+:func:`aelfrice.retrieval.retrieve_v2`; this module holds the lane mechanics,
+the flag resolver lives in :func:`aelfrice.retrieval.is_hrr_expand_enabled`.
+
+The lane is a *candidate-expansion* step, distinct from the #152 structural
+lane (a parallel marker-routed query path that replaces the textual lane).
+When enabled it seeds from the top FTS5 hits, probes the shared
+:class:`~aelfrice.hrr_index.HRRStructIndex` for single-hop semantic
+neighbours in both edge directions, and merges the recovered beliefs into the
+candidate set *before* scoring/packing — exactly the predecessor's L3
+``_hrr_expand`` step (predecessor ``retrieval.py:348-389``), re-expressed on
+the current structural-index substrate rather than the removed ``HRRGraph``.
+
+The struct index encodes only *outgoing* edges
+(``struct[b] = sum bind(role[e.kind], id[e.dst])``), so:
+
+- **forward** out-neighbours of a seed are recovered by
+  ``unbind(role[kind], struct[seed])`` followed by a cleanup matvec against
+  the id-vector matrix;
+- **reverse** in-neighbours are recovered by the existing
+  :meth:`HRRStructIndex.probe`, which ranks beliefs whose outgoing structure
+  contains ``bind(role[kind], id[seed])``.
+
+Determinism (#981 AC2, AC5): every operation is a numpy FFT / matvec over the
+deterministically-seeded struct matrix. There is **no** ``random`` /
+``betavariate`` anywhere in this path. :func:`precompute_expand_neighbors`
+materialises a byte-stable ``hrr_expand_neighbors`` SQLite table (row order:
+``similarity`` DESC, then ``neighbor_id`` ASC); two builds over the same store
+produce an identical table.
+
+This is *implement-and-ablate* (#981): it lands the lane plus its ablation
+arm and does **not** flip any default. Flipping the default reverses the
+locked #605 determinism philosophy and is routed to a re-opened #897.
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Final
+
+import numpy as np
+
+from aelfrice.hrr import Vector, unbind
+from aelfrice.models import EDGE_TYPES
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from aelfrice.hrr_index import HRRStructIndex
+    from aelfrice.models import Belief
+    from aelfrice.store import MemoryStore
+
+# Semantic edge kinds worth probing for vocabulary bridging. The predecessor
+# (``retrieval.py:335-345``) used SUPERSEDES / CONTRADICTS / SUPPORTS / CALLS
+# / CITES / TESTS / IMPLEMENTS. ``CALLS`` is not in the current
+# ``models.EDGE_TYPES`` schema, so the *live* set is the intersection with
+# EDGE_TYPES (computed at call time via :func:`hrr_expand_edge_types` so a
+# future CALLS edge type joins automatically). Co-occurrence / structural
+# edges (RELATES_TO, DERIVED_FROM, TEMPORAL_NEXT, RESOLVES) add noise without
+# vocabulary-gap signal and are deliberately excluded.
+_HRR_EXPAND_KIND_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "SUPERSEDES",
+        "CONTRADICTS",
+        "SUPPORTS",
+        "CALLS",
+        "CITES",
+        "TESTS",
+        "IMPLEMENTS",
+    }
+)
+
+# Lane defaults, mirroring the predecessor: cap seeds at 5, pull top-3 per
+# (seed, kind, direction) probe, return the top-5 merged neighbours. Fixed
+# here (not Thompson-sampled — there is no sampling in this lane).
+DEFAULT_SEED_CAP: Final[int] = 5
+DEFAULT_PER_PROBE_K: Final[int] = 3
+DEFAULT_EXPAND_TOP_K: Final[int] = 5
+DEFAULT_MAX_NODES: Final[int] = 2000
+# Similarity floor on the raw HRR inner product. A true single-hop bound term
+# scores ~1.0 (bind/unbind of unit vectors); orthogonal noise from unrelated
+# bindings is ~1/sqrt(dim) (~0.044 at the default dim=512). 0.1 sits well
+# above the noise floor and well below a true match, rejecting cleanup spuria
+# in both directions (forward unbind-cleanup and reverse probe use the same
+# raw-dot scale).
+DEFAULT_SIM_FLOOR: Final[float] = 0.1
+
+FORWARD: Final[str] = "forward"
+REVERSE: Final[str] = "reverse"
+
+
+def hrr_expand_edge_types() -> tuple[str, ...]:
+    """Semantic edge kinds probed by the expansion lane.
+
+    Returns the intersection of the predecessor's HRR edge set with the live
+    :data:`aelfrice.models.EDGE_TYPES`, sorted for deterministic iteration.
+    """
+    return tuple(sorted(_HRR_EXPAND_KIND_NAMES & EDGE_TYPES))
+
+
+def _id_matrix(index: "HRRStructIndex") -> np.ndarray:
+    """Build the ``(N, dim)`` id-vector matrix aligned to ``belief_ids``.
+
+    ``index.id_vecs`` is keyed by belief id; row ``i`` corresponds to
+    ``index.belief_ids[i]`` so a cleanup matvec result indexes straight back
+    into ``belief_ids``. Returns an empty ``(0, dim)`` array for an empty
+    index.
+    """
+    bids = index.belief_ids
+    if not bids:
+        return np.zeros((0, index.dim), dtype=np.float64)
+    return np.stack([np.asarray(index.id_vecs[bid]) for bid in bids], axis=0)
+
+
+def _topk_from_scores(
+    scores: np.ndarray,
+    belief_ids: list[str],
+    *,
+    exclude: str,
+    top_k: int,
+    sim_floor: float,
+) -> list[tuple[str, float]]:
+    """Return up to ``top_k`` ``(belief_id, score)`` pairs above ``sim_floor``.
+
+    Sorted by score DESC then belief id ASC (the deterministic tie-break used
+    everywhere in this lane). ``exclude`` drops the seed itself.
+    """
+    if scores.size == 0 or top_k <= 0:
+        return []
+    # Candidate rows above the floor, excluding the seed. Float comparison is
+    # deterministic for identical inputs.
+    hits: list[tuple[str, float]] = []
+    for i in np.nonzero(scores >= sim_floor)[0]:
+        bid = belief_ids[int(i)]
+        if bid == exclude:
+            continue
+        hits.append((bid, float(scores[int(i)])))
+    hits.sort(key=lambda p: (-p[1], p[0]))
+    return hits[:top_k]
+
+
+def _forward_neighbors(
+    index: "HRRStructIndex",
+    id_matrix: np.ndarray,
+    seed_id: str,
+    kind: str,
+    *,
+    top_k: int,
+    sim_floor: float,
+) -> list[tuple[str, float]]:
+    """Out-neighbours: beliefs the seed points TO via ``kind``.
+
+    ``unbind(role[kind], struct[seed])`` recovers the superposed id vectors of
+    ``kind``-typed destinations; the cleanup matvec ``id_matrix @ probe`` ranks
+    candidate beliefs. Deterministic.
+    """
+    role = index.role_vecs.get(kind)
+    row = index._index.get(seed_id)
+    if role is None or row is None or index.struct.size == 0:
+        return []
+    probe = unbind(np.asarray(role), np.ascontiguousarray(index.struct[row]))
+    scores = id_matrix @ probe
+    return _topk_from_scores(
+        scores, index.belief_ids, exclude=seed_id, top_k=top_k, sim_floor=sim_floor,
+    )
+
+
+def _reverse_neighbors(
+    index: "HRRStructIndex",
+    seed_id: str,
+    kind: str,
+    *,
+    top_k: int,
+    sim_floor: float,
+) -> list[tuple[str, float]]:
+    """In-neighbours: beliefs that point TO the seed via ``kind``.
+
+    Delegates to :meth:`HRRStructIndex.probe` (which ranks beliefs whose
+    outgoing structure contains ``bind(role[kind], id[seed])``), then applies
+    the floor and the deterministic tie-break.
+    """
+    raw = index.probe(kind, seed_id, top_k=top_k)
+    hits = [(bid, score) for bid, score in raw if score >= sim_floor and bid != seed_id]
+    hits.sort(key=lambda p: (-p[1], p[0]))
+    return hits[:top_k]
+
+
+def neighbor_rows(
+    index: "HRRStructIndex",
+    seed_id: str,
+    *,
+    id_matrix: np.ndarray | None = None,
+    kinds: tuple[str, ...] | None = None,
+    per_probe_k: int = DEFAULT_PER_PROBE_K,
+    sim_floor: float = DEFAULT_SIM_FLOOR,
+) -> list[tuple[str, str, str, float]]:
+    """Per-direction neighbour rows for one seed.
+
+    Returns ``(neighbor_id, edge_type, direction, similarity)`` tuples across
+    every probed kind and both directions, sorted by ``similarity`` DESC then
+    ``neighbor_id`` ASC then ``edge_type`` ASC then ``direction`` ASC — a
+    total order, so the output (and any table built from it) is byte-stable.
+    """
+    if kinds is None:
+        kinds = hrr_expand_edge_types()
+    if id_matrix is None:
+        id_matrix = _id_matrix(index)
+    rows: list[tuple[str, str, str, float]] = []
+    for kind in kinds:
+        for nid, sim in _forward_neighbors(
+            index, id_matrix, seed_id, kind,
+            top_k=per_probe_k, sim_floor=sim_floor,
+        ):
+            rows.append((nid, kind, FORWARD, sim))
+        for nid, sim in _reverse_neighbors(
+            index, seed_id, kind, top_k=per_probe_k, sim_floor=sim_floor,
+        ):
+            rows.append((nid, kind, REVERSE, sim))
+    rows.sort(key=lambda r: (-r[3], r[0], r[1], r[2]))
+    return rows
+
+
+def precompute_expand_neighbors(
+    store: "MemoryStore",
+    index: "HRRStructIndex",
+    *,
+    per_probe_k: int = DEFAULT_PER_PROBE_K,
+    max_nodes: int = DEFAULT_MAX_NODES,
+    sim_floor: float = DEFAULT_SIM_FLOOR,
+    now_iso: str | None = None,
+) -> int:
+    """Materialise the ``hrr_expand_neighbors`` table; return rows written.
+
+    For each active belief (``valid_to IS NULL``, ``id`` ASC, capped at
+    ``max_nodes``) the lane's forward + reverse single-hop neighbours are
+    written across every semantic edge kind. The table is fully replaced each
+    run. Insertion order is the total order from :func:`neighbor_rows`, so two
+    runs over an unchanged store produce a byte-identical table (#981 AC2).
+
+    ``now_iso`` pins the ``created_at`` column for determinism in tests; when
+    ``None`` the current UTC time is used (the table's byte-equality test
+    pins it, production does not need to).
+    """
+    conn: sqlite3.Connection = store.connection
+    if now_iso is None:
+        now_iso = datetime.now(timezone.utc).isoformat()
+    kinds = hrr_expand_edge_types()
+    id_matrix = _id_matrix(index)
+
+    seed_ids: list[str] = [
+        str(r[0])
+        for r in conn.execute(
+            "SELECT id FROM beliefs WHERE valid_to IS NULL "
+            "ORDER BY id ASC LIMIT ?",
+            (max_nodes,),
+        ).fetchall()
+    ]
+
+    conn.execute("DELETE FROM hrr_expand_neighbors")
+    written = 0
+    for seed_id in seed_ids:
+        rows = neighbor_rows(
+            index, seed_id,
+            id_matrix=id_matrix, kinds=kinds,
+            per_probe_k=per_probe_k, sim_floor=sim_floor,
+        )
+        if not rows:
+            continue
+        conn.executemany(
+            "INSERT OR REPLACE INTO hrr_expand_neighbors "
+            "(belief_id, neighbor_id, similarity, edge_type, direction, "
+            "created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (seed_id, nid, sim, etype, direction, now_iso)
+                for (nid, etype, direction, sim) in rows
+            ],
+        )
+        written += len(rows)
+    conn.commit()
+    return written
+
+
+def _neighbors_from_table(
+    store: "MemoryStore", seed_ids: list[str], *, sim_floor: float,
+) -> list[str] | None:
+    """Look up precomputed neighbour ids for the seeds, or ``None`` if the
+    table is absent / empty.
+
+    Returns neighbour ids ordered by ``similarity`` DESC then ``neighbor_id``
+    ASC (deduplicated, keeping the strongest similarity per neighbour). A
+    missing table (pre-migration DB) returns ``None`` so the caller falls back
+    to a live probe.
+    """
+    conn: sqlite3.Connection = store.connection
+    placeholders = ",".join("?" for _ in seed_ids)
+    try:
+        rows = conn.execute(
+            f"SELECT neighbor_id, MAX(similarity) AS sim "
+            f"FROM hrr_expand_neighbors "
+            f"WHERE belief_id IN ({placeholders}) AND similarity >= ? "
+            f"GROUP BY neighbor_id "
+            f"ORDER BY sim DESC, neighbor_id ASC",
+            (*seed_ids, sim_floor),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return None
+    if not rows:
+        return None
+    return [str(r[0]) for r in rows]
+
+
+def expand_seeds(
+    store: "MemoryStore",
+    index: "HRRStructIndex",
+    seed_ids: list[str],
+    *,
+    seed_cap: int = DEFAULT_SEED_CAP,
+    per_probe_k: int = DEFAULT_PER_PROBE_K,
+    top_k: int = DEFAULT_EXPAND_TOP_K,
+    sim_floor: float = DEFAULT_SIM_FLOOR,
+) -> list["Belief"]:
+    """Single-hop HRR expansion of the FTS5 seeds into extra candidates.
+
+    Caps the seeds at ``seed_cap``, gathers forward + reverse semantic
+    neighbours (from the precomputed ``hrr_expand_neighbors`` table when
+    present, else a live probe against ``index``), drops seeds themselves and
+    soft-deleted / invalid beliefs, and returns up to ``top_k`` beliefs in
+    deterministic similarity order. Empty seed list or empty index returns
+    ``[]``.
+    """
+    seeds = [s for s in seed_ids[:seed_cap] if s]
+    if not seeds or index.struct.size == 0 or top_k <= 0:
+        return []
+    seed_set = set(seeds)
+
+    neighbor_ids = _neighbors_from_table(store, seeds, sim_floor=sim_floor)
+    if neighbor_ids is None:
+        # Live fallback: probe the index directly. Merge across seeds keeping
+        # the strongest similarity per neighbour, deterministic tie-break.
+        id_matrix = _id_matrix(index)
+        best: dict[str, float] = {}
+        for seed_id in seeds:
+            for nid, _etype, _dir, sim in neighbor_rows(
+                index, seed_id,
+                id_matrix=id_matrix,
+                per_probe_k=per_probe_k, sim_floor=sim_floor,
+            ):
+                if sim > best.get(nid, float("-inf")):
+                    best[nid] = sim
+        neighbor_ids = [
+            nid for nid, _sim in sorted(
+                best.items(), key=lambda p: (-p[1], p[0]),
+            )
+        ]
+
+    out: list["Belief"] = []
+    for nid in neighbor_ids:
+        if nid in seed_set:
+            continue
+        belief = store.get_belief(nid)
+        if belief is None or belief.valid_to is not None:
+            continue
+        out.append(belief)
+        if len(out) >= top_k:
+            break
+    return out

--- a/src/aelfrice/hrr_expand.py
+++ b/src/aelfrice/hrr_expand.py
@@ -39,7 +39,6 @@ locked #605 determinism philosophy and is routed to a re-opened #897.
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Final
 
 import numpy as np
@@ -91,6 +90,11 @@ DEFAULT_MAX_NODES: Final[int] = 2000
 # dim=512 — well below 0.5; a false positive would need ~128 same-role
 # crosstalk terms to clear the floor.)
 DEFAULT_SIM_FLOOR: Final[float] = 0.5
+# ``created_at`` is an audit-only column never read by retrieval. The cache
+# is a derived, wholesale-rebuilt table, so its default rebuild timestamp is a
+# fixed sentinel (not wall-clock) — two rebuilds over an unchanged store stay
+# byte-identical (#981 AC2).
+_REBUILD_CREATED_AT: Final[str] = "1970-01-01T00:00:00+00:00"
 
 FORWARD: Final[str] = "forward"
 REVERSE: Final[str] = "reverse"
@@ -244,13 +248,15 @@ def precompute_expand_neighbors(
     run. Insertion order is the total order from :func:`neighbor_rows`, so two
     runs over an unchanged store produce a byte-identical table (#981 AC2).
 
-    ``now_iso`` pins the ``created_at`` column for determinism in tests; when
-    ``None`` the current UTC time is used (the table's byte-equality test
-    pins it, production does not need to).
+    ``now_iso`` pins the ``created_at`` column; it defaults to a fixed rebuild
+    sentinel (not wall-clock) so two rebuilds over an unchanged store stay
+    byte-identical (#981 AC2). ``created_at`` is audit-only and never read by
+    retrieval, so this derived cache prefers an idempotent rebuild over a real
+    timestamp.
     """
     conn: sqlite3.Connection = store._conn  # noqa: SLF001 — same pattern as replay.py/telemetry.py
     if now_iso is None:
-        now_iso = datetime.now(timezone.utc).isoformat()
+        now_iso = _REBUILD_CREATED_AT
     kinds = hrr_expand_edge_types()
     id_matrix = _id_matrix(index)
 

--- a/src/aelfrice/hrr_expand.py
+++ b/src/aelfrice/hrr_expand.py
@@ -44,7 +44,7 @@ from typing import TYPE_CHECKING, Final
 
 import numpy as np
 
-from aelfrice.hrr import Vector, unbind
+from aelfrice.hrr import unbind
 from aelfrice.models import EDGE_TYPES
 
 if TYPE_CHECKING:  # pragma: no cover - typing only

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -153,6 +153,14 @@ SIGNED_LAPLACIAN_FLAG: Final[str] = "use_signed_laplacian"
 HEAT_KERNEL_FLAG: Final[str] = "use_heat_kernel"
 POSTERIOR_RANKING_FLAG: Final[str] = "use_posterior_ranking"
 HRR_STRUCTURAL_FLAG: Final[str] = "use_hrr_structural"
+# #981 HRR vocabulary-bridge *expansion* lane flag. Distinct from the #152
+# structural lane (HRR_STRUCTURAL_FLAG): structural is a marker-routed query
+# path that replaces the textual lane; expansion is an additive candidate
+# source that probes the same struct index for single-hop semantic
+# neighbours of the FTS5 seeds and merges them before scoring. Default-OFF
+# (resolver default False) — landing the lane + ablation only; a default
+# flip reverses locked #605 and is routed to a re-opened #897.
+HRR_EXPAND_FLAG: Final[str] = "use_hrr_expand"
 # v2.1 #434 type-aware compression flag. Default-OFF at v2.0.0 until the
 # lab-side bench gate (A2 + A4 in docs/design/feature-type-aware-compression.md)
 # clears. ON populates RetrievalResult.compressed_beliefs with per-belief
@@ -215,6 +223,8 @@ ENV_BM25F: Final[str] = "AELFRICE_BM25F"
 ENV_HEAT_KERNEL: Final[str] = "AELFRICE_HEAT_KERNEL"
 # v1.7.0 HRR structural-query env override. Tri-state like ENV_BM25F.
 ENV_HRR_STRUCTURAL: Final[str] = "AELFRICE_HRR_STRUCTURAL"
+# #981 HRR expansion-lane env override. Tri-state like ENV_BM25F; default-OFF.
+ENV_HRR_EXPAND: Final[str] = "AELFRICE_HRR_EXPAND"
 # #698 HRR persist env override. "0" disables; "1" forces on.
 # Mirrors _ENV_PERSIST in hrr_index (same value; imported at call site).
 ENV_HRR_PERSIST: Final[str] = "AELFRICE_HRR_PERSIST"
@@ -581,6 +591,21 @@ def _env_hrr_structural_override() -> bool | None:
     recognised truthy/falsy value, else None. Symmetric to
     `_env_bm25f_override`."""
     raw = os.environ.get(ENV_HRR_STRUCTURAL)
+    if raw is None:
+        return None
+    norm = raw.strip().lower()
+    if norm in _ENV_FALSY:
+        return False
+    if norm in _ENV_TRUTHY:
+        return True
+    return None
+
+
+def _env_hrr_expand_override() -> bool | None:
+    """Return True/False if AELFRICE_HRR_EXPAND is set to a recognised
+    truthy/falsy value, else None. Symmetric to
+    `_env_hrr_structural_override`."""
+    raw = os.environ.get(ENV_HRR_EXPAND)
     if raw is None:
         return None
     norm = raw.strip().lower()
@@ -1579,6 +1604,37 @@ def is_hrr_structural_enabled(
     return True
 
 
+def is_hrr_expand_enabled(
+    explicit: bool | None = None,
+    *,
+    start: Path | None = None,
+) -> bool:
+    """Resolve the HRR vocabulary-bridge expansion-lane flag (#981).
+
+    Precedence (first decisive wins):
+      1. AELFRICE_HRR_EXPAND env var (truthy / falsy normalised).
+      2. Explicit `explicit` kwarg from the caller.
+      3. `[retrieval] use_hrr_expand` in `.aelfrice.toml`.
+      4. Default: **False** — the expansion lane is OFF by default. #981
+         lands the lane + its ablation arm only; flipping the default
+         reverses the locked #605 determinism philosophy and is routed to a
+         re-opened #897. Opt in for the ablation via the env var, kwarg, or
+         TOML key.
+
+    Passing the flag (any rung) never raises — an unset / unrecognised value
+    falls through to the next rung and ultimately to False (AC1).
+    """
+    env = _env_hrr_expand_override()
+    if env is not None:
+        return env
+    if explicit is not None:
+        return explicit
+    toml_value = _read_toml_flag_for(HRR_EXPAND_FLAG, start)
+    if toml_value is not None:
+        return toml_value
+    return False
+
+
 def is_hrr_persist_enabled(
     explicit: bool | None = None,
     *,
@@ -1960,6 +2016,10 @@ class LaneTelemetry:
     # token-budget trimming. ``l1`` tracks what was packed; the delta
     # is what the hook's coverage line surfaces to the user.
     l1_candidates: int = 0
+    # #981 HRR expansion lane. Count of beliefs the vocabulary-bridge
+    # expansion lane merged into the candidate set (0 when the lane is off,
+    # the default). Lets the ablation read the lane's contribution per call.
+    hrr_expand: int = 0
 
 
 # Per-process snapshot of the most recent retrieval call. Test-
@@ -2700,6 +2760,8 @@ def retrieve_with_tiers(
     eigenbasis_cache: GraphEigenbasisCache | None = None,
     use_type_aware_compression: bool | None = None,
     use_intentional_clustering: bool | None = None,
+    hrr_expand_enabled: bool | None = None,
+    hrr_struct_index_cache: HRRStructIndexCache | None = None,
 ) -> tuple[
     list[Belief], list[str], list[str], list[str], list[list[str]],
 ]:
@@ -2865,9 +2927,45 @@ def retrieve_with_tiers(
             used += cost
             l1_ids_list.append(b.id)
 
+    # #981 HRR vocabulary-bridge expansion lane (additive, default-OFF).
+    # Probes the shared struct index for single-hop semantic neighbours of
+    # the FTS5 seeds (the packed L1 hits) and merges them into the candidate
+    # set before BFS. On a miss — flag off (the default), no index cache, no
+    # seeds, or an empty index — it is a no-op and the output is byte-
+    # identical to the pre-#981 path. The lane is deterministic (numpy FFT /
+    # matvec over the seeded struct index; no random / betavariate).
+    hrr_expand_ids_list: list[str] = []
+    hrr_expanded: list[Belief] = []
+    if (
+        is_hrr_expand_enabled(hrr_expand_enabled)
+        and query.strip()
+        and hrr_struct_index_cache is not None
+        and l1_packed
+    ):
+        from aelfrice.hrr_expand import expand_seeds
+
+        seen_pre: set[str] = locked_ids | l25_ids | set(l1_ids_list)
+        for b in expand_seeds(
+            store,
+            hrr_struct_index_cache.get(),
+            [b.id for b in l1_packed],
+        ):
+            if b.id in seen_pre:
+                continue
+            cost = _cost(b)
+            if used + cost > effective_budget:
+                break
+            out.append(b)
+            hrr_expanded.append(b)
+            hrr_expand_ids_list.append(b.id)
+            seen_pre.add(b.id)
+            used += cost
+
     bfs_chains: list[list[str]] = []
     if bfs_on and query.strip():
-        seeds: list[Belief] = list(locked) + list(l25) + list(l1_packed)
+        seeds: list[Belief] = (
+            list(locked) + list(l25) + list(l1_packed) + list(hrr_expanded)
+        )
         if seeds:
             hops = expand_bfs(
                 seeds,
@@ -2879,6 +2977,7 @@ def retrieve_with_tiers(
             )
             seen_ids: set[str] = (
                 locked_ids | l25_ids | set(l1_ids_list)
+                | set(hrr_expand_ids_list)
             )
             for hop in hops:
                 if hop.belief.id in seen_ids:
@@ -2900,6 +2999,7 @@ def retrieve_with_tiers(
         expansion_gate_reason=gate_decision.reason,
         expansion_gate_skipped_bfs=gate_skipped_bfs,
         l1_candidates=len(l1),
+        hrr_expand=len(hrr_expand_ids_list),
     )
     return out, locked_ids_list, l25_ids_list, l1_ids_list, bfs_chains
 
@@ -2924,6 +3024,7 @@ def retrieve_v2(
     use_type_aware_compression: bool | None = None,
     use_intentional_clustering: bool | None = None,
     use_hrr_structural: bool | None = None,
+    use_hrr_expand: bool | None = None,
     hrr_struct_index_cache: HRRStructIndexCache | None = None,
     with_doc_anchors: bool = False,
     now_ts: int | None = None,
@@ -2980,6 +3081,19 @@ def retrieve_v2(
       no env / kwarg / TOML override is set. Opt out via
       `AELFRICE_HRR_STRUCTURAL=0`, `use_hrr_structural=False`, or
       `[retrieval] use_hrr_structural = false` in `.aelfrice.toml`.
+    - `use_hrr_expand` (#981) — when True, the HRR vocabulary-bridge
+      *expansion* lane runs as an additive candidate source: it probes
+      the struct index for single-hop semantic neighbours of the FTS5
+      seeds and merges them into the candidate set before BFS. Distinct
+      from `use_hrr_structural` (a marker-routed replacement lane).
+      Default-OFF — #981 lands the lane + ablation only; a default flip
+      reverses locked #605 and is routed to a re-opened #897. Opt in via
+      `AELFRICE_HRR_EXPAND=1`, the kwarg, or
+      `[retrieval] use_hrr_expand = true`. The lane is a no-op (byte-
+      identical output) unless a `hrr_struct_index_cache` is available;
+      when the flag is on and no cache is passed, an ephemeral in-memory
+      cache is built so the lane still fires (callers running the lane
+      hot should pass an explicit cache to amortise the build).
     - `hrr_struct_index_cache` (#152) — explicit
       `HRRStructIndexCache` to reuse an already-built index across
       calls. None falls through to a fresh build per call.
@@ -3019,6 +3133,15 @@ def retrieve_v2(
         ),
     )
 
+    # #981 expansion-lane index cache. When the lane resolves ON but no cache
+    # was passed, build an ephemeral in-memory cache so the lane still fires
+    # (no persistence — store_path is not threaded into this wrapper). When
+    # the lane is OFF (the default) the cache stays None and the build is
+    # skipped entirely, so the default path is unchanged.
+    expand_cache = hrr_struct_index_cache
+    if is_hrr_expand_enabled(use_hrr_expand) and expand_cache is None:
+        expand_cache = HRRStructIndexCache(store=store)
+
     retrieve_start = time.perf_counter()
     (
         out,
@@ -3041,6 +3164,8 @@ def retrieve_v2(
         bm25f_cache=bm25f_cache,
         use_type_aware_compression=use_type_aware_compression,
         use_intentional_clustering=use_intentional_clustering,
+        hrr_expand_enabled=use_hrr_expand,
+        hrr_struct_index_cache=expand_cache,
     )
     retrieve_elapsed = time.perf_counter() - retrieve_start
     if include_locked:

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -508,6 +508,25 @@ _SCHEMA: tuple[str, ...] = (
     """,
     "CREATE INDEX IF NOT EXISTS idx_belief_touches_session_fire "
     "ON belief_touches(session_id, last_fire_idx DESC)",
+    # #981 HRR vocabulary-bridge expansion lane. Precomputed single-hop
+    # semantic neighbours (forward + reverse) for the FTS5-seed expansion
+    # step. A derived cache, rebuilt wholesale by
+    # `hrr_expand.precompute_expand_neighbors`; no FK so the rebuild does not
+    # depend on insert order or cascade timing. `similarity` is the raw HRR
+    # inner product (REAL, 8-byte IEEE round-trip → byte-stable table). The
+    # PRIMARY KEY prefix (belief_id) backs the `WHERE belief_id IN (...)`
+    # runtime lookup.
+    """
+    CREATE TABLE IF NOT EXISTS hrr_expand_neighbors (
+        belief_id   TEXT NOT NULL,
+        neighbor_id TEXT NOT NULL,
+        similarity  REAL NOT NULL,
+        edge_type   TEXT NOT NULL,
+        direction   TEXT NOT NULL,
+        created_at  TEXT NOT NULL,
+        PRIMARY KEY (belief_id, neighbor_id, edge_type, direction)
+    )
+    """,
 )
 
 # Marker key for the entity-index one-shot backfill. Empty value =

--- a/tests/test_hrr_expand.py
+++ b/tests/test_hrr_expand.py
@@ -1,0 +1,303 @@
+"""Tests for the HRR vocabulary-bridge expansion lane (#981).
+
+Covers the issue's acceptance criteria:
+
+1. ``use_hrr_expand`` resolves via env > kwarg > TOML > default-OFF; passing
+   it never raises.
+2. The lane is deterministic — the precomputed neighbour table is byte-equal
+   across two runs over the same store.
+3. No regression with the flag off — ``retrieve_v2`` output is byte-identical
+   to the pre-lane path.
+5. No ``random`` / ``betavariate`` is introduced into the lane.
+6. The default stays OFF.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import numpy as np
+import pytest
+
+from aelfrice import hrr_expand as hx
+from aelfrice.hrr_index import HRRStructIndex, HRRStructIndexCache
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CITES,
+    EDGE_CONTRADICTS,
+    EDGE_RELATES_TO,
+    EDGE_SUPPORTS,
+    EDGE_TYPES,
+    LOCK_NONE,
+    Belief,
+    Edge,
+)
+from aelfrice.retrieval import (
+    ENV_HRR_EXPAND,
+    is_hrr_expand_enabled,
+    retrieve_v2,
+)
+from aelfrice.store import MemoryStore
+
+_SEED = 7
+
+
+def _mk(bid: str, content: str) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        created_at="2026-04-28T00:00:00Z",
+        last_retrieved_at=None,
+    )
+
+
+def _toy_store() -> MemoryStore:
+    """b1 -CONTRADICTS-> b2; b3 -SUPPORTS-> b2; b4 -CITES-> b5;
+    b1 -RELATES_TO-> b5 (RELATES_TO is *not* a probed semantic kind)."""
+    s = MemoryStore(":memory:")
+    s.insert_belief(_mk("b1", "alpha contradicts gamma"))
+    s.insert_belief(_mk("b2", "beta singular target topic"))
+    s.insert_belief(_mk("b3", "zeta supports gamma"))
+    s.insert_belief(_mk("b4", "delta cites epsilon"))
+    s.insert_belief(_mk("b5", "epsilon material"))
+    s.insert_edge(Edge(src="b1", dst="b2", type=EDGE_CONTRADICTS, weight=1.0))
+    s.insert_edge(Edge(src="b3", dst="b2", type=EDGE_SUPPORTS, weight=1.0))
+    s.insert_edge(Edge(src="b4", dst="b5", type=EDGE_CITES, weight=1.0))
+    s.insert_edge(Edge(src="b1", dst="b5", type=EDGE_RELATES_TO, weight=1.0))
+    return s
+
+
+def _built_index(store: MemoryStore) -> HRRStructIndex:
+    idx = HRRStructIndex(dim=512, seed=_SEED)
+    idx.build(store, seed=_SEED)
+    return idx
+
+
+# --- AC1 / AC6: resolver --------------------------------------------------
+
+
+def test_resolver_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_HRR_EXPAND, raising=False)
+    assert is_hrr_expand_enabled() is False
+
+
+def test_resolver_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_HRR_EXPAND, "1")
+    assert is_hrr_expand_enabled() is True
+    monkeypatch.setenv(ENV_HRR_EXPAND, "0")
+    assert is_hrr_expand_enabled() is False
+    # Env wins over an explicit kwarg.
+    monkeypatch.setenv(ENV_HRR_EXPAND, "0")
+    assert is_hrr_expand_enabled(True) is False
+
+
+def test_resolver_kwarg(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_HRR_EXPAND, raising=False)
+    assert is_hrr_expand_enabled(True) is True
+    assert is_hrr_expand_enabled(False) is False
+
+
+def test_resolver_toml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path,
+) -> None:
+    monkeypatch.delenv(ENV_HRR_EXPAND, raising=False)
+    (tmp_path / ".aelfrice.toml").write_text(
+        "[retrieval]\nuse_hrr_expand = true\n"
+    )
+    assert is_hrr_expand_enabled(start=tmp_path) is True
+
+
+def test_resolver_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Unrecognised env value falls through to the next rung, not an error.
+    monkeypatch.setenv(ENV_HRR_EXPAND, "maybe")
+    assert is_hrr_expand_enabled() is False
+    assert is_hrr_expand_enabled(True) is True
+
+
+# --- edge-type set --------------------------------------------------------
+
+
+def test_edge_types_intersect_live_schema() -> None:
+    probed = set(hx.hrr_expand_edge_types())
+    # Every probed kind is a real edge type.
+    assert probed <= EDGE_TYPES
+    # The semantic kinds present in the current schema are probed.
+    for kind in ("SUPERSEDES", "CONTRADICTS", "SUPPORTS", "CITES", "TESTS", "IMPLEMENTS"):
+        assert kind in probed
+    # CALLS is not in the current schema, so it is not probed.
+    assert "CALLS" not in probed
+    # Co-occurrence / structural kinds are excluded.
+    assert "RELATES_TO" not in probed
+    # Deterministic (sorted) iteration order.
+    assert list(hx.hrr_expand_edge_types()) == sorted(probed)
+
+
+# --- AC2: determinism -----------------------------------------------------
+
+
+def _table_rows(store: MemoryStore) -> list[tuple]:
+    return [
+        tuple(r)
+        for r in store._conn.execute(  # noqa: SLF001
+            "SELECT belief_id, neighbor_id, similarity, edge_type, direction "
+            "FROM hrr_expand_neighbors ORDER BY rowid"
+        ).fetchall()
+    ]
+
+
+def test_precompute_table_byte_stable_across_runs() -> None:
+    store = _toy_store()
+    idx = _built_index(store)
+    n1 = hx.precompute_expand_neighbors(store, idx, now_iso="2026-01-01T00:00:00Z")
+    rows1 = _table_rows(store)
+    n2 = hx.precompute_expand_neighbors(store, idx, now_iso="2026-01-01T00:00:00Z")
+    rows2 = _table_rows(store)
+    assert n1 == n2
+    assert rows1 == rows2
+
+
+def test_precompute_table_stable_across_independent_index_builds() -> None:
+    # Two stores with identical content + a fresh index build each produce
+    # the same neighbour table (the index seed is fixed).
+    rows_a = _table_rows(_precomputed(_toy_store()))
+    rows_b = _table_rows(_precomputed(_toy_store()))
+    assert rows_a == rows_b
+
+
+def _precomputed(store: MemoryStore) -> MemoryStore:
+    hx.precompute_expand_neighbors(
+        store, _built_index(store), now_iso="2026-01-01T00:00:00Z",
+    )
+    return store
+
+
+def test_true_edges_dominate_noise_floor() -> None:
+    store = _toy_store()
+    idx = _built_index(store)
+    hx.precompute_expand_neighbors(store, idx, now_iso="2026-01-01T00:00:00Z")
+    rows = _table_rows(store)
+    # Only the three semantic edges (each surfaced forward + reverse) survive
+    # the floor; the RELATES_TO edge and all cleanup noise are rejected.
+    pairs = {(r[0], r[1]) for r in rows}
+    assert ("b1", "b2") in pairs and ("b2", "b1") in pairs  # CONTRADICTS
+    assert ("b2", "b3") in pairs and ("b3", "b2") in pairs  # SUPPORTS
+    assert ("b4", "b5") in pairs and ("b5", "b4") in pairs  # CITES
+    # RELATES_TO is not a probed kind → never surfaces.
+    assert ("b1", "b5") not in pairs and ("b5", "b1") not in pairs
+    # Every surviving similarity is near a true bound term (~1.0), well above
+    # the per-pair noise floor.
+    assert all(r[2] > 0.5 for r in rows)
+    assert min(r[2] for r in rows) > idx.noise_floor() * 5
+
+
+# --- neighbour recovery + expand_seeds ------------------------------------
+
+
+def test_expand_seeds_surfaces_both_directions() -> None:
+    store = _toy_store()
+    idx = _built_index(store)
+    # b2's in-neighbours are b1 (CONTRADICTS) and b3 (SUPPORTS).
+    got = sorted(b.id for b in hx.expand_seeds(store, idx, ["b2"]))
+    assert got == ["b1", "b3"]
+
+
+def test_expand_seeds_table_and_live_paths_agree() -> None:
+    table_store = _precomputed(_toy_store())
+    live_store = _toy_store()  # no precompute table populated
+    idx_t = _built_index(table_store)
+    idx_l = _built_index(live_store)
+    table_ids = [b.id for b in hx.expand_seeds(table_store, idx_t, ["b2"])]
+    live_ids = [b.id for b in hx.expand_seeds(live_store, idx_l, ["b2"])]
+    assert table_ids == live_ids
+
+
+def test_expand_seeds_excludes_seed_and_respects_top_k() -> None:
+    store = _toy_store()
+    idx = _built_index(store)
+    got = hx.expand_seeds(store, idx, ["b2"], top_k=1)
+    assert len(got) == 1
+    assert all(b.id != "b2" for b in got)
+
+
+def test_expand_seeds_excludes_soft_deleted() -> None:
+    store = _toy_store()
+    store.soft_delete_belief("b1")  # CONTRADICTS neighbour of b2
+    idx = _built_index(store)
+    got = {b.id for b in hx.expand_seeds(store, idx, ["b2"])}
+    assert "b1" not in got
+    assert "b3" in got
+
+
+def test_expand_seeds_empty_inputs() -> None:
+    store = _toy_store()
+    idx = _built_index(store)
+    assert hx.expand_seeds(store, idx, []) == []
+    empty_idx = HRRStructIndex(dim=512, seed=_SEED)
+    empty_idx.build(MemoryStore(":memory:"), seed=_SEED)
+    assert hx.expand_seeds(store, empty_idx, ["b2"]) == []
+
+
+# --- AC3: no regression with the flag off ---------------------------------
+
+
+def test_retrieve_v2_flag_off_is_byte_identical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(ENV_HRR_EXPAND, raising=False)
+    store = _toy_store()
+    baseline = retrieve_v2(store, "gamma", use_hrr_structural=False)
+    off = retrieve_v2(
+        store, "gamma", use_hrr_structural=False, use_hrr_expand=False,
+    )
+    assert [b.id for b in off.beliefs] == [b.id for b in baseline.beliefs]
+
+
+# --- lane wiring: net-new merge + telemetry -------------------------------
+
+
+def test_retrieve_v2_flag_on_merges_net_new(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(ENV_HRR_EXPAND, raising=False)
+    store = _toy_store()
+    cache = HRRStructIndexCache(store=store, seed=_SEED)
+    # Query matches only b2; BFS disabled so the expansion lane is the sole
+    # source of b2's semantic neighbours b1 / b3.
+    off = retrieve_v2(
+        store, "singular", use_hrr_structural=False,
+        use_bfs=False, use_hrr_expand=False,
+    )
+    on = retrieve_v2(
+        store, "singular", use_hrr_structural=False,
+        use_bfs=False, use_hrr_expand=True,
+        hrr_struct_index_cache=cache,
+    )
+    off_ids = {b.id for b in off.beliefs}
+    on_ids = {b.id for b in on.beliefs}
+    assert off_ids == {"b2"}
+    assert {"b1", "b3"} <= on_ids
+    assert off_ids < on_ids
+
+
+# --- AC5: determinism — no sampling in the lane ---------------------------
+
+
+def test_lane_source_has_no_randomness() -> None:
+    # AST scan (not a substring grep — the module docstring legitimately
+    # mentions "random"/"betavariate" to document their absence). No
+    # `import random` / `from random`, and no `.betavariate` attribute use.
+    import ast
+
+    tree = ast.parse(pathlib.Path(hx.__file__).read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            assert all(a.name.split(".")[0] != "random" for a in node.names)
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] != "random"
+        if isinstance(node, ast.Attribute):
+            assert node.attr != "betavariate"

--- a/tests/test_hrr_expand.py
+++ b/tests/test_hrr_expand.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import pathlib
 
-import numpy as np
 import pytest
 
 from aelfrice import hrr_expand as hx


### PR DESCRIPTION
## Summary

Restores the deterministic, embeddings-free **HRR vocabulary-bridge expansion
lane** behind a default-off `use_hrr_expand` flag on `retrieve_v2`, then
ablates it. This is the lane the v3.0.1 calibration notes name as the cause of
the LoCoMo delta (66.1% → 40.88%). Scoped to **implement-and-ablate, not flip
a default** — a default flip reverses locked #605 and is routed to a re-opened
#897.

Closes #981.

## What landed (5 atomic commits)

1. `feat(store)` — `hrr_expand_neighbors` cache table (derived, rebuilt
   wholesale; `similarity` REAL → byte-stable).
2. `feat(hrr_expand)` — the lane: forward out-neighbours via
   `unbind(role[kind], struct[seed])` + id-matrix cleanup, reverse
   in-neighbours via the existing `probe()`; semantic edge kinds only
   (predecessor set ∩ live `EDGE_TYPES`; `CALLS` absent from current schema).
   `precompute_expand_neighbors` (byte-stable table) + `expand_seeds`
   (table read, live-probe fallback). Built on the current `HRRStructIndex`
   substrate, **reusing the v2.1 persisted/mmap index path** — not a revival
   of the removed predecessor `HRRGraph`.
3. `feat(retrieval)` — `use_hrr_expand` resolver (env > kwarg > TOML >
   **False**), wired into `retrieve_with_tiers` between L1 packing and BFS
   (additive candidate source, budget-accounted, deduped, also seeds BFS).
   `LaneTelemetry.hrr_expand` surfaces per-call contribution.
4. `test(hrr_expand)` — 17 tests across the acceptance criteria.
5. `test(bench)` — the #977-sweep ablation arm.

## Acceptance criteria

1. ✅ `use_hrr_expand` wired (env/kwarg/TOML/default-off); passing it never raises.
2. ✅ Deterministic — byte-equal neighbour table across two runs (tie-break
   similarity DESC, neighbor_id ASC); numpy FFT/matvec only. Default-off keeps
   the #437 reproducibility path byte-identical.
3. ✅ No regression with the flag off — `retrieve_v2` output byte-identical
   (test + 688-test related-suite sweep green).
4. ✅ #977-sweep `+HRR-expand` arm; per-category LoCoMo reported (below).
5. ✅ No `betavariate`/`random` in the retrieval path (AST-scan test).
6. ✅ Default stays OFF; default-flip explicitly out of scope (→ #897).

## Ablation — the honest finding

`benchmarks/hrr_expand_ablation.py` runs LoCoMo under a 2×4 matrix (edge
substrate {none, contradicts-988} × {baseline, +hrr-expand, +bfs, all-on}),
scored with the LoCoMo adapter's deterministic retrieval-overlap F1 (the
scorer the issue's honest-uplift caveat references; no LLM reader → fully
reproducible).

**The HRR-expand and BFS lanes traverse semantic edges, and vanilla LoCoMo
ingest writes zero edges (1240 beliefs, 0 edges/conversation).** Therefore:

- `substrate=none`: every arm identical, `expand_hits=0` — the lane is
  **inert**. This is the #977 "BFS inert / 0 edges" finding, generalised.
- `substrate=contradicts-988` (#988 `write_semantic_edges`, ~46 CONTRADICTS
  edges/conversation): HRR-expand **activates** (`expand_hits>0`) but yields
  **no measurable retrieval-overlap F1 uplift** — the thin CONTRADICTS-only
  bridge does not surface answer-bearing beliefs.

This empirically confirms the issue's "do not pre-bank the 25.2 pp" caveat and
the #988-reframes-#981/#977 framing: **HRR-expand is a *consumer* of a
semantic-edge substrate; its uplift is gated on that substrate existing and
being dense/typed enough** — which the current default-off, CONTRADICTS-only
#988 writer does not yet provide on LoCoMo.

Full LoCoMo10 (1947 QA, retrieval-overlap F1, budget 2000):

| substrate | arm | overall | Δ vs base | lane merges | c1 multi-hop | c2 temporal | c3 open | c4 single-hop | c5 adversarial |
|---|---|--:|--:|--:|--:|--:|--:|--:|--:|
| none (0 edges) | baseline | 2.11% | — | 0 | 10.46% | 0.75% | 0.80% | 1.10% | 0.0% |
| none | +hrr-expand | 2.11% | +0.00 | 0 | 10.46% | 0.75% | 0.80% | 1.10% | 0.0% |
| none | +bfs | 2.11% | +0.00 | 0 | 10.46% | 0.75% | 0.80% | 1.10% | 0.0% |
| none | all-on | 2.11% | +0.00 | 0 | 10.46% | 0.75% | 0.80% | 1.10% | 0.0% |
| contradicts-988 (1394 edges) | baseline | 2.11% | — | 0 | 10.46% | 0.75% | 0.80% | 1.10% | 0.0% |
| contradicts-988 | **+hrr-expand** | 2.11% | **−0.00** | **446** | 10.46% | 0.74% | 0.79% | 1.09% | 0.0% |
| contradicts-988 | +bfs | 2.11% | +0.00 | 0 | 10.46% | 0.75% | 0.80% | 1.10% | 0.0% |
| contradicts-988 | all-on | 2.11% | −0.00 | 446 | 10.46% | 0.74% | 0.79% | 1.09% | 0.0% |

Reading: with no edge substrate every arm is byte-identical (lane inert). With #988's 1394 CONTRADICTS edges the HRR-expand lane **activates** — it merges 446 beliefs across the corpus — yet overall F1 is unchanged and the per-category effect is a marginal **negative** (temporal/open/single-hop each down ~0.0001). `+bfs` stays byte-identical to baseline even with edges (BFS inert, per #977). Absolute F1 is low because this is retrieval-token-overlap against the concatenated context, not reader accuracy; the arm *deltas* are the deliverable, and they are flat-to-slightly-negative.

LongMemEval / MAB / StructMemEval are deferred: their full corpora are not
present locally (only micro smoke fixtures) and several are structurally
unscorable per the project's bench notes. LoCoMo is the corpus the delta is
measured on.

Design: `docs/design/feature-hrr-expand-lane.md`.

## Summary by Sourcery

Introduce a deterministic HRR-based vocabulary-bridge expansion lane for retrieval, guarded by a default-off flag and fully ablated on LoCoMo, while preserving existing retrieval behavior when disabled.

New Features:
- Add an HRR vocabulary-bridge expansion lane that expands FTS5 seed hits via single-hop semantic neighbors from the structural index as an additive candidate source.
- Introduce a precomputed hrr_expand_neighbors cache table and associated utilities to materialize and query deterministic HRR neighbor relationships for beliefs.
- Add a dedicated benchmark runner to ablate the HRR expansion and BFS lanes on LoCoMo under different semantic-edge substrates.

Enhancements:
- Extend retrieval configuration to resolve use_hrr_expand via environment, kwargs, and TOML, wire it into retrieve_v2, and expose lane contribution via telemetry.
- Reuse the existing HRR structural index through an optional cache when running the expansion lane, including automatic ephemeral cache construction when needed.

Documentation:
- Document the HRR vocabulary-bridge expansion lane design, determinism guarantees, semantics, and ablation findings in a dedicated design document.

Tests:
- Add comprehensive tests for the HRR expansion lane covering flag resolution, edge-type selection, determinism and byte-stable neighbor tables, retrieval invariance with the lane off, lane wiring behavior, and absence of randomness in the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional HRR vocabulary-bridge expansion retrieval lane that discovers semantic neighbors using deterministic structural probes, enhancing candidate discovery with configurable on/off control via environment variables and configuration.

* **Documentation**
  * Added comprehensive design documentation covering the expansion lane's behavior, determinism guarantees, configuration options, and ablation results under LoCoMo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->