### PR TITLE
perf(ingest): incremental per-turn edge detection (#1000)

### DIFF
--- a/src/aelfrice/dedup.py
+++ b/src/aelfrice/dedup.py
@@ -197,6 +197,7 @@ def _jaccard_prefiltered_pairs(
     *,
     jaccard_min: float,
     max_pairs: int,
+    restrict_to_ids: frozenset[str] | None = None,
 ) -> tuple[
     list[tuple[str, str, str, str, frozenset[str], frozenset[str], float]],
     int,
@@ -204,13 +205,18 @@ def _jaccard_prefiltered_pairs(
 ]:
     """Return `[(id_a, content_a, id_b, content_b, tokens_a, tokens_b,
     jaccard)]` for every pair clearing `jaccard_min`, plus the raw
-    candidate count (all O(n^2) pairs visited) and a `truncated`
-    boolean.
+    candidate count (pairs actually scored) and a `truncated` boolean.
 
     Tokens are cached per belief id so each belief tokenises once
     even if it participates in many pairs. The pair list is sorted
     deterministically by `(id_a, id_b)` and truncated to `max_pairs`
     if larger.
+
+    When ``restrict_to_ids`` is provided, only pairs where at least one
+    endpoint ID is in the set are scored and counted. Pairs where both
+    endpoints are absent from the set are skipped before Jaccard
+    computation. When ``restrict_to_ids`` is ``None`` (the default),
+    behavior is identical to before this parameter was added.
     """
     n = len(beliefs)
     token_cache: list[frozenset[str]] = [
@@ -229,6 +235,12 @@ def _jaccard_prefiltered_pairs(
             id_b, content_b = beliefs[j]
             tb = token_cache[j]
             if not content_b.strip():
+                continue
+            if (
+                restrict_to_ids is not None
+                and id_a not in restrict_to_ids
+                and id_b not in restrict_to_ids
+            ):
                 continue
             raw_count += 1
             j_score = jaccard(ta, tb)

--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -296,13 +296,19 @@ def _ingest_turn_ids(
             anchor_text=anchor,
         ))
 
-    # #988/#999: optionally build the semantic-edge substrate at ingest.
+    # #988/#999/#1000: optionally build the semantic-edge substrate at ingest.
     # Writes CONTRADICTS (#988), SUPPORTS (REFINES verdicts, #999), and
     # SUPERSEDES (dedup clusters, #999) edges across the store so the graph
     # lanes (HRR-expand #981, BFS) are no longer starved on a CONTRADICTS-only
     # graph. Default-OFF (is_auto_relationship_detection_enabled): when off,
     # this branch is never entered and ingest is byte-identical to today.
     # Gated on `inserted` so corroboration-only turns skip the audit.
+    # The CONTRADICTS build is incremental (delta-scoped, #1000): only pairs
+    # touching at least one belief from `inserted` are evaluated, which is
+    # provably equivalent to a full-store audit for discovering new edges
+    # while avoiding the O(n²) re-scan of the whole store every turn. The
+    # SUPPORTS/SUPERSEDES writers still do full-store passes — extending the
+    # delta-scoping to them is tracked as a follow-up.
     if inserted:
         from aelfrice.dedup import write_supersedes_edges
         from aelfrice.relationship_detector import (
@@ -312,7 +318,7 @@ def _ingest_turn_ids(
         )
 
         if is_auto_relationship_detection_enabled():
-            write_semantic_edges(store)
+            write_semantic_edges(store, new_belief_ids=inserted)
             write_supports_edges(store)
             write_supersedes_edges(store)
 

--- a/src/aelfrice/relationship_detector.py
+++ b/src/aelfrice/relationship_detector.py
@@ -394,6 +394,7 @@ def relationships_audit(
     residual_overlap_min: float = DEFAULT_RESIDUAL_OVERLAP_MIN,
     confidence_min: float = DEFAULT_CONFIDENCE_MIN,
     max_candidate_pairs: int = DEFAULT_MAX_CANDIDATE_PAIRS,
+    restrict_to_ids: set[str] | frozenset[str] | None = None,
 ) -> RelationshipsAuditReport:
     """Walk the store, classify near-pair relationships, return a report.
 
@@ -404,6 +405,12 @@ def relationships_audit(
     by sharing the full classifier.
 
     ``unrelated`` verdicts are dropped from the pair list.
+
+    When ``restrict_to_ids`` is provided, candidate-pair generation is
+    scoped to pairs where at least one endpoint is in the set. Passes
+    the filter through to ``_jaccard_prefiltered_pairs`` unchanged.
+    Default ``None`` ⇒ full-store audit, byte-identical to prior
+    behaviour.
 
     Raises ``ValueError`` on malformed thresholds.
     """
@@ -431,10 +438,14 @@ def relationships_audit(
             truncated=False,
         )
 
+    _restrict: frozenset[str] | None = (
+        frozenset(restrict_to_ids) if restrict_to_ids is not None else None
+    )
     candidates, raw_count, truncated = _jaccard_prefiltered_pairs(
         beliefs,
         jaccard_min=jaccard_min,
         max_pairs=max_candidate_pairs,
+        restrict_to_ids=_restrict,
     )
 
     pairs: list[RelationshipPair] = []

--- a/src/aelfrice/relationship_detector.py
+++ b/src/aelfrice/relationship_detector.py
@@ -55,6 +55,7 @@ import os
 import re
 import sys
 import tomllib
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Final, IO, cast
@@ -904,6 +905,7 @@ def write_semantic_edges(
     confidence_min: float = DEFAULT_CONFIDENCE_MIN,
     max_candidate_pairs: int = DEFAULT_MAX_CANDIDATE_PAIRS,
     max_edges_per_belief: int = DEFAULT_MAX_EDGES_PER_BELIEF,
+    new_belief_ids: Sequence[str] | None = None,
 ) -> SemanticEdgeWriteReport:
     """Emit CONTRADICTS edges for high-confidence contradicting pairs (#988).
 
@@ -936,10 +938,31 @@ def write_semantic_edges(
     ``(belief_a_id, belief_b_id)`` order, so which edges survive the cap is
     itself deterministic.
 
+    **Incremental mode** (``new_belief_ids`` is not ``None``): candidate-pair
+    generation is scoped to pairs touching at least one belief in
+    ``new_belief_ids`` (the delta inserted during the current turn).
+    Every old-old pair (both endpoints from prior turns) was already
+    generated and processed when the later of its two endpoints was first
+    inserted, so restricting to delta-involving pairs produces the same new
+    edges as a full-store audit would — without re-scanning the whole store.
+
+    In incremental mode the write-gate budget for each endpoint is seeded
+    from its existing CONTRADICTS edge count in the store before the write
+    loop runs. This makes the ``max_edges_per_belief`` cap a true hard bound
+    across turns (matching the docstring's stated intent) without needing to
+    re-visit old-old pairs to discover prior edges. In full-store mode
+    (``new_belief_ids`` is ``None``) the loop itself counts existing edges
+    as they are encountered, preserving the original behaviour exactly.
+
     Stdlib-only: no LLM, no embedding. Delegates detection to
     ``relationships_audit``.
     """
     from aelfrice.models import Edge, EDGE_CONTRADICTS
+
+    restrict: frozenset[str] | None = (
+        frozenset(new_belief_ids) if new_belief_ids is not None else None
+    )
+    incremental = restrict is not None
 
     report = relationships_audit(
         store,
@@ -947,6 +970,7 @@ def write_semantic_edges(
         residual_overlap_min=residual_overlap_min,
         confidence_min=confidence_min,
         max_candidate_pairs=max_candidate_pairs,
+        restrict_to_ids=restrict,
     )
 
     high_pairs = [
@@ -956,7 +980,28 @@ def write_semantic_edges(
     # `report.pairs` is already sorted by (belief_a_id, belief_b_id);
     # preserve that order so the write-gate is deterministic.
 
-    edges_per_belief: dict[str, int] = {}
+    # In incremental mode, seed each endpoint's budget from its existing
+    # CONTRADICTS edge count so the hard per-belief cap is enforced across
+    # turns, not just within this call.
+    if incremental:
+        endpoint_ids = {
+            eid
+            for p in high_pairs
+            for eid in (p.belief_a_id, p.belief_b_id)
+        }
+        existing_edges = store.edges_for_beliefs(list(endpoint_ids))
+        edges_per_belief: dict[str, int] = {}
+        for e in existing_edges:
+            if e.type == EDGE_CONTRADICTS:
+                edges_per_belief[e.src] = edges_per_belief.get(e.src, 0) + 1
+                edges_per_belief[e.dst] = edges_per_belief.get(e.dst, 0) + 1
+    else:
+        edges_per_belief = {}
+    # In full-store mode, existing-skip branch increments edges_per_belief
+    # (original behaviour). In incremental mode it must NOT — the seed
+    # already reflects those edges.
+    count_existing_in_loop = not incremental
+
     n_written = 0
     n_skipped_existing = 0
     n_gated = 0
@@ -976,10 +1021,12 @@ def write_semantic_edges(
         src_id, dst_id = (a_id, b_id) if a_id < b_id else (b_id, a_id)
         if store.get_edge(src_id, dst_id, EDGE_CONTRADICTS) is not None:
             n_skipped_existing += 1
-            # Count existing edges toward the budget for a hard per-belief
-            # bound across re-runs.
-            edges_per_belief[a_id] = edges_per_belief.get(a_id, 0) + 1
-            edges_per_belief[b_id] = edges_per_belief.get(b_id, 0) + 1
+            if count_existing_in_loop:
+                # Count existing edges toward the budget for a hard per-belief
+                # bound across re-runs (full-store mode only; incremental mode
+                # seeds the budget from the store before the loop).
+                edges_per_belief[a_id] = edges_per_belief.get(a_id, 0) + 1
+                edges_per_belief[b_id] = edges_per_belief.get(b_id, 0) + 1
             continue
         store.insert_edge(
             Edge(src=src_id, dst=dst_id, type=EDGE_CONTRADICTS, weight=1.0)

--- a/tests/test_relationship_detector_incremental.py
+++ b/tests/test_relationship_detector_incremental.py
@@ -1,0 +1,301 @@
+"""Tests for incremental edge detection in write_semantic_edges (#1000).
+
+Covers:
+1. Incremental == full-audit edge set (no cap pressure, across simulated turns).
+2. Determinism of the incremental path.
+3. Full-store mode (new_belief_ids=None) backward-compat / no-op parity.
+4. Hard per-belief cap enforced across turns in incremental mode.
+5. restrict_to_ids unit test on _jaccard_prefiltered_pairs directly.
+
+All tests use real MemoryStore(":memory:") — no mocks.
+Stdlib-only, deterministic, no LLM, no embeddings.
+"""
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from aelfrice.dedup import _jaccard_prefiltered_pairs
+from aelfrice.models import (
+    BELIEF_FACTUAL,
+    EDGE_CONTRADICTS,
+    LOCK_NONE,
+    Belief,
+)
+from aelfrice.relationship_detector import (
+    DEFAULT_MAX_EDGES_PER_BELIEF,
+    write_semantic_edges,
+)
+from aelfrice.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# Belief content fixtures — universal-affirmation vs negation pairs generate
+# high-confidence CONTRADICTS scores (score 1.0).  All share the same
+# residual-content token pattern so the detector fires reliably.
+# ---------------------------------------------------------------------------
+
+# Turn-1 pair
+_T1_ALWAYS = "the cache layer always stores the user session token"
+_T1_NEVER = "the cache layer never stores the user session token"
+
+# Turn-2 pair (different subject, no overlap with Turn-1 content)
+_T2_ALWAYS = "the scheduler always runs the backup job at midnight"
+_T2_NEVER = "the scheduler never runs the backup job at midnight"
+
+# Turn-3 pair
+_T3_ALWAYS = "the config loader always reads environment variables first"
+_T3_NEVER = "the config loader never reads environment variables first"
+
+# Lexically distant filler — does not contradict anything above.
+_FILLER = "the harbor seals bask on the warm rocks at noon each day"
+
+
+def _make_belief(
+    store: MemoryStore,
+    *,
+    belief_id: str,
+    content: str,
+    created_at: str = "2026-01-01T00:00:00Z",
+) -> Belief:
+    b = Belief(
+        id=belief_id,
+        content=content,
+        content_hash=hashlib.sha256(content.encode()).hexdigest(),
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        created_at=created_at,
+        last_retrieved_at=None,
+    )
+    store.insert_belief(b)
+    return b
+
+
+def _contradicts_edges(store: MemoryStore) -> list[tuple[str, str, str]]:
+    """Return all CONTRADICTS edges as sorted (src, dst, type) tuples."""
+    rows = store._conn.execute(  # type: ignore[attr-defined]
+        "SELECT src, dst, type FROM edges WHERE type = ? ORDER BY src, dst",
+        (EDGE_CONTRADICTS,),
+    ).fetchall()
+    return [(r[0], r[1], r[2]) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# 1. Incremental == full-audit edge set
+# ---------------------------------------------------------------------------
+
+
+def test_incremental_equals_full_audit_edge_set() -> None:
+    """Incremental per-turn calls produce the same final edge set as a single
+    full-store audit over all turns combined."""
+
+    # Path A: insert all beliefs, then run one full-store audit.
+    store_a = MemoryStore(":memory:")
+    _make_belief(store_a, belief_id="a1", content=_T1_ALWAYS)
+    _make_belief(store_a, belief_id="a2", content=_T1_NEVER)
+    _make_belief(store_a, belief_id="b1", content=_T2_ALWAYS)
+    _make_belief(store_a, belief_id="b2", content=_T2_NEVER)
+    _make_belief(store_a, belief_id="c1", content=_T3_ALWAYS)
+    _make_belief(store_a, belief_id="c2", content=_T3_NEVER)
+    _make_belief(store_a, belief_id="f1", content=_FILLER)
+    write_semantic_edges(store_a)  # full-store, new_belief_ids=None
+    edges_full = _contradicts_edges(store_a)
+
+    # Path B: insert turn-by-turn, run incremental after each turn.
+    store_b = MemoryStore(":memory:")
+    # Turn 1
+    _make_belief(store_b, belief_id="a1", content=_T1_ALWAYS)
+    _make_belief(store_b, belief_id="a2", content=_T1_NEVER)
+    write_semantic_edges(store_b, new_belief_ids=["a1", "a2"])
+    # Turn 2
+    _make_belief(store_b, belief_id="b1", content=_T2_ALWAYS)
+    _make_belief(store_b, belief_id="b2", content=_T2_NEVER)
+    write_semantic_edges(store_b, new_belief_ids=["b1", "b2"])
+    # Turn 3
+    _make_belief(store_b, belief_id="c1", content=_T3_ALWAYS)
+    _make_belief(store_b, belief_id="c2", content=_T3_NEVER)
+    _make_belief(store_b, belief_id="f1", content=_FILLER)
+    write_semantic_edges(store_b, new_belief_ids=["c1", "c2", "f1"])
+    edges_incremental = _contradicts_edges(store_b)
+
+    assert edges_incremental == edges_full, (
+        f"Incremental path produced different edges.\n"
+        f"  Full-store: {edges_full}\n"
+        f"  Incremental: {edges_incremental}"
+    )
+    # Sanity: at least the three turn-pairs should each have one edge.
+    assert len(edges_full) >= 3
+
+
+# ---------------------------------------------------------------------------
+# 2. Determinism — two incremental runs on identical input are byte-equal
+# ---------------------------------------------------------------------------
+
+
+def test_incremental_is_deterministic() -> None:
+    """Two incremental builds on identical input produce byte-equal edge tables."""
+
+    def build() -> list[tuple[str, str, str]]:
+        s = MemoryStore(":memory:")
+        _make_belief(s, belief_id="a1", content=_T1_ALWAYS)
+        _make_belief(s, belief_id="a2", content=_T1_NEVER)
+        write_semantic_edges(s, new_belief_ids=["a1", "a2"])
+        _make_belief(s, belief_id="b1", content=_T2_ALWAYS)
+        _make_belief(s, belief_id="b2", content=_T2_NEVER)
+        write_semantic_edges(s, new_belief_ids=["b1", "b2"])
+        return _contradicts_edges(s)
+
+    assert build() == build()
+
+
+# ---------------------------------------------------------------------------
+# 3. Full-store mode (new_belief_ids=None) backward-compat parity
+# ---------------------------------------------------------------------------
+
+
+def test_full_store_mode_backward_compat() -> None:
+    """write_semantic_edges with new_belief_ids=None is unchanged — same edges
+    as expected from the original full-audit path."""
+    store = MemoryStore(":memory:")
+    _make_belief(store, belief_id="x1", content=_T1_ALWAYS)
+    _make_belief(store, belief_id="x2", content=_T1_NEVER)
+    _make_belief(store, belief_id="x3", content=_FILLER)
+
+    report = write_semantic_edges(store)  # new_belief_ids=None (default)
+    assert report.n_edges_written == 1
+    edges = _contradicts_edges(store)
+    assert edges == [("x1", "x2", EDGE_CONTRADICTS)]
+
+
+def test_full_store_idempotent_parity() -> None:
+    """Second call in full-store mode writes nothing (idempotency preserved)."""
+    store = MemoryStore(":memory:")
+    _make_belief(store, belief_id="x1", content=_T1_ALWAYS)
+    _make_belief(store, belief_id="x2", content=_T1_NEVER)
+    write_semantic_edges(store)
+    report2 = write_semantic_edges(store)
+    assert report2.n_edges_written == 0
+    assert report2.n_edges_skipped_existing == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Hard per-belief cap enforced across turns in incremental mode
+# ---------------------------------------------------------------------------
+
+
+def test_incremental_hard_cap_across_turns() -> None:
+    """Hub belief accretes at most max_edges_per_belief CONTRADICTS edges
+    across multiple incremental turns."""
+    cap = 3  # set low to stress the cross-turn enforcement
+
+    # "hub" always contradicts "n_i" (never variant) for each i.
+    # Introduce hub + n_1, n_2 in turn 1; n_3, n_4 in turn 2; n_5, n_6 in turn 3.
+    # With cap=3, hub should never exceed 3 edges regardless of turn count.
+
+    base_text = "the indexer always rebuilds the search index on startup"
+
+    def _never_variant(i: int) -> str:
+        # Vary by appending a token that doesn't break the residual content
+        # overlap enough to drop below jaccard_min, but gives distinct IDs.
+        return f"the indexer never rebuilds the search index on startup run{i}"
+
+    store = MemoryStore(":memory:")
+    hub_id = "hub"
+    _make_belief(store, belief_id=hub_id, content=base_text)
+
+    spoke_ids = [f"n{i}" for i in range(1, 7)]
+    for sid in spoke_ids:
+        _make_belief(
+            store, belief_id=sid,
+            content=_never_variant(int(sid[1:]))
+        )
+
+    # Simulate three turns introducing the spokes in pairs.
+    turn_deltas = [
+        [hub_id, "n1", "n2"],  # turn 1: hub + n1, n2
+        ["n3", "n4"],          # turn 2
+        ["n5", "n6"],          # turn 3
+    ]
+    for delta in turn_deltas:
+        write_semantic_edges(store, new_belief_ids=delta, max_edges_per_belief=cap)
+
+    # Count hub's CONTRADICTS edges directly from the store.
+    hub_edge_count = store._conn.execute(  # type: ignore[attr-defined]
+        "SELECT COUNT(*) FROM edges WHERE type = ? AND (src = ? OR dst = ?)",
+        (EDGE_CONTRADICTS, hub_id, hub_id),
+    ).fetchone()[0]
+
+    assert hub_edge_count <= cap, (
+        f"Hub accreted {hub_edge_count} edges, exceeding cap {cap}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. restrict_to_ids unit test on _jaccard_prefiltered_pairs
+# ---------------------------------------------------------------------------
+
+
+def test_restrict_to_ids_filters_pairs() -> None:
+    """With restrict_to_ids, every returned pair has at least one endpoint in
+    the set; restrict_to_ids=None returns the superset."""
+    # Build a small beliefs list: ids sorted ASC (as store.list_beliefs_for_indexing does).
+    beliefs = [
+        ("a", _T1_ALWAYS),
+        ("b", _T1_NEVER),
+        ("c", _T2_ALWAYS),
+        ("d", _T2_NEVER),
+    ]
+    restrict = frozenset({"a", "b"})
+
+    pairs_restricted, raw_restricted, _ = _jaccard_prefiltered_pairs(
+        beliefs,
+        jaccard_min=0.0,
+        max_pairs=1000,
+        restrict_to_ids=restrict,
+    )
+    pairs_full, raw_full, _ = _jaccard_prefiltered_pairs(
+        beliefs,
+        jaccard_min=0.0,
+        max_pairs=1000,
+        restrict_to_ids=None,
+    )
+
+    # Every restricted pair must have at least one endpoint in the set.
+    for id_a, _, id_b, *_ in pairs_restricted:
+        assert id_a in restrict or id_b in restrict, (
+            f"Pair ({id_a}, {id_b}) has no endpoint in restrict set {restrict}"
+        )
+
+    # Full set must be at least as large as restricted set.
+    assert raw_full >= raw_restricted
+    assert len(pairs_full) >= len(pairs_restricted)
+
+    # Pairs that are old-old (neither endpoint in restrict) must not appear.
+    old_old_in_restricted = [
+        (id_a, id_b)
+        for id_a, _, id_b, *_ in pairs_restricted
+        if id_a not in restrict and id_b not in restrict
+    ]
+    assert old_old_in_restricted == []
+
+
+def test_restrict_to_ids_none_is_full_scan() -> None:
+    """restrict_to_ids=None returns all pairs (same count as unrestricted call)."""
+    beliefs = [
+        ("a", _T1_ALWAYS),
+        ("b", _T1_NEVER),
+        ("c", _T2_ALWAYS),
+    ]
+    pairs_none, raw_none, _ = _jaccard_prefiltered_pairs(
+        beliefs, jaccard_min=0.0, max_pairs=1000, restrict_to_ids=None
+    )
+    pairs_explicit_none, raw_explicit_none, _ = _jaccard_prefiltered_pairs(
+        beliefs, jaccard_min=0.0, max_pairs=1000
+    )
+    # Both forms (omitted and explicit None) must give the same result.
+    assert raw_none == raw_explicit_none
+    assert pairs_none == pairs_explicit_none

--- a/tests/test_relationship_detector_incremental.py
+++ b/tests/test_relationship_detector_incremental.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 
 import hashlib
 
-import pytest
-
 from aelfrice.dedup import _jaccard_prefiltered_pairs
 from aelfrice.models import (
     BELIEF_FACTUAL,
@@ -23,10 +21,7 @@ from aelfrice.models import (
     LOCK_NONE,
     Belief,
 )
-from aelfrice.relationship_detector import (
-    DEFAULT_MAX_EDGES_PER_BELIEF,
-    write_semantic_edges,
-)
+from aelfrice.relationship_detector import write_semantic_edges
 from aelfrice.store import MemoryStore
 
 


### PR DESCRIPTION
## Summary

Makes the `#988` semantic-edge build **incremental** so per-turn auto-relationship ingest no longer re-audits the whole store on every turn.

Closes #1000.

## Problem

`write_semantic_edges(store)` audits the entire store via an O(n²) candidate-pair scan capped at `max_candidate_pairs` (5000). Wired into ingest per-turn, this produced two unsatisfactory build paths (both measured on LoCoMo10):

- **Per-turn** full audit every turn → **25–40 min/conv** (the O(n²) whole-store re-scan).
- **Single post-ingest pass** → hits the 5000-pair cap and **undercounts ~57%** (conv-0: 46 edges vs the per-turn 72).

Same root cause: candidate-pair generation rescans the whole store instead of scoping to what changed.

## Fix

Scope candidate-pair generation to pairs touching at least one belief newly inserted that turn (the delta `inserted` already computed in `ingest._ingest_turn_ids`).

**Why this is equivalent to the full audit:** every old-old high-confidence pair (both endpoints from prior turns) was already generated and processed in the turn when the *later* of its two endpoints was first inserted. So the only *new* edges a full audit writes each turn are exactly the delta-involving pairs — restricting to them discovers the same edges without the whole-store rescan. Because each turn adds a bounded number of pairs, the per-turn build never hits the 5000-pair cap, recovering the ~57% the single pass lost.

### Write-gate preserved across turns

`max_edges_per_belief` (default 8) caps how many CONTRADICTS edges a belief accretes. The full audit enforced this by re-encountering a belief's prior edges each call. In incremental mode those old-old pairs aren't generated, so each endpoint's write-gate budget is **seeded from its existing CONTRADICTS edge count** in the store before the write loop — making the cap a true hard per-belief bound across turns. Full-store mode (`new_belief_ids=None`) is byte-identical to before.

## Changes (atomic commits)

1. `refactor(dedup)` — `restrict_to_ids` filter on `_jaccard_prefiltered_pairs` (skip before Jaccard; `None` ⇒ unchanged).
2. `feat(relationship_detector)` — thread `restrict_to_ids` through `relationships_audit`.
3. `feat(relationship_detector)` — `new_belief_ids` incremental mode in `write_semantic_edges` with store-seeded write-gate budget.
4. `feat(ingest)` — pass the per-turn delta (`inserted`) to `write_semantic_edges`.
5. `test(relationship_detector)` — 7 tests: incremental==full equivalence, determinism, full-store/idempotent backward-compat, hard-cap across turns, and `restrict_to_ids` unit coverage.

## Determinism / scope

Stdlib-only, no `random`/embeddings/LLM — #605 posture holds. Sort and canonicalization unchanged, so edge tables stay byte-stable. Default-off flag (`AELFRICE_AUTO_RELATIONSHIPS`) unchanged; a fresh install still writes no edges and full-store mode is byte-identical.

## Acceptance

- [x] Incremental per-turn build reproduces the full-audit edge set (unit test).
- [x] No cap-truncation undercount: per-turn deltas never hit `max_candidate_pairs`.
- [x] Determinism preserved; no regression with the flag off.
- [x] Per-belief cap holds as a hard bound across turns (unit test, cap=3).

LoCoMo10 wall-clock and exact-count reproduction against the per-turn baseline are a lab-side verification (the corpus lives lab-side); the equivalence and hard-cap properties are proven here by unit tests on synthetic stores.

## Summary by Sourcery

Make semantic edge detection incremental by scoping per-turn candidate generation to newly inserted beliefs, preserving determinism and full-store behavior while avoiding whole-store rescans.

Enhancements:
- Add optional ID-based restriction to Jaccard prefiltered pair generation and thread it through the relationship audit pipeline to support delta-scoped edge detection.
- Introduce incremental mode in semantic edge writing that uses new belief IDs and existing edges to enforce a hard per-belief cap across turns while keeping full-store mode behavior unchanged.
- Update ingest to pass each turn’s inserted belief IDs into semantic edge writing so per-turn auto-relationship detection runs incrementally instead of re-auditing the full store.

Tests:
- Add incremental vs full-audit equivalence, determinism, backward-compatibility, cross-turn cap enforcement, and restrict_to_ids coverage tests for semantic edge detection.