### PR TITLE
release: v3.7.0

### DIFF
--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -8,6 +8,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.0] - 2026-06-23
+
+The graph-substrate and phantom-lifecycle wave. The belief graph gained an
+explicit relationship substrate written at ingest (`CONTRADICTS` edges,
+default-off, #988/#1000), the host harness's own auto-memory writes now mirror
+through into that graph (#985), and the phantom-belief lifecycle became
+observable and self-maintaining end to end — trigger-driven generation
+(#980), opt-in SessionStart auto-GC (#980), and a status/stats surface for the
+whole lifecycle (#980). Plus a default-off HRR vocabulary-bridge expansion lane
+that was wired, ablated over LoCoMo, and left off as recall-neutral (#981). One
+experiment — denser `SUPPORTS`/`SUPERSEDES` edges (#999) — was reverted after
+the operator ratified a `CONTRADICTS`-only substrate (#998 A4); only the
+incremental per-turn edge detector survives.
+
+### Added
+
+- **Phantom-belief lifecycle: trigger-driven generation, auto-GC, and a status surface ([#980](https://github.com/robotrocketscience/aelfrice/issues/980)).** Three landings complete the phantom lifecycle. (1) Deterministic 3-signal trigger-driven generation on normal turns ([PR #994](https://github.com/robotrocketscience/aelfrice/pull/994), [PR #996](https://github.com/robotrocketscience/aelfrice/pull/996)) — a phantom-opportunity detector fires on `UserPromptSubmit` and supersedes the earlier gap-only design; opt-in via `[phantom_generation]` in config, resolved from the payload cwd. (2) Opt-in phantom auto-GC on `SessionStart` ([PR #995](https://github.com/robotrocketscience/aelfrice/pull/995)), default-off. (3) Phantom lifecycle counts surfaced in `aelf status` and `aelf:stats` ([PR #991](https://github.com/robotrocketscience/aelfrice/pull/991)), with per-session phantom-generation state tracked in the session ring.
+- **`claude-memory` write-through mirror into the belief graph ([#985](https://github.com/robotrocketscience/aelfrice/issues/985), [PR #992](https://github.com/robotrocketscience/aelfrice/pull/992)).** A `PostToolUse` mirror hook parses the host harness's auto-memory frontmatter and mirrors those writes into the aelfrice belief graph as a distinct `claude_memory` ingest/corroboration source kind, registered via `aelf setup`. Default-off behind a mirror flag; the two stores complement rather than collide.
+- **`CONTRADICTS` semantic-edge substrate built at ingest ([#988](https://github.com/robotrocketscience/aelfrice/issues/988), [PR #990](https://github.com/robotrocketscience/aelfrice/pull/990)).** `write_semantic_edges` writes `CONTRADICTS` edges into the belief graph during ingest behind a default-off auto-relationship-detection flag. Incremental per-turn detection ([#1000](https://github.com/robotrocketscience/aelfrice/issues/1000), [PR #1003](https://github.com/robotrocketscience/aelfrice/pull/1003)) passes only the per-turn delta to the writer with a store-seeded write-gate budget, so steady-state ingest cost stays bounded.
+- **Default-off HRR vocabulary-bridge expansion lane (wired, then ablated) ([#981](https://github.com/robotrocketscience/aelfrice/issues/981), [PR #997](https://github.com/robotrocketscience/aelfrice/pull/997)).** A deterministic HRR expansion lane (`use_hrr_expand`, default-off) with an `hrr_expand_neighbors` cache table, wired into `retrieve_v2` and ablated over LoCoMo. The arm is **recall-neutral** on the dense substrate (+0.13pp, 2/1540 queries), so the lane ships off-by-default; HRR is not the retrieval lever. See the design doc + ablation findings.
+
+### Fixed
+
+- **Soft-deleted beliefs excluded from every retrieval lane ([#980](https://github.com/robotrocketscience/aelfrice/issues/980), [PR #987](https://github.com/robotrocketscience/aelfrice/pull/987), [PR #993](https://github.com/robotrocketscience/aelfrice/pull/993)).** Soft-deleted (phantom-GC'd and user-deleted) beliefs leaked back through retrieval; they are now filtered from all local retrieval lanes and from the federation peer-search lane, pinned by tests.
+- **Temporal-sort half-life test anchored to real `now` ([#982](https://github.com/robotrocketscience/aelfrice/issues/982), [PR #983](https://github.com/robotrocketscience/aelfrice/pull/983)).** `retrieve_v2`'s temporal decay runs against the real wall clock with no injection seam; a fixed-`NOW` fixture drifted ~45 days against a 3600 s half-life until the float64 decay underflowed to `0.0` and collapsed sort order, red-ing out `main` on 2026-06-22. The test now anchors to real `now`. Production was never at risk (default half-life is 7 days).
+
+### Reverted
+
+- **Denser `SUPPORTS`/`SUPERSEDES` edge substrate declined ([#998](https://github.com/robotrocketscience/aelfrice/issues/998) A4, revert [#999](https://github.com/robotrocketscience/aelfrice/issues/999), [PR #1005](https://github.com/robotrocketscience/aelfrice/pull/1005)).** The `SUPPORTS` (from REFINES verdicts) and `SUPERSEDES` (within dedup clusters) edge writers added in [PR #1002](https://github.com/robotrocketscience/aelfrice/pull/1002) were reverted after the operator ratified a `CONTRADICTS`-only substrate (#998 decision A4). The incremental per-turn `CONTRADICTS` detector (#1000) is kept.
+
+### Internal
+
+- **`retrieve_v2` clock-injection seam ([#986](https://github.com/robotrocketscience/aelfrice/issues/986), [PR #989](https://github.com/robotrocketscience/aelfrice/pull/989)).** `retrieve_v2` gained an optional `now` seam so temporal decay can be pinned in tests, closing the last clock-seam-less temporal path.
+- **γ rerank reorder assertion at the `retrieve()` level ([#978](https://github.com/robotrocketscience/aelfrice/issues/978), [PR #984](https://github.com/robotrocketscience/aelfrice/pull/984)).** Test-only: assert that γ rerank reorders results by posterior at the public `retrieve()` boundary, not just inside the reranker.
+
+### Documentation
+
+- README retrieval-lanes figure refresh, v3.5.0 status true-up, and the L2-off-by-default note ([PR #976](https://github.com/robotrocketscience/aelfrice/pull/976)).
+
+### Dependencies
+
+- Bump `pyjwt` 2.12.1 → 2.13.0 in the `uv` group ([PR #969](https://github.com/robotrocketscience/aelfrice/pull/969)).
+
 ## [3.6.0] - 2026-06-19
 
 The `project_context` provenance wave: a column added in v3.2 (#858) but never
@@ -504,7 +547,8 @@ The cadence-policy completion + conversation-aware retrieval wave.
 
 - **`urllib3` 2.6.3 → 2.7.0 for CVE patches** ([#640](https://github.com/robotrocketscience/aelfrice/issues/640)). Lockfile-only dependency bump pulled in via `uv lock` to clear two CVEs flagged by GitHub's dependency scanner. `urllib3` is a transitive dep (via `requests` in the publish workflow and the `gh` CLI's Python shim); aelfrice itself does not import it. No source change.
 
-[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v3.6.0...HEAD
+[Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v3.7.0...HEAD
+[3.7.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.5.1...v3.6.0
 [3.5.1]: https://github.com/robotrocketscience/aelfrice/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/robotrocketscience/aelfrice/compare/51cea5c4...v3.5.0

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Scopes: `--scope all` (everything, capped by `--max-notes`), `--scope recent` (n
 
 ## Status
 
-Latest stable: **v3.5.1** (2026-06-10). Per-entry detail in [CHANGELOG § 3.5.1](CHANGELOG/v3.md). Per-version history: [docs/concepts/ROADMAP.md](docs/concepts/ROADMAP.md). Known limits: [docs/user/LIMITATIONS.md](docs/user/LIMITATIONS.md).
+Latest stable: **v3.7.0** (2026-06-23). Per-entry detail in [CHANGELOG § 3.7.0](CHANGELOG/v3.md). Per-version history: [docs/concepts/ROADMAP.md](docs/concepts/ROADMAP.md). Known limits: [docs/user/LIMITATIONS.md](docs/user/LIMITATIONS.md).
 
 [![OSSInsight](https://img.shields.io/badge/OSSInsight-analytics-blue)](https://ossinsight.io/analyze/robotrocketscience/aelfrice)
 <!-- bench-canonical-badge:start -->

--- a/docs/concepts/ROADMAP.md
+++ b/docs/concepts/ROADMAP.md
@@ -9,7 +9,7 @@ Per-issue tracking: [LIMITATIONS.md](../user/LIMITATIONS.md). Release log: [CHAN
 
 aelfrice is a rebuild of an earlier research line on Bayesian + graph-backed memory for AI coding agents. The research codebase explored FTS5 retrieval, vocabulary bridging, BFS multi-hop traversal, entity-indexed retrieval, type-aware compression, correction detection, and a multi-tool MCP surface, with results against MAB, LoCoMo, LongMemEval, StructMemEval, and AMA-Bench.
 
-v1.0 shipped the foundation (SQLite store, Beta-Bernoulli scoring, BM25 retrieval, CLI, MCP, host hook wiring, synthetic benchmark harness). The v1.x line recovered the remaining features incrementally; v2.0 reached feature parity with the research line plus the reproducibility-harness scaffolding; v3.0 added wonder lifecycle, wonder/reason parity, read-only federation, and the eval-harness completion. The current line is **v3.6.0**.
+v1.0 shipped the foundation (SQLite store, Beta-Bernoulli scoring, BM25 retrieval, CLI, MCP, host hook wiring, synthetic benchmark harness). The v1.x line recovered the remaining features incrementally; v2.0 reached feature parity with the research line plus the reproducibility-harness scaffolding; v3.0 added wonder lifecycle, wonder/reason parity, read-only federation, and the eval-harness completion. The current line is **v3.7.0**.
 
 This is a rebuild, not a port. Structural issues that survived the research line were fixed at the foundation layer. Every behavioural claim is backed by a test or a benchmark, with a transparent issue trail for items that are not.
 
@@ -38,6 +38,7 @@ This is a rebuild, not a port. Structural issues that survived the research line
 | **v3.5.0** | shipped 2026-06-04 | visibility/observability wave — per-project feed log + `aelf feed` (#931), SessionStart recap (#934), contradiction marker on `aelf search` (#938), `aelf speculative` (#937), `aelf stale` (#933), `aelf audit-claude-memory` (#935), `aelf review` (#936), duplicate-issue PreToolUse guard (#941), statusline counts (#932) |
 | **v3.5.1** | shipped 2026-06-10 | patch — scanner skips `.claude/` on onboard (#955); INEDIBLE marker propagation to ingest-transcript paths (#958); v3.5.0 docs-vs-code reconciliation wave (#952, #957, #964) |
 | **v3.6.0** | shipped 2026-06-19 | `project_context` provenance — repo-identity auto-stamp on write + idempotent backfill + migrate provenance preservation (#970, ADR 0003; decision 4 ratified keep-opt-in #973); transcript-logger consecutive-duplicate turn guard so duplicated hook registrations don't inflate turn density (#968); `hook_audit` sink extracted from `hook.py` off the heavy retrieval import path (#968) |
+| **v3.7.0** | shipped 2026-06-23 | graph-substrate + phantom-lifecycle wave — `CONTRADICTS` semantic-edge substrate at ingest, default-off + incremental per-turn (#988, #1000); `claude-memory` write-through mirror into the belief graph (#985); phantom lifecycle made observable + self-maintaining — trigger-driven generation, opt-in SessionStart auto-GC, status/stats surface, soft-delete retrieval hygiene (#980); default-off HRR vocabulary-bridge expansion lane wired + ablated recall-neutral (#981); denser `SUPPORTS`/`SUPERSEDES` edges reverted per `CONTRADICTS`-only ratification (#998 A4, revert #999) |
 
 ## What shipped
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "3.6.0"
+version = "3.7.0"
 description = "Persistent memory for AI coding agents. Local SQLite + UserPromptSubmit hook — matched beliefs in the prompt before the model sees it. Deterministic, auditable, no embeddings, no cloud."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## v3.7.0 — graph-substrate and phantom-lifecycle wave

Cuts the release covering the 62 commits merged since v3.6.0 (PRs #983–#1005).

### Highlights
- **`CONTRADICTS` semantic-edge substrate at ingest** — default-off, with incremental per-turn detection (#988, #1000).
- **`claude-memory` write-through mirror** into the belief graph (#985).
- **Phantom lifecycle made observable + self-maintaining** — trigger-driven generation, opt-in SessionStart auto-GC, status/stats surface, soft-delete retrieval hygiene (#980).
- **Default-off HRR vocabulary-bridge expansion lane**, wired + ablated recall-neutral (#981).
- **Denser `SUPPORTS`/`SUPERSEDES` edges reverted** per `CONTRADICTS`-only ratification (#998 A4, revert #999); incremental `CONTRADICTS` kept.

### Release mechanics
- `pyproject.toml` 3.6.0 → 3.7.0; `uv.lock` regenerated.
- `CHANGELOG/v3.md`: dated `## [3.7.0]` section + compare-link footnote; `[Unreleased]` drained.
- README "Latest stable" + `docs/concepts/ROADMAP.md` reconciled.
- Release commit SSH-signed. No source changes — version/lock/docs only.

Merge via the `ready-to-merge` label, then tag `v3.7.0` on the merge commit to trigger `publish.yml`.