### PR TITLE
feat(ingest): capture turns on Stop cadence, not only at compaction (#1011)

### DIFF
--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Conversational facts are captured on a session cadence, not only at compaction ([#1011](https://github.com/robotrocketscience/aelfrice/issues/1011)).** Belief ingestion previously fired only on the PreCompact rotation (`transcript_logger._handle_pre_compact`), so a session that ended *without* compacting logged its turns to `turns.jsonl` but never folded them into beliefs — a fresh session could not recall what the user had stated, the core-capture promise. The `Stop` hook now flushes the live `turns.jsonl` through `aelf ingest-transcript` once `AELFRICE_INGEST_STOP_FLUSH_TURNS` (default `12`) new turns have accumulated since the last flush. Ingestion is idempotent per `(source_label, sentence)`, so re-ingesting the live file captures only new statements without inflating the store, and the file is **not** rotated — the rebuilder / retrieval recent-turns window is preserved. Set the env var to `0` to restore PreCompact-only capture.
+
 ## [3.7.0] - 2026-06-23
 
 The graph-substrate and phantom-lifecycle wave. The belief graph gained an

--- a/src/aelfrice/transcript_logger.py
+++ b/src/aelfrice/transcript_logger.py
@@ -67,6 +67,20 @@ DUP_WINDOW_SECONDS: Final[float] = 2.0
 # inside the sub-10ms budget even when rotation has not run recently.
 _TAIL_READ_BYTES: Final[int] = 65536
 
+# #1011: Stop-cadence ingestion flush. Belief ingestion historically fired
+# ONLY on the PreCompact rotation (`_handle_pre_compact`). A session that
+# ends without compacting logged its turns to turns.jsonl but never folded
+# them into beliefs, so a fresh session could not recall what the user
+# stated — the core-capture failure. On Stop, once >= STOP_FLUSH_TURNS new
+# turns have accumulated since the last flush, spawn `aelf ingest-transcript`
+# over the LIVE turns.jsonl. Ingestion is idempotent per (source_label,
+# sentence), so re-ingesting the live file captures only new statements and
+# never inflates the store; the file is NOT rotated, so the rebuilder / UPS
+# recent-turns window (which reads the live turns.jsonl) is left intact.
+DEFAULT_STOP_FLUSH_TURNS: Final[int] = 12
+STOP_FLUSH_TURNS_ENV: Final[str] = "AELFRICE_INGEST_STOP_FLUSH_TURNS"
+STOP_FLUSH_CURSOR_FILENAME: Final[str] = ".stop_flush_cursor"
+
 
 def transcripts_dir() -> Path:
     """Resolve the transcripts directory path.
@@ -387,6 +401,9 @@ def _handle_stop(payload: dict[str, object]) -> None:
         role="assistant", text=text, session_id=sid, ctx=_turn_context(),
     )
     _append_turn(line)
+    # #1011: fold accumulated turns into beliefs without waiting for a
+    # compaction. Fail-soft — a flush error must never break turn logging.
+    _maybe_stop_flush(transcripts_dir())
 
 
 def _handle_pre_compact(payload: dict[str, object]) -> None:
@@ -445,6 +462,77 @@ def _spawn_background_ingest(archive_file: Path) -> None:
         # Non-blocking: leave the archive in place; a later
         # `aelf ingest-transcript` run picks it up.
         pass
+
+
+def _stop_flush_threshold() -> int:
+    """New turns required since the last flush before a Stop triggers an
+    ingest. `AELFRICE_INGEST_STOP_FLUSH_TURNS` overrides the default; a
+    value <= 0 disables Stop-cadence flushing (PreCompact-only, the
+    pre-#1011 behaviour)."""
+    raw = os.environ.get(STOP_FLUSH_TURNS_ENV)
+    if raw is None:
+        return DEFAULT_STOP_FLUSH_TURNS
+    try:
+        return int(raw)
+    except ValueError:
+        return DEFAULT_STOP_FLUSH_TURNS
+
+
+def _count_turn_lines(path: Path) -> int:
+    """Count role-bearing turn lines in turns.jsonl. The cheap `'"role"'`
+    substring test avoids JSON-parsing every line on the hook hot path —
+    event markers (compaction_start, etc.) carry no `role` key, so they
+    are excluded. Returns 0 on any read error (fail-soft)."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            return sum(1 for line in f if '"role"' in line)
+    except OSError:
+        return 0
+
+
+def _read_flush_cursor(tdir: Path) -> int:
+    try:
+        text = (tdir / STOP_FLUSH_CURSOR_FILENAME).read_text().strip()
+        return int(text) if text else 0
+    except (OSError, ValueError):
+        return 0
+
+
+def _write_flush_cursor(tdir: Path, value: int) -> None:
+    try:
+        (tdir / STOP_FLUSH_CURSOR_FILENAME).write_text(str(value))
+    except OSError:
+        pass
+
+
+def _maybe_stop_flush(tdir: Path) -> bool:
+    """#1011: on Stop, ingest the live turns.jsonl once >= threshold new
+    turns have accumulated since the last flush. Returns True iff a flush
+    fired.
+
+    No rotation: `ingest_jsonl` reads the whole file and dedupes per
+    (source_label, sentence), so re-ingesting the live file captures only
+    statements not yet in the store — never inflating it — while leaving
+    the rebuilder / UPS recent-turns window (which reads the live
+    turns.jsonl) intact. The cursor records the turn count at the last
+    flush; a count below the cursor means turns.jsonl was rotated
+    (PreCompact) or reset, so the cursor is treated as 0.
+    """
+    threshold = _stop_flush_threshold()
+    if threshold <= 0:
+        return False
+    src = tdir / TURNS_FILENAME
+    if not src.exists():
+        return False
+    now = _count_turn_lines(src)
+    last = _read_flush_cursor(tdir)
+    if now < last:
+        last = 0
+    if now - last < threshold:
+        return False
+    _spawn_background_ingest(src)
+    _write_flush_cursor(tdir, now)
+    return True
 
 
 _Handler = Callable[[dict[str, object]], None]

--- a/src/aelfrice/transcript_logger.py
+++ b/src/aelfrice/transcript_logger.py
@@ -443,12 +443,17 @@ def _handle_post_compact(payload: dict[str, object]) -> None:
     })
 
 
-def _spawn_background_ingest(archive_file: Path) -> None:
+def _spawn_background_ingest(archive_file: Path) -> bool:
     """Spawn `aelf ingest-transcript <archive>` detached. Best-effort.
 
     Detached so the PreCompact hook returns within budget regardless
     of ingest progress. Stdin/out/err -> /dev/null; the ingest
     process owns its own logging via the store's normal pathways.
+
+    Returns True iff the subprocess was launched. The Stop-cadence
+    caller (`_maybe_stop_flush`) uses this to advance its cursor only
+    on a successful spawn, so a failed launch is retried at the next
+    Stop rather than being silently marked flushed (#1012 review).
     """
     try:
         with open(os.devnull, "w") as devnull:
@@ -461,7 +466,8 @@ def _spawn_background_ingest(archive_file: Path) -> None:
         # `aelf` not on PATH (highly unusual) or fork failure.
         # Non-blocking: leave the archive in place; a later
         # `aelf ingest-transcript` run picks it up.
-        pass
+        return False
+    return True
 
 
 def _stop_flush_threshold() -> int:
@@ -502,6 +508,9 @@ def _write_flush_cursor(tdir: Path, value: int) -> None:
     try:
         (tdir / STOP_FLUSH_CURSOR_FILENAME).write_text(str(value))
     except OSError:
+        # Fail-soft: a non-writable transcripts dir must never break the
+        # Stop hook. The cursor simply isn't advanced, so the next Stop
+        # re-evaluates and re-flushes (ingestion is idempotent).
         pass
 
 
@@ -530,7 +539,11 @@ def _maybe_stop_flush(tdir: Path) -> bool:
         last = 0
     if now - last < threshold:
         return False
-    _spawn_background_ingest(src)
+    # Advance the cursor only on a successful spawn (#1012 review): if the
+    # ingest can't launch, leave the cursor so the next Stop retries rather
+    # than silently marking these turns flushed and reopening the recall gap.
+    if not _spawn_background_ingest(src):
+        return False
     _write_flush_cursor(tdir, now)
     return True
 

--- a/tests/test_transcript_logger.py
+++ b/tests/test_transcript_logger.py
@@ -377,3 +377,93 @@ def test_per_turn_latency_under_budget(tdir: Path) -> None:
     assert p95 < 50.0, f"p95={p95:.2f}ms exceeds 50ms regression guard"
     assert (tdir / "turns.jsonl").is_file()
     assert os.path.getsize(tdir / "turns.jsonl") > 0
+
+
+# ---------------------------------------------------------------------------
+# #1011: Stop-cadence ingestion flush (ingest live turns.jsonl, no rotation).
+# ---------------------------------------------------------------------------
+
+
+def _write_turns(tdir: Path, n: int) -> None:
+    """Pre-populate turns.jsonl with n distinct role-bearing turn lines."""
+    lines = [
+        json.dumps({"role": "user", "text": f"fact number {i}", "session_id": "s"})
+        for i in range(n)
+    ]
+    (tdir / "turns.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def captured_ingest(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Record _spawn_background_ingest targets instead of forking `aelf`."""
+    calls: list[Path] = []
+    monkeypatch.setattr(tl, "_spawn_background_ingest", lambda p: calls.append(p))
+    return calls
+
+
+def test_count_turn_lines_excludes_markers(tdir: Path) -> None:
+    src = tdir / "turns.jsonl"
+    src.write_text(
+        json.dumps({"role": "user", "text": "a"}) + "\n"
+        + json.dumps({"event": "compaction_start"}) + "\n"
+        + json.dumps({"role": "assistant", "text": "b"}) + "\n",
+        encoding="utf-8",
+    )
+    assert tl._count_turn_lines(src) == 2
+
+
+def test_stop_flush_fires_at_threshold(
+    tdir: Path, captured_ingest: list[Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AELFRICE_INGEST_STOP_FLUSH_TURNS", "3")
+    _write_turns(tdir, 2)
+    rc = _run_main({"hook_event_name": "Stop"})  # +1 assistant stub -> 3
+    assert rc == 0
+    # Ingest the LIVE turns.jsonl in place; no rotation/archive.
+    assert captured_ingest == [tdir / "turns.jsonl"]
+    assert (tdir / "turns.jsonl").is_file()
+    archive = tdir / "archive"
+    assert not archive.exists() or not list(archive.glob("*"))
+    assert (tdir / tl.STOP_FLUSH_CURSOR_FILENAME).read_text().strip() == "3"
+
+
+def test_stop_flush_below_threshold_no_fire(
+    tdir: Path, captured_ingest: list[Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AELFRICE_INGEST_STOP_FLUSH_TURNS", "12")
+    _write_turns(tdir, 2)
+    rc = _run_main({"hook_event_name": "Stop"})  # -> 3 turns, < 12
+    assert rc == 0
+    assert captured_ingest == []
+
+
+def test_stop_flush_disabled_when_zero(
+    tdir: Path, captured_ingest: list[Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AELFRICE_INGEST_STOP_FLUSH_TURNS", "0")
+    _write_turns(tdir, 100)
+    rc = _run_main({"hook_event_name": "Stop"})
+    assert rc == 0
+    assert captured_ingest == []
+
+
+def test_stop_flush_does_not_refire_until_next_threshold(
+    tdir: Path, captured_ingest: list[Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AELFRICE_INGEST_STOP_FLUSH_TURNS", "3")
+    _write_turns(tdir, 3)
+    tl._write_flush_cursor(tdir, 3)  # already flushed at 3
+    rc = _run_main({"hook_event_name": "Stop"})  # -> 4 turns, 4-3 < 3
+    assert rc == 0
+    assert captured_ingest == []
+
+
+def test_stop_flush_resets_cursor_after_rotation(
+    tdir: Path, captured_ingest: list[Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AELFRICE_INGEST_STOP_FLUSH_TURNS", "3")
+    tl._write_flush_cursor(tdir, 500)  # stale cursor from a rotated session
+    _write_turns(tdir, 2)
+    rc = _run_main({"hook_event_name": "Stop"})  # fresh count 3 < cursor -> reset to 0
+    assert rc == 0
+    assert captured_ingest == [tdir / "turns.jsonl"]

--- a/tests/test_transcript_logger.py
+++ b/tests/test_transcript_logger.py
@@ -395,9 +395,15 @@ def _write_turns(tdir: Path, n: int) -> None:
 
 @pytest.fixture
 def captured_ingest(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
-    """Record _spawn_background_ingest targets instead of forking `aelf`."""
+    """Record _spawn_background_ingest targets instead of forking `aelf`.
+
+    Returns True like a successful spawn so the cursor advances; the
+    spawn-failure path is covered by test_stop_flush_failed_spawn_*.
+    """
     calls: list[Path] = []
-    monkeypatch.setattr(tl, "_spawn_background_ingest", lambda p: calls.append(p))
+    monkeypatch.setattr(
+        tl, "_spawn_background_ingest", lambda p: bool(calls.append(p)) or True
+    )
     return calls
 
 
@@ -467,3 +473,25 @@ def test_stop_flush_resets_cursor_after_rotation(
     rc = _run_main({"hook_event_name": "Stop"})  # fresh count 3 < cursor -> reset to 0
     assert rc == 0
     assert captured_ingest == [tdir / "turns.jsonl"]
+
+
+def test_stop_flush_failed_spawn_does_not_advance_cursor(
+    tdir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # #1012 review: if the ingest can't be spawned, the cursor must NOT
+    # advance, so the next Stop retries rather than silently dropping the
+    # turns and reopening the recall gap.
+    monkeypatch.setenv("AELFRICE_INGEST_STOP_FLUSH_TURNS", "3")
+    monkeypatch.setattr(tl, "_spawn_background_ingest", lambda p: False)
+    _write_turns(tdir, 3)
+    assert tl._maybe_stop_flush(tdir) is False
+    assert not (tdir / tl.STOP_FLUSH_CURSOR_FILENAME).exists()
+
+    # Next Stop with a working spawn flushes and advances the cursor.
+    calls: list[Path] = []
+    monkeypatch.setattr(
+        tl, "_spawn_background_ingest", lambda p: bool(calls.append(p)) or True
+    )
+    assert tl._maybe_stop_flush(tdir) is True
+    assert calls == [tdir / "turns.jsonl"]
+    assert (tdir / tl.STOP_FLUSH_CURSOR_FILENAME).read_text().strip() == "3"


### PR DESCRIPTION
## What

Addresses the core capture defect in #1011: facts stated in a session that ends **without compacting** were logged to `turns.jsonl` but never ingested into beliefs, so a fresh session could not recall what the user had said.

## Why

Belief ingestion fired only on the PreCompact rotation (`transcript_logger._handle_pre_compact` → `aelf ingest-transcript`). Most sessions end before they compact, so their conversational facts were never folded into beliefs. Diagnosed across 5 local stores: conversation-derived beliefs were days-to-weeks stale while `turns.jsonl` kept logging in real time (logged-but-not-ingested). Full diagnostic in #1011.

## Changes

- `transcript_logger._handle_stop` now flushes the live `turns.jsonl` through `aelf ingest-transcript` once `AELFRICE_INGEST_STOP_FLUSH_TURNS` (default `12`) new turns have accumulated since the last flush, tracked by a `.stop_flush_cursor` file.
- **No rotation.** `ingest_jsonl` dedupes per `(source_label, sentence)`, so re-ingesting the live file captures only new statements without inflating the store, and the rebuilder / UPS recent-turns window — which reads the live `turns.jsonl` (`context_rebuilder.py:245`) — is preserved.
- The cursor resets when the live turn count drops below it (i.e. PreCompact rotated or reset the file).
- Setting the env var to `0` restores PreCompact-only capture.

## Verification

- `pytest tests/test_transcript_logger.py` → 31 passed (7 new); adjacent transcript/ingest suites → 117 passed.
- Idempotency proven end-to-end against a temp store: re-ingesting the same `turns.jsonl` adds **0** beliefs; appending one turn then re-ingesting adds exactly **1** (assistant turns correctly skipped).

## Scope / follow-ups (remaining #1011 ACs)

- Signal/noise: de-rank bulk document-chunk beliefs vs user-stated facts in retrieval (separate change).
- Efficiency: a never-compacting session re-scans the whole live file each flush (idempotent, but O(n) per flush) — a tail-window optimization is a follow-up.
- `aelf doctor` logged-but-not-ingested gap detector.

Addresses #1011 (core capture trigger). Remaining acceptance criteria stay tracked on the umbrella.

## Summary by Sourcery

Ensure conversational turns are ingested into beliefs on session Stop events rather than only on compaction, with a configurable stop-flush cadence and fail-soft behavior.

Bug Fixes:
- Fix missing belief ingestion for sessions that end without compaction by triggering transcript ingestion on Stop once enough new turns have accumulated.

Enhancements:
- Introduce a stop-flush threshold and cursor-tracking mechanism to ingest the live turns.jsonl without rotating it, preserving recent-turns windows.

Documentation:
- Document the new Stop-cadence ingestion behavior and configuration in the v3 changelog.

Tests:
- Add tests covering stop-flush triggering, threshold handling, cursor reset after rotation, and exclusion of non-turn markers from ingestion counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic ingestion of recent conversation turns after a session ends, once enough new turns have accumulated.
  * The flush threshold can be adjusted with an environment variable; setting it to `0` keeps the earlier behavior.

* **Bug Fixes**
  * Ingestion now works without rotating the recent turns file, preserving data for later rebuilding or retrieval.
  * Repeated flushes are handled safely and resume correctly if the transcript state is reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->