### PR TITLE
feat(retrieval): default-off origin-tier rerank lane de-ranking doc chunks below user facts (#1011)

### DIFF
--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Origin-tier rerank lane — de-rank document-chunk beliefs below user-stated facts ([#1011](https://github.com/robotrocketscience/aelfrice/issues/1011)).** Default-OFF opt-in (`AELFRICE_USE_ORIGIN_TIER_RERANK` env / `[retrieval] use_origin_tier_rerank` TOML). When enabled, the L1 rerank (`_l1_hits`) adds a log-additive per-origin multiplier so `user_stated` / `user_validated` facts outrank bulk `document_recent` chunks that merely share keyword overlap — the signal/noise failure where a store flooded with ingested article chunks drowns the few user-stated facts. Inert (byte-identical) when off; the weight map is ablation-pending (LoCoMo) before any default-on flip, mirroring the #981 HRR-lane pattern.
+
 ## [3.7.0] - 2026-06-23
 
 The graph-substrate and phantom-lifecycle wave. The belief graph gained an

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -200,6 +200,23 @@ USE_GAMMA_POSTERIOR_TEMPERATURE_FLAG: Final[str] = (
 # decision per issue #817 §"Out of scope" deferred composition).
 USE_ZETA_POSTERIOR_RERANK_FLAG: Final[str] = "use_zeta_posterior_rerank"
 
+# #1011 origin-tier rerank lane. Default-OFF. When ON, the L1 rerank adds a
+# log-additive per-origin multiplier so user-stated facts outrank bulk
+# document-chunk beliefs that merely share keyword overlap — the signal/noise
+# failure where a store flooded with ingested article chunks (origin
+# document_recent / agent_inferred) drowns the few user_stated facts. Inert
+# (byte-identical) when off; the weight map is ablation-pending (LoCoMo)
+# before any default-on flip — mirrors the #981 HRR-lane pattern. Origins
+# absent from the map keep multiplier 1.0.
+ORIGIN_TIER_RERANK_FLAG: Final[str] = "use_origin_tier_rerank"
+ENV_USE_ORIGIN_TIER_RERANK: Final[str] = "AELFRICE_USE_ORIGIN_TIER_RERANK"
+DEFAULT_ORIGIN_TIER_WEIGHTS: Final[dict[str, float]] = {
+    "user_stated": 3.0,
+    "user_validated": 3.0,
+    "user_transcript": 1.5,
+    "document_recent": 0.5,
+}
+
 PLACEHOLDER_FLAGS: Final[tuple[str, ...]] = (
     SIGNED_LAPLACIAN_FLAG,
     POSTERIOR_RANKING_FLAG,
@@ -445,6 +462,21 @@ def _extract_hash_n_literals(query: str) -> list[str]:
     boost, keep the byte-identical FTS5 short-circuit".
     """
     return _HASH_N_LITERAL_RE.findall(query)
+
+
+def _origin_tier_boosted(
+    score: float, origin: str, tiers: dict[str, float] | None,
+) -> float:
+    """Add `log(tiers[origin])` to `score` — log-additive, the same space as
+    `partial_bayesian_score` / `_hash_n_boosted`. A None map (lane off), an
+    unmapped origin, or a unit / non-positive multiplier leaves `score`
+    unchanged, so the lane is a strict no-op by default (#1011)."""
+    if tiers is None:
+        return score
+    mult = tiers.get(origin)
+    if mult is None or mult <= 0.0 or mult == 1.0:
+        return score
+    return score + math.log(mult)
 
 
 def _hash_n_boosted(score: float, content: str, literals: list[str]) -> float:
@@ -1958,6 +1990,50 @@ def resolve_use_zeta_posterior_rerank(
     return False
 
 
+def _env_use_origin_tier_rerank_override() -> bool | None:
+    """Return True/False if AELFRICE_USE_ORIGIN_TIER_RERANK is set to a
+    recognised truthy/falsy value, else None. Symmetric to
+    `_env_use_zeta_posterior_rerank_override`."""
+    raw = os.environ.get(ENV_USE_ORIGIN_TIER_RERANK)
+    if raw is None:
+        return None
+    norm = raw.strip().lower()
+    if norm in _ENV_FALSY:
+        return False
+    if norm in _ENV_TRUTHY:
+        return True
+    return None
+
+
+def resolve_origin_tier_rerank(
+    explicit: bool | None = None,
+    *,
+    start: Path | None = None,
+) -> dict[str, float] | None:
+    """Resolve the #1011 origin-tier rerank lane.
+
+    Returns the per-origin weight map when enabled, else None (lane off —
+    the default, a byte-identical no-op). Precedence mirrors
+    `resolve_use_zeta_posterior_rerank`:
+      1. AELFRICE_USE_ORIGIN_TIER_RERANK env var.
+      2. Explicit `explicit` kwarg.
+      3. `[retrieval] use_origin_tier_rerank` in `.aelfrice.toml`.
+      4. Default: False.
+
+    Weights are not yet operator-tunable; the default map ships pending a
+    LoCoMo ablation before any default-on flip.
+    """
+    env = _env_use_origin_tier_rerank_override()
+    if env is not None:
+        on = env
+    elif explicit is not None:
+        on = explicit
+    else:
+        toml_value = _read_toml_flag_for(ORIGIN_TIER_RERANK_FLAG, start)
+        on = toml_value if toml_value is not None else False
+    return dict(DEFAULT_ORIGIN_TIER_WEIGHTS) if on else None
+
+
 def _assert_gamma_zeta_mutual_exclusion(
     gamma_on: bool, zeta_on: bool,
 ) -> None:
@@ -2254,6 +2330,7 @@ def _l1_hits(
     heat_kernel_on: bool = False,
     gamma_temperature: float | None = None,
     zeta_params: tuple[float, float, float] | None = None,
+    origin_tier: dict[str, float] | None = None,
 ) -> list[Belief]:
     """Run L1: FTS5 BM25 search (default) or BM25F sparse-matvec
     (v1.5.0 opt-in), optionally reranked by partial-Bayesian score.
@@ -2385,6 +2462,7 @@ def _l1_hits(
             and not hash_n_literals
             and gamma_temperature is None
             and zeta_params is None
+            and origin_tier is None
         ):
             return [b for b, _ in beliefs]
         # BM25F scores are non-negative; the rerank uses `raw` as the
@@ -2424,6 +2502,7 @@ def _l1_hits(
                     -raw, b.alpha, b.beta, posterior_weight,
                 )
             s = _hash_n_boosted(s, b.content, hash_n_literals)
+            s = _origin_tier_boosted(s, b.origin, origin_tier)
             keyed.append((s, b.id, b))
         keyed.sort(key=lambda x: (-x[0], x[1]))
         return [b for _, _, b in keyed]
@@ -2434,6 +2513,7 @@ def _l1_hits(
         and not hash_n_literals
         and gamma_temperature is None
         and zeta_params is None
+        and origin_tier is None
     ):
         return store.search_beliefs(query, limit=l1_limit)
     scored = store.search_beliefs_scored(query, limit=l1_limit)
@@ -2475,6 +2555,7 @@ def _l1_hits(
                 bm25_raw, b.alpha, b.beta, posterior_weight,
             )
         s = _hash_n_boosted(s, b.content, hash_n_literals)
+        s = _origin_tier_boosted(s, b.origin, origin_tier)
         keyed.append((s, b.id, b))
     # Higher score = more relevant. Tie-break on id ASC for
     # determinism (matches the convention in bfs_multihop and L2.5).
@@ -2582,6 +2663,7 @@ def retrieve(
         (ZETA_ALPHA_DEFAULT, ZETA_BETA_DEFAULT, ZETA_SCALE_DEFAULT)
         if zeta_on else None
     )
+    origin_tier = resolve_origin_tier_rerank()
     compress_on = resolve_use_type_aware_compression(
         use_type_aware_compression,
     )
@@ -2661,6 +2743,7 @@ def retrieve(
             eigenbasis_cache=eigenbasis_cache, heat_kernel_on=heat_on,
             gamma_temperature=gamma_t,
             zeta_params=zeta_params,
+            origin_tier=origin_tier,
         )
         l1 = [
             b for b in raw_l1
@@ -2812,6 +2895,7 @@ def retrieve_with_tiers(
         (ZETA_ALPHA_DEFAULT, ZETA_BETA_DEFAULT, ZETA_SCALE_DEFAULT)
         if zeta_on else None
     )
+    origin_tier = resolve_origin_tier_rerank()
     # #741 adaptive expansion-gate. Same shape as retrieve(): short-
     # circuit BFS on broad prompts; L0 / L1 / L2.5-entity unaffected.
     # #760: pass store + now_ts for the meta-belief token-threshold
@@ -2882,6 +2966,7 @@ def retrieve_with_tiers(
             eigenbasis_cache=eigenbasis_cache, heat_kernel_on=heat_on,
             gamma_temperature=gamma_t,
             zeta_params=zeta_params,
+            origin_tier=origin_tier,
         )
         l1 = [
             b for b in raw_l1

--- a/tests/test_origin_tier_rerank.py
+++ b/tests/test_origin_tier_rerank.py
@@ -1,0 +1,127 @@
+"""#1011 origin-tier rerank lane: de-rank bulk document-chunk beliefs
+below user-stated facts that share keyword overlap.
+
+The lane is default-OFF (a byte-identical no-op). When enabled it adds a
+log-additive per-origin multiplier in the `_l1_hits` rerank, so a
+`user_stated` fact outranks a `document_recent` chunk even when the chunk
+has the stronger raw BM25 match. Weights are ablation-pending (LoCoMo)
+before any default-on flip.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from aelfrice.models import BELIEF_FACTUAL, LOCK_NONE, Belief
+from aelfrice.retrieval import (
+    DEFAULT_ORIGIN_TIER_WEIGHTS,
+    _origin_tier_boosted,
+    resolve_origin_tier_rerank,
+    retrieve,
+)
+from aelfrice.store import MemoryStore
+
+_ENV = "AELFRICE_USE_ORIGIN_TIER_RERANK"
+
+
+def _mk(bid: str, content: str, origin: str) -> Belief:
+    return Belief(
+        id=bid,
+        content=content,
+        content_hash=f"h_{bid}",
+        alpha=1.0,
+        beta=1.0,
+        type=BELIEF_FACTUAL,
+        lock_level=LOCK_NONE,
+        locked_at=None,
+        created_at="2026-05-11T00:00:00Z",
+        last_retrieved_at=None,
+        origin=origin,
+    )
+
+
+def _build() -> MemoryStore:
+    """A document chunk with the stronger raw BM25 match (4x term
+    frequency) plus a single user-stated fact on the same topic."""
+    s = MemoryStore(":memory:")
+    s.insert_belief(
+        _mk("DOC", "job search job search job search job search market advice",
+            "document_recent"),
+    )
+    s.insert_belief(
+        _mk("USER", "job search update advanced to round two", "user_stated"),
+    )
+    return s
+
+
+# --- resolver --------------------------------------------------------------
+
+
+def test_resolver_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_ENV, raising=False)
+    assert resolve_origin_tier_rerank() is None
+
+
+def test_resolver_env_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV, "1")
+    assert resolve_origin_tier_rerank() == DEFAULT_ORIGIN_TIER_WEIGHTS
+
+
+def test_resolver_env_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV, "0")
+    assert resolve_origin_tier_rerank() is None
+
+
+def test_resolver_explicit_overrides_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(_ENV, raising=False)
+    assert resolve_origin_tier_rerank(explicit=True) == DEFAULT_ORIGIN_TIER_WEIGHTS
+
+
+# --- _origin_tier_boosted --------------------------------------------------
+
+
+def test_boost_noop_when_tiers_none() -> None:
+    assert _origin_tier_boosted(5.0, "user_stated", None) == 5.0
+
+
+def test_boost_lifts_user_stated() -> None:
+    w = DEFAULT_ORIGIN_TIER_WEIGHTS
+    assert _origin_tier_boosted(0.0, "user_stated", w) == pytest.approx(math.log(3.0))
+
+
+def test_boost_demotes_document_recent() -> None:
+    w = DEFAULT_ORIGIN_TIER_WEIGHTS
+    assert _origin_tier_boosted(0.0, "document_recent", w) == pytest.approx(
+        math.log(0.5),
+    )
+
+
+def test_boost_noop_for_unmapped_origin() -> None:
+    w = DEFAULT_ORIGIN_TIER_WEIGHTS
+    assert _origin_tier_boosted(2.0, "agent_inferred", w) == 2.0
+
+
+# --- end-to-end through retrieve() -----------------------------------------
+
+
+def test_lane_off_keeps_bm25_baseline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default (off): the higher-BM25 document chunk ranks first, and the
+    order is stable across calls — a byte-identical no-op."""
+    monkeypatch.delenv(_ENV, raising=False)
+    first = [b.id for b in retrieve(_build(), "job search")]
+    second = [b.id for b in retrieve(_build(), "job search")]
+    assert first == second
+    assert first.index("DOC") < first.index("USER")
+
+
+def test_lane_on_lifts_user_fact_above_document_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Enabled: the user_stated fact is reranked above the document chunk
+    despite the chunk's stronger raw BM25 match."""
+    monkeypatch.setenv(_ENV, "1")
+    ids = [b.id for b in retrieve(_build(), "job search")]
+    assert ids.index("USER") < ids.index("DOC"), ids


### PR DESCRIPTION
## What

Second #1011 AC: a **default-OFF** retrieval lane that de-ranks bulk document-chunk beliefs below user-stated facts. (Sibling of #1012, which fixed capture.)

## Why

The store floods with `filesystem`-origin document chunks — ingested article paragraphs. In one real store, 25,701 beliefs held only **12** `user_stated` facts vs **29,416** document chunks, so retrieval surfaces boilerplate instead of what the user actually said. Even with capture fixed (#1012), the user's facts can be out-ranked by keyword-overlapping article text.

## Changes

- New lane gated by `AELFRICE_USE_ORIGIN_TIER_RERANK` (env) / `[retrieval] use_origin_tier_rerank` (TOML), resolved by `resolve_origin_tier_rerank` (mirrors `resolve_use_zeta_posterior_rerank`).
- When on, `_l1_hits` applies `_origin_tier_boosted` after `_hash_n_boosted` in **both** the BM25F and FTS5 rerank loops — a log-additive per-origin multiplier (`user_stated`/`user_validated` ×3, `user_transcript` ×1.5, `document_recent` ×0.5; unmapped origins ×1.0).
- **Inert by default.** Both byte-identical short-circuits gate on `origin_tier is None`, so when off the lane is a strict no-op.

## Verification

- New suite (10 tests): resolver precedence, `_origin_tier_boosted` unit cases, and end-to-end through `retrieve()` — off keeps the BM25 baseline (document chunk first), on lifts the `user_stated` fact above it.
- **Regression**: full retrieval/ranking suites (`-k "retriev or rank or zeta or gamma or posterior or bm25 or hash_n or l0 or bayesian or heat"`) → **488 passed, 10 skipped, 0 failures**. Byte-identical contracts hold.

## Not in scope — ablation gate

The weight map is **not validated on LoCoMo**. Per the repo's lane discipline (#981 HRR, #977 γ/ζ), the keep/kill decision and weight-tuning require a LoCoMo ablation; this PR ships the lane **off** so it is safe to land and ablate. The ablation is the follow-up before any default-on flip.

Addresses #1011 (signal/noise de-rank). Remaining ACs (`aelf doctor` gap detector, `--since` backfill) stay on the umbrella.

## Summary by Sourcery

Introduce an opt-in origin-tier rerank lane in retrieval that prioritizes user-stated facts over bulk document-chunk beliefs while remaining inert by default.

New Features:
- Add an origin-tier rerank lane that applies per-origin weighting in L1 scoring so user-stated and validated facts outrank bulk document chunks when enabled.

Enhancements:
- Integrate origin-tier weighting into both BM25F and FTS5 L1 rerank paths in a way that preserves byte-identical behavior when the lane is disabled.

Documentation:
- Document the origin-tier rerank lane, configuration flags, and default-off behavior in the v3 changelog.

Tests:
- Add a dedicated test suite covering origin-tier lane resolution, per-origin boosting behavior, and end-to-end retrieval ordering with the lane on and off.