### PR TITLE
release: v3.8.0

### DIFF
--- a/CHANGELOG/v3.md
+++ b/CHANGELOG/v3.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.0] - 2026-06-30
+
+The locks-hygiene and passive-capture wave. Locks gain a frozen/reference tier
+split with bounded manifest injection, near-duplicate dedup at write time, a
+provenance-split injection framing so user-locked rules are honored, and a
+relevance-budget floor so a fat lock set can no longer starve query-relevant
+retrieval ([#1016](https://github.com/robotrocketscience/aelfrice/issues/1016),
+[#1014](https://github.com/robotrocketscience/aelfrice/issues/1014),
+[#1023](https://github.com/robotrocketscience/aelfrice/issues/1023)).
+Conversational capture closes its last gap: turns now fold into beliefs on a
+`Stop` cadence — not only at compaction — with `aelf doctor` ingest-gap
+detection, `--backfill-ingest`, and `--prune-noise` GC for historical ingestion
+noise ([#1011](https://github.com/robotrocketscience/aelfrice/issues/1011),
+[#1029](https://github.com/robotrocketscience/aelfrice/issues/1029)).
+
 ### Added
 
 - **`aelf doctor --backfill-ingest`: fold logged-but-not-ingested turns into beliefs ([#1011](https://github.com/robotrocketscience/aelfrice/issues/1011)).** The companion action to the `ingest_gap` audit warning (#1034): when turns were logged to `turns.jsonl` but never ingested — a session that ended without compaction before the Stop-cadence flush existed, or with `AELFRICE_INGEST_STOP_FLUSH_TURNS=0` — this folds the backlog into beliefs in one command. Idempotent (`ingest_jsonl` dedupes per `(source_label, sentence)`, using the same default `transcript` label the Stop/PreCompact flush uses, so re-running is a no-op), and it does **not** rotate the live log — the rebuilder/UPS recent-turns window is untouched. Reports lines read, turns ingested, and new beliefs/edges. Closes the last #1011 sub-task.
@@ -579,6 +594,7 @@ The cadence-policy completion + conversation-aware retrieval wave.
 - **`urllib3` 2.6.3 → 2.7.0 for CVE patches** ([#640](https://github.com/robotrocketscience/aelfrice/issues/640)). Lockfile-only dependency bump pulled in via `uv lock` to clear two CVEs flagged by GitHub's dependency scanner. `urllib3` is a transitive dep (via `requests` in the publish workflow and the `gh` CLI's Python shim); aelfrice itself does not import it. No source change.
 
 [Unreleased]: https://github.com/robotrocketscience/aelfrice/compare/v3.7.0...HEAD
+[3.8.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/robotrocketscience/aelfrice/compare/v3.5.1...v3.6.0
 [3.5.1]: https://github.com/robotrocketscience/aelfrice/compare/v3.5.0...v3.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aelfrice"
-version = "3.7.0"
+version = "3.8.0"
 description = "Persistent memory for AI coding agents. Local SQLite + UserPromptSubmit hook — matched beliefs in the prompt before the model sees it. Deterministic, auditable, no embeddings, no cloud."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aelfrice"
-version = "3.7.0"
+version = "3.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Release v3.8.0

Cuts the 42 commits accumulated on `main` since v3.7.0 into a release. No code change — version bump + changelog drain + lock refresh only.

**Theme — the locks-hygiene and passive-capture wave:**

- **Layered locks (#1016)** — frozen/reference tier split with bounded manifest injection, near-duplicate lock dedup at write time, provenance-split injection framing so user-locked rules are honored (0/3 → 5/5 rule compliance), `aelf doctor` lock-budget pressure warning.
- **Relevance-budget floor (#1014, #1023)** — a fat lock set can no longer starve query-relevant retrieval; floor raised 0.25 → 0.50 after an empirical sweep.
- **Passive capture closes its last gap (#1011)** — turns fold into beliefs on a `Stop` cadence, not only at compaction; `aelf doctor` ingest-gap detector + `--backfill-ingest` + pollution-recovery benchmark.
- **Corpus hygiene (#1029, #1025, #1027, #1020)** — `--prune-noise` backfill GC, harness-metadata/question ingest filters, per-source corroboration dedup.
- **#1031** — rebuild-block injection moved from PreCompact (rejected by the harness) to SessionStart(compact).

### Changes in this PR
- `pyproject.toml` + `uv.lock` → `3.8.0`
- `CHANGELOG/v3.md`: `[Unreleased]` → `## [3.8.0] - 2026-06-30` + compare-link footnote; `[Unreleased]` drained

### Verification
- `uv lock` clean (120 packages, `aelfrice 3.7.0 → 3.8.0`)
- `import aelfrice` OK
- Release commit SSH-signed
- CHANGELOG satisfies the `release-docs-check` gate: dated `[3.8.0]` section, compare-link footnote, drained `[Unreleased]`

### Next steps (after staging-gate passes + merge)
`git tag v3.8.0 <merge-sha> && git push github v3.8.0` → `publish.yml` fires Trusted-Publishing to PyPI.

## Summary by Sourcery

Prepare the 3.8.0 release by updating version metadata, changelog entries, and dependency locks.

Enhancements:
- Add a documented 3.8.0 release section describing recent locks-hygiene and passive-capture improvements.
- Update version references to 3.8.0 in project configuration and refresh the dependency lockfile.

Documentation:
- Record the 3.8.0 release in the v3 changelog with date, summary text, and compare-link footnote, draining the previous Unreleased section.