### PR TITLE
feat(bench): adapter scorer recalibration auditor (#1048)

### DIFF
--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -1,15 +1,22 @@
 name: Bench Smoke
 
-# PR-smoke for the four benchmark adapters (#476).
+# PR-smoke for the four benchmark adapters (#476) plus adapter scorer
+# recalibration (#1048).
 #
-# Exercises each adapter's `--retrieve-only` CLI path against a
-# schema-matching micro-fixture under `tests/fixtures/bench_smoke/`,
-# asserting non-zero retrieved-belief counts per item. Two-minute
-# dispatcher-contract validation only — real-data shape coverage
-# stays with the nightly `bench-canonical` cron.
+# Two checks run on every relevant PR:
 #
-# Runs on every PR that touches code, adapters, fixtures, or the
-# smoke test itself. Docs-only PRs short-circuit to a pass.
+# 1. Adapter smoke (test_bench_smoke.py) — exercises each adapter's
+#    `--retrieve-only` CLI path against a schema-matching micro-fixture
+#    under `tests/fixtures/bench_smoke/`, asserting non-zero retrieved-
+#    belief counts.  Two-minute dispatcher-contract validation only.
+#
+# 2. Scorer recalibration (test_recalibrate.py) — runs each adapter's
+#    scorer function against a pinned oracle fixture and asserts the
+#    computed score falls within its expected band.  Catches scorer
+#    drift before it silently misreports a product regression.
+#
+# Real-data shape coverage stays with the nightly `bench-canonical` cron.
+# Docs-only PRs short-circuit to a pass.
 
 on:
   pull_request:
@@ -43,6 +50,7 @@ jobs:
               - 'src/**'
               - 'benchmarks/**'
               - 'tests/test_bench_smoke.py'
+              - 'tests/test_recalibrate.py'
               - 'tests/fixtures/bench_smoke/**'
               - 'pyproject.toml'
               - 'uv.lock'
@@ -62,6 +70,10 @@ jobs:
       - if: steps.filter.outputs.relevant == 'true'
         name: Run bench-smoke tests
         run: uv run pytest tests/test_bench_smoke.py -v --timeout=120
+
+      - if: steps.filter.outputs.relevant == 'true'
+        name: Run adapter scorer recalibration check
+        run: uv run pytest tests/test_recalibrate.py -v --timeout=60
 
       - if: steps.filter.outputs.relevant != 'true'
         run: echo "No bench-smoke-relevant paths changed; reporting pass."

--- a/benchmarks/oracle_fixtures/locomo_scorer.json
+++ b/benchmarks/oracle_fixtures/locomo_scorer.json
@@ -1,0 +1,111 @@
+{
+  "adapter": "locomo",
+  "scorer": "benchmarks.locomo_adapter.score_qa",
+  "description": "Oracle fixtures for the LoCoMo token-F1 scorer (benchmarks/locomo_adapter.py::score_qa). Covers all five categories: single-hop (4), temporal (2), open-ended (3), multi-hop (1), adversarial (5). All inputs are synthetic and not derived from the LoCoMo upstream dataset (CC BY-NC 4.0).",
+  "oracles": [
+    {
+      "label": "cat4 perfect match",
+      "category": 4,
+      "prediction": "hello world",
+      "ground_truth": "hello world",
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "cat4 zero overlap",
+      "category": 4,
+      "prediction": "three four five",
+      "ground_truth": "nine ten",
+      "expected_lower": 0.0,
+      "expected_upper": 0.0
+    },
+    {
+      "label": "cat4 partial overlap — one of two prediction tokens matches",
+      "category": 4,
+      "prediction": "hello world",
+      "ground_truth": "hello",
+      "expected_lower": 0.65,
+      "expected_upper": 0.68
+    },
+    {
+      "label": "cat2 temporal exact",
+      "category": 2,
+      "prediction": "monday morning",
+      "ground_truth": "monday morning",
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "cat2 temporal zero",
+      "category": 2,
+      "prediction": "tuesday afternoon",
+      "ground_truth": "friday evening",
+      "expected_lower": 0.0,
+      "expected_upper": 0.0
+    },
+    {
+      "label": "cat3 open-ended exact — uses only first semicolon-delimited part of ground truth",
+      "category": 3,
+      "prediction": "hello",
+      "ground_truth": "hello; some extra text that should be ignored",
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "cat3 open-ended zero",
+      "category": 3,
+      "prediction": "completely wrong answer",
+      "ground_truth": "totally different; or this",
+      "expected_lower": 0.0,
+      "expected_upper": 0.0
+    },
+    {
+      "label": "cat1 multi-hop perfect — both sub-answers present in prediction",
+      "category": 1,
+      "prediction": "red, blue",
+      "ground_truth": "red, blue",
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "cat1 multi-hop partial — first sub-answer present, second absent",
+      "category": 1,
+      "prediction": "red",
+      "ground_truth": "red, blue",
+      "expected_lower": 0.49,
+      "expected_upper": 0.51
+    },
+    {
+      "label": "cat1 multi-hop zero — neither sub-answer present",
+      "category": 1,
+      "prediction": "green",
+      "ground_truth": "red, blue",
+      "expected_lower": 0.0,
+      "expected_upper": 0.0
+    },
+    {
+      "label": "cat5 adversarial correct refusal — contains 'no information available'",
+      "category": 5,
+      "prediction": "no information available about this",
+      "ground_truth": "",
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "cat5 adversarial correct refusal — contains 'not mentioned'",
+      "category": 5,
+      "prediction": "this topic is not mentioned in the conversation",
+      "ground_truth": "",
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "cat5 adversarial wrong — model guesses instead of refusing",
+      "category": 5,
+      "prediction": "yes definitely happened last Tuesday",
+      "ground_truth": "",
+      "expected_lower": 0.0,
+      "expected_upper": 0.0
+    }
+  ]
+}

--- a/benchmarks/oracle_fixtures/mab_scorer.json
+++ b/benchmarks/oracle_fixtures/mab_scorer.json
@@ -1,0 +1,114 @@
+{
+  "adapter": "mab",
+  "scorer": "benchmarks.qa_scoring",
+  "description": "Oracle fixtures for the MAB/AMA-Bench QA scorer (benchmarks/qa_scoring.py). Tests score_exact_match, score_substring_exact_match, score_f1, and score_multi_answer. Pure stdlib — no nltk or LLM required. All inputs are synthetic.",
+  "oracles": [
+    {
+      "label": "sem hit — ground truth is substring of prediction",
+      "scorer_fn": "score_substring_exact_match",
+      "prediction": "paris is the capital of france",
+      "ground_truth": "paris",
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "sem miss — ground truth absent from prediction",
+      "scorer_fn": "score_substring_exact_match",
+      "prediction": "berlin is the capital of germany",
+      "ground_truth": "paris",
+      "expected_lower": 0.0,
+      "expected_upper": 0.0
+    },
+    {
+      "label": "sem articles stripped in both sides",
+      "scorer_fn": "score_substring_exact_match",
+      "prediction": "we saw the moon last night",
+      "ground_truth": "the moon",
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "sem empty ground truth is zero",
+      "scorer_fn": "score_substring_exact_match",
+      "prediction": "anything at all",
+      "ground_truth": "",
+      "expected_lower": 0.0,
+      "expected_upper": 0.0
+    },
+    {
+      "label": "em identical",
+      "scorer_fn": "score_exact_match",
+      "prediction": "paris",
+      "ground_truth": "paris",
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "em case insensitive",
+      "scorer_fn": "score_exact_match",
+      "prediction": "Paris",
+      "ground_truth": "paris",
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "em longer prediction fails",
+      "scorer_fn": "score_exact_match",
+      "prediction": "paris france",
+      "ground_truth": "paris",
+      "expected_lower": 0.0,
+      "expected_upper": 0.0
+    },
+    {
+      "label": "f1 perfect match",
+      "scorer_fn": "score_f1",
+      "prediction": "paris france",
+      "ground_truth": "paris france",
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "f1 no overlap",
+      "scorer_fn": "score_f1",
+      "prediction": "paris",
+      "ground_truth": "berlin",
+      "expected_lower": 0.0,
+      "expected_upper": 0.0
+    },
+    {
+      "label": "f1 partial — 2 of 3 prediction tokens match both ground truth tokens",
+      "scorer_fn": "score_f1",
+      "prediction": "paris france capital",
+      "ground_truth": "paris france",
+      "expected_lower": 0.79,
+      "expected_upper": 0.81
+    },
+    {
+      "label": "multi_answer em — exact match found in candidate list",
+      "scorer_fn": "score_multi_answer",
+      "score_key": "exact_match",
+      "prediction": "paris",
+      "ground_truths": ["london", "paris", "berlin"],
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "multi_answer sem — substring match found in candidate list",
+      "scorer_fn": "score_multi_answer",
+      "score_key": "substring_exact_match",
+      "prediction": "the capital is paris and it is beautiful",
+      "ground_truths": ["london", "paris", "berlin"],
+      "expected_lower": 1.0,
+      "expected_upper": 1.0
+    },
+    {
+      "label": "multi_answer all-zero — no candidate matches",
+      "scorer_fn": "score_multi_answer",
+      "score_key": "f1",
+      "prediction": "unknown city",
+      "ground_truths": ["london", "paris", "berlin"],
+      "expected_lower": 0.0,
+      "expected_upper": 0.0
+    }
+  ]
+}

--- a/benchmarks/recalibrate.py
+++ b/benchmarks/recalibrate.py
@@ -1,0 +1,322 @@
+"""Adapter scorer drift check — verifier recalibration auditor.
+
+Runs each scored adapter's scorer function against a pinned oracle fixture
+and asserts the computed score falls within the expected band.  A score
+outside the band means the scorer has drifted from its known-correct
+behaviour; any benchmark run produced by that scorer is suspect.
+
+This guard is complementary to `verify_clean.py` (which checks retrieval
+files for ground-truth contamination).  `recalibrate.py` checks that the
+scorer *logic* still maps retrieval output to a score correctly.
+
+Usage:
+    uv run python -m benchmarks.recalibrate           # all adapters
+    uv run python -m benchmarks.recalibrate locomo    # one adapter by name
+    uv run python -m benchmarks.recalibrate --list    # list registered adapters
+
+Exit codes:
+    0 — all oracle checks passed
+    1 — one or more oracle checks failed (scorer drift detected)
+    2 — usage error
+
+Design notes:
+    - Oracle fixtures live under benchmarks/oracle_fixtures/ as JSON files.
+    - Each fixture is a dict with an "oracles" list of input/band tuples.
+    - The scorer is called directly (no live LLM, no retrieval, no I/O).
+    - For adapters whose "score" is produced by a live LLM judge
+      (LongMemEval, StructMemEval, AMA-Bench), the judge call itself cannot
+      be oracle-checked deterministically — see docs/concepts/BENCHMARKS.md
+      for the documented limitation.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+_HERE: Path = Path(__file__).parent
+_ORACLE_DIR: Path = _HERE / "oracle_fixtures"
+
+# Registry: adapter_name → oracle fixture filename.
+# Add an entry here and a matching JSON file in oracle_fixtures/ when
+# adding oracle coverage for a new adapter's scorer.
+ADAPTER_FIXTURES: dict[str, str] = {
+    "locomo": "locomo_scorer.json",
+    "mab": "mab_scorer.json",
+}
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OracleFail:
+    """One oracle tuple that produced a score outside its expected band."""
+
+    adapter: str
+    label: str
+    observed: float
+    expected_lower: float
+    expected_upper: float
+
+    def __str__(self) -> str:
+        return (
+            f"  FAIL  [{self.adapter}] {self.label!r}\n"
+            f"        observed {self.observed:.6f}  "
+            f"expected [{self.expected_lower:.6f}, {self.expected_upper:.6f}]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Band check primitive
+# ---------------------------------------------------------------------------
+
+
+def _check_oracle_tuple(
+    *,
+    adapter: str,
+    label: str,
+    observed: float,
+    expected_lower: float,
+    expected_upper: float,
+) -> OracleFail | None:
+    """Return an OracleFail if observed is outside [expected_lower, expected_upper],
+    else None.
+    """
+    if observed < expected_lower or observed > expected_upper:
+        return OracleFail(
+            adapter=adapter,
+            label=label,
+            observed=observed,
+            expected_lower=expected_lower,
+            expected_upper=expected_upper,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Fixture loading
+# ---------------------------------------------------------------------------
+
+
+def load_fixture(adapter_name: str) -> dict[str, Any]:
+    """Load and parse the oracle fixture JSON for *adapter_name*."""
+    filename = ADAPTER_FIXTURES.get(adapter_name)
+    if filename is None:
+        known = ", ".join(sorted(ADAPTER_FIXTURES))
+        msg = f"Unknown adapter {adapter_name!r}. Known: {known}"
+        raise KeyError(msg)
+    path = _ORACLE_DIR / filename
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)  # type: ignore[no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# Per-adapter scorer runners
+# ---------------------------------------------------------------------------
+
+
+def _run_locomo_oracle(
+    oracles: list[dict[str, Any]],
+    scorer_fn: Callable[..., float] | None = None,
+) -> list[OracleFail]:
+    """Run the LoCoMo oracle tuples against *scorer_fn*.
+
+    *scorer_fn* defaults to ``benchmarks.locomo_adapter.score_qa``.
+    Pass a replacement to test a broken scorer in unit tests.
+    """
+    if scorer_fn is None:
+        from benchmarks.locomo_adapter import score_qa as scorer_fn  # type: ignore[assignment]
+
+    fails: list[OracleFail] = []
+    for oracle in oracles:
+        label: str = oracle["label"]
+        prediction: str = oracle["prediction"]
+        ground_truth: str = oracle["ground_truth"]
+        category: int = int(oracle["category"])
+        expected_lower: float = float(oracle["expected_lower"])
+        expected_upper: float = float(oracle["expected_upper"])
+
+        observed: float = scorer_fn(prediction, ground_truth, category)
+        result = _check_oracle_tuple(
+            adapter="locomo",
+            label=label,
+            observed=observed,
+            expected_lower=expected_lower,
+            expected_upper=expected_upper,
+        )
+        if result is not None:
+            fails.append(result)
+    return fails
+
+
+def _run_mab_oracle(
+    oracles: list[dict[str, Any]],
+    scorer_fn: Callable[..., Any] | None = None,
+) -> list[OracleFail]:
+    """Run the MAB/qa_scoring oracle tuples.
+
+    *scorer_fn* is only consulted for the simple single-output scorers
+    (score_exact_match, score_substring_exact_match, score_f1).  For
+    score_multi_answer the function is always imported from qa_scoring
+    (it returns a dict, not a float, so the injected scorer API would
+    need special casing — pass a wrapped callable if you need to test it).
+    """
+    import benchmarks.qa_scoring as qs  # noqa: PLC0415
+
+    _DEFAULT_SCORERS: dict[str, Callable[..., float]] = {
+        "score_exact_match": qs.score_exact_match,
+        "score_substring_exact_match": qs.score_substring_exact_match,
+        "score_f1": qs.score_f1,
+    }
+
+    fails: list[OracleFail] = []
+    for oracle in oracles:
+        label: str = oracle["label"]
+        fn_name: str = oracle["scorer_fn"]
+        expected_lower: float = float(oracle["expected_lower"])
+        expected_upper: float = float(oracle["expected_upper"])
+
+        if fn_name == "score_multi_answer":
+            prediction: str = oracle["prediction"]
+            ground_truths: list[str] = oracle["ground_truths"]
+            score_key: str = oracle["score_key"]
+            scores: dict[str, float] = qs.score_multi_answer(prediction, ground_truths)
+            observed: float = scores[score_key]
+        else:
+            # Simple single-output scorer — allow injection via scorer_fn
+            if scorer_fn is not None:
+                fn: Callable[..., float] = scorer_fn
+            else:
+                fn = _DEFAULT_SCORERS.get(fn_name, _DEFAULT_SCORERS["score_f1"])
+            prediction = oracle["prediction"]
+            ground_truth: str = oracle["ground_truth"]
+            observed = fn(prediction, ground_truth)
+
+        result = _check_oracle_tuple(
+            adapter="mab",
+            label=label,
+            observed=observed,
+            expected_lower=expected_lower,
+            expected_upper=expected_upper,
+        )
+        if result is not None:
+            fails.append(result)
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# Public API (used by tests)
+# ---------------------------------------------------------------------------
+
+_RUNNERS: dict[str, Callable[..., list[OracleFail]]] = {
+    "locomo": _run_locomo_oracle,
+    "mab": _run_mab_oracle,
+}
+
+
+def run_adapter_oracles(
+    adapter_name: str,
+    scorer_fn: Callable[..., Any] | None = None,
+) -> list[OracleFail]:
+    """Load and run the oracle fixture for *adapter_name*.
+
+    *scorer_fn* is forwarded to the adapter-specific runner — useful in
+    tests to substitute a broken scorer and verify the mechanism fires.
+
+    Returns a (possibly empty) list of OracleFail objects.
+    """
+    fixture = load_fixture(adapter_name)
+    runner = _RUNNERS[adapter_name]
+    return runner(fixture["oracles"], scorer_fn)
+
+
+def run_all_oracles() -> list[OracleFail]:
+    """Run all registered adapters.  Returns the combined list of failures."""
+    all_fails: list[OracleFail] = []
+    for name in ADAPTER_FIXTURES:
+        all_fails.extend(run_adapter_oracles(name))
+    return all_fails
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _print_header() -> None:
+    print("=" * 60)
+    print("Adapter scorer recalibration check")
+    print("=" * 60)
+
+
+def main() -> None:
+    """CLI entry point."""
+    args = sys.argv[1:]
+
+    if "--list" in args:
+        print("Registered adapters:")
+        for name, fname in sorted(ADAPTER_FIXTURES.items()):
+            print(f"  {name:20s}  {_ORACLE_DIR / fname}")
+        sys.exit(0)
+
+    if not args:
+        # Run all adapters
+        targets = list(ADAPTER_FIXTURES)
+    else:
+        targets = args
+        unknown = [t for t in targets if t not in ADAPTER_FIXTURES]
+        if unknown:
+            print(f"Unknown adapter(s): {', '.join(unknown)}")
+            print(f"Known: {', '.join(sorted(ADAPTER_FIXTURES))}")
+            sys.exit(2)
+
+    _print_header()
+    all_fails: list[OracleFail] = []
+    for name in targets:
+        print(f"\nChecking [{name}] ...")
+        try:
+            fails = run_adapter_oracles(name)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  ERROR loading adapter {name!r}: {exc}")
+            all_fails.append(
+                OracleFail(
+                    adapter=name,
+                    label="<load error>",
+                    observed=float("nan"),
+                    expected_lower=float("nan"),
+                    expected_upper=float("nan"),
+                )
+            )
+            continue
+
+        if fails:
+            for f in fails:
+                print(str(f))
+            all_fails.extend(fails)
+        else:
+            fixture = load_fixture(name)
+            n = len(fixture.get("oracles", []))
+            print(f"  PASS  {n} oracle tuples checked")
+
+    print()
+    print("=" * 60)
+    if all_fails:
+        print(f"DRIFT DETECTED: {len(all_fails)} oracle tuple(s) failed.")
+        print("Scorer logic has changed relative to the pinned oracle.")
+        print("Fix the scorer or update the oracle fixture (with review).")
+        sys.exit(1)
+    else:
+        total = sum(
+            len(load_fixture(n).get("oracles", [])) for n in targets
+        )
+        print(f"ALL PASS: {total} oracle tuples checked across {len(targets)} adapter(s).")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/concepts/BENCHMARKS.md
+++ b/docs/concepts/BENCHMARKS.md
@@ -306,6 +306,96 @@ JSONL files (`run_<i>.jsonl`, with `{turn_idx, matched, rationale}` rows
 read by `read_judge_responses`); kappa.json itself only carries per-pair
 agreement scores, not per-row verdicts.
 
+## Scorer recalibration
+
+Adapters can silently misreport scores when the adapter (not the product)
+regresses.  `verify_clean.py` guards against ground-truth contamination of
+retrieval files; `benchmarks/recalibrate.py` guards against scorer-logic
+drift by checking each scorer against a pinned oracle fixture.
+
+### Problem
+
+A subtly broken scorer — wrong field read, bag-of-words scoring where
+stemmed F1 was intended, stale category dispatch — reports a low number
+indistinguishable (to CI) from a real product regression.  This was the
+root cause of several "low benchmark number" investigations that turned out
+to be harness artifacts rather than product defects.
+
+### Mechanism
+
+Each scored adapter that has deterministic (stdlib-only) scoring logic has
+a pinned **oracle fixture** under `benchmarks/oracle_fixtures/` containing
+`(prediction, ground_truth[, category], expected_lower, expected_upper)`
+tuples.  The recalibration check:
+
+1. Loads each fixture JSON.
+2. Calls the scorer function directly on each tuple (no retrieval, no LLM).
+3. Asserts the returned score falls within `[expected_lower, expected_upper]`.
+4. Exits non-zero if any tuple is outside its band.
+
+Bands are explicit author-specified ranges, not relative-to-canonical
+computations.  A narrow band (e.g. `[1.0, 1.0]`) exercises exact
+correctness; a wider band (e.g. `[0.65, 0.68]`) tolerates minor floating-
+point differences while still catching the class of bugs that shift scores
+significantly (field swap, wrong branch, wrong formula).
+
+### Run the check
+
+```bash
+uv run python -m benchmarks.recalibrate          # all adapters
+uv run python -m benchmarks.recalibrate locomo   # one adapter
+uv run python -m benchmarks.recalibrate --list   # show registered adapters
+```
+
+The check also runs automatically in the `bench-smoke` CI job on every PR
+that touches `benchmarks/`.
+
+### Covered adapters
+
+| Adapter | Oracle fixture | Scorer checked | Notes |
+|---|---|---|---|
+| LoCoMo | `oracle_fixtures/locomo_scorer.json` | `locomo_adapter.score_qa` | All 5 categories (1=multi-hop, 2=temporal, 3=open-ended, 4=single-hop, 5=adversarial) |
+| MAB | `oracle_fixtures/mab_scorer.json` | `qa_scoring.*` | `score_exact_match`, `score_substring_exact_match`, `score_f1`, `score_multi_answer` |
+
+### Adapters not oracle-checked
+
+| Adapter | Reason |
+|---|---|
+| LongMemEval | The final "score" is a binary verdict produced by an LLM judge; the verdict-aggregation logic (`longmemeval_score.py`) is a trivial counter already covered by `tests/test_longmemeval_scoring.py`.  Oracle-checking the judge call itself requires a live model. |
+| StructMemEval | Same — per-task LLM judge; aggregation logic tested in `test_structmemeval_*`. |
+| AMA-Bench | Not oracle-checked end-to-end; only the shared `qa_scoring.score_multi_answer` helper is covered via the MAB fixture. |
+
+### Adding an oracle fixture for a new adapter
+
+1. Create `benchmarks/oracle_fixtures/<adapter>_scorer.json` following the
+   schema of the existing fixtures:
+   ```json
+   {
+     "adapter": "<adapter>",
+     "scorer": "<dotted.module.path.to.scorer_fn>",
+     "description": "...",
+     "oracles": [
+       {
+         "label": "descriptive name",
+         "<scorer-specific input fields>": "...",
+         "expected_lower": 0.0,
+         "expected_upper": 1.0
+       }
+     ]
+   }
+   ```
+2. Add a runner function `_run_<adapter>_oracle` in `benchmarks/recalibrate.py`
+   that calls the scorer and feeds each tuple through `_check_oracle_tuple`.
+3. Register the adapter in `ADAPTER_FIXTURES` and `_RUNNERS`.
+4. Add tests in `tests/test_recalibrate.py`:
+   - A `test_<adapter>_oracle_all_pass` that verifies the real scorer passes.
+   - A broken-scorer variant to prove the mechanism fires.
+5. Run `uv run python -m benchmarks.recalibrate <adapter>` and
+   `uv run pytest tests/test_recalibrate.py -v` to confirm.
+
+Oracle fixtures must be **synthetic** (not derived from upstream datasets)
+and should cover all branches / categories of the scorer logic.
+
 ## Audit record
 
 Every academic run produces:

--- a/tests/test_recalibrate.py
+++ b/tests/test_recalibrate.py
@@ -1,0 +1,249 @@
+"""Tests for benchmarks/recalibrate.py — adapter scorer drift check.
+
+Split into two groups:
+
+1. Framework tests — no external dependencies.  These exercise the band
+   check primitive and the broken-adapter regression proof.  They run in
+   any Python environment (no [benchmarks] extras needed).
+
+2. Adapter oracle tests — verify real scorer functions against the pinned
+   oracle fixtures.  The locomo test needs nltk (benchmarks extras);
+   the mab test uses benchmarks.qa_scoring (pure stdlib, no extras).
+"""
+from __future__ import annotations
+
+import pytest
+
+from benchmarks import recalibrate
+
+
+# ---------------------------------------------------------------------------
+# Framework tests — no extras needed
+# ---------------------------------------------------------------------------
+
+
+class TestBandCheck:
+    """Unit tests for the _check_oracle_tuple primitive."""
+
+    def test_pass_exact_lower_bound(self) -> None:
+        result = recalibrate._check_oracle_tuple(
+            adapter="x", label="lbl", observed=0.4,
+            expected_lower=0.4, expected_upper=0.6,
+        )
+        assert result is None
+
+    def test_pass_exact_upper_bound(self) -> None:
+        result = recalibrate._check_oracle_tuple(
+            adapter="x", label="lbl", observed=0.6,
+            expected_lower=0.4, expected_upper=0.6,
+        )
+        assert result is None
+
+    def test_pass_midpoint(self) -> None:
+        result = recalibrate._check_oracle_tuple(
+            adapter="x", label="lbl", observed=0.5,
+            expected_lower=0.4, expected_upper=0.6,
+        )
+        assert result is None
+
+    def test_fail_below_lower(self) -> None:
+        fail = recalibrate._check_oracle_tuple(
+            adapter="mytest", label="too low", observed=0.3,
+            expected_lower=0.4, expected_upper=0.6,
+        )
+        assert fail is not None
+        assert fail.adapter == "mytest"
+        assert fail.label == "too low"
+        assert fail.observed == pytest.approx(0.3)
+
+    def test_fail_above_upper(self) -> None:
+        fail = recalibrate._check_oracle_tuple(
+            adapter="mytest", label="too high", observed=0.7,
+            expected_lower=0.4, expected_upper=0.6,
+        )
+        assert fail is not None
+        assert fail.observed == pytest.approx(0.7)
+
+    def test_point_band_exact_match(self) -> None:
+        result = recalibrate._check_oracle_tuple(
+            adapter="x", label="lbl", observed=1.0,
+            expected_lower=1.0, expected_upper=1.0,
+        )
+        assert result is None
+
+    def test_point_band_miss(self) -> None:
+        fail = recalibrate._check_oracle_tuple(
+            adapter="x", label="lbl", observed=0.99,
+            expected_lower=1.0, expected_upper=1.0,
+        )
+        assert fail is not None
+
+
+class TestBrokenAdapterCaught:
+    """Regression test: a deliberately broken scorer is caught by the oracle.
+
+    This proves the mechanism works — if recalibrate.py can be tricked into
+    reporting PASS for a broken scorer, the whole guard is useless.
+    """
+
+    def test_broken_locomo_scorer_caught(self) -> None:
+        """Scorer that always returns 0.0 is caught by locomo oracle tuples
+        that expect non-zero scores (e.g., exact matches → 1.0).
+        """
+        def always_zero(prediction: str, ground_truth: str, category: int) -> float:
+            return 0.0
+
+        fixture = recalibrate.load_fixture("locomo")
+        fails = recalibrate._run_locomo_oracle(fixture["oracles"], scorer_fn=always_zero)
+
+        # Oracle has tuples with expected_lower=1.0 (exact matches)
+        # The broken scorer returns 0.0 for all of them → must be caught.
+        assert len(fails) > 0, (
+            "Broken scorer (always 0.0) was not caught by locomo oracle. "
+            "The recalibration mechanism is not working."
+        )
+        # Every failure should have observed=0.0
+        for f in fails:
+            assert f.observed == pytest.approx(0.0)
+
+    def test_broken_locomo_scorer_labels_reported(self) -> None:
+        """Failure labels are present and readable in the OracleFail objects."""
+        def always_zero(prediction: str, ground_truth: str, category: int) -> float:
+            return 0.0
+
+        fixture = recalibrate.load_fixture("locomo")
+        fails = recalibrate._run_locomo_oracle(fixture["oracles"], scorer_fn=always_zero)
+        labels = {f.label for f in fails}
+        # At minimum the exact-match cases (expected 1.0) should appear.
+        assert any("perfect match" in lbl or "exact" in lbl.lower() for lbl in labels), (
+            f"Expected exact-match label in failures; got: {labels}"
+        )
+
+    def test_broken_mab_sem_scorer_caught(self) -> None:
+        """Scorer that always returns 0.0 is caught for MAB SEM oracle tuples
+        that expect 1.0 (substring match hits).
+        """
+        def always_zero(prediction: str, ground_truth: str) -> float:
+            return 0.0
+
+        fixture = recalibrate.load_fixture("mab")
+        # Only simple (non-multi_answer) scorers go through scorer_fn injection.
+        # Filter to those tuples to keep assertion clean.
+        simple_oracles = [
+            o for o in fixture["oracles"] if o["scorer_fn"] != "score_multi_answer"
+        ]
+        fails = recalibrate._run_mab_oracle(simple_oracles, scorer_fn=always_zero)
+
+        # Oracle has sem/em/f1 hit cases with expected_lower=1.0
+        assert len(fails) > 0, (
+            "Broken scorer (always 0.0) was not caught by mab oracle. "
+            "The recalibration mechanism is not working."
+        )
+
+    def test_correct_scorer_passes_all_locomo_oracles(self) -> None:
+        """Identity-with-locomo scorer: any scorer that agrees with score_qa
+        on the oracle inputs should produce zero failures.
+
+        This sub-test uses a lambda that delegates to the real scorer to
+        verify the pass path of the framework without importing nltk directly
+        (the import is inside the lambda, which is evaluated lazily; if nltk
+        is absent this specific assertion body is also unreachable — but the
+        outer test_locomo_oracle_all_pass covers the production path with a
+        proper importorskip).
+        """
+        # If nltk is not available, skip this cross-check.
+        nltk = pytest.importorskip("nltk", reason="[benchmarks] extras needed for locomo scorer")
+        _ = nltk  # only needed to trigger the skip if absent
+
+        from benchmarks.locomo_adapter import score_qa
+
+        def correct_scorer(prediction: str, ground_truth: str, category: int) -> float:
+            return score_qa(prediction, ground_truth, category)
+
+        fixture = recalibrate.load_fixture("locomo")
+        fails = recalibrate._run_locomo_oracle(fixture["oracles"], scorer_fn=correct_scorer)
+        assert fails == [], f"Correct scorer produced unexpected failures: {fails}"
+
+
+# ---------------------------------------------------------------------------
+# Real adapter oracle tests
+# ---------------------------------------------------------------------------
+
+
+def test_locomo_oracle_all_pass() -> None:
+    """Real LoCoMo scorer passes all pinned oracle tuples."""
+    pytest.importorskip("nltk", reason="[benchmarks] extras required for LoCoMo scorer")
+    fails = recalibrate.run_adapter_oracles("locomo")
+    assert fails == [], (
+        "LoCoMo scorer oracle failures detected:\n"
+        + "\n".join(str(f) for f in fails)
+    )
+
+
+def test_mab_oracle_all_pass() -> None:
+    """Real MAB/qa_scoring scorer passes all pinned oracle tuples.
+
+    qa_scoring.py is pure stdlib — no extras needed.
+    """
+    fails = recalibrate.run_adapter_oracles("mab")
+    assert fails == [], (
+        "MAB scorer oracle failures detected:\n"
+        + "\n".join(str(f) for f in fails)
+    )
+
+
+def test_run_all_oracles_returns_no_fails() -> None:
+    """run_all_oracles() passes on the real code-base (requires benchmarks extras)."""
+    pytest.importorskip("nltk", reason="[benchmarks] extras required")
+    fails = recalibrate.run_all_oracles()
+    assert fails == [], (
+        "Scorer oracle failures from run_all_oracles():\n"
+        + "\n".join(str(f) for f in fails)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry / fixture-loading sanity
+# ---------------------------------------------------------------------------
+
+
+def test_all_registered_fixtures_exist() -> None:
+    """Every entry in ADAPTER_FIXTURES points to an existing JSON file."""
+    for name, fname in recalibrate.ADAPTER_FIXTURES.items():
+        path = recalibrate._ORACLE_DIR / fname
+        assert path.exists(), (
+            f"Oracle fixture for adapter {name!r} not found: {path}"
+        )
+
+
+def test_fixture_schema_has_required_fields() -> None:
+    """Each oracle fixture has adapter, scorer, description, and oracles fields."""
+    for name in recalibrate.ADAPTER_FIXTURES:
+        data = recalibrate.load_fixture(name)
+        for field in ("adapter", "scorer", "description", "oracles"):
+            assert field in data, (
+                f"Fixture {name!r} missing required field {field!r}"
+            )
+        assert isinstance(data["oracles"], list), (
+            f"Fixture {name!r} 'oracles' must be a list"
+        )
+        assert len(data["oracles"]) > 0, (
+            f"Fixture {name!r} has empty oracles list"
+        )
+
+
+def test_each_oracle_tuple_has_band() -> None:
+    """Each oracle tuple has expected_lower, expected_upper, and label."""
+    for name in recalibrate.ADAPTER_FIXTURES:
+        data = recalibrate.load_fixture(name)
+        for i, oracle in enumerate(data["oracles"]):
+            for field in ("label", "expected_lower", "expected_upper"):
+                assert field in oracle, (
+                    f"Fixture {name!r} oracle[{i}] missing field {field!r}"
+                )
+            lo = float(oracle["expected_lower"])
+            hi = float(oracle["expected_upper"])
+            assert lo <= hi, (
+                f"Fixture {name!r} oracle[{i}] {oracle['label']!r}: "
+                f"expected_lower {lo} > expected_upper {hi}"
+            )


### PR DESCRIPTION
Closes #1048.

## What

Adds a **verifier-recalibration auditor** for benchmark adapter scorers. Benchmark adapters can silently misreport scores when the *adapter* (not the product) regresses — an adapter scoring the product at 30% when it should be ~70% is indistinguishable to CI from a real product regression. `verify_clean.py` guards clean-run hazards (gold leakage etc.); this adds the missing check that a scorer still maps retrieval output to a score *correctly*.

## How

- **`benchmarks/recalibrate.py`** — runs each registered adapter's scorer function directly against a pinned oracle fixture and asserts the computed score falls in an author-specified band. Deterministic: no live LLM, no retrieval, no I/O. CLI (`python -m benchmarks.recalibrate [adapter] | --list`) with exit codes 0 (pass) / 1 (drift) / 2 (usage).
- **`benchmarks/oracle_fixtures/{locomo,mab}_scorer.json`** — 26 pinned tuples total. LoCoMo covers all 5 `score_qa` categories; MAB covers the four `qa_scoring` functions. Bands are tight (near-exact for the deterministic cases) because these scorers are deterministic — a real drift is caught, not masked by a wide band.
- **`tests/test_recalibrate.py`** — band-primitive tests + a `TestBrokenAdapterCaught` class that injects a broken scorer and proves the auditor fires, and confirms the correct scorer passes all oracles.
- **CI** — wired into `bench-smoke` (which already installs the `benchmarks` extra, so the nltk-backed LoCoMo oracles actually run in CI).
- **Docs** — `docs/concepts/BENCHMARKS.md` documents the recalibration contract and how to add an oracle fixture for a new adapter.

## Design note

Chose a focused sibling over reusing `tolerance.py`: that module compares full nightly run-reports (schema v2) against a canonical baseline with computed relative bands. Recalibration calls scorer functions directly on `(input, expected-band)` tuples with author-specified bands — wrapping those in the run-report schema would be artificial coupling.

## Scope / limitations

LLM-judge adapters (LongMemEval, StructMemEval) are **not** oracle-checked — their final score comes from a live judge, which can't be verified deterministically; their verdict-aggregation logic is already unit-tested. This is documented in BENCHMARKS.md. AMA-Bench scoring routes through `qa_scoring.score_multi_answer`, already covered by the MAB fixture.

## Verification

- `python -m benchmarks.recalibrate` → ALL PASS, 26 oracle tuples across 2 adapters (exit 0).
- `pytest tests/test_recalibrate.py` → 17 passed.
- Broken-adapter regression confirms the mechanism catches drift.

## Summary by Sourcery

Add a deterministic recalibration auditor for benchmark adapter scorers and wire it into documentation, fixtures, tests, and CI.

New Features:
- Introduce a benchmarks.recalibrate CLI to run adapter scorer functions against pinned oracle fixtures and detect drift.
- Add oracle fixtures for LoCoMo and MAB/AMA-Bench scorers to validate their scoring outputs against expected bands.

Enhancements:
- Document the scorer recalibration contract, coverage, and onboarding process for new adapters in BENCHMARKS.md.
- Extend the bench-smoke workflow to run the scorer recalibration tests alongside existing adapter smoke checks on relevant PRs.

Tests:
- Add unit and integration tests for the recalibration framework, including broken-scorer regression proofs and oracle coverage for LoCoMo and MAB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added oracle-based scorer recalibration that validates adapter scoring against pinned expected score bands.
  * Introduced new oracle fixtures for LoCoMo and MAB to cover additional evaluation scenarios.

* **Documentation**
  * Added a “Scorer recalibration” guide, including how checks run in CI and how to add new oracle coverage.

* **Tests**
  * Added a full recalibration test suite covering band-check behavior, mismatch detection via intentionally broken scorers, real oracle runs, and fixture/schema validation.

* **Chores**
  * Updated the bench smoke CI workflow to run recalibration when relevant benchmark tests change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->