### PR TITLE
docs: bump README 'Latest stable' to v3.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Scopes: `--scope all` (everything, capped by `--max-notes`), `--scope recent` (n
 
 ## Status
 
-Latest stable: **v3.7.0** (2026-06-23). Per-entry detail in [CHANGELOG § 3.7.0](CHANGELOG/v3.md). Per-version history: [docs/concepts/ROADMAP.md](docs/concepts/ROADMAP.md). Known limits: [docs/user/LIMITATIONS.md](docs/user/LIMITATIONS.md).
+Latest stable: **v3.8.0** (2026-06-30). Per-entry detail in [CHANGELOG § 3.8.0](CHANGELOG/v3.md). Per-version history: [docs/concepts/ROADMAP.md](docs/concepts/ROADMAP.md). Known limits: [docs/user/LIMITATIONS.md](docs/user/LIMITATIONS.md).
 
 [![OSSInsight](https://img.shields.io/badge/OSSInsight-analytics-blue)](https://ossinsight.io/analyze/robotrocketscience/aelfrice)
 <!-- bench-canonical-badge:start -->


### PR DESCRIPTION
The README's "Latest stable" line still advertised **v3.7.0** (2026-06-23), but `main` is **v3.8.0** (2026-06-30, tagged and released — `pyproject.toml` version = 3.8.0). Updates the version, date, and the CHANGELOG anchor to § 3.8.0.

One-line doc change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Refresh README status line with the latest stable version v3.8.0, release date, and CHANGELOG section link.