### PR TITLE
docs: quantify the #1045 wide-retrieval knob trade-offs

### DIFF
--- a/docs/user/CONFIG.md
+++ b/docs/user/CONFIG.md
@@ -75,6 +75,22 @@ posterior_weight = 0.5
 # the per-prompt injection hook. AELFRICE_L1_LIMIT and
 # AELFRICE_RETRIEVAL_TOKEN_BUDGET env vars override; explicit kwargs on
 # retrieve() / retrieve_v2() override TOML in turn.
+#
+# Measured characterization (LongMemEval oracle, 364 questions across dev
+# + held-out confirmation; per-turn gold labels; deterministic reruns):
+#   - The knobs are a PAIR. l1_limit=200 + token_budget=8000 lifts
+#     whole-set recall by +8.6pp (dev) / +9.5pp (held-out) over the
+#     defaults. l1_limit alone at the default budget is nearly inert
+#     (~+1pp): the extra candidates are trimmed before they can matter.
+#   - Recovery plateaus at l1_limit=200; 400 adds ~nothing for 40% more
+#     packed tokens.
+#   - Top-rank ordering is UNAFFECTED (MRR / recall@1 identical to three
+#     decimals in every measured cell): widening only adds beliefs deep
+#     in the packed set. Consumers that read the whole retrieval block
+#     benefit; consumers that act on the top few results will see no
+#     change.
+#   - Cost at 200/8000: ~4-5.7x injected tokens vs defaults. This is why
+#     the defaults stay put and wide retrieval is opt-in.
 l1_limit = 50
 token_budget = 2400
 


### PR DESCRIPTION
Documents the measured characterization of the \`l1_limit\` + \`token_budget\` wide-retrieval knobs, from a 364-question labeled study on the LongMemEval oracle set (174 development questions + 190 held-out confirmation questions, per-turn gold labels, byte-identical deterministic reruns).

### What the study established

- **The knobs are a pair.** \`l1_limit=200\` + \`token_budget=8000\` lifts whole-set recall by **+8.6pp (dev) / +9.5pp (held-out)** over the 50/2400 defaults. \`l1_limit\` alone at the default budget is nearly inert (~+1pp) — extra candidates are trimmed before they can matter.
- **Recovery plateaus at \`l1_limit=200\`.** 400 adds ~nothing (one additional recovery in 29 held-out misses) for ~40% more packed tokens.
- **Top-rank ordering is unaffected** — MRR and recall@1 identical to three decimals in every measured cell. Widening adds beliefs deep in the packed set only; recovered answers land at ranks ~40–170.
- **Cost: ~4–5.7× injected tokens** at 200/8000, which is why the defaults stay put and wide retrieval remains opt-in.

Confirmation targets (recovery ≥50% of candidate-misses, plateau, top-rank invariance, l1-alone-inert) were pre-registered before the held-out run; all four passed (recovery 62%).

Docs-only change; no code touched.

## Summary by Sourcery

Documentation:
- Add configuration docs summarizing recall gains, plateau behavior, rank invariance, and token-cost impact of wide retrieval settings l1_limit and token_budget.