### PR TITLE
fix(cli): search --budget help derives its default via %(default)s (#1077)

### DIFF
--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -6344,7 +6344,7 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
     p_search.add_argument("query", help="keyword query")
     p_search.add_argument(
         "--budget", type=int, default=DEFAULT_TOKEN_BUDGET,
-        help="output token budget (default 2400)",
+        help="output token budget (default %(default)s)",
     )
     p_search.add_argument(
         "--json", action="store_true", default=False,


### PR DESCRIPTION
## What

Closes #1077. The `aelf search --budget` help string hardcoded `"default 2000"` while the actual `default=DEFAULT_TOKEN_BUDGET` is **2400** (`retrieval.py:125`). Surfaced as code-side drift **C1** by the #1075 docs audit (docs were right; the in-code help was wrong).

## How

One line: the help string now uses argparse's native `%(default)s` interpolation, so it renders the live default and can never drift from it again:

```
$ aelf search --help
  --budget BUDGET  output token budget (default 2400)
```

## Note for the in-flight #1075 in-code pass

`src/aelfrice/benchmark.py:64` carries the same stale claim in a docstring ("Higher than retrieval's default 2000"). Left untouched here — it belongs to the in-code documentation tranche already in progress under #1075; flagging so it lands in that ledger.

## Summary by Sourcery

Bug Fixes:
- Correct the `aelf search --budget` help message so it always reflects the current default token budget via argparse's `%(default)s` interpolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `aelf search --budget` help text to display the default value automatically.
  * The command’s behavior remains unchanged; only the help message was improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->