### PR TITLE
docs: #1075 in-code audit MED/LOW follow-up — 48 fixes across src/aelfrice

### DIFF
--- a/src/aelfrice/auditor.py
+++ b/src/aelfrice/auditor.py
@@ -1,10 +1,12 @@
 """Structural auditor for `aelf health`.
 
-Three mechanical checks in v1.1.0. Each fires `severity='fail'` when the
-invariant is violated; `aelf health` exits 1 if any failure is present
-so CI can gate on it. Informational metrics (credal gap, thread counts,
-feedback coverage, average confidence) are reported alongside but do
-not affect exit status.
+Six mechanical checks. Three (from v1.1.0) fire `severity='fail'` when
+the invariant is violated; `aelf health` exits 1 if any failure is
+present so CI can gate on it. Three more added since — `corpus_volume`
+(#116), `lock_budget` (#1016-D), `ingest_gap` (#1011) — fire
+`severity='warn'` instead and do not affect exit status. Informational
+metrics (credal gap, thread counts, feedback coverage, average
+confidence) are reported alongside but do not affect exit status.
 
 Checks:
   - orphan_threads     threads (graph relationships) whose src or dst
@@ -24,8 +26,9 @@ make available.
 
 The internal schema and code keep "edges"; user-facing labels surface as
 "threads" per the v1.1.0 cosmetic rename. `CHECK_ORPHAN_EDGES` is kept
-as a deprecated alias for the constant (same value as the new
-`CHECK_ORPHAN_THREADS`) for v1.0 importer compatibility; remove in v1.2.0.
+as a deprecated alias for the constant (same value as
+`CHECK_ORPHAN_THREADS`) for v1.0 importer compatibility; still present
+as of v3.8.0, not yet removed.
 """
 from __future__ import annotations
 

--- a/src/aelfrice/bm25.py
+++ b/src/aelfrice/bm25.py
@@ -426,6 +426,7 @@ class BM25Index:
             dl                 float32 x n_docs
             idf                float32 x n_terms
             tf.indptr          int64 x (n_docs + 1)
+            nnz                uint64   len(tf.data)
             tf.indices         int64 x nnz
             tf.data            float32 x nnz
 

--- a/src/aelfrice/cadence.py
+++ b/src/aelfrice/cadence.py
@@ -7,7 +7,9 @@ maintainer-typical workloads `/clear` faster than the harness compacts,
 so PreCompact-only ("P0" in #749 body terminology) misses most of the
 state-recovery opportunities.
 
-This module implements two of the policies pre-registered by #749:
+This module implements four of the policies pre-registered by #749
+and #876: P1 every-K-turns, P2 ctx-threshold + phase-boundary,
+P3-velocity, and P3-substantive.
 
 * **P1 every-K-turns** (#749 §"Pre-registered policies to evaluate"):
   a deterministic, monotonic-counter-keyed cadence policy that fires
@@ -17,6 +19,11 @@ This module implements two of the policies pre-registered by #749:
   fraction of a configured byte-window AND the most-recent user
   prompt looks like a task-boundary signal. Composite predicate;
   both conditions must hold.
+* **P3-velocity** (#876 axis 1): fires when transcript bytes-per-turn
+  density since the last fire exceeds a configurable threshold.
+* **P3-substantive** (#876 axis 1): fires when the ratio of
+  substantive turns in a rolling window exceeds a configurable
+  threshold.
 
 The rebuilder's side effects (rebuild_log entry, touch-state refresh)
 accumulate at the chosen cadence instead of at whatever rate the

--- a/src/aelfrice/cadence_score.py
+++ b/src/aelfrice/cadence_score.py
@@ -4,7 +4,9 @@ Reads ``<project>/.git/aelfrice/cadence_shadow/<session_id>.jsonl`` rows
 written by the Stop-hook shadow-evaluation path and emits aggregate
 statistics: per-policy fire-rate (counts of ``would_fire=true``),
 selected-policy live fire-rate, and a 2x2 agreement matrix between the
-two currently-implemented policies (P1 vs P2).
+original two policies (P1 vs P2), retained for backward compatibility —
+see ``pairwise_agreement`` on ``ShadowSummary`` for the generalised
+table across all four currently-implemented policies.
 
 Designed to surface as ``aelf cadence-score``. The scoring is offline:
 inputs are the already-written shadow log; no live cadence state is

--- a/src/aelfrice/calibration_metrics.py
+++ b/src/aelfrice/calibration_metrics.py
@@ -1,12 +1,14 @@
 """Relevance-calibration metrics for the close-the-loop harness (#365 R1).
 
-Pure-stdlib leaf module. Three functions:
+Pure-stdlib leaf module. Five functions:
 
 - ``precision_at_k`` — precision at rank K (the gate metric per #365 Q3).
 - ``roc_auc`` — ROC-AUC via Mann-Whitney U with average-rank tie handling.
 - ``spearman_rho`` — Spearman rank correlation with average-rank ties.
+- ``ordered_top_k_overlap`` — fraction of top-k positions where two ranked lists agree (#796 R4).
+- ``rank_biased_overlap`` — rank-biased overlap (RBO), top-weighted ranking similarity (#796 R4).
 
-All three are deterministic: same input list → bytes-identical float
+All five are deterministic: same input list → bytes-identical float
 return value across reruns. Used by:
 
 - ``scripts/audit_rebuild_log.py --calibrate-corpus`` (R1, this PR).

--- a/src/aelfrice/canvas_export.py
+++ b/src/aelfrice/canvas_export.py
@@ -20,7 +20,8 @@ runs), not from any force-directed layout. Honors locked
 Encoding policy (subject to operator feedback per #763)
 -------------------------------------------------------
 
-- Nodes: ``type="text"``, ``text = belief.content[:NODE_TEXT_MAX]``.
+- Nodes: ``type="text"``, ``text = _truncate(belief.content, NODE_TEXT_MAX)`` (truncated
+  content with a trailing ``…`` when it exceeds the cap).
   Locked beliefs get preset color ``"5"`` (cyan); otherwise posterior
   mean buckets to ``"4"`` green (mu>=0.75), no color (0.25<=mu<0.75),
   or ``"6"`` red (mu<0.25). Width/height fixed.

--- a/src/aelfrice/claude_memory.py
+++ b/src/aelfrice/claude_memory.py
@@ -275,9 +275,10 @@ def is_mirror_enabled(
       2. Explicit ``explicit`` kwarg from the caller.
       3. ``[memory] mirror_claude_memory`` in ``.aelfrice.toml``.
       4. Default: **False** — the mirror is opt-in, consistent with the
-         narrow-surface PHILOSOPHY (#605) and the opt-in default posture
-         ratified for new behaviours (ADR 0003 decision 4, #606). With the
-         mirror off, ``/aelf:audit-claude-memory`` remains the bridge.
+         narrow-surface PHILOSOPHY (#605) and the opt-in-by-default precedent
+         set by ADR 0003 decision 4 (#973); ratified for this mirror under
+         #985. With the mirror off, ``/aelf:audit-claude-memory`` remains the
+         bridge.
     """
     env = _env_mirror_override()
     if env is not None:

--- a/src/aelfrice/cli.py
+++ b/src/aelfrice/cli.py
@@ -7698,7 +7698,7 @@ def build_parser(*, show_advanced: bool = False) -> argparse.ArgumentParser:
         "--claude-memory-mirror", dest="claude_memory_mirror",
         action=argparse.BooleanOptionalAction, default=True,
         help=(
-            "wire the PostToolUse:Write|Edit hook that mirrors the upstream auto-memory tool "
+            "wire the PostToolUse:Write|Edit|MultiEdit hook that mirrors the upstream auto-memory tool "
             "memory writes into the belief graph (#985). The hook is "
             "installed ON by default but stays INERT until you opt in via "
             "AELFRICE_MIRROR_CLAUDE_MEMORY=1 or [memory] "

--- a/src/aelfrice/context_rebuilder.py
+++ b/src/aelfrice/context_rebuilder.py
@@ -296,10 +296,12 @@ def rebuild(
 ) -> str:
     """Build the rebuild context block. Pure function.
 
-    Legacy v1.2.0a0 entry point. Preserved for backwards compatibility
-    with the `aelf rebuild` CLI and the eval harness. Uses the legacy
-    per-token union retrieval. New callers (the v1.4 hook) should use
-    `rebuild_v14()` for the L0+L1+L2.5 path.
+    Legacy v1.2.0a0 entry point. Retained for the direct-caller
+    unit-test suite (`tests/test_context_rebuilder.py`); the `aelf
+    rebuild` CLI and the eval harness have both moved to
+    `rebuild_v14()`. Uses the legacy per-token union retrieval. New
+    callers (the v1.4 hook) should use `rebuild_v14()` for the
+    L0+L1+L2.5 path.
 
     Given a list of recent turns and an open MemoryStore, retrieve the
     most relevant beliefs and emit the formatted XML block.
@@ -612,11 +614,15 @@ def rebuild_v14(
 
 
 def emit_pre_compact_envelope(block: str) -> str:
-    """Wrap a rebuild block in the Claude Code PreCompact JSON envelope.
+    """Wrap a rebuild block in the JSON envelope the pre-#1031
+    PreCompact contract used.
 
-    The harness expects `additionalContext` under
-    `hookSpecificOutput`. Identical wire shape to the v1.2.x search-
-    tool hook (`hook_search_tool.py`).
+    Retained for the legacy `main()` entry point and tests only: the
+    harness rejects `additionalContext` emitted from a PreCompact
+    hook, so this envelope is not part of the live
+    SessionStart(source == "compact") injection path, which writes
+    the raw block to stdout instead. Identical wire shape to the
+    v1.2.x search-tool hook (`hook_search_tool.py`).
     """
     payload: dict[str, object] = {
         "hookSpecificOutput": {
@@ -865,9 +871,9 @@ def _retrieve_for_rebuild(
 ) -> list[Belief]:
     """Per-token union retrieval over recent-turn text.
 
-    Legacy v1.2.0a0 path; preserved so the existing `aelf rebuild`
-    CLI behaves byte-identical to the alpha. v1.4 callers use the
-    `retrieve()`-based path in `rebuild_v14`.
+    Legacy v1.2.0a0 path, reachable only via `rebuild()` (now
+    unit-test-only); the `aelf rebuild` CLI moved to the
+    `retrieve()`-based `rebuild_v14()` path.
 
     L0 locked beliefs always come first and are never trimmed.
     """

--- a/src/aelfrice/db_paths.py
+++ b/src/aelfrice/db_paths.py
@@ -11,8 +11,8 @@ closes 14+ module-import cycles flagged by CodeQL (#499 Cluster C).
 `cli.py` re-exports the symbols here for backward compatibility with
 tests and external callers that already use `aelfrice.cli.db_path`.
 
-Imports here must stay leaf-side: `aelfrice.store` (which itself only
-imports `models` + `ulid`) is the only intra-package dep.
+Imports here must stay leaf-side: `aelfrice.store` (which imports
+`models`, `meta_beliefs`, and `ulid`) is the only intra-package dep.
 """
 from __future__ import annotations
 

--- a/src/aelfrice/derivation.py
+++ b/src/aelfrice/derivation.py
@@ -223,12 +223,18 @@ def derive(inp: DerivationInput) -> DerivationOutput:
        factual with alpha=1.0 / beta=1.0; the id is assigned here,
        invoked from `triple_extractor.ingest_triples` via the
        derivation worker.
-    3. All other paths (filesystem, python_ast, feedback_loop_synthesis,
-       legacy_unknown): run `classify_sentence`; skip when
-       `persist=False`. Transcript-ingest rows that carry
-       `raw_meta["role"]=="user"` (#888) get the undeflated USER_SOURCE
-       prior and `origin=user_transcript`; all other classifier-path
-       rows get the deflated prior and `origin=agent_inferred`.
+    3. Override paths: when `override_belief_type` is set, skip
+       `classify_sentence` and look up the source-adjusted prior
+       directly (origin=agent_inferred). When `route_overrides` is
+       set, skip `classify_sentence` and use the router-supplied
+       (type, origin, alpha, beta) verbatim.
+    4. All other paths (filesystem, python_ast, feedback_loop_synthesis,
+       legacy_unknown), when neither override is set: run
+       `classify_sentence`; skip when `persist=False`. Transcript-ingest
+       rows that carry `raw_meta["role"]=="user"` (#888) get the
+       undeflated USER_SOURCE prior and `origin=user_transcript`; all
+       other classifier-path rows get the deflated prior and
+       `origin=agent_inferred`.
 
     The belief `id` is derived deterministically from the input so that
     re-deriving the same input yields the same id — replay equality is

--- a/src/aelfrice/derivation_worker.py
+++ b/src/aelfrice/derivation_worker.py
@@ -32,7 +32,7 @@ Design properties:
   empty derived_belief_ids whose deterministic belief id already exists
   in `beliefs`) and stamps it.
 
-- **Concurrency.** Belief id is sha256(source + text)[:16]; two parallel
+- **Concurrency.** Belief id is sha256(source + NUL + text)[:16]; two parallel
   workers producing the same id converge on one row via the content_hash
   UNIQUE constraint inside `insert_or_corroborate`. Each worker stamps its
   own log row independently — log rows are 1:1 with raw inputs, not

--- a/src/aelfrice/doc_linker_types.py
+++ b/src/aelfrice/doc_linker_types.py
@@ -4,7 +4,7 @@ Extracted from `aelfrice.doc_linker` so `aelfrice.store` can read the
 `DocAnchor` shape without closing a `doc_linker ↔ store` import cycle
 (`doc_linker.link_belief_to_document` calls `store.link_belief_to_document`,
 and `store` returns `DocAnchor` rows back). Mirrors the leaf-module
-pattern used in #500 for `np_pattern` / `classification_core` / `db_paths`.
+pattern used in #499 for `np_pattern` / `classification_core` / `db_paths`.
 
 This module imports nothing from the rest of `aelfrice` — keep it that way.
 """

--- a/src/aelfrice/doctor.py
+++ b/src/aelfrice/doctor.py
@@ -351,10 +351,11 @@ class DoctorReport:
     missing_runtime_deps: list[str] = field(
         default_factory=lambda: cast(list[str], [])
     )
-    # Default-on auto-capture hook basenames (since v2.1, #529) that
-    # are absent from every scanned settings.json. Pre-v2.1 installs
-    # that ran `aelf setup` before the default flip end up here
-    # (#557): they have retrieval-only wiring and need a re-run.
+    # Default-on auto-capture hook basenames (v2.1/#529 for the first
+    # three; v3.0/#582 for the stop-hook) that are absent from every
+    # scanned settings.json. Installs that predate the relevant
+    # default flip end up here (#557): they have retrieval-only
+    # wiring and need a re-run.
     missing_auto_capture_hooks: list[str] = field(
         default_factory=lambda: cast(list[str], [])
     )
@@ -606,8 +607,10 @@ def _scan_orphan_slash_commands(
 ) -> list[str]:
     """Return slash-command basenames whose CLI subcommand is missing.
 
-    Ignores `aelf-*` files that wrap meta commands (none ship today
-    but reserved). Returns sorted basenames so the CLI report stable.
+    Checks every `.md` file directly under `slash_dir` against `known`;
+    there is no special-casing for any filename prefix (no bundled
+    slash-command file uses an `aelf-*` naming pattern today). Returns
+    sorted basenames so the CLI report is stable.
     """
     if not slash_dir.is_dir():
         return []

--- a/src/aelfrice/entity_extractor.py
+++ b/src/aelfrice/entity_extractor.py
@@ -175,7 +175,7 @@ class Entity:
 
     `raw` is the literal matched substring; `lower` is `raw.lower()`
     used as the index key. `kind` is one of the KIND_* constants.
-    `span_start` / `span_end` are byte offsets into the source text
+    `span_start` / `span_end` are character offsets into the source text
     used by the future highlighting / span-aware ranker (currently
     written for free since the regex `Match` exposes them).
     """

--- a/src/aelfrice/expansion_gate.py
+++ b/src/aelfrice/expansion_gate.py
@@ -1,8 +1,9 @@
 """Adaptive expansion-gate for retrieval (#741).
 
 Cheap deterministic prompt-shape gate that decides whether to run the
-expensive expansion layers (BFS multi-hop, HRR structural) for a given
-query. Broad natural-language prompts that lack structural markers are
+expensive BFS multi-hop expansion layer for a given query (the
+HRR-structural field is reserved for a future gate but stays on
+unconditionally in v1). Broad natural-language prompts that lack structural markers are
 unlikely to benefit from graph expansion and pay the highest latency
 cost on those lanes — the gate short-circuits expansion on them while
 keeping L0 / L1 / L2.5-entity always on.
@@ -23,7 +24,8 @@ Heuristics (all deterministic, stdlib-only):
   - Length: prompt token count > ``BROAD_PROMPT_TOKEN_THRESHOLD``
     (default 80) → broad signal.
   - Structural-marker absence: no ``#NNN`` issue refs, no file paths
-    (``src/...``, ``tests/...``, ``docs/...``, ``benchmarks/...``),
+    (``src/...``, ``tests/...``, ``docs/...``, ``benchmarks/...``,
+    ``scripts/...``),
     no snake_case / camelCase identifiers, no edge-type names
     (``SUPPORTS``, ``CONTRADICTS``, ...) → broad signal.
   - Question-form prefix: starts with ``what``, ``why``, ``how``,

--- a/src/aelfrice/hook.py
+++ b/src/aelfrice/hook.py
@@ -1452,7 +1452,7 @@ def _record_injection_events(
     """Append one ``injection_events`` row per injected belief.
 
     Fires from the UPS hook after retrieval has decided which beliefs
-    will appear in the rendered ``<aelfrice-rebuild>`` block. The
+    will appear in the rendered ``<aelfrice-memory>`` block. The
     sweeper at the *next* UPS turn (#779 Layer 3) reads these rows,
     scores ``referenced`` against the assistant transcript, and pushes
     one update per active consumer into the meta-belief substrate.
@@ -2613,12 +2613,12 @@ def _read_recent_for_pre_compact(
 
     Resolution order:
       1. <payload.cwd>/.git/aelfrice/transcripts/turns.jsonl -- the
-         canonical aelfrice log written by the per-turn UserPromptSubmit/
-         Stop hooks once transcript_ingest ships. Preferred when
-         present.
+         canonical aelfrice log written by the transcript-logger's
+         UserPromptSubmit/Stop hooks (shipped v1.2.0, #111; installed
+         by default via `aelf setup`). Preferred when present.
       2. <payload.transcript_path> -- Claude Code's internal per-session
-         transcript JSONL. Fallback for the alpha while transcript_ingest
-         is unshipped.
+         transcript JSONL. Fallback for hosts where the transcript-logger
+         hooks are not installed.
       3. Empty list -- both sources missing or unreadable.
     """
     cwd_obj = payload.get(_CWD_KEY)

--- a/src/aelfrice/hook_search.py
+++ b/src/aelfrice/hook_search.py
@@ -42,7 +42,7 @@ from aelfrice.store import MemoryStore
 
 HOOK_FEEDBACK_SOURCE: Final[str] = "hook"
 """`source` value written into feedback_history for every hook-driven
-retrieval row. LIMITATIONS.md commits this string publicly; downstream
+retrieval row. ARCHITECTURE.md commits this string publicly; downstream
 analysis (e.g. `SELECT ... WHERE source = 'hook'`) depends on it."""
 
 HOOK_RETRIEVAL_VALENCE: Final[float] = 0.1

--- a/src/aelfrice/hook_search_tool.py
+++ b/src/aelfrice/hook_search_tool.py
@@ -783,7 +783,7 @@ def _do_search(
 
 
 def _db_path_accepts_cwd(db_path_fn: object) -> bool:
-    """Best-effort detection: does aelfrice.cli.db_path() accept a cwd kw?
+    """Best-effort detection: does aelfrice.db_paths.db_path() accept a cwd kw?
 
     v1.1.0 db_path() reads cwd from os.getcwd(); a later patch may add a
     cwd parameter for callers that need to scope to a specific worktree.

--- a/src/aelfrice/hook_tail.py
+++ b/src/aelfrice/hook_tail.py
@@ -136,7 +136,7 @@ def format_record(
 ) -> str:
     """Render one audit record as multi-line text suitable for tail output.
 
-    Header line: `<HH:MM:SS>  <hook>  <tokens>tok  <latency>ms  L0×N L1×M`.
+    Header line: `<HH:MM:SS>  <hook>  <tokens> tok  <latency> ms  L0×N L1×M`.
     Then one indented line per belief from `beliefs[]` (when present).
     `include_blob=False` suppresses the per-belief snippet bodies and
     leaves just the header line + per-belief identifiers.

--- a/src/aelfrice/ingest.py
+++ b/src/aelfrice/ingest.py
@@ -122,8 +122,9 @@ def ingest_turn(
       3. Insert classifications with `persist=True` as beliefs.
 
     Idempotent on (source, sentence) pairs: re-ingesting the same turn
-    triggers `INSERT OR IGNORE` semantics in the store (belief id
-    derives from the sha256 of source + sentence). Sentences whose
+    resolves to the same belief id (sha256 of source + sentence) via a
+    content-hash lookup in `insert_or_corroborate`, which corroborates
+    the existing row instead of re-inserting it. Sentences whose
     classification returns `persist=False` (questions, empty text) are
     skipped.
 
@@ -429,18 +430,22 @@ def ingest_jsonl(
         usable (issue #115 — retroactive ingestion of historical
         Claude Code session logs).
 
-    Within a session, consecutive turns are linked with DERIVED_FROM
+    Within a session, consecutive user turns are linked with DERIVED_FROM
     edges from turn N+1's last belief back to turn N's last belief,
     `anchor_text` set to the prior turn's text (truncated to
-    ANCHOR_TEXT_MAX_LEN).
+    ANCHOR_TEXT_MAX_LEN). Assistant-role lines are excluded from belief
+    creation and edge-wiring by the #785 speaker-attribution gate, so
+    edges bridge across any intervening assistant turns rather than
+    linking strictly consecutive lines.
 
     Idempotency: ingest_turn dedupes per (source_label, sentence), so
     re-running on the same file produces zero new beliefs. Edge
     inserts are wrapped in a duplicate-PK guard for the same reason.
 
     Lines without role/text (compaction markers, file-history
-    snapshots, tool-result entries, malformed) are counted under
-    `skipped_lines` and ignored without raising.
+    snapshots, tool-result entries, malformed), plus well-formed
+    assistant-role lines excluded by the #785 speaker-attribution gate,
+    are counted under `skipped_lines` and ignored without raising.
     """
     from aelfrice.inedible import is_inedible_path
 

--- a/src/aelfrice/mcp_server.py
+++ b/src/aelfrice/mcp_server.py
@@ -12,26 +12,26 @@ Tests import the pure handlers directly; they never need the optional
 `[project.optional-dependencies].mcp` and is only required when a host
 actually starts the server via `serve()`.
 
-Tool surface (all under the `aelf:` namespace at the host):
+Tool surface (function names registered at the host; MCP tool ids use underscores, a different namespace than the /aelf:* slash commands):
 
-  aelf:onboard         polymorphic — three input shapes:
+  aelf_onboard         polymorphic — three input shapes:
                          {path}                          -> start session
                          {session_id, classifications}   -> finish session
                          {}                              -> list pending
-  aelf:search          {query, budget?}                  -> hits
-  aelf:lock            {statement}                       -> id + action
-  aelf:locked          {limit?, offset?}                 -> locked beliefs
-  aelf:demote          {belief_id}                       -> demoted bool
-  aelf:validate        {belief_id, source?}              -> origin promotion
-  aelf:unlock          {belief_id}                       -> lock cleared
-  aelf:promote         {belief_id, source?}              -> alias of validate
-  aelf:feedback        {belief_id, signal, source?}      -> updated priors
-  aelf:confirm         {belief_id, source?, note?}       -> affirmed priors
-  aelf:stats           {}                                -> counts
-  aelf:health          {}                                -> regime report
-  aelf:wonder          {query, budget?, depth?, agent_count?} -> research axes
-  aelf:wonder_persist  {query, budget?, depth?, top?, seed?} -> insert summary
-  aelf:wonder_gc       {ttl_days?, dry_run?}            -> gc summary
+  aelf_search          {query, budget?}                  -> hits
+  aelf_lock            {statement}                       -> id + action
+  aelf_locked          {limit?, offset?}                 -> locked beliefs
+  aelf_demote          {belief_id}                       -> demoted bool
+  aelf_validate        {belief_id, source?}              -> origin promotion
+  aelf_unlock          {belief_id}                       -> lock cleared
+  aelf_promote         {belief_id, source?}              -> alias of validate
+  aelf_feedback        {belief_id, signal, source?}      -> updated priors
+  aelf_confirm         {belief_id, source?, note?}       -> affirmed priors
+  aelf_stats           {}                                -> counts
+  aelf_health          {}                                -> regime report
+  aelf_wonder          {query, budget?, depth?, agent_count?} -> research axes
+  aelf_wonder_persist  {query, budget?, depth?, top?, seed?} -> insert summary
+  aelf_wonder_gc       {ttl_days?, dry_run?}            -> gc summary
 
 The polymorphic onboard is a single MCP tool, not three (per pre-commit
 on tool-surface invisibility — the host LLM should not see plumbing
@@ -1628,12 +1628,15 @@ def serve() -> None:
         Read-only.
 
         Returns: {"kind": "stats.snapshot",
+                  "version": str,
                   "beliefs": int,
                   "edges": int,    # v1.0 key (retained indefinitely; prefer threads)
                   "threads": int,  # v1.1 key (forward-compatible alias)
                   "locked": int,
                   "feedback_events": int,
-                  "onboard_sessions_total": int}
+                  "onboard_sessions_total": int,
+                  "phantoms": {"active": int, "promoted": int,
+                              "retired": int, "latest": str | None}}
         """
         store = _open_default_store()
         try:

--- a/src/aelfrice/models.py
+++ b/src/aelfrice/models.py
@@ -1,6 +1,6 @@
 """Domain dataclasses for aelfrice.
 
-Load-bearing fields only. 4 belief types, 5 edge types, 2 lock levels. No
+Load-bearing fields only. 5 belief types, 10 edge types, 2 lock levels. No
 multi-source tagging, no rigor tier, no bitemporal event_time — those are
 deferred to a later release.
 """
@@ -369,7 +369,7 @@ class Belief:
     review workflow. The review candidate sorter treats NULL as the
     oldest possible timestamp so unreviewed beliefs surface first.
 
-    `lock_tier` (v3.7 #1016-B) is the layered-lock tier — 'frozen'
+    `lock_tier` (v3.8 #1016-B) is the layered-lock tier — 'frozen'
     (always injected verbatim) or 'reference' (bounded, manifest-only).
     Only meaningful when `lock_level == LOCK_USER`. Defaults to 'frozen'
     so every existing lock keeps its pre-#1016 always-verbatim behaviour

--- a/src/aelfrice/pre_issue_create_hook.py
+++ b/src/aelfrice/pre_issue_create_hook.py
@@ -34,9 +34,9 @@ Both are mutually honoured; the first that evaluates truthy wins.
 
 Body-file safety
 ----------------
-``--body-file <F>`` paths that resolve under ``~/.claude/`` are refused; the
-body read is silently skipped (treated as empty string) so the guard still
-runs on title tokens alone.
+``--body-file <F>`` is read (paths that resolve under ``~/.claude/`` are
+refused and treated as empty), but the body content is not currently used
+in scoring in any case -- the guard always evaluates title tokens alone.
 """
 from __future__ import annotations
 
@@ -60,7 +60,8 @@ TOP_N_CANDIDATES: int = 5
 """Maximum number of candidates printed in the BLOCK message."""
 
 TOP_K_QUERY_TOKENS: int = 3
-"""Number of highest-value query tokens forwarded to gh/git searches."""
+"""Number of query tokens forwarded to gh/git searches (selected in
+alphabetical order for determinism, not ranked by importance)."""
 
 GH_RESULT_LIMIT: int = 20
 """Maximum candidates requested from `gh issue list`."""

--- a/src/aelfrice/project_warm.py
+++ b/src/aelfrice/project_warm.py
@@ -36,7 +36,7 @@ Resolution order for `resolve_project_root(path)`:
 Deny-glob defaults catch the common false-positive cases:
 `/tmp/**`, `/var/folders/**`, `~/Downloads/**`, `~/Desktop/**`.
 Override via `~/.aelfrice/config.json`'s `project_warm.deny_globs`
-key (list of strings; `~` expanded at load time).
+key (list of strings; `~` expanded at match time, not at config-load time).
 """
 from __future__ import annotations
 

--- a/src/aelfrice/reason.py
+++ b/src/aelfrice/reason.py
@@ -208,9 +208,11 @@ def classify(
 
     Determinism: impasse list order is fixed by construction order in
     this function (``NO_CHANGE`` first, then ``CONSTRAINT_FAILURE``,
-    then ``TIE``, then ``GAP``); within each kind impasses are emitted
-    in hop-list order (which itself is deterministic per
-    :func:`aelfrice.bfs_multihop.expand_bfs`'s ordering contract).
+    then posterior-mean ``TIE``, then ``GAP``, then — only when
+    ``paths`` is supplied — fork-based ``TIE`` impasses last); within
+    each kind impasses are emitted in hop-list order (which itself is
+    deterministic per :func:`aelfrice.bfs_multihop.expand_bfs`'s
+    ordering contract).
 
     ``paths`` (R2, #658): when supplied, the classifier additionally
     emits a ``TIE`` impasse when two CONTRADICTS-forked paths share a

--- a/src/aelfrice/retrieval.py
+++ b/src/aelfrice/retrieval.py
@@ -3656,7 +3656,8 @@ class RetrievalCache:
     at different stores never share state.
 
     Cache key includes the entity-index flag (v1.3.0 default-on),
-    the BFS flag (v1.3.0 default-off), and `posterior_weight`
+    the BFS flag (v1.3.0 default-off), `use_bm25f_anchors`
+    (v1.7.0 default-on per #154), and `posterior_weight`
     (v1.3.0 default 0.5, rounded to `POSTERIOR_WEIGHT_KEY_PRECISION`
     decimals so floating-point jitter does not fragment the cache).
     Two queries that differ in any of these are distinct entries.

--- a/src/aelfrice/review.py
+++ b/src/aelfrice/review.py
@@ -14,7 +14,11 @@ apply_decisions(store, decisions, *, now: str) -> ApplyReport
 Exceptions
 ----------
 AmbiguousRowError   — raised by parse_review_file when a row has >1 checked box
-MalformedRowError   — raised by parse_review_file when a row's ID is missing
+MalformedRowError   — defense-in-depth in parse_review_file's belief-ID
+                      check; unreachable via the current row regex, which
+                      requires at least one non-whitespace ID character to
+                      match at all (rows with no ID token are silently
+                      ignored, not raised on)
 """
 from __future__ import annotations
 
@@ -238,8 +242,8 @@ def apply_decisions(
 
     Verdict semantics:
     - keep   → update_last_confirmed_at(belief_id, now)
-    - remove → soft_delete_belief (existing primitive; writes audit via
-               feedback_history)
+    - remove → soft_delete_belief (existing primitive), followed by an
+               explicit insert_feedback_event(source="review:remove") audit row
     - lock   → set lock_level=user, locked_at=now, origin=user_stated,
                write a 'review:lock' audit row
     - skip   → no-op (belief stays in the next review cycle)

--- a/src/aelfrice/scanner.py
+++ b/src/aelfrice/scanner.py
@@ -107,7 +107,7 @@ class LLMRouter(Protocol):
     """Minimal interface scanner needs from an LLM-classify driver.
 
     Production callers pass `aelfrice.llm_classifier.ScannerRouter`
-    (defined in cli.py to keep the SDK lazily-imported); tests pass a
+    (defined there, with the SDK import kept lazy inside its methods); tests pass a
     mock. The protocol decouples scanner.py from the optional
     `anthropic` SDK at module-load.
 
@@ -169,7 +169,9 @@ def scan_repo(
 
     Idempotent: a belief id is `sha256(source\\x00text)[:16]`, so
     re-scanning the same tree produces no duplicates. Existing beliefs
-    are detected via `MemoryStore.get_belief(id)` and skipped.
+    are detected via `MemoryStore.insert_or_corroborate()`'s content-hash
+    lookup (`get_belief_by_content_hash`) and corroborated instead of
+    re-inserted.
 
     Non-persistable candidates (classifier returned `persist=False` —
     empty paragraphs, question-form sentences) are counted in

--- a/src/aelfrice/session_ring.py
+++ b/src/aelfrice/session_ring.py
@@ -774,9 +774,9 @@ def read_phantom_state(session_id: str | None) -> dict[str, Any]:
 def read_ring_state(session_id: str | None) -> dict[str, Any]:
     """Return the ring shape for ``session_id``, or ``{}`` when absent.
 
-    Read-only. Surface for ``aelf doctor`` telemetry — callers should
-    treat the dict as opaque and read ``ring`` length, ``ring_max``, and
-    ``evicted_total`` for display.
+    Read-only. Primary surface for the hook's cadence dispatcher
+    (``aelfrice.hook``) to read P1/P3/phantom ring state on each fire;
+    ``aelf doctor`` instead uses the session-agnostic ``read_ring_file()``.
     """
     if not session_id:
         return {}

--- a/src/aelfrice/store.py
+++ b/src/aelfrice/store.py
@@ -1083,8 +1083,9 @@ class MemoryStore:
 
         Called from every belief insert / update path. Local-write
         rule per the #204 spec: `vv[local_scope] += 1` on every
-        write. Idempotent INSERT OR REPLACE on the composite PK keeps
-        the row count bounded by `n_beliefs * n_scopes`.
+        write. Idempotent `INSERT ... ON CONFLICT DO UPDATE` (increment)
+        on the composite PK keeps the row count bounded by
+        `n_beliefs * n_scopes`.
         """
         self._conn.execute(
             "INSERT INTO belief_versions (belief_id, scope_id, counter) "
@@ -2361,9 +2362,10 @@ class MemoryStore:
         not raise under normal input.
 
         Lazy import of `aelfrice.entity_extractor` to keep the import
-        graph acyclic (entity_extractor only imports triple_extractor,
-        not store) and so the extra cost of regex compilation is paid
-        once on first insert rather than at module load.
+        graph acyclic (entity_extractor imports only
+        `aelfrice.np_pattern`, not store) and so the extra cost of
+        regex compilation is paid once on first insert rather than at
+        module load.
         """
         from aelfrice.entity_extractor import extract_entities
 
@@ -3018,8 +3020,9 @@ class MemoryStore:
         `session_id` and `source_path_hash` are nullable: pass None
         when unavailable; no exception is raised.
 
-        #1020: idempotent per `(belief_id, session_id, source_path_hash)`
-        via `INSERT OR IGNORE` against the `uq_belief_corroborations_source`
+        #1020: idempotent per `(belief_id, session_id, source_path_hash,
+        source_type)` via `INSERT OR IGNORE` against the
+        `uq_belief_corroborations_source`
         UNIQUE index. Re-ingesting the same source in the same session (the
         #1012 Stop-flush re-reading `turns.jsonl`) no longer inflates the
         count — corroboration measures *distinct* re-assertions, not raw
@@ -3590,8 +3593,8 @@ class MemoryStore:
         increments ``touch_count`` by 1, and OR-s ``event_kind`` into
         the bitmask.
 
-        Raises ``ValueError`` on empty ``belief_id`` / ``session_id``
-        or non-positive ``fire_idx`` / ``event_kind``. The FK to
+        Raises ``ValueError`` on empty ``belief_id`` / ``session_id``,
+        a negative ``fire_idx``, or a non-positive ``event_kind``. The FK to
         ``beliefs(id)`` is enforced at write time when foreign keys
         are on (test fixtures must populate ``beliefs`` first or
         disable FK enforcement for isolated unit tests).

--- a/src/aelfrice/triple_extractor.py
+++ b/src/aelfrice/triple_extractor.py
@@ -1,9 +1,11 @@
 """Mechanical (subject, relation, object) triple extraction from prose.
 
 Pure regex over a fixed pattern bank. No POS tagger, no embedding,
-no LLM. Reusable by every v1.x ingest caller that has prose at
-hand: the v1.2.0 commit-ingest hook, transcript-ingest, manual
-`aelf remember` calls, and the v1.3.0 entity-index path.
+no LLM. Reusable by any v1.x ingest caller that has prose at
+hand. Current call sites: the v1.2.0 commit-ingest hook
+(`hook_commit_ingest.py`) and the context-rebuilder's query-enrichment
+pass (`context_rebuilder.py`, `extract_triples` only). Not currently
+wired into transcript-ingest or `aelf remember`.
 
 Two-piece API per docs/design/triple_extractor.md:
 

--- a/src/aelfrice/wonder/strategies.py
+++ b/src/aelfrice/wonder/strategies.py
@@ -72,7 +72,7 @@ def random_walk(
     """RW: start from high-uncertainty atoms; walk ``depth`` hops.
 
     Seed selection: any belief whose ``uncertainty_score(α, β)``
-    exceeds ``uncertainty_floor`` is eligible. RNG samples
+    meets or exceeds ``uncertainty_floor`` is eligible. RNG samples
     ``n_walks`` seeds *with replacement* — empirically observed
     sample variance is what the spec wants to falsify, so resampling
     is allowed.


### PR DESCRIPTION
Part of #1075 (v4.0.0 docs-audit release gate) — the follow-up fixing the
**48 MEDIUM/LOW in-code documentation findings** enumerated in the audit ledger
`docs/audits/DOCS-AUDIT-2026-07-04-incode.md` (§ MEDIUM/LOW), landed by the
CRITICAL/HIGH pass in #1080.

## What this does

Corrects 48 MEDIUM/LOW in-code doc-drift items across **33 `src/aelfrice/`
files** — stale-but-checkable docstrings, argparse/MCP descriptions, and field
comments. Each was **independently reproduced against code at HEAD** by a
per-file fixer pass (default-skip on any subjective/unreproducible claim; 0 of
48 were skipped — all resolved to real factual drift). Surgical, doc-text-only,
per-file atomic commits.

Representative corrections:
- `store.py`: `_bump_belief_version` said `INSERT OR REPLACE` (actual: `ON CONFLICT DO UPDATE`); `record_corroboration` idempotency key omitted `source_type` from its 4-column unique index; `_write_belief_entities` claimed `entity_extractor` imports `triple_extractor` (actual: `np_pattern`).
- `hook.py`: `_record_injection_events` docstring named the `<aelfrice-rebuild>` block (it fires on the UPS path, which renders `<aelfrice-memory>`); `_read_recent_for_pre_compact` still described an unshipped `transcript_ingest` gate.
- `retrieval.py`: `RetrievalCache` cache-key enumeration omitted `use_bm25f_anchors` (corrected to its real default posture after independent check, not the reader's stale suggestion).
- `cli.py`: `--claude-memory-mirror` help missed `MultiEdit` in the wired `PostToolUse` matcher.
- Plus 40 more across doctor, mcp_server, models, cadence, ingest, scanner, reason, review, auditor, expansion_gate, etc.

## Discretion + tests

No newly-added line carries a banned harness/model literal (the fixer neutralized
or skipped those). No test asserted a changed string — the `<aelfrice-rebuild>`
tests exercise the rebuild path, not the edited UPS-path docstring. Full suite
green.

## Relation to #1080 / #1075

- Independent of #1080 (touches the same files at different lines; sequential
  FF-merge, whichever lands first). Together they clear the **in-code layer**
  CRITICAL→LOW.
- The ledger's "MED/LOW deferred" disposition should flip to *fixed* once both
  land (trivial follow-up).
- Does **not** close #1075: the 1 discretion-deferred `llm_classifier` finding,
  the `tests/`+`benchmarks/` `.py` docstring layer, and #1078's deferred doc-file
  buckets remain before the v4.0.0 tag.
