### PR TITLE
fix(classification): drop hedged conversational floats at ingest (#1081)

### DIFF
--- a/src/aelfrice/classification_core.py
+++ b/src/aelfrice/classification_core.py
@@ -81,6 +81,63 @@ _QUESTION_PREFIXES: Final[tuple[str, ...]] = (
     "could ",
 )
 
+# Statement-form speculative floats (#1081). Unlike `_is_question` these do
+# NOT end in `?` — they are declarative in *form* but tentative in *force*:
+# a floated idea or musing ("Maybe we need X", "What if we tried Y") rather
+# than an assertion. Passive transcript capture was storing these as
+# `factual` beliefs; they read as conversation, not durable knowledge.
+#
+# Two high-precision arms keep false positives low:
+#  - LEADING hedge: the sentence *opens* with a hedge marker. A sentence
+#    that starts with "Maybe " / "What if " / "Should we " (no `?`) is almost
+#    always a float; a genuine assertion that merely *contains* "maybe"
+#    mid-sentence is not matched.
+#  - a small set of unambiguous proposal-hedge PHRASES ("we probably need",
+#    "maybe we") that signal a floated proposal wherever they appear.
+#
+# Applied only to the default-factual bucket (see `classify_sentence` step
+# 6), so a typed requirement / correction / preference is never dropped for
+# being hedged. Bald hedge-free musings ("All averages are not useful.")
+# have no deterministic signal and are intentionally out of scope for this
+# ingest gate — they are handled by the retrieval / curation lanes
+# (#1081 directions C/D), not here. Pure/deterministic: replay-stable.
+_FLOAT_LEADING_HEDGES: Final[tuple[str, ...]] = (
+    "maybe ",
+    "maybe,",
+    "perhaps ",
+    "perhaps,",
+    "what if ",
+    "how about ",
+    "what about ",
+    "i wonder ",
+    "i wonder if",
+    "wondering if ",
+    "not sure ",
+    "i guess ",
+    "i suppose ",
+    "or maybe ",
+    "or perhaps ",
+    "or should ",
+    "or we could ",
+    "or we should ",
+    "should we ",
+    "could we ",
+    "shouldn't we ",
+    "shouldnt we ",
+)
+
+_FLOAT_INTERNAL_HEDGES: Final[tuple[str, ...]] = (
+    "maybe we ",
+    "maybe there ",
+    "maybe it would ",
+    "we probably need ",
+    "we could probably ",
+    "we might want ",
+    "we should probably ",
+    "not sure if ",
+    "not sure whether ",
+)
+
 # An internal sentence boundary: ./!/? — optionally followed by a closing
 # quote/paren/bracket — then whitespace. The closers matter: a prior
 # sentence ending in `."` / `.)` / `?"` must still register as a boundary so
@@ -165,6 +222,26 @@ def _is_question(text_lower: str) -> bool:
     return _SENTENCE_BOUNDARY_RE.search(s[:-1]) is None
 
 
+def _is_speculative_float(text_lower: str) -> bool:
+    """True when the sentence is a hedged/hypothetical float (#1081).
+
+    Declarative in form (no trailing `?`, so `_is_question` misses it) but
+    tentative in force — a floated idea or musing rather than an assertion.
+    Matches only high-precision markers: a LEADING hedge (the sentence opens
+    with "maybe …" / "what if …" / "should we …" and friends) or one of a
+    small set of unambiguous proposal-hedge phrases ("we probably need …",
+    "maybe we …"). Callers apply this only to the default-factual bucket, so
+    a typed requirement / correction / preference is never dropped for being
+    hedged. Pure and deterministic — re-runs identically on `aelf rebuild`.
+    """
+    s = text_lower.strip()
+    if not s:
+        return False
+    if s.startswith(_FLOAT_LEADING_HEDGES):
+        return True
+    return any(phrase in s for phrase in _FLOAT_INTERNAL_HEDGES)
+
+
 def _has_any(text_lower: str, keywords: tuple[str, ...]) -> bool:
     return any(kw in text_lower for kw in keywords)
 
@@ -181,7 +258,8 @@ def classify_sentence(text: str, source: str) -> ClassificationResult:
     3. User source + requirement keywords -> requirement.
     4. User source + correction-detector positive -> correction.
     5. Preference keywords -> preference.
-    6. Default -> factual.
+    6. Speculative float (hedged musing, #1081) -> factual, persist=False.
+    7. Default -> factual.
 
     Always sets pending_classification=True in v1.0; the host-handshake
     path that flips it to False ships at v0.6.0.
@@ -259,7 +337,23 @@ def classify_sentence(text: str, source: str) -> ClassificationResult:
             pending_classification=True,
         )
 
-    # 6. Default: factual.
+    # 6. Speculative float (#1081): a hedged musing that reached the
+    #    default-factual bucket (not a typed requirement/correction/
+    #    preference). Declarative in form but tentative in force — passive
+    #    capture was storing these conversational fragments as beliefs.
+    #    persist=False, like questions. Placed last so a hedged sentence
+    #    that IS a requirement/correction/preference is kept.
+    if _is_speculative_float(text_lower):
+        alpha, beta = get_source_adjusted_prior(BELIEF_FACTUAL, source)
+        return ClassificationResult(
+            belief_type=BELIEF_FACTUAL,
+            alpha=alpha,
+            beta=beta,
+            persist=False,
+            pending_classification=True,
+        )
+
+    # 7. Default: factual.
     alpha, beta = get_source_adjusted_prior(BELIEF_FACTUAL, source)
     return ClassificationResult(
         belief_type=BELIEF_FACTUAL,

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -252,6 +252,101 @@ def test_factual_default_uses_factual_prior() -> None:
     assert (r.alpha, r.beta) == (a, b)
 
 
+# --- Speculative-float filter (#1081) ------------------------------------
+
+
+def test_float_leading_maybe_no_persist() -> None:
+    """A statement-form hedge that opens with 'maybe' is a float, not a
+    belief — even though it has no trailing '?' so `_is_question` misses it.
+    """
+    r = classify_sentence("maybe we need one more layer before targets.", "user")
+    assert r.belief_type == BELIEF_FACTUAL
+    assert r.persist is False
+
+
+def test_float_leading_hedges_no_persist() -> None:
+    """Each high-precision leading hedge marks the sentence as a float."""
+    for t in (
+        "Perhaps the retry count is off.",
+        "What if we tried a calendar concept instead.",
+        "Should we flip the default.",
+        "Could we batch these writes.",
+        "Not sure this handles unicode.",
+        "I wonder about a dedicated lane here.",
+        "I guess we could split the module.",
+        "Or maybe there should be a separate schedule.",
+        "How about a second index.",
+    ):
+        assert classify_sentence(t, "user").persist is False, t
+
+
+def test_float_internal_proposal_hedge_no_persist() -> None:
+    """Unambiguous proposal-hedge phrases float the sentence wherever they
+    appear, not only at the start."""
+    for t in (
+        "We probably need a new concept of a calendar.",
+        "Honestly we might want to revisit the budget.",
+        "For onboarding we should probably add a banner.",
+        "Not sure if the lane survives the trim.",
+    ):
+        assert classify_sentence(t, "user").persist is False, t
+
+
+def test_float_dropped_result_stays_factual_and_pending() -> None:
+    """A dropped float keeps the factual type/prior and the pending flag —
+    only `persist` flips, mirroring the question path."""
+    r = classify_sentence("maybe we should cache the tree.", "user")
+    assert r.belief_type == BELIEF_FACTUAL
+    assert (r.alpha, r.beta) == TYPE_PRIORS[BELIEF_FACTUAL]
+    assert r.pending_classification is True
+
+
+def test_midsentence_hedge_word_persists() -> None:
+    """A genuine assertion that merely CONTAINS a hedge word mid-sentence
+    (not a leading hedge, not a proposal-hedge phrase) is kept."""
+    for t in (
+        "The test probably fails on slow hardware.",
+        "This maybe-flag controls the lane.",
+        "Users perhaps expect the older default.",
+    ):
+        assert classify_sentence(t, "user").persist is True, t
+
+
+def test_leading_should_be_is_not_a_float() -> None:
+    """'should we' hedges a proposal; 'should be' asserts one. Only the
+    former is filtered."""
+    r = classify_sentence("There should be a lock on this belief.", "user")
+    assert r.persist is True
+
+
+def test_bald_musing_without_hedge_persists_out_of_scope() -> None:
+    """Hedge-free declarative musings have no deterministic signal and are
+    intentionally out of scope for this ingest gate (handled downstream)."""
+    r = classify_sentence("All averages are not useful.", "user")
+    assert r.persist is True
+
+
+def test_typed_belief_kept_even_when_hedged() -> None:
+    """The float check runs last, so a requirement / correction / preference
+    is never dropped for being hedged — the type signal wins."""
+    req = classify_sentence("maybe the commits must be signed.", "user")
+    assert req.belief_type == BELIEF_REQUIREMENT
+    assert req.persist is True
+    pref = classify_sentence("maybe I prefer tabs over spaces.", "user")
+    assert pref.belief_type == BELIEF_PREFERENCE
+    assert pref.persist is True
+
+
+def test_float_filter_case_insensitive() -> None:
+    assert classify_sentence("MAYBE WE NEED A CALENDAR.", "user").persist is False
+
+
+def test_float_filter_deterministic() -> None:
+    r1 = classify_sentence("what if we added a spine lane.", "user")
+    r2 = classify_sentence("what if we added a spine lane.", "user")
+    assert r1.persist == r2.persist is False
+
+
 # --- Result object surface -----------------------------------------------
 
 


### PR DESCRIPTION
Part of **#1081** — direction A of the four approved (ingest gate, resolution lifecycle, retrieval suppression, backlog cleanup). This is the ingest-gate piece; #1081 stays open as the umbrella for D/C/B.

## Problem

Passive transcript capture stored statement-form musings as `factual` beliefs. `classify_sentence` dropped only trailing-`?` questions (`_is_question`), so hedged declaratives — the reporter's own examples *"Maybe we need one more layer"*, *"We probably need a new concept of a calendar"* — passed every filter and became beliefs. The store filled with half-thoughts that read as conversation, not durable knowledge.

## Fix

`_is_speculative_float`, a deterministic keyword predicate mirroring `_is_question`:

- **Leading hedge** — the sentence *opens* with a hedge marker (`maybe …`, `what if …`, `should we …`, `not sure …`, `i wonder …`, …). A sentence that starts with a hedge is almost always a float; one that merely *contains* "maybe" mid-sentence is not matched.
- **Proposal-hedge phrase** — a small set of unambiguous phrases (`we probably need`, `maybe we`, `we might want`, …) matched anywhere.

Placed **last** in the pipeline (step 6, before default-factual), so a typed requirement / correction / preference is never dropped for being hedged — the type signal wins.

## Scope boundary (honest)

High-precision by design. Two classes are intentionally **kept** and left to #1081's downstream lanes (C retrieval-suppress / D curation):

- mid-sentence hedge words in genuine assertions (*"The test probably fails on slow hardware."*)
- bald hedge-free musings (*"All averages are not useful."*) — no deterministic signal catches these without semantics, which #605 keeps out of aelfrice.

Consistent with the locked #605 philosophy (deterministic, narrow surface, no embeddings) — same class as the existing question filter.

## Behavior / compatibility

- Default-on, unflagged — matches the `_is_question` / #1027 precedent (both drop `persist=False` content with no flag).
- Pure and replay-stable: re-runs identically on `aelf rebuild`. Existing stored floats prune on the next rebuild-from-log (complements direction D); no migration in this PR.

## Tests

10 new atomic tests in `test_classification.py`: per-arm drops, false-positive guards (mid-sentence hedge kept, `should be` vs `should we`, bald musing kept, typed-belief-kept-when-hedged), case-insensitivity, determinism. An end-to-end `ingest_jsonl` check (run locally) confirms a float + a question are dropped while a real assertion + requirement persist. Full suite green (5,639 passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sentence classification to recognize tentative or hedged declarative statements and treat them as non-persistent factual items.
  * Better distinguishes genuine statements from “speculative float” phrasing, including several edge cases and case variations.

* **Bug Fixes**
  * Prevents hedged statements from being incorrectly locked in as persistent classifications.
  * Preserves stronger intent categories when hedging is present, instead of letting the hedge override the main meaning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->