### PR TITLE
docs: #1075 tests/benchmarks in-code audit — 49 fixes across 41 files

### DIFF
--- a/benchmarks/bfs_latency_v3.py
+++ b/benchmarks/bfs_latency_v3.py
@@ -27,7 +27,7 @@ named entities (``topic_NN_entity_K``) embedded in belief bodies so
 the L2.5 entity-index path has something to hit. Edges follow a
 deterministic intra-topic chain (each belief points SUPPORTS-style
 to the next two in its topic) plus one cross-topic CITES per topic,
-yielding ~25k edges.
+yielding ~20.2k edges (10,000 x 2 SUPPORTS + 200 CITES).
 
 The corpus is *not* a real-world distribution. The point is to
 exercise the v3.0 default retrieval stack against a store whose
@@ -52,7 +52,7 @@ Refs
 ----
 
 - Issue #739: BFS default-flip gated on this bench.
-- ``src/aelfrice/retrieval.py::is_bfs_enabled`` line 1144 — the
+- ``src/aelfrice/retrieval.py::is_bfs_enabled`` (currently line 2385) — the
   resolver whose default this bench is gating.
 - ``src/aelfrice/benchmark.py`` — convention used for the smaller
   v0.9 latency floor and multi-hop accuracy harnesses.

--- a/benchmarks/context_rebuilder/__init__.py
+++ b/benchmarks/context_rebuilder/__init__.py
@@ -7,9 +7,11 @@ fixture corpus at `benchmarks/context-rebuilder/fixtures/synthetic/`).
 
 This package is *scaffolding only*: it loads a transcript fixture,
 optionally forces a midpoint context-clear, and measures token-cost
-delta + PreCompact hook latency. It does NOT score continuation
-fidelity -- that is a separate v1.4.x deliverable tracked at
-issue #138 (continuation-fidelity scorer).
+delta + PreCompact hook latency. This package originally shipped as
+fidelity-scoring scaffolding only (#136); the continuation-fidelity
+scorer landed at #138 and now lives alongside it in ``score.py``
+(``score_continuation_fidelity``), wired into ``replay.run()`` via
+``score_method`` / ``post_clear_answers``.
 
 Public surface:
 

--- a/benchmarks/context_rebuilder/__main__.py
+++ b/benchmarks/context_rebuilder/__main__.py
@@ -20,9 +20,9 @@ The issue's acceptance phrasing (`python -m
 benchmarks.context_rebuilder.replay <fixture>`) names the `replay`
 submodule explicitly, so this file mirrors `python -m
 benchmarks.context_rebuilder` to the same CLI for both invocation
-forms. `replay.py` does not have its own `if __name__ ==
-"__main__":` block; it routes through here via the
-`benchmarks.context_rebuilder.replay` module's import-time alias
+forms. `replay.py` has its own `if __name__ ==
+"__main__":` block (at its end) that uses `runpy.run_module` to
+invoke this file's CLI, so both invocation forms produce identical
 established at the bottom of this file.
 """
 from __future__ import annotations

--- a/benchmarks/context_rebuilder/dynamic_probe.py
+++ b/benchmarks/context_rebuilder/dynamic_probe.py
@@ -11,8 +11,8 @@ fidelity at same-or-lower token cost). Otherwise: park to v1.5."
 The two candidates:
 
   1. **rate-of-growth.** Fire at the first turn whose 4-turn
-     rolling token-count delta exceeds the median per-turn token
-     count of the fixture. Rationale: catches moments of rapid
+     rolling average token count exceeds 1.5x the median per-turn
+     token count of the fixture. Rationale: catches moments of rapid
      working-state expansion -- the failure mode the spec calls
      out as "agent stops being able to compress its own state".
 
@@ -143,8 +143,8 @@ def _rate_of_growth_clear_at(turns: list[ReplayTurn]) -> int:
     for i in range(window, len(turns)):
         delta = sum(per_turn[i - window:i])
         # Average per-turn delta over the window vs. the per-turn
-        # median; fire when the window's average exceeds the median
-        # by at least the median (i.e. the window is double-fast).
+        # median; fire when the window's average exceeds 1.5x the
+        # per-turn median (i.e. the window is running 50% hotter).
         if delta / float(window) > median * 1.5:
             return i
     return max(1, len(turns) - 1)

--- a/benchmarks/mab_reader.py
+++ b/benchmarks/mab_reader.py
@@ -1,8 +1,9 @@
 """MAB LLM reader: generates answers from retrieval context.
 
 Takes a retrieval JSON file (question + context pairs) and sends each
-to an LLM reader to generate answers. Writes predictions file compatible
-with exp5_score.py.
+to an LLM reader to generate answers. Writes a predictions file
+(``{id, llm_prediction}`` per row); score it against MAB ground truth
+with ``mab_adapter.score_multi_answer`` or an equivalent external scorer.
 
 Usage:
     uv run python benchmarks/mab_reader.py /tmp/exp6_temporal.json --model opus

--- a/docs/audits/DOCS-AUDIT-2026-07-04-tests-bench.md
+++ b/docs/audits/DOCS-AUDIT-2026-07-04-tests-bench.md
@@ -1,0 +1,143 @@
+# In-code documentation audit — `tests/` + `benchmarks/` — 2026-07-04
+
+> **Third companion to `DOCS-AUDIT-2026-07-04.md`.** The first pass audited the
+> doc-file surface (README, `docs/**`, slash-command docs, benchmark READMEs).
+> `DOCS-AUDIT-2026-07-04-incode.md` then audited the in-code documentation layer
+> of every `.py` under `src/aelfrice/` (103 files) and **explicitly deferred**
+> the `tests/` and `benchmarks/` `.py` docstrings to a tracked follow-up (its
+> § Scope table: "recorded, **not** line-audited this pass"). This record is
+> that follow-up — it closes the in-code layer for the #1075 v4.0.0 release gate.
+
+## Scope
+
+| | Surface | Disposition |
+|---|---|---|
+| ✅ | Every `.py` under `tests/` — **387 files**, in-code docs only | audited, this record |
+| ✅ | Every `.py` under `benchmarks/` — **48 files**, in-code docs only | audited, this record |
+
+**435 files total.** Pinned at `github/main` HEAD `a74fbee5`. In-code
+documentation only: module docstrings, class/function/method docstrings,
+argparse `help=`/`description=` strings, and inline doc comments that make a
+checkable factual claim. Runtime/test logic is out of scope except where a
+docstring's claim had to be checked against the assertion it describes.
+
+## Method
+
+15-batch multi-agent audit: files were partitioned into 15 doc-weight-balanced
+batches (~29 files each), one reader per batch verifying every doc-bearing
+construct against the code it describes — following claims across modules into
+`src/aelfrice/**` (e.g. a test docstring asserting "`retrieve_v2` combines
+L0+L1+L2.5" was checked against both the test's assertions and `retrieve_v2`'s
+real behavior). **Every CRITICAL/HIGH finding was independently re-verified by
+direct code inspection** (default-reject on uncertainty) before any fix was
+written; 1 HIGH was dropped there. Fixes are surgical, doc-text-only, one
+atomic commit per file. No code behavior changed.
+
+## Coverage
+
+- **Files audited:** 435 / 435 (100%)
+- **Doc-bearing constructs (docstrings + doc comments):** ~2,917
+- **Findings:** 2 CRITICAL + 33 HIGH + 10 MEDIUM + 7 LOW = **52**
+  - **49 fixed in place** (this PR) — 1 CRITICAL + 32 HIGH + 10 MEDIUM + 6 LOW
+  - **2 deferred** — out of doc-only scope (code changes; see below)
+  - **1 dropped** on re-verify — claim not confidently reproducible
+
+Absence of a file from a fix is a recorded disposition (audited-clean), not a
+silent skip. The overwhelming majority of the 435 files had no checkable
+factual drift — test docstrings mostly restate what a test verifies, and those
+that made specific claims (constants, defaults, issue/PR numbers, API names,
+version gates) were checked and held.
+
+## Recurring drift patterns
+
+Most findings clustered into a few stale-reference classes, useful signal for
+future audits:
+
+- **`#1031` PreCompact → SessionStart(compact) move.** Several test/e2e
+  docstrings still describe the rebuild block as emitted by the PreCompact hook;
+  since #1031 the harness rejects `additionalContext` from PreCompact and the
+  block is emitted by `SessionStart` when `source == "compact"`.
+- **Shipped-but-doc'd-as-placeholder flags.** `use_heat_kernel` (#150/#154) and
+  `use_hrr_structural` (#152) shipped and left `PLACEHOLDER_FLAGS`, but several
+  docstrings still list them as unwired placeholders.
+- **Default-flip drift.** `use_intentional_clustering` (#436) and the heat-kernel
+  flag (#154) flipped to default-**on**; docstrings still said default-off.
+- **Stale skip messages.** `bench_gate` skip strings cite issues (`#201`, `#228`,
+  `#229`) as "not yet implemented" though the modules shipped (or shipped under a
+  different design) and those issues are CLOSED.
+- **`docs/design/` → `docs/design/historical/` relocations** (commit `096b01c3`):
+  `relevance_floor.md`, `lru_query_cache.md`, `belief_retention_class.md`.
+- **Stale line-number pointers.** The four `bench_gate/test_bfs_multihop_*.py`
+  scaffolds all cited `bfs_multihop.py:155-160` for the zero-weight skip logic,
+  which now lives at `bfs_multihop.py:212-213`.
+
+## CRITICAL — fixed in place (1)
+
+| # | File:line | Claim (doc said) | Reality (code does) | Fix |
+|---|---|---|---|---|
+| 1 | `tests/test_bm25_index.py`:182 (+ module docstring :17, `pytest_addoption` stub :38) | Perf test is opt-in via `pytest --run-perf`. | `--run-perf` is registered nowhere: `tests/conftest.py` has no `pytest_addoption`, and the in-file stub's body is `pass` (pytest does not collect `pytest_addoption` from a plain test module). `pytest --run-perf` errors with "unrecognized arguments"; the test is permanently skipped unless the `_has_run_perf` guard is edited. | Docstrings rewritten to describe reality (no working `--run-perf` flag; bypass the guard to run locally). |
+
+## HIGH — fixed in place (32)
+
+Materially misleading: wrong defaults/counts/versions, wrong API/flag names,
+wrong issue references, `unwired/unimplemented` claims false at HEAD, or a
+docstring describing an assertion the test no longer makes. Representative
+entries (full list = the 32 `docs(...)` commits on this branch):
+
+| File:line | Was | Now |
+|---|---|---|
+| `tests/test_heat_kernel.py`:15 | AC7 flag default **False** | default **True** (flipped #154 after #437 11/11 gate) |
+| `tests/test_hrr.py`:34,90 | noise-floor figures cited at **dim=2048** | test uses `DEFAULT_DIM` = **512** (`hrr.py:37`); `1/√512 ≈ 0.044` |
+| `tests/test_insert_belief_gate.py`:6 | `INSERT_BELIEF_ALLOWLIST` = 4 modules | 5 modules — adds `wonder.lifecycle` (#548) |
+| `tests/test_doctor_classify_orphans.py`:149 | `alpha+beta < 2` | `alpha+beta <= 2` (`store.py:3892`, inclusive) |
+| `tests/test_cli.py`:551 | `aelf health` "is gone" | retained as deprecated `argparse.SUPPRESS` alias of `aelf doctor graph` |
+| `tests/test_mcp_server.py`:377 | `edges` "removed in v1.2.0" | never removed; both keys emitted indefinitely (`mcp_server.py:812`) |
+| `tests/test_composition_tracker.py`:5 | 4 placeholder flags | 2 (`use_signed_laplacian`, `use_posterior_ranking`); heat-kernel/HRR shipped |
+| `tests/test_clustering_integration.py`:3 | byte-identical **default-OFF** | default-**ON** (#436) |
+| `tests/test_hook_project_context_filter.py`:111 | `scope='user'` is a taxonomy member | no `'user'` scope in #688 taxonomy; user-promotion is `lock_level==LOCK_USER` |
+| `tests/e2e/test_source_type_discrimination.py`:85 | records `source_type` in `belief_corroborations` | reads `source_kind` from `ingest_log` |
+| `tests/regression/test_commit_ingest_latency.py`:11 | 200 ms p95 envelope | `P95_BUDGET_MS = 1500.0` |
+| `tests/test_cli_eval.py`:138 | "future R5 CI status-check surface" | R5 shipped: `.github/workflows/eval-calibration.yml` |
+| `tests/test_context_rebuilder_hook.py`:5 / `tests/e2e/test_hook_inject_roundtrip.py`:3 | PreCompact emits the block | SessionStart(compact) emits it; PreCompact neutered (#1031) |
+| `tests/test_derivation_worker_route_overrides.py`:9,12 | `if was_inserted` guard in `scanner.py:301-310` | relocated to `derivation_worker.py` (#265 PR-B) |
+| `tests/bench_gate/test_{contradiction,wonder_consolidation}.py`:18 | modules "not yet implemented (#201/#228)" | modules ship; issues CLOSED |
+| `tests/bench_gate/test_dedup.py`:4 | skips until `#197` detector ships | `aelfrice.dedup` ships but exposes no `classify()`; gate errors, not skips |
+| `tests/bench_gate/test_intentional_clustering.py`:9 | retrieval wiring is a pending follow-up | wiring shipped default-on (#436 R6) |
+| `tests/retrieve_uplift_runner.py`:17,72,804 | `use_hrr_structural` placeholder; clustering "mutually exclusive with compression" | HRR shipped (not exposed on `retrieve()`); clustering composable since #878 |
+| `benchmarks/context_rebuilder/__init__.py`:10 | fidelity scoring "tracked at #138" (undone) | #138 shipped; `score_continuation_fidelity` lives in `score.py` |
+| `benchmarks/context_rebuilder/__main__.py`:23 | `replay.py` has no `__main__`; routes via alias | `replay.py` has its own `__main__` using `runpy.run_module` |
+| `benchmarks/mab_reader.py`:4 | writes file "compatible with `exp5_score.py`" | `exp5_score.py` never existed; scorer is `mab_adapter.py` |
+| `benchmarks/bfs_latency_v3.py`:30,55 | "~25k edges"; `is_bfs_enabled` line 1144 | ~20.2k edges (10k×2 SUPPORTS + 200 CITES); `is_bfs_enabled` at line 2385 |
+| `tests/test_slash_commands.py`:216 | all `HIDDEN_SUBCOMMANDS` hidden from `--help` | `mcp` is visible in `--help` (real `help=`); "hidden" means "no slash file" |
+
+## MEDIUM (10) + LOW (6) — fixed in place
+
+Stale doc-path pointers (`docs/design/` → `historical/`; `docs/specs/` →
+`docs/design/`), stale line-number references (the `bfs_multihop.py:155-160`
+family → `212-213`), version-attribution slips (`v0.5.0` → `v0.6.0`), and
+arithmetic/count typos in explanatory comments (`Three` → `Four`;
+`20%` → `~16.7%`; `60%` → `~66%`; `bm25.py line 243` → `244`;
+`dynamic_probe` fire threshold `median` → `1.5× median`). Each is one of the
+`docs(...)` commits on this branch.
+
+## Deferred — NOT fixed here (2, require code changes)
+
+These surfaced through the doc audit but are code defects, out of scope for a
+doc-text-only PR. Recorded here for coverage honesty; route to a code-fix issue.
+
+| File:line | Issue | Why deferred |
+|---|---|---|
+| `benchmarks/longmemeval_budget_sweep.py`:87-94 | The documented `Usage:` recipe crashes: the script calls `retrieve_v2(..., top_k=top_k, ...)` but `retrieve_v2` (`retrieval.py:3366`) takes `l1_limit`, not `top_k`, and has no `**kwargs` — `TypeError` on the first sweep iteration. | Fix is a code change (rename the call-site kwarg to `l1_limit`), not a docstring edit. A doc note alone would leave a broken benchmark. |
+| `tests/test_contradiction.py`:478 | `test_class_names_cover_all_three_classes` asserts over `CLASS_NAMES`, which now has **six** entries (`contradiction.py:97-104`), not three; the name implies full coverage it does not provide. | Fixing requires renaming the test or extending its assertion (a code change), not a doc edit. |
+
+## Dropped on re-verify (1)
+
+| File:line | Finding | Why dropped |
+|---|---|---|
+| `tests/test_value_compare.py`:89 | Claim that the `\b`-boundary test cannot distinguish correct word-boundary matching from a substring match (because the two tokens share a `group_id`). | The docstring names `asynchrony`; the refutation reasoned about `asynchronous`. The exact `ENUM_VOCAB` group membership needed to rewrite the docstring correctly could not be pinned with confidence — default-reject rather than ship a possibly-wrong "correction." |
+
+## Reversibility
+
+Every commit on `docs/issue-1075-tests-bench-incode` is doc-text-only and
+independently revertable (`git revert <sha>`); no code, tests, or fixtures
+changed behavior. `git revert github/main..HEAD` undoes the whole pass.

--- a/tests/bench_gate/test_bfs_multihop_derived_from.py
+++ b/tests/bench_gate/test_bfs_multihop_derived_from.py
@@ -8,7 +8,7 @@ https://github.com/robotrocketscience/aelfrice/issues/382#issuecomment-437268301
 `DERIVED_FROM` ships only when it demonstrates **≥+5pp BFS multi-hop hit@k
 uplift** on the labeled fixture vs. the same fixture run with
 `BFS_EDGE_WEIGHTS[DERIVED_FROM]` zeroed (which causes the BFS expander to
-skip DERIVED_FROM edges per `bfs_multihop.py:155-160`).
+skip DERIVED_FROM edges per `bfs_multihop.py:212-213`).
 
 Skips cleanly when `AELFRICE_CORPUS_ROOT` is unset (public CI), when the
 `derived_from_edge/` module dir is missing, or when the corpus has fewer than

--- a/tests/bench_gate/test_bfs_multihop_implements.py
+++ b/tests/bench_gate/test_bfs_multihop_implements.py
@@ -5,7 +5,7 @@ https://github.com/robotrocketscience/aelfrice/issues/382#issuecomment-437268301
 `IMPLEMENTS` ships only when it demonstrates **≥+5pp BFS multi-hop hit@k
 uplift** on the labeled fixture vs. the same fixture run with
 `BFS_EDGE_WEIGHTS[IMPLEMENTS]` zeroed (which causes the BFS expander to
-skip IMPLEMENTS edges per `bfs_multihop.py:155-160`).
+skip IMPLEMENTS edges per `bfs_multihop.py:212-213`).
 
 Skips cleanly when `AELFRICE_CORPUS_ROOT` is unset (public CI), when the
 `implements_edge/` module dir is missing, or when the corpus has fewer than

--- a/tests/bench_gate/test_bfs_multihop_temporal_next.py
+++ b/tests/bench_gate/test_bfs_multihop_temporal_next.py
@@ -5,7 +5,7 @@ https://github.com/robotrocketscience/aelfrice/issues/382#issuecomment-437268301
 `TEMPORAL_NEXT` ships only when it demonstrates **≥+5pp BFS multi-hop hit@k
 uplift** on the labeled fixture vs. the same fixture run with
 `BFS_EDGE_WEIGHTS[TEMPORAL_NEXT]` zeroed (which causes the BFS expander to
-skip TEMPORAL_NEXT edges per `bfs_multihop.py:155-160`).
+skip TEMPORAL_NEXT edges per `bfs_multihop.py:212-213`).
 
 Skips cleanly when `AELFRICE_CORPUS_ROOT` is unset (public CI), when the
 `temporal_next_edge/` module dir is missing, or when the corpus has fewer than

--- a/tests/bench_gate/test_bfs_multihop_tests.py
+++ b/tests/bench_gate/test_bfs_multihop_tests.py
@@ -5,7 +5,7 @@ https://github.com/robotrocketscience/aelfrice/issues/382#issuecomment-437268301
 `TESTS` ships only when it demonstrates **≥+5pp BFS multi-hop hit@k
 uplift** on the labeled fixture vs. the same fixture run with
 `BFS_EDGE_WEIGHTS[TESTS]` zeroed (which causes the BFS expander to
-skip TESTS edges per `bfs_multihop.py:155-160`).
+skip TESTS edges per `bfs_multihop.py:212-213`).
 
 Skips cleanly when `AELFRICE_CORPUS_ROOT` is unset (public CI), when the
 `tests_edge/` module dir is missing, or when the corpus has fewer than

--- a/tests/bench_gate/test_contradiction.py
+++ b/tests/bench_gate/test_contradiction.py
@@ -15,7 +15,7 @@ def test_contradiction_detector_against_corpus(aelfrice_corpus_root: Path) -> No
         from aelfrice import relationship_detector  # type: ignore[attr-defined]
     except ModuleNotFoundError as exc:
         if exc.name in {"aelfrice", "aelfrice.relationship_detector"}:
-            pytest.skip("contradiction detector not yet implemented (#201)")
+            pytest.skip("contradiction detector module missing from this checkout")
         raise
 
     correct = 0

--- a/tests/bench_gate/test_dedup.py
+++ b/tests/bench_gate/test_dedup.py
@@ -1,8 +1,10 @@
 """Bench gate for #197 deduplication module.
 
 Loads the lab-mounted corpus and runs the dedup detector against the
-labels. Skips on public CI (corpus absent) and skips again here until
-the detector module from #197 ships.
+labels. Skips on public CI (corpus absent). NOTE: ``aelfrice.dedup``
+now ships (#197 R1+) but exposes no ``classify(belief_a, belief_b)`` —
+this gate errors (AttributeError), not skips, once run against the
+lab corpus.
 """
 from __future__ import annotations
 

--- a/tests/bench_gate/test_intentional_clustering.py
+++ b/tests/bench_gate/test_intentional_clustering.py
@@ -7,8 +7,8 @@ directly, then checks ``cluster_coverage@k`` against a baseline.
 
 Public CI skips when ``AELFRICE_CORPUS_ROOT`` is unset (corpus content
 lives lab-side per the directory-of-origin rule). The retrieval-side
-wiring (``use_intentional_clustering`` flag in ``retrieve_v2``) is the
-follow-up gate; this scaffold tests the module independently so the
+wiring (``use_intentional_clustering`` in ``retrieve_v2``) already
+shipped and defaults on (#436 R6); this scaffold tests the module directly so the
 substrate can land before the wiring.
 """
 from __future__ import annotations

--- a/tests/bench_gate/test_promotion_trigger.py
+++ b/tests/bench_gate/test_promotion_trigger.py
@@ -15,7 +15,7 @@ def test_promotion_trigger_against_corpus(aelfrice_corpus_root: Path) -> None:
         from aelfrice import promotion_trigger  # type: ignore[attr-defined]
     except ModuleNotFoundError as exc:
         if exc.name in {"aelfrice", "aelfrice.promotion_trigger"}:
-            pytest.skip("promotion_trigger rule not yet implemented (#229)")
+            pytest.skip("promotion_trigger module was never built — #229 shipped via a different design (aelf lock/validate); this bench-gate corpus is stale")
         raise
 
     correct = 0

--- a/tests/bench_gate/test_wonder_consolidation.py
+++ b/tests/bench_gate/test_wonder_consolidation.py
@@ -15,7 +15,7 @@ def test_wonder_consolidation_against_corpus(aelfrice_corpus_root: Path) -> None
         from aelfrice import wonder_consolidation  # type: ignore[attr-defined]
     except ModuleNotFoundError as exc:
         if exc.name in {"aelfrice", "aelfrice.wonder_consolidation"}:
-            pytest.skip("wonder_consolidation strategy not yet implemented (#228)")
+            pytest.skip("wonder_consolidation strategy module missing from this checkout")
         raise
 
     # Expected human ratings 1-5; strategy outputs a generated phantom

--- a/tests/e2e/test_hook_inject_roundtrip.py
+++ b/tests/e2e/test_hook_inject_roundtrip.py
@@ -1,6 +1,7 @@
 """E2E scenario #2 (#334): hook -> ingest -> rebuild -> inject roundtrip.
 
-Exercises the seam the UserPromptSubmit / PreCompact hooks travel:
+Exercises the seam the UserPromptSubmit / SessionStart(compact) hooks
+travel (the PreCompact hook is neutered per #1031 and emits nothing):
 
     pre-seeded store + recent-turn transcript
         -> rebuild_v14 (the same code path the hook calls)

--- a/tests/e2e/test_source_type_discrimination.py
+++ b/tests/e2e/test_source_type_discrimination.py
@@ -82,8 +82,8 @@ def test_three_paths_record_distinct_source_types(
     tmp_path: Path,
 ) -> None:
     """All three first-class ingest paths must record their declared
-    `source_type` in `belief_corroborations`. Asserts the union of
-    observed source_types contains the three declared constants.
+    `source_kind` in `ingest_log`. Asserts the union of
+    observed source_kind values contains the three declared constants.
     """
     # Path 1: cli_remember via `aelf lock`.
     aelf_run("lock", "Quokkas calibrate the knob carefully on Tuesdays.")

--- a/tests/regression/test_commit_ingest_latency.py
+++ b/tests/regression/test_commit_ingest_latency.py
@@ -8,7 +8,7 @@ spec target is for the in-process hook body. We measure exactly that:
 build a payload pointing at a real commit in a tmp git repo, then
 time the hook's `_do_ingest` end-to-end across N=20 iterations.
 
-Asserts a generous 200ms p95 envelope so the test catches a 10x
+Asserts a generous 1500ms p95 envelope so the test catches a 10x
 regression without flaking on shared CI runners. Median is reported
 but not asserted on — assertion would be too noisy.
 """

--- a/tests/regression/test_onboard_to_search_end_to_end.py
+++ b/tests/regression/test_onboard_to_search_end_to_end.py
@@ -1,6 +1,6 @@
 """End-to-end regression: scan a fixture repo and find what was scanned.
 
-Cumulative integration scenario added at v0.5.0. Exercises scanner
+Cumulative integration scenario added at v0.6.0. Exercises scanner
 (filesystem + git + AST extractors + scan_repo orchestrator) +
 classification (regex fallback) + store (CRUD + FTS5) + retrieval
 (L0 locked + L1 BM25) in one realistic flow:

--- a/tests/retrieve_uplift_runner.py
+++ b/tests/retrieve_uplift_runner.py
@@ -14,7 +14,7 @@ Five flags exercised:
 - `use_signed_laplacian` (#149) — placeholder; warns if true
 - `use_heat_kernel` (#150) — wired via `heat_kernel_enabled`
 - `use_posterior_ranking` (#151) — wired via non-zero `posterior_weight`
-- `use_hrr_structural` (#152) — placeholder; warns if true
+- `use_hrr_structural` (#152) — default-ON in `retrieve_v2()` (marker-routed HRR lane); not exposed on `retrieve()`, so this entry is a no-op here
 
 The placeholders that haven't yet plumbed into `retrieve()` will
 trivially produce uplift=0 — the harness reports that as evidence
@@ -69,8 +69,9 @@ _TS = "2026-05-05T00:00:00+00:00"
 # Five v1.7 flags. Each entry maps the flag name to a `kwargs` lambda
 # that produces the kwargs to pass to `retrieve()` when the flag is
 # toggled ON. Flags not in this dict are kept at their default-off
-# state. `use_signed_laplacian` and `use_hrr_structural` are
-# placeholder-only in main today — listed here so the harness records
+# state. `use_signed_laplacian` is placeholder-only in main today;
+# `use_hrr_structural` has shipped (default-ON in `retrieve_v2`) but is
+# not exposed through `retrieve()`'s kwargs — listed here so the harness records
 # their no-op status; once the lanes land in `retrieve()`, only this
 # table needs the new wire.
 FLAG_KWARGS: dict[str, Callable[[], dict]] = {  # type: ignore[type-arg]
@@ -800,8 +801,9 @@ def run_compression_a2_uplift(
 
     Both arms disable L2.5 entity index and L3 BFS so the compression
     effect is isolated to the L1 pack-loop budget. ``intentional
-    clustering`` is held off both arms (mutually exclusive with
-    compression per ``retrieval.py``).
+    clustering`` is held off both arms to isolate the compression
+    effect for this metric (composable with compression since #878 —
+    not mutually exclusive).
 
     Degenerate cases the gate-side commentary should expect:
     - All-``fact`` or all-locked rows produce identical OFF/ON arms

--- a/tests/test_bench_tolerance.py
+++ b/tests/test_bench_tolerance.py
@@ -55,7 +55,7 @@ def test_classify_pass_inside_band():
 
 def test_classify_warn_at_60pct_drift():
     """Drift >50% of band half-width → warn."""
-    # band is [0.465, 0.535], half=0.035, 60% drift = 0.021 from canonical
+    # band is [0.465, 0.535], half=0.035, ~66% drift = 0.023 from canonical
     v, note = tolerance.classify(0.5, 0.523, 0.465, 0.535)
     assert v == Verdict.WARN
     assert "drift" in note

--- a/tests/test_bm25_index.py
+++ b/tests/test_bm25_index.py
@@ -14,9 +14,10 @@ Plus L1-lane integration tests for the `use_bm25f_anchors` opt-in plumb
 into `retrieve()`, and a rebuild-on-mutation test for the
 `BM25IndexCache` invalidation hookup.
 
-All tests are deterministic. Per project policy the perf test is
-opt-in via `--run-perf`; in CI it is collected but skipped by
-default to keep wall-clock under the 5s pytest timeout.
+All tests are deterministic. The perf test is gated by `_has_run_perf`,
+but no `--run-perf` CLI option is registered in this suite (see the
+no-op `pytest_addoption` stub below), so it is always skipped unless
+the guard is edited — it cannot be opted into via `pytest --run-perf`.
 """
 from __future__ import annotations
 
@@ -36,8 +37,12 @@ from aelfrice.store import MemoryStore
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:  # pragma: no cover
-    """Hook so the --run-perf flag is accepted at the per-file level
-    without polluting the suite-wide conftest. pytest collects this
+    """Historical no-op stub: pytest does not invoke `pytest_addoption`
+    for a plain test module, and this body never calls
+    `parser.addoption`, so `--run-perf` is not registered here or
+    anywhere; `_has_run_perf` always falls back to False. Kept as a
+    marker; wire into `tests/conftest.py` to actually enable the flag.
+    (Former intent below, retained for context.) pytest collects this
     if the suite imports this file with `pytest -p tests.test_bm25_index`,
     but since we register it inline, we just guard the perf test with
     a skip when the flag is missing."""
@@ -179,7 +184,9 @@ def test_score_latency_under_5ms_n50k(request: pytest.FixtureRequest) -> None:
     """AC5: median sparse-matvec score latency <= 5ms at N=50k.
 
     Skipped by default to keep CI under the per-test 5s wall-clock
-    cap. Run locally with `pytest --run-perf`.
+    cap. NOTE: `--run-perf` is not a registered pytest option (the
+    stub above is a no-op), so it always skips; to run locally,
+    temporarily bypass the `_has_run_perf` guard.
     """
     if not _has_run_perf(request):
         pytest.skip("perf test gated on --run-perf")

--- a/tests/test_bm25f_anchor_weight_meta.py
+++ b/tests/test_bm25f_anchor_weight_meta.py
@@ -84,7 +84,7 @@ def test_decode_anchor_weight_monotonic_non_decreasing() -> None:
 def test_decode_anchor_weight_returns_int() -> None:
     """``BM25Index.build`` accepts only ``int`` anchor_weight (it
     replicates the anchor token stream that many times — see bm25.py
-    line 243). Decode must therefore return ``int`` not ``float``.
+    line 244). Decode must therefore return ``int`` not ``float``.
     """
     for v in (0.0, 0.123, 0.5, 0.876, 1.0):
         result = decode_meta_bm25f_anchor_weight(v)

--- a/tests/test_claude_memory.py
+++ b/tests/test_claude_memory.py
@@ -75,7 +75,7 @@ Some introductory text that is not a bullet.
 
 def test_parse_memory_bullets_count() -> None:
     bullets = parse_memory_bullets(_SYNTHETIC_MEMORY_MD, source_path="MEMORY.md")
-    # Three correctly-formed bullets: Fake topic, Another topic, No description, Final item
+    # Four correctly-formed bullets: Fake topic, Another topic, No description, Final item
     assert len(bullets) == 4
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -548,8 +548,9 @@ def test_health_points_at_aelf_regime_for_classifier(isolated_db: Path) -> None:
 def test_status_now_aliases_stats(isolated_db: Path) -> None:
     """v1.3 rename: `aelf status` runs the counts snapshot (was `aelf stats`).
 
-    The v1.1 alias of `aelf health` is gone — graph audit moved to
-    `aelf doctor graph`.
+    `aelf health` is retained as a deprecated back-compat alias of
+    `aelf doctor graph` (hidden from --help via argparse.SUPPRESS); it
+    is not removed.
     """
     code_st, out_st = _run("stats")
     code_status, out_status = _run("status")

--- a/tests/test_cli_eval.py
+++ b/tests/test_cli_eval.py
@@ -135,8 +135,9 @@ def test_eval_empty_corpus_returns_1(tmp_path: Path) -> None:
 
 def test_eval_json_keys_sorted_for_diff_stability(tmp_path: Path) -> None:
     """JSON output keys are sorted so the line is diff-stable across
-    Python versions / dict-ordering changes — important for the future
-    R5 CI status-check surface that diffs runs."""
+    Python versions / dict-ordering changes — used by the #365 R5 CI
+    status-check surface (.github/workflows/eval-calibration.yml) that
+    diffs runs against a pinned baseline."""
     corpus = _toy_corpus(tmp_path / "toy.jsonl")
     rc, output = _run(["eval", "--corpus", str(corpus), "--json"])
     assert rc == 0

--- a/tests/test_clustering_integration.py
+++ b/tests/test_clustering_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for #436 intentional clustering wired into retrieve_v2.
 
-Covers flag-precedence resolution, byte-identical default-OFF behavior,
+Covers flag-precedence resolution, byte-identical default-ON behavior
+(matching explicit ``use_intentional_clustering=True``, #436),
 the diversity-aware pack on graph-connected candidates, locked-belief
 pre-include, and the compose-reconciliation with type-aware compression
 (#878 — was a mutual-exclusion guard at v2.0.0, now composes via the

--- a/tests/test_composition_tracker.py
+++ b/tests/test_composition_tracker.py
@@ -3,8 +3,7 @@
 Covers:
 
 - Placeholder flag warner emits one stderr line per recognised
-  flag (`use_signed_laplacian`, `use_heat_kernel`,
-  `use_posterior_ranking`, `use_hrr_structural`) and is silent
+  flag (`use_signed_laplacian`, `use_posterior_ranking`) and is silent
   when none are set.
 - Warner is idempotent within a process — second call produces
   no new warnings unless the seen-set is reset.

--- a/tests/test_context_rebuilder.py
+++ b/tests/test_context_rebuilder.py
@@ -316,7 +316,7 @@ def test_find_aelfrice_log_returns_none_outside_git(
 
 
 def test_default_token_budget_matches_spec_default() -> None:
-    """Spec docs/specs/context_rebuilder.md sets default 2000."""
+    """Spec docs/design/context_rebuilder.md sets default 2000."""
     assert DEFAULT_TOKEN_BUDGET == 2000
 
 

--- a/tests/test_context_rebuilder_hook.py
+++ b/tests/test_context_rebuilder_hook.py
@@ -2,9 +2,10 @@
 
 One test per acceptance criterion:
 
-  AC1. Hook fires on PreCompact and emits `additionalContext` with
+  AC1. SessionStart (source=='compact') emits a rebuild block carrying
        locked + session-scoped + retrieve() hits, ordered as:
-       L0 locked -> session-scoped -> L2.5 + L1.
+       L0 locked -> session-scoped -> L2.5 + L1. (PreCompact itself no
+       longer emits additionalContext; the harness rejects it — #1031.)
   AC2. Empty transcript / missing store: hook exits 0 with no
        `additionalContext` written. Tool path unaffected.
   AC3. Reproducibility: two fires with identical inputs (same

--- a/tests/test_derivation_worker_route_overrides.py
+++ b/tests/test_derivation_worker_route_overrides.py
@@ -5,11 +5,13 @@ splice contract ratified on PR #478:
 
   - `route_overrides` flows through `raw_meta -> DerivationInput`.
   - When set, `derive()` skips the regex classifier and uses the router's
-    `(type, origin, alpha, beta)`. Byte-identical to today's scanner.py
-    direct-write LLM-classify path on the same input.
+    `(type, origin, alpha, beta)`. Byte-identical to scanner.py's
+    pre-migration direct-write LLM-classify path (now routed through
+    `record_ingest` + `run_worker`) on the same input.
   - The worker emits a `feedback_history` audit row when
     `audit_source` is set AND the belief was newly inserted (matches
-    today's scanner.py:301-310 `if was_inserted` guard).
+    the `if was_inserted` guard now in `derivation_worker.py`,
+    relocated there from scanner.py by #265 PR-B).
   - Absent `route_overrides`, today's regex-path behavior is unchanged.
 
 Scanner-side migration to `record_ingest + run_worker` lives in commit 2.

--- a/tests/test_doctor_classify_orphans.py
+++ b/tests/test_doctor_classify_orphans.py
@@ -146,7 +146,7 @@ def stub_anthropic(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_orphan_finder_picks_unknown_low_prior(memdb: MemoryStore) -> None:
-    """find_orphan_beliefs selects type='unknown' AND alpha+beta < 2."""
+    """find_orphan_beliefs selects type='unknown' AND alpha+beta <= 2."""
     _make_belief(memdb, belief_id="o1", content="orphan one", belief_type="unknown",
                  alpha=1.0, beta=1.0)
     # Already typed — not an orphan

--- a/tests/test_doctor_promote_retention.py
+++ b/tests/test_doctor_promote_retention.py
@@ -78,7 +78,7 @@ def _corr(
 
 
 def test_promotion_thresholds_match_spec() -> None:
-    """docs/design/belief_retention_class.md §4 nails N=3, M=2."""
+    """docs/design/historical/belief_retention_class.md §4 nails N=3, M=2."""
     assert PROMOTE_RETENTION_MIN_CORROBORATIONS == 3
     assert PROMOTE_RETENTION_MIN_SESSIONS == 2
 

--- a/tests/test_heat_kernel.py
+++ b/tests/test_heat_kernel.py
@@ -12,7 +12,7 @@ Acceptance map (#150 § "Acceptance criteria"):
 - AC5: per-query latency ≤ 10 ms at N=50k (perf-gated)
 - AC6: eigenbasis loaded once per process — covered structurally by
        the existing GraphEigenbasisCache tests
-- AC7: feature-flag default is False (use_heat_kernel)
+- AC7: feature-flag default is True (use_heat_kernel), opt-out via env/kwarg/TOML (flipped per #154 after the #437 11/11 gate)
 """
 from __future__ import annotations
 

--- a/tests/test_hook_project_context_filter.py
+++ b/tests/test_hook_project_context_filter.py
@@ -108,9 +108,11 @@ def test_mismatching_context_dropped(
 
 
 def test_user_scope_bypasses_filter(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A user-promoted belief (scope='user') is cross-context regardless
-    of its stored project_context. Cross-context promotion is what scope
-    'user' MEANS in v3.0 #688's federation visibility taxonomy."""
+    """A belief with an arbitrary non-'project' scope value bypasses the
+    filter (only scope=='project' rows are checked against project_context).
+    User-promotion itself is tracked via lock_level==LOCK_USER, not via
+    scope (there is no 'user' scope in the #688 taxonomy) — see
+    _filter_by_project_context's docstring."""
     monkeypatch.setenv("AELFRICE_PROJECT_CONTEXT", "retrieval-v3")
     hits = [
         _b("u", project_context="other", scope="user",

--- a/tests/test_hrr.py
+++ b/tests/test_hrr.py
@@ -31,7 +31,7 @@ def test_unbind_inverts_bind_high_similarity() -> None:
     """Plate 1995 with random unit keys: ``unbind(k, bind(k, v))``
     is ``v`` filtered per-frequency by ``|fft(k)|²``. With random
     Gaussian keys (non-unitary) the empirical cosine similarity sits
-    at ~0.71 (range ~0.69–0.72 across seeds 0–9 at dim=2048), not
+    well above the noise floor at dim=512 (DEFAULT_DIM), not
     the ~1.0 you'd get with unitary keys. Cleanup memory recovers
     the true filler from the degraded vector — that is the standard
     HRR recovery pipeline."""
@@ -87,7 +87,7 @@ def test_unbind_single_pair_recovery_above_threshold() -> None:
 def test_superposed_recovery_above_capacity_threshold() -> None:
     """Two bound pairs in superposition: unbinding either key
     should recover the corresponding filler at cosine similarity
-    well above the noise floor (1/sqrt(dim) ~ 0.022 at dim=2048)."""
+    well above the noise floor (1/sqrt(dim) ~ 0.044 at dim=512, DEFAULT_DIM)."""
     rng = _rng()
     k1, v1 = random_vector(DEFAULT_DIM, rng), random_vector(DEFAULT_DIM, rng)
     k2, v2 = random_vector(DEFAULT_DIM, rng), random_vector(DEFAULT_DIM, rng)

--- a/tests/test_insert_belief_gate.py
+++ b/tests/test_insert_belief_gate.py
@@ -5,7 +5,7 @@ When `AELFRICE_WRITE_LOG_AUTHORITATIVE` is on, `insert_belief()`
 walks the call stack to find the first frame outside `aelfrice.store`
 and raises `WriteLogAuthorityViolation` unless that module appears in
 `INSERT_BELIEF_ALLOWLIST` = {derivation_worker, wonder.simulator,
-benchmark, migrate}. With the flag off (production default at this
+wonder.lifecycle, benchmark, migrate}. With the flag off (production default at this
 commit), the check is a no-op.
 
 Each test states a falsifiable hypothesis about the gate contract.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -374,7 +374,7 @@ def test_feedback_unknown_belief_returns_error(store: MemoryStore) -> None:
 def test_stats_returns_count_keys(store: MemoryStore) -> None:
     out = tool_stats(store)
     # v1.1.0 emits both `edges` (deprecated) and `threads` (canonical).
-    # `edges` removed in v1.2.0.
+    # The planned v1.2.0 removal of `edges` never happened; both keys are emitted indefinitely.
     assert {
         "beliefs", "edges", "threads", "locked", "feedback_events",
         "onboard_sessions_total",

--- a/tests/test_relevance_floor.py
+++ b/tests/test_relevance_floor.py
@@ -172,7 +172,7 @@ def test_empty_path_default_zero_floor_packs_normally(tmp_path: Path) -> None:
 
 
 def test_default_floor_constants_match_spec() -> None:
-    """Pin the placeholder values to `docs/design/relevance_floor.md` §4.
+    """Pin the placeholder values to `docs/design/historical/relevance_floor.md` §4.
     A change to either trips this test so a follow-up calibration
     PR cannot slip past review unnoticed."""
     assert DEFAULT_FLOOR_SESSION == 0.10

--- a/tests/test_retrieval_cache.py
+++ b/tests/test_retrieval_cache.py
@@ -1,4 +1,4 @@
-"""Acceptance tests for `RetrievalCache` (docs/design/lru_query_cache.md).
+"""Acceptance tests for `RetrievalCache` (docs/design/historical/lru_query_cache.md).
 
 Eight tests, one per acceptance criterion. All deterministic, in-memory
 SQLite, < 100 ms wall clock per test.

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -213,7 +213,9 @@ def test_upgrade_slash_keeps_step_2_imperative() -> None:
     )
 
 
-# Subparsers intentionally hidden from --help at v1.3. Aliases live one
+# Subparsers intentionally shipped without a slash-command file (most,
+# but not all, are also hidden from --help; `mcp` is a visible-in---help
+# exception kept here because it has no slash file). Aliases live one
 # minor and are deleted at v1.4 (`health`, `stats`); the rest stay
 # callable indefinitely as scripting / hook entry points.
 HIDDEN_SUBCOMMANDS = frozenset({

--- a/tests/test_value_compare.py
+++ b/tests/test_value_compare.py
@@ -141,7 +141,7 @@ def test_numeric_zero_zero_no_conflict() -> None:
 def test_numeric_custom_tolerance_overrides_default() -> None:
     a = extract_values("alpha is 0.5")
     b = extract_values("alpha is 0.6")
-    # 20% diff. With default 1% tol this conflicts; with 50% tol it doesn't.
+    # ~16.7% diff. With default 1% tol this conflicts; with 50% tol it doesn't.
     assert find_conflicts(a, b, numeric_rel_tol=0.5) == ()
     assert find_conflicts(a, b, numeric_rel_tol=0.01) != ()
 


### PR DESCRIPTION
Closes the in-code documentation layer for the #1075 v4.0.0 release gate:
the `tests/` + `benchmarks/` `.py` docstring bucket that the `src/aelfrice/`
in-code pass (`DOCS-AUDIT-2026-07-04-incode.md`) explicitly deferred.

## What this is

A 15-batch multi-agent audit of **all 435 `.py` files** under `tests/` (387)
and `benchmarks/` (48), verifying every doc-bearing construct (module/class/
function docstrings, argparse `help=`, inline doc comments) against the code it
describes at `github/main`. Every CRITICAL/HIGH finding was independently
re-verified by direct code inspection (default-reject on uncertainty) before
any fix. Doc-text-only; **no code behavior changed**. One atomic signed commit
per file.

Ledger: `docs/audits/DOCS-AUDIT-2026-07-04-tests-bench.md` (third companion to
the doc-file and `src/` in-code ledgers).

## Coverage

- **435 / 435 files audited (100%)**, ~2,917 doc constructs
- **52 findings:** 2 CRITICAL + 33 HIGH + 10 MEDIUM + 7 LOW
  - **49 fixed here** (1 CRIT + 32 HIGH + 10 MED + 6 LOW) — 41 files
  - **2 deferred** — code defects out of doc-only scope (see ledger § Deferred):
    a genuinely-broken `longmemeval_budget_sweep.py` recipe (`retrieve_v2`
    called with `top_k=` instead of `l1_limit=` → `TypeError`), and a
    `test_contradiction.py` test-rename. Both want a code-fix follow-up.
  - **1 dropped** on re-verify (`test_value_compare.py:89` — vocab semantics
    not confidently pinnable)

## Recurring drift fixed

`#1031` PreCompact→SessionStart(compact) move · shipped flags still doc'd as
placeholders (`use_heat_kernel`/`use_hrr_structural`) · default-flip drift
(`use_intentional_clustering`, heat-kernel → default-on) · stale `bench_gate`
skip messages citing CLOSED issues (`#201/#228/#229`) · `docs/design/` →
`historical/` path moves · stale `bfs_multihop.py:155-160` line pointers →
`212-213`.

Per-file `docs(<scope>): ...` commits let each correction be reviewed and
reverted independently.
